### PR TITLE
feat(try): "Чому критично?" — explain why each critical field matters

### DIFF
--- a/docs/critical_explanations.json
+++ b/docs/critical_explanations.json
@@ -1,0 +1,429 @@
+{
+  "version": "0.1",
+  "status": "draft_pending_review",
+  "generic": {
+    "demographics.ecog": {
+      "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+      "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+      "affects": [
+        "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+        "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+        "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+        "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+        "При ECOG 4 — engine зазвичай повертає лише best supportive care"
+      ],
+      "sources": [
+        "SRC-ECOG-OKEN-1982"
+      ]
+    },
+    "demographics.age": {
+      "short": "Вік модулює дози, вибір регімена і допуск до трансплантації.",
+      "why": "Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але\nвін входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)\nі визначає верхні межі для intensive протоколів та трансплантації.\nEngine використовує вік разом із ECOG/коморбідностями, не як\nсамостійний фільтр.\n",
+      "affects": [
+        "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI",
+        "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)",
+        "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)",
+        "Допуск у клінічні випробування (вікові межі протоколів)"
+      ],
+      "sources": [
+        "SRC-NCCN-AGE-FRAILTY-2024"
+      ]
+    },
+    "line_of_therapy": {
+      "short": "Лінія терапії повністю змінює простір допустимих регімен-блоків.",
+      "why": "Engine має окремі алгоритм-блоки для 1L / 2L / 3L+. Той самий пацієнт\nу 1L і 2L отримує абсолютно різні рекомендації: previous exposure\nблокує retreatment-резистентні класи (наприклад, post-BTKi у CLL\nвиключає re-BTKi), а relapsed/refractory статус відкриває targeted\nагенти, які у 1L заборонені guideline-ами.\n",
+      "affects": [
+        "Вибір алгоритм-блоку (1L vs salvage vs maintenance)",
+        "Виключення класів, до яких пацієнт уже резистентний",
+        "Допуск до CAR-T / bispecifics (зазвичай ≥3L у DLBCL/MM)",
+        "Розгляд clinical-trial referral (часто primary option у 3L+)"
+      ],
+      "sources": [
+        "SRC-NCCN-LINE-OF-THERAPY-DEFINITIONS"
+      ]
+    },
+    "findings.hbsag": {
+      "short": "HBsAg критичний перед anti-CD20 / high-dose стероїдами — ризик HBV reactivation з фульмінантним гепатитом.",
+      "why": "Anti-CD20 (rituximab, obinutuzumab) і пролонговані стероїди викликають\nреактивацію хронічного або resolved HBV з risk fatal hepatitis. AASLD\n2024 і ESMO infection-prevention guideline вимагають universal HBsAg\n+ anti-HBc screening ПЕРЕД першою дозою. HBsAg+ → entecavir/TDF\nprophylaxis обов'язковий за 1-2 тиж до старту і ≥12 міс після\nостанньої дози.\n",
+      "affects": [
+        "Призначення antiviral prophylaxis (entecavir/TDF) — обов'язкове при HBsAg+",
+        "Час старту терапії (затримка 1-2 тиж на ramp-up antiviral)",
+        "Моніторинг ALT + HBV DNA кожні 1-3 міс під час лікування",
+        "Продовження prophylaxis ≥12 міс після завершення anti-CD20",
+        "Відмова від anti-CD20 на користь альтернатив, якщо prophylaxis недоступний"
+      ],
+      "sources": [
+        "SRC-AASLD-HBV-2024",
+        "SRC-EASL-HBV-2025",
+        "SRC-ESMO-INFECTIONS-2016"
+      ]
+    },
+    "findings.iwcll_indication_present": {
+      "short": "Без iwCLL active-disease criteria CLL не лікують — watch-and-wait перевершує ранній старт.",
+      "why": "Random-старт терапії у asymptomatic CLL погіршує OS (CLL1, German\nCLL Study Group). Лікування стартує ЛИШЕ при формальних iwCLL\nactive-disease criteria (≥1 з: progressive lymphocytosis з doubling\n<6 міс, progressive cytopenias Hb<10 / Plt<100, bulky/painful\nadenopathy, splenomegaly з симптомами, B-symptoms, autoimmune\ncytopenia рефрактерна до стероїдів).\n",
+      "affects": [
+        "Старт vs watch-and-wait — фундаментальне рішення 1L",
+        "Якщо false → engine видає 'no treatment indication' замість регімена",
+        "Часовий горизонт next-visit (W&W → 3-6 міс reassessment)"
+      ],
+      "sources": [
+        "SRC-IWCLL-HALLEK-2018",
+        "SRC-ESMO-CLL-2024"
+      ]
+    },
+    "biomarkers.BIO-CLL-HIGH-RISK-GENETICS": {
+      "short": "TP53/del(17p)/complex karyotype визначають вибір BTKi/BCL2 vs застарілі CIT.",
+      "why": "High-risk genetics (TP53mut, del(17p), complex karyotype, unmutated\nIGHV) роблять FCR/BR клінічно неприйнятними — короткий PFS, високий\nризик Richter. Engine обере BTKi або fixed-duration VenO. NCCN\nprefers Ven+Obinutuzumab для del(17p)/TP53 — fixed-duration з\nкращим quality of life ніж indefinite BTKi.\n",
+      "affects": [
+        "Виключення CIT (FCR/BR) як 1L",
+        "Вибір між continuous BTKi (acala/zanu) та fixed-duration VenO",
+        "Інтенсивність моніторингу (high-risk → коротші intervals)",
+        "Раннє обговорення alloSCT при young-fit з double-hit (TP53 + complex)"
+      ],
+      "sources": [
+        "SRC-CLL14-FISCHER-2019",
+        "SRC-ESMO-CLL-2024",
+        "SRC-NCCN-CLL-2024"
+      ]
+    },
+    "findings.tp53_mutation": {
+      "short": "TP53mut робить FCR/BR клінічно беззмістовними — короткий PFS, ризик Richter.",
+      "why": "~5-7% newly-diagnosed CLL мають TP53mut (без del(17p)); ще ~5-10% —\ndel(17p) ± TP53mut. Обидва — найгірший single-marker prognostic.\nStandard chemoimmunotherapy дає median PFS <2 років. BTKi/BCL2-\ntargeted перевершують CIT з великим ефектом.\n",
+      "affects": [
+        "Hard contraindication для FCR/BR як 1L",
+        "Direct path → BTKi або fixed-duration VenO",
+        "Раннє обговорення alloSCT при молодих fit пацієнтах"
+      ],
+      "sources": [
+        "SRC-ESMO-CLL-2024",
+        "SRC-NCCN-CLL-2024"
+      ]
+    },
+    "findings.del_17p": {
+      "short": "del(17p) — найгірший single marker у CLL; same management як TP53mut.",
+      "why": "del(17p) виявляється FISH у ~5-10% NDxg CLL. Прогностично еквівалентний\nTP53mut і часто з ним co-existує. Engine трактує del(17p) OR TP53mut\nяк композитний high-risk trigger.\n",
+      "affects": [
+        "Те саме що TP53mut — виключає CIT, направляє на targeted",
+        "Композитний 'TP53-aberrant' стан з тими ж терапевтичними наслідками"
+      ],
+      "sources": [
+        "SRC-ESMO-CLL-2024"
+      ]
+    },
+    "biomarkers.BIO-HCV-RNA": {
+      "short": "HCV RNA+ при HCV-MZL — antiviral-first track перевершує chemoimmunotherapy.",
+      "why": "У HCV-associated marginal zone lymphoma elimination HCV (DAA — sof/vel\nабо glec/pib) дає lymphoma response у 40-75% без жодної chemo. Це\neтіологічна терапія, не паліатив. Якщо HCV RNA negative — engine\nповертається до стандартного BR-track.\n",
+      "affects": [
+        "Вибір antiviral-first vs immediate BR-aggressive",
+        "Час старту chemo (відкласти на 12-24 тиж DAA, потім reassess)",
+        "Гепатологічний референс перед стартом",
+        "Fallback на BR якщо HCV negative або після DAA немає response"
+      ],
+      "sources": [
+        "SRC-AASLD-HCV-2023",
+        "SRC-EASL-HCV-2024",
+        "SRC-ARCAINI-2014",
+        "SRC-ESMO-MZL-2024"
+      ]
+    },
+    "findings.HCV RNA positive": {
+      "short": "Технічне дзеркало BIO-HCV-RNA для engine clause — заповнюється автоматично.",
+      "why": "Boolean форма HCV RNA для рул-енджин патернів. Семантично ідентичне\nBIO-HCV-RNA (positive/negative). Дублювання — implementation detail\nengine, не клінічна differentia.\n",
+      "affects": [
+        "Те саме що BIO-HCV-RNA"
+      ],
+      "sources": []
+    },
+    "demographics.decompensated_cirrhosis": {
+      "short": "Декомпенсований цироз (Child-Pugh B/C) блокує glec/pib і обмежує choice DAA + chemo.",
+      "why": "Glecaprevir/pibrentasvir contraindicated при Child-Pugh B/C. Sof/vel\n± ribavirin — лише вибір. Декомпенсований цироз також знижує\nпереносимість R-CHOP/BR (печінкова токсичність, тромбоцитопенія).\nEngine розглядає dose-reduction або відкладення active treatment.\n",
+      "affects": [
+        "Вибір DAA-режима (sof/vel only, не glec/pib)",
+        "Можлива відмова від chemoimmunotherapy на користь rituximab-mono",
+        "Hepatology consult обов'язковий",
+        "Розгляд orthotopic liver transplant referral при young-fit"
+      ],
+      "sources": [
+        "SRC-AASLD-HCV-2023",
+        "SRC-CHILD-PUGH-1973"
+      ]
+    },
+    "findings.dominant_nodal_mass_cm": {
+      "short": "Bulky disease (≥7 см) — пряма indication для chemo-first навіть при HCV+.",
+      "why": "Bulky tumor burden не reduce достатньо швидко лише antiviral-ом —\nризик progressive симптомів / compression syndrome. Engine\nпереключає на BR-aggressive негайно, з DAA конкурентно або після.\n",
+      "affects": [
+        "Override antiviral-first track → BR-aggressive як 1L",
+        "Прискорений старт terapія (тижні, не місяці)",
+        "Розгляд debulking radiation якщо локалізована маса"
+      ],
+      "sources": [
+        "SRC-ESMO-MZL-2024"
+      ]
+    },
+    "findings.symptomatic_b_symptoms_severe": {
+      "short": "Тяжкі B-симптоми — relative indication для chemo навіть без bulky.",
+      "why": "Severe B-symptoms (T>38°C, drenching night sweats, weight loss >10%\nза 6 міс) сигналізують aggressive lymphoma biology. Watchful waiting\nнеприйнятний. Engine розглядає BR незалежно від HCV статусу.\n",
+      "affects": [
+        "Relative indication для immediate chemo",
+        "Workup на трансформацію (PET-CT, repeat biopsy найбільшого вузла)"
+      ],
+      "sources": [
+        "SRC-ESMO-MZL-2024"
+      ]
+    },
+    "findings.Indolent presentation (non-bulky, asymptomatic or minimally symptomatic)": {
+      "short": "Технічне дзеркало для algorithm clause — заповнюється автоматично.",
+      "why": "Boolean composite для рул-енджин: true ⇔ non-bulky (<7cm) AND no\nsevere B-symptoms. Не клінічно вводиться окремо.\n",
+      "affects": [
+        "Дозволяє antiviral-first track при HCV+"
+      ],
+      "sources": []
+    },
+    "findings.biopsy_shows_dlbcl": {
+      "short": "Трансформація в DLBCL — повна зміна алгоритму з MZL на DLBCL-specific.",
+      "why": "Histologic transformation indolent → aggressive lymphoma (DLBCL,\nRichter в CLL) — окрема клінічна сутність. Лікування вже НЕ MZL/CLL,\nа de novo DLBCL: R-CHOP-21 ± consolidation, потенційно CAR-T у 2L.\nPrognosis значно гірший.\n",
+      "affects": [
+        "Перехід engine на DLBCL algorithm (інша disease entity)",
+        "Старт R-CHOP-21 × 6 циклів",
+        "Workup на CNS involvement (CNS-IPI)",
+        "Раннє обговорення CD19 CAR-T при relapsed/refractory"
+      ],
+      "sources": [
+        "SRC-ESMO-DLBCL-2024"
+      ]
+    },
+    "demographics.fit_for_transplant": {
+      "short": "Transplant-eligibility — clinical judgment, не вікова межа; визначає 1L architecture у MM.",
+      "why": "Transplant-eligibility — інтегральна оцінка hematologist (frailty,\ncardiac/renal, prior treatments, social support), а НЕ просто age\ncutoff. Eligible пацієнти отримують induction → autoSCT →\nmaintenance; ineligible — continuous induction до progression.\n",
+      "affects": [
+        "Вибір induction (VRd/D-VRd → ASCT vs continuous DRd / VRd-lite)",
+        "Stem-cell collection до melphalan exposure",
+        "Maintenance strategy (lenalidomide indefinite vs fixed)"
+      ],
+      "sources": [
+        "SRC-ESMO-MM-2023",
+        "SRC-IMWG-FRAILTY-2015"
+      ]
+    },
+    "biomarkers.BIO-MM-CYTOGENETICS-HR": {
+      "short": "High-risk cytogenetics (t(4;14), t(14;16), del(17p), gain1q ≥3) — D-VRd замість VRd.",
+      "why": "Composite high-risk cytogenetics має значно гірший PFS на VRd alone.\nDaratumumab-quadruplet (D-VRd, GRIFFIN/PERSEUS) дає значно глибші\nresponses і покращує MRD-negativity rate, з прийнятним safety\nprofile.\n",
+      "affects": [
+        "Default 1L induction → D-VRd замість VRd при transplant-eligible",
+        "Інтенсифікація maintenance (consider Dara-Len замість Len-mono)",
+        "Запис у early-relapse-risk моніторинг"
+      ],
+      "sources": [
+        "SRC-PERSEUS-SONNEVELD-2024",
+        "SRC-GRIFFIN-VOORHEES-2023",
+        "SRC-ESMO-MM-2023"
+      ]
+    },
+    "findings.creatinine_clearance_ml_min": {
+      "short": "CrCl визначає dose-adjustments для lenalidomide, daratumumab, melphalan.",
+      "why": "Renal impairment (frequent у MM через cast nephropathy) вимагає\ndose-adjusted lenalidomide (CrCl <60 — 10 mg; <30 — 15 mg q48h або\nVd-only). Bortezomib безпечний при будь-якому CrCl. Daratumumab\nбезпечний, але потребує enhanced monitoring перших інфузій.\n",
+      "affects": [
+        "Lenalidomide dose (25/15/10 mg по CrCl bands)",
+        "Hydration / monitoring schedule перших циклів",
+        "Розгляд plasma exchange при cast nephropathy + light-chain",
+        "Можлива заміна Len → Pomalidomide (renally safer)"
+      ],
+      "sources": [
+        "SRC-ESMO-MM-2023",
+        "SRC-IMWG-RENAL-2016"
+      ]
+    },
+    "demographics.pregnancy_status": {
+      "short": "Вагітність — абсолютна заборона lenalidomide / pomalidomide / thalidomide (тератогени).",
+      "why": "IMiDs (len, pom, thal) — категорія X, абсолютна contraindication при\nвагітності або можливості завагітніти без contraception. REMS у US\nвимагає 2 негативних тестів + 2 методів контрацепції. Engine блокує\nVRd / D-VRd / DRd і fall'ить на bortezomib + dex (Vd) як bridging.\n",
+      "affects": [
+        "Hard block на IMiD-containing регімени",
+        "Default fallback → Vd або CyBorD (cyclophosphamide+bort+dex)",
+        "OB/GYN consult обов'язковий перед стартом",
+        "REMS-style enrollment (де доступний)"
+      ],
+      "sources": [
+        "SRC-FDA-LENALIDOMIDE-LABEL",
+        "SRC-ESMO-MM-2023"
+      ]
+    }
+  },
+  "by_disease": {
+    "DIS-AML": {
+      "demographics.ecog": {
+        "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+        "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+        "affects": [
+          "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+          "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+          "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+          "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+          "При ECOG 4 — engine зазвичай повертає лише best supportive care",
+          "ECOG ≥2 у віці ≥75 → engine надає перевагу azacitidine+venetoclax замість 7+3."
+        ],
+        "sources": [
+          "SRC-ECOG-OKEN-1982"
+        ]
+      },
+      "demographics.age": {
+        "short": "Вік модулює дози, вибір регімена і допуск до трансплантації.",
+        "why": "Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але\nвін входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)\nі визначає верхні межі для intensive протоколів та трансплантації.\nEngine використовує вік разом із ECOG/коморбідностями, не як\nсамостійний фільтр.\n",
+        "affects": [
+          "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI",
+          "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)",
+          "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)",
+          "Допуск у клінічні випробування (вікові межі протоколів)",
+          "Age ≥75 → engine рекомендує aza+ven замість 7+3 навіть при ECOG 0-1."
+        ],
+        "sources": [
+          "SRC-NCCN-AGE-FRAILTY-2024"
+        ]
+      }
+    },
+    "DIS-DLBCL": {
+      "demographics.ecog": {
+        "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+        "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+        "affects": [
+          "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+          "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+          "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+          "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+          "При ECOG 4 — engine зазвичай повертає лише best supportive care",
+          "ECOG ≥3 виключає R-CHOP; розглядається R-mini-CHOP або palliative."
+        ],
+        "sources": [
+          "SRC-ECOG-OKEN-1982"
+        ]
+      },
+      "demographics.age": {
+        "short": "Вік модулює дози, вибір регімена і допуск до трансплантації.",
+        "why": "Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але\nвін входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)\nі визначає верхні межі для intensive протоколів та трансплантації.\nEngine використовує вік разом із ECOG/коморбідностями, не як\nсамостійний фільтр.\n",
+        "affects": [
+          "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI",
+          "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)",
+          "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)",
+          "Допуск у клінічні випробування (вікові межі протоколів)",
+          "Age >60 — додає 1 бал до IPI; age >80 → R-mini-CHOP як default."
+        ],
+        "sources": [
+          "SRC-NCCN-AGE-FRAILTY-2024"
+        ]
+      }
+    },
+    "DIS-MM": {
+      "demographics.ecog": {
+        "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+        "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+        "affects": [
+          "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+          "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+          "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+          "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+          "При ECOG 4 — engine зазвичай повертає лише best supportive care",
+          "ECOG ≥2 + frailty → engine знижує дози (Vd замість VRd) як frailty-adjusted режим."
+        ],
+        "sources": [
+          "SRC-ECOG-OKEN-1982"
+        ]
+      },
+      "demographics.age": {
+        "short": "Вік модулює дози, вибір регімена і допуск до трансплантації.",
+        "why": "Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але\nвін входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)\nі визначає верхні межі для intensive протоколів та трансплантації.\nEngine використовує вік разом із ECOG/коморбідностями, не як\nсамостійний фільтр.\n",
+        "affects": [
+          "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI",
+          "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)",
+          "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)",
+          "Допуск у клінічні випробування (вікові межі протоколів)",
+          "Age ≤70 + fit → transplant-eligible track (VRd→ASCT→Lenalidomide maint)."
+        ],
+        "sources": [
+          "SRC-NCCN-AGE-FRAILTY-2024"
+        ]
+      }
+    },
+    "DIS-PDAC": {
+      "demographics.ecog": {
+        "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+        "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+        "affects": [
+          "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+          "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+          "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+          "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+          "При ECOG 4 — engine зазвичай повертає лише best supportive care",
+          "ECOG ≥2 виключає FOLFIRINOX; default стає gemcitabine + nab-paclitaxel або gem mono."
+        ],
+        "sources": [
+          "SRC-ECOG-OKEN-1982"
+        ]
+      }
+    },
+    "DIS-NSCLC": {
+      "demographics.ecog": {
+        "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+        "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+        "affects": [
+          "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+          "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+          "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+          "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+          "При ECOG 4 — engine зазвичай повертає лише best supportive care",
+          "ECOG ≥2 — relative-contraindication для platinum-doublet; розглядається single-agent IO або BSC."
+        ],
+        "sources": [
+          "SRC-ECOG-OKEN-1982"
+        ]
+      }
+    },
+    "DIS-SCLC": {
+      "demographics.ecog": {
+        "short": "ECOG визначає, чи пацієнт фізично витримає активне лікування.",
+        "why": "ECOG Performance Status — кількісна шкала функціонального стану (0=\nповністю активний → 4=прикутий до ліжка). У переважній більшості\nрегімен-визначальних алгоритмів engine використовує ECOG як перший\nбезбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,\nякі не переживуть токсичність, ще ДО того як розглядати біомаркери.\n",
+        "affects": [
+          "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)",
+          "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)",
+          "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)",
+          "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)",
+          "При ECOG 4 — engine зазвичай повертає лише best supportive care",
+          "ECOG ≥3 — etoposide+platinum протипоказаний; топотекан у редукції або BSC."
+        ],
+        "sources": [
+          "SRC-ECOG-OKEN-1982"
+        ]
+      }
+    },
+    "DIS-FL": {
+      "demographics.age": {
+        "short": "Вік модулює дози, вибір регімена і допуск до трансплантації.",
+        "why": "Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але\nвін входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)\nі визначає верхні межі для intensive протоколів та трансплантації.\nEngine використовує вік разом із ECOG/коморбідностями, не як\nсамостійний фільтр.\n",
+        "affects": [
+          "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI",
+          "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)",
+          "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)",
+          "Допуск у клінічні випробування (вікові межі протоколів)",
+          "Age ≥60 — додає 1 бал до FLIPI."
+        ],
+        "sources": [
+          "SRC-NCCN-AGE-FRAILTY-2024"
+        ]
+      }
+    },
+    "DIS-MCL": {
+      "demographics.age": {
+        "short": "Вік модулює дози, вибір регімена і допуск до трансплантації.",
+        "why": "Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але\nвін входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)\nі визначає верхні межі для intensive протоколів та трансплантації.\nEngine використовує вік разом із ECOG/коморбідностями, не як\nсамостійний фільтр.\n",
+        "affects": [
+          "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI",
+          "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)",
+          "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)",
+          "Допуск у клінічні випробування (вікові межі протоколів)",
+          "Age ≤65 — допуск до Nordic/HyperCVAD + autoSCT консолідації."
+        ],
+        "sources": [
+          "SRC-NCCN-AGE-FRAILTY-2024"
+        ]
+      }
+    }
+  }
+}

--- a/docs/en/try.html
+++ b/docs/en/try.html
@@ -248,6 +248,8 @@ let coreBundleLoaded = false;
 const loadedDiseases = new Set();
 let questionnaires = [];     // loaded from /questionnaires.json
 let examples = [];           // loaded from /examples.json
+let criticalExplanations = null;  // loaded from /critical_explanations.json
+                                  // { generic: {field: {...}}, by_disease: {DIS: {field: {...}}} }
 let activeQuest = null;      // currently selected questionnaire
 let generating = false;      // true while runEngine is mid-flight; blocks
                              // input via <main inert> + overlay so the
@@ -542,14 +544,43 @@ function renderForm(quest) {
       ${group.description ? `<p class="quest-group-desc">${escHtml(group.description)}</p>` : ''}
     `;
     for (const q of group.questions || []) {
-      groupEl.appendChild(renderQuestion(q));
+      groupEl.appendChild(renderQuestion(q, quest.disease_id));
     }
     questGroups.appendChild(groupEl);
   }
   updateRunBtnEnabled();
 }
 
-function renderQuestion(q) {
+// Lookup explanation for a critical field, preferring per-disease override
+// over generic. Returns null if no entry — caller renders no button.
+function getCriticalExplanation(field, diseaseId) {
+  if (!criticalExplanations || !field) return null;
+  const byDisease = (criticalExplanations.by_disease || {})[diseaseId] || {};
+  if (byDisease[field]) return byDisease[field];
+  const generic = (criticalExplanations.generic || {})[field];
+  return generic || null;
+}
+
+function renderCriticalExplanationPanel(exp) {
+  const affects = (exp.affects || []).map(a => `<li>${escHtml(a)}</li>`).join('');
+  const sources = (exp.sources || [])
+    .map(s => `<span class="why-crit-source">${escHtml(s)}</span>`)
+    .join('');
+  const why = (exp.why || '').trim();
+  const whyHtml = why
+    ? why.split(/\n\s*\n/).map(p => `<p>${escHtml(p)}</p>`).join('')
+    : '';
+  return `
+    <div class="why-crit-panel" hidden>
+      ${exp.short ? `<p class="why-crit-short">${escHtml(exp.short)}</p>` : ''}
+      ${whyHtml ? `<div class="why-crit-section"><h5>Чому це критично</h5>${whyHtml}</div>` : ''}
+      ${affects ? `<div class="why-crit-section"><h5>Як впливає на план</h5><ul>${affects}</ul></div>` : ''}
+      ${sources ? `<div class="why-crit-section"><h5>Джерела</h5><div class="why-crit-sources">${sources}</div></div>` : ''}
+    </div>
+  `;
+}
+
+function renderQuestion(q, diseaseId) {
   const wrap = document.createElement('div');
   wrap.className = 'quest-q';
   wrap.dataset.field = q.field;
@@ -558,6 +589,11 @@ function renderQuestion(q) {
   const fieldId = 'fld-' + q.field.replace(/[^A-Za-z0-9]/g, '_');
 
   const triggers = (q.triggers || []).map(t => `<span class="trigger-pill">${escHtml(t)}</span>`).join('');
+  const criticalExp = impact === 'critical' ? getCriticalExplanation(q.field, diseaseId) : null;
+  const whyBtnHtml = criticalExp
+    ? `<button type="button" class="why-crit-btn" aria-expanded="false" aria-controls="${fieldId}-why">Чому критично?</button>`
+    : '';
+  const whyPanelHtml = criticalExp ? renderCriticalExplanationPanel(criticalExp) : '';
 
   let inputHtml = '';
   const placeholder = q.range_min !== undefined && q.range_max !== undefined
@@ -595,12 +631,27 @@ function renderQuestion(q) {
     <div class="quest-q-head">
       <label for="${fieldId}" class="quest-q-label">${escHtml(q.label)}</label>
       <span class="impact-pill impact-${impact}">${IMPACT_LABEL[impact] || impact}</span>
+      ${whyBtnHtml}
     </div>
     ${inputHtml}
     ${q.units ? `<span class="quest-units">${escHtml(q.units)}</span>` : ''}
     ${q.helper ? `<p class="quest-helper">${escHtml(q.helper)}</p>` : ''}
     ${triggers ? `<div class="quest-triggers">${triggers}</div>` : ''}
+    ${whyPanelHtml}
   `;
+
+  // Wire why-critical toggle (if rendered).
+  const whyBtn = wrap.querySelector('.why-crit-btn');
+  const whyPanel = wrap.querySelector('.why-crit-panel');
+  if (whyBtn && whyPanel) {
+    whyPanel.id = fieldId + '-why';
+    whyBtn.addEventListener('click', () => {
+      const open = whyPanel.hasAttribute('hidden');
+      if (open) whyPanel.removeAttribute('hidden');
+      else whyPanel.setAttribute('hidden', '');
+      whyBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
 
   // Apply default value
   const inp = wrap.querySelector('input,select');
@@ -1430,12 +1481,18 @@ function yieldToBrowser(ms) {
 // ── Boot ──────────────────────────────────────────────────────────────────
 async function loadAssets() {
   setStatus('Завантажую опитувальники…');
-  const [qResp, exResp] = await Promise.all([
+  const [qResp, exResp, ceResp] = await Promise.all([
     fetch('/questionnaires.json'),
     fetch('/examples.json'),
+    fetch('/critical_explanations.json').catch(() => null),
   ]);
   questionnaires = await qResp.json();
   examples = await exResp.json();
+  try {
+    criticalExplanations = ceResp && ceResp.ok ? await ceResp.json() : null;
+  } catch (_) {
+    criticalExplanations = null;
+  }
 
   // Disease selector
   diseaseSelect.innerHTML = '<option value="">— оберіть —</option>';

--- a/docs/style.css
+++ b/docs/style.css
@@ -769,6 +769,52 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
 }
 .quest-q[data-impact="recommended"] { border-left: 3px solid var(--green-600); }
 
+.why-crit-btn {
+  margin-left: 6px;
+  font-family: var(--font-mono); font-size: 10px;
+  letter-spacing: 0.4px;
+  background: transparent; color: var(--red);
+  border: 1px solid color-mix(in srgb, var(--red) 35%, transparent);
+  padding: 2px 8px; border-radius: 3px;
+  cursor: pointer; transition: background 0.15s;
+}
+.why-crit-btn:hover { background: var(--red-bg); }
+.why-crit-btn[aria-expanded="true"] {
+  background: var(--red-bg);
+  border-color: var(--red);
+}
+.why-crit-btn[aria-expanded="true"]::after { content: " ▾"; }
+.why-crit-btn[aria-expanded="false"]::after { content: " ▸"; }
+
+.why-crit-panel {
+  margin-top: 10px;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--red) 4%, var(--gray-50));
+  border-left: 3px solid color-mix(in srgb, var(--red) 50%, transparent);
+  border-radius: 0 4px 4px 0;
+  font-size: 13px; line-height: 1.5;
+}
+.why-crit-short {
+  font-weight: 600; color: var(--gray-900);
+  margin: 0 0 8px;
+}
+.why-crit-section { margin-top: 10px; }
+.why-crit-section:first-child { margin-top: 0; }
+.why-crit-section h5 {
+  font-family: var(--font-mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.6px;
+  color: var(--gray-700); margin: 0 0 4px; font-weight: 600;
+}
+.why-crit-section p { margin: 0 0 6px; }
+.why-crit-section ul { margin: 0; padding-left: 20px; }
+.why-crit-section li { margin-bottom: 3px; }
+.why-crit-sources { display: flex; flex-wrap: wrap; gap: 6px; }
+.why-crit-source {
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--gray-100); color: var(--gray-700);
+  padding: 2px 7px; border-radius: 3px;
+}
+
 .quest-whatif {
   margin-top: 10px; padding: 8px 10px;
   background: white; border: 1px dashed var(--gray-200);

--- a/docs/try.html
+++ b/docs/try.html
@@ -248,6 +248,8 @@ let coreBundleLoaded = false;
 const loadedDiseases = new Set();
 let questionnaires = [];     // loaded from /questionnaires.json
 let examples = [];           // loaded from /examples.json
+let criticalExplanations = null;  // loaded from /critical_explanations.json
+                                  // { generic: {field: {...}}, by_disease: {DIS: {field: {...}}} }
 let activeQuest = null;      // currently selected questionnaire
 let generating = false;      // true while runEngine is mid-flight; blocks
                              // input via <main inert> + overlay so the
@@ -542,14 +544,43 @@ function renderForm(quest) {
       ${group.description ? `<p class="quest-group-desc">${escHtml(group.description)}</p>` : ''}
     `;
     for (const q of group.questions || []) {
-      groupEl.appendChild(renderQuestion(q));
+      groupEl.appendChild(renderQuestion(q, quest.disease_id));
     }
     questGroups.appendChild(groupEl);
   }
   updateRunBtnEnabled();
 }
 
-function renderQuestion(q) {
+// Lookup explanation for a critical field, preferring per-disease override
+// over generic. Returns null if no entry — caller renders no button.
+function getCriticalExplanation(field, diseaseId) {
+  if (!criticalExplanations || !field) return null;
+  const byDisease = (criticalExplanations.by_disease || {})[diseaseId] || {};
+  if (byDisease[field]) return byDisease[field];
+  const generic = (criticalExplanations.generic || {})[field];
+  return generic || null;
+}
+
+function renderCriticalExplanationPanel(exp) {
+  const affects = (exp.affects || []).map(a => `<li>${escHtml(a)}</li>`).join('');
+  const sources = (exp.sources || [])
+    .map(s => `<span class="why-crit-source">${escHtml(s)}</span>`)
+    .join('');
+  const why = (exp.why || '').trim();
+  const whyHtml = why
+    ? why.split(/\n\s*\n/).map(p => `<p>${escHtml(p)}</p>`).join('')
+    : '';
+  return `
+    <div class="why-crit-panel" hidden>
+      ${exp.short ? `<p class="why-crit-short">${escHtml(exp.short)}</p>` : ''}
+      ${whyHtml ? `<div class="why-crit-section"><h5>Чому це критично</h5>${whyHtml}</div>` : ''}
+      ${affects ? `<div class="why-crit-section"><h5>Як впливає на план</h5><ul>${affects}</ul></div>` : ''}
+      ${sources ? `<div class="why-crit-section"><h5>Джерела</h5><div class="why-crit-sources">${sources}</div></div>` : ''}
+    </div>
+  `;
+}
+
+function renderQuestion(q, diseaseId) {
   const wrap = document.createElement('div');
   wrap.className = 'quest-q';
   wrap.dataset.field = q.field;
@@ -558,6 +589,11 @@ function renderQuestion(q) {
   const fieldId = 'fld-' + q.field.replace(/[^A-Za-z0-9]/g, '_');
 
   const triggers = (q.triggers || []).map(t => `<span class="trigger-pill">${escHtml(t)}</span>`).join('');
+  const criticalExp = impact === 'critical' ? getCriticalExplanation(q.field, diseaseId) : null;
+  const whyBtnHtml = criticalExp
+    ? `<button type="button" class="why-crit-btn" aria-expanded="false" aria-controls="${fieldId}-why">Чому критично?</button>`
+    : '';
+  const whyPanelHtml = criticalExp ? renderCriticalExplanationPanel(criticalExp) : '';
 
   let inputHtml = '';
   const placeholder = q.range_min !== undefined && q.range_max !== undefined
@@ -595,12 +631,27 @@ function renderQuestion(q) {
     <div class="quest-q-head">
       <label for="${fieldId}" class="quest-q-label">${escHtml(q.label)}</label>
       <span class="impact-pill impact-${impact}">${IMPACT_LABEL[impact] || impact}</span>
+      ${whyBtnHtml}
     </div>
     ${inputHtml}
     ${q.units ? `<span class="quest-units">${escHtml(q.units)}</span>` : ''}
     ${q.helper ? `<p class="quest-helper">${escHtml(q.helper)}</p>` : ''}
     ${triggers ? `<div class="quest-triggers">${triggers}</div>` : ''}
+    ${whyPanelHtml}
   `;
+
+  // Wire why-critical toggle (if rendered).
+  const whyBtn = wrap.querySelector('.why-crit-btn');
+  const whyPanel = wrap.querySelector('.why-crit-panel');
+  if (whyBtn && whyPanel) {
+    whyPanel.id = fieldId + '-why';
+    whyBtn.addEventListener('click', () => {
+      const open = whyPanel.hasAttribute('hidden');
+      if (open) whyPanel.removeAttribute('hidden');
+      else whyPanel.setAttribute('hidden', '');
+      whyBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
 
   // Apply default value
   const inp = wrap.querySelector('input,select');
@@ -1430,12 +1481,18 @@ function yieldToBrowser(ms) {
 // ── Boot ──────────────────────────────────────────────────────────────────
 async function loadAssets() {
   setStatus('Завантажую опитувальники…');
-  const [qResp, exResp] = await Promise.all([
+  const [qResp, exResp, ceResp] = await Promise.all([
     fetch('/questionnaires.json'),
     fetch('/examples.json'),
+    fetch('/critical_explanations.json').catch(() => null),
   ]);
   questionnaires = await qResp.json();
   examples = await exResp.json();
+  try {
+    criticalExplanations = ceResp && ceResp.ok ? await ceResp.json() : null;
+  } catch (_) {
+    criticalExplanations = null;
+  }
 
   // Disease selector
   diseaseSelect.innerHTML = '<option value="">— оберіть —</option>';

--- a/knowledge_base/hosted/content/critical_field_explanations.yaml
+++ b/knowledge_base/hosted/content/critical_field_explanations.yaml
@@ -1,0 +1,356 @@
+# Critical-field explanations
+# ────────────────────────────────────────────────────────────────────────────
+# Per CHARTER §6.1: clinical content; status=draft_pending_review during v0.1
+# (dev-mode exemption per project memory). Two-reviewer signoff required
+# before promotion to status=approved.
+#
+# Schema:
+#   - field            (string, required)  — questionnaire field id
+#   - base.short       (string, required)  — one-sentence headline (≤ 120 chars)
+#   - base.why         (string, required)  — why this field is critical
+#   - base.affects     (list,   required)  — concrete decisions it changes
+#   - base.sources     (list)              — Source entity IDs (KB-resolved)
+#   - per_disease      (map, disease_id → override)
+#       overrides any base key, OR provides:
+#         affects_addendum (string) — extra bullet appended to base.affects
+#         why_addendum     (string) — extra paragraph appended to base.why
+#
+# Coverage target: every (disease_id, field) marked impact=critical in
+# questionnaires.json must resolve to base or base+override.
+# ────────────────────────────────────────────────────────────────────────────
+status: draft_pending_review
+version: "0.1"
+
+entries:
+
+  # ── GENERIC (cover ≥95% of critical pairs) ────────────────────────────────
+
+  - field: demographics.ecog
+    base:
+      short: "ECOG визначає, чи пацієнт фізично витримає активне лікування."
+      why: |
+        ECOG Performance Status — кількісна шкала функціонального стану (0=
+        повністю активний → 4=прикутий до ліжка). У переважній більшості
+        регімен-визначальних алгоритмів engine використовує ECOG як перший
+        безбіомаркерний фільтр: він відсікає intensive-track для пацієнтів,
+        які не переживуть токсичність, ще ДО того як розглядати біомаркери.
+      affects:
+        - "Вибір інтенсивності схеми (intensive vs reduced-intensity vs BSC)"
+        - "Допуск до high-dose chemo + autoSCT/alloSCT (зазвичай ECOG ≤2)"
+        - "Допуск до клінічних випробувань (більшість вимагає ECOG ≤2)"
+        - "Розрахунок прогностичних індексів (IPI, R-IPI, IPSS-R, MIPI, ISS)"
+        - "При ECOG 4 — engine зазвичай повертає лише best supportive care"
+      sources:
+        - SRC-ECOG-OKEN-1982
+    per_disease:
+      DIS-AML:
+        affects_addendum: "ECOG ≥2 у віці ≥75 → engine надає перевагу azacitidine+venetoclax замість 7+3."
+      DIS-DLBCL:
+        affects_addendum: "ECOG ≥3 виключає R-CHOP; розглядається R-mini-CHOP або palliative."
+      DIS-MM:
+        affects_addendum: "ECOG ≥2 + frailty → engine знижує дози (Vd замість VRd) як frailty-adjusted режим."
+      DIS-PDAC:
+        affects_addendum: "ECOG ≥2 виключає FOLFIRINOX; default стає gemcitabine + nab-paclitaxel або gem mono."
+      DIS-NSCLC:
+        affects_addendum: "ECOG ≥2 — relative-contraindication для platinum-doublet; розглядається single-agent IO або BSC."
+      DIS-SCLC:
+        affects_addendum: "ECOG ≥3 — etoposide+platinum протипоказаний; топотекан у редукції або BSC."
+
+  - field: demographics.age
+    base:
+      short: "Вік модулює дози, вибір регімена і допуск до трансплантації."
+      why: |
+        Вік сам по собі НЕ є контраіндикацією (CHARTER: efficacy-first), але
+        він входить у більшість прогностичних шкал (IPI, R-ISS, IPSS-R, MIPI)
+        і визначає верхні межі для intensive протоколів та трансплантації.
+        Engine використовує вік разом із ECOG/коморбідностями, не як
+        самостійний фільтр.
+      affects:
+        - "Бал у IPI / R-IPI / IPSS-R / MIPI / ISS / FLIPI"
+        - "Допуск до високодозної терапії з autoSCT (зазвичай ≤70-75)"
+        - "Вибір induction-схеми у AML/ALL (intensive vs hypomethylating)"
+        - "Допуск у клінічні випробування (вікові межі протоколів)"
+      sources:
+        - SRC-NCCN-AGE-FRAILTY-2024
+    per_disease:
+      DIS-DLBCL:
+        affects_addendum: "Age >60 — додає 1 бал до IPI; age >80 → R-mini-CHOP як default."
+      DIS-AML:
+        affects_addendum: "Age ≥75 → engine рекомендує aza+ven замість 7+3 навіть при ECOG 0-1."
+      DIS-MM:
+        affects_addendum: "Age ≤70 + fit → transplant-eligible track (VRd→ASCT→Lenalidomide maint)."
+      DIS-FL:
+        affects_addendum: "Age ≥60 — додає 1 бал до FLIPI."
+      DIS-MCL:
+        affects_addendum: "Age ≤65 — допуск до Nordic/HyperCVAD + autoSCT консолідації."
+
+  - field: line_of_therapy
+    base:
+      short: "Лінія терапії повністю змінює простір допустимих регімен-блоків."
+      why: |
+        Engine має окремі алгоритм-блоки для 1L / 2L / 3L+. Той самий пацієнт
+        у 1L і 2L отримує абсолютно різні рекомендації: previous exposure
+        блокує retreatment-резистентні класи (наприклад, post-BTKi у CLL
+        виключає re-BTKi), а relapsed/refractory статус відкриває targeted
+        агенти, які у 1L заборонені guideline-ами.
+      affects:
+        - "Вибір алгоритм-блоку (1L vs salvage vs maintenance)"
+        - "Виключення класів, до яких пацієнт уже резистентний"
+        - "Допуск до CAR-T / bispecifics (зазвичай ≥3L у DLBCL/MM)"
+        - "Розгляд clinical-trial referral (часто primary option у 3L+)"
+      sources:
+        - SRC-NCCN-LINE-OF-THERAPY-DEFINITIONS
+
+  - field: findings.hbsag
+    base:
+      short: "HBsAg критичний перед anti-CD20 / high-dose стероїдами — ризик HBV reactivation з фульмінантним гепатитом."
+      why: |
+        Anti-CD20 (rituximab, obinutuzumab) і пролонговані стероїди викликають
+        реактивацію хронічного або resolved HBV з risk fatal hepatitis. AASLD
+        2024 і ESMO infection-prevention guideline вимагають universal HBsAg
+        + anti-HBc screening ПЕРЕД першою дозою. HBsAg+ → entecavir/TDF
+        prophylaxis обов'язковий за 1-2 тиж до старту і ≥12 міс після
+        останньої дози.
+      affects:
+        - "Призначення antiviral prophylaxis (entecavir/TDF) — обов'язкове при HBsAg+"
+        - "Час старту терапії (затримка 1-2 тиж на ramp-up antiviral)"
+        - "Моніторинг ALT + HBV DNA кожні 1-3 міс під час лікування"
+        - "Продовження prophylaxis ≥12 міс після завершення anti-CD20"
+        - "Відмова від anti-CD20 на користь альтернатив, якщо prophylaxis недоступний"
+      sources:
+        - SRC-AASLD-HBV-2024
+        - SRC-EASL-HBV-2025
+        - SRC-ESMO-INFECTIONS-2016
+
+  # ── DISEASE-SPECIFIC ──────────────────────────────────────────────────────
+
+  - field: findings.iwcll_indication_present
+    base:
+      short: "Без iwCLL active-disease criteria CLL не лікують — watch-and-wait перевершує ранній старт."
+      why: |
+        Random-старт терапії у asymptomatic CLL погіршує OS (CLL1, German
+        CLL Study Group). Лікування стартує ЛИШЕ при формальних iwCLL
+        active-disease criteria (≥1 з: progressive lymphocytosis з doubling
+        <6 міс, progressive cytopenias Hb<10 / Plt<100, bulky/painful
+        adenopathy, splenomegaly з симптомами, B-symptoms, autoimmune
+        cytopenia рефрактерна до стероїдів).
+      affects:
+        - "Старт vs watch-and-wait — фундаментальне рішення 1L"
+        - "Якщо false → engine видає 'no treatment indication' замість регімена"
+        - "Часовий горизонт next-visit (W&W → 3-6 міс reassessment)"
+      sources:
+        - SRC-IWCLL-HALLEK-2018
+        - SRC-ESMO-CLL-2024
+
+  - field: biomarkers.BIO-CLL-HIGH-RISK-GENETICS
+    base:
+      short: "TP53/del(17p)/complex karyotype визначають вибір BTKi/BCL2 vs застарілі CIT."
+      why: |
+        High-risk genetics (TP53mut, del(17p), complex karyotype, unmutated
+        IGHV) роблять FCR/BR клінічно неприйнятними — короткий PFS, високий
+        ризик Richter. Engine обере BTKi або fixed-duration VenO. NCCN
+        prefers Ven+Obinutuzumab для del(17p)/TP53 — fixed-duration з
+        кращим quality of life ніж indefinite BTKi.
+      affects:
+        - "Виключення CIT (FCR/BR) як 1L"
+        - "Вибір між continuous BTKi (acala/zanu) та fixed-duration VenO"
+        - "Інтенсивність моніторингу (high-risk → коротші intervals)"
+        - "Раннє обговорення alloSCT при young-fit з double-hit (TP53 + complex)"
+      sources:
+        - SRC-CLL14-FISCHER-2019
+        - SRC-ESMO-CLL-2024
+        - SRC-NCCN-CLL-2024
+
+  - field: findings.tp53_mutation
+    base:
+      short: "TP53mut робить FCR/BR клінічно беззмістовними — короткий PFS, ризик Richter."
+      why: |
+        ~5-7% newly-diagnosed CLL мають TP53mut (без del(17p)); ще ~5-10% —
+        del(17p) ± TP53mut. Обидва — найгірший single-marker prognostic.
+        Standard chemoimmunotherapy дає median PFS <2 років. BTKi/BCL2-
+        targeted перевершують CIT з великим ефектом.
+      affects:
+        - "Hard contraindication для FCR/BR як 1L"
+        - "Direct path → BTKi або fixed-duration VenO"
+        - "Раннє обговорення alloSCT при молодих fit пацієнтах"
+      sources:
+        - SRC-ESMO-CLL-2024
+        - SRC-NCCN-CLL-2024
+
+  - field: findings.del_17p
+    base:
+      short: "del(17p) — найгірший single marker у CLL; same management як TP53mut."
+      why: |
+        del(17p) виявляється FISH у ~5-10% NDxg CLL. Прогностично еквівалентний
+        TP53mut і часто з ним co-existує. Engine трактує del(17p) OR TP53mut
+        як композитний high-risk trigger.
+      affects:
+        - "Те саме що TP53mut — виключає CIT, направляє на targeted"
+        - "Композитний 'TP53-aberrant' стан з тими ж терапевтичними наслідками"
+      sources:
+        - SRC-ESMO-CLL-2024
+
+  - field: biomarkers.BIO-HCV-RNA
+    base:
+      short: "HCV RNA+ при HCV-MZL — antiviral-first track перевершує chemoimmunotherapy."
+      why: |
+        У HCV-associated marginal zone lymphoma elimination HCV (DAA — sof/vel
+        або glec/pib) дає lymphoma response у 40-75% без жодної chemo. Це
+        eтіологічна терапія, не паліатив. Якщо HCV RNA negative — engine
+        повертається до стандартного BR-track.
+      affects:
+        - "Вибір antiviral-first vs immediate BR-aggressive"
+        - "Час старту chemo (відкласти на 12-24 тиж DAA, потім reassess)"
+        - "Гепатологічний референс перед стартом"
+        - "Fallback на BR якщо HCV negative або після DAA немає response"
+      sources:
+        - SRC-AASLD-HCV-2023
+        - SRC-EASL-HCV-2024
+        - SRC-ARCAINI-2014
+        - SRC-ESMO-MZL-2024
+
+  - field: findings.HCV RNA positive
+    base:
+      short: "Технічне дзеркало BIO-HCV-RNA для engine clause — заповнюється автоматично."
+      why: |
+        Boolean форма HCV RNA для рул-енджин патернів. Семантично ідентичне
+        BIO-HCV-RNA (positive/negative). Дублювання — implementation detail
+        engine, не клінічна differentia.
+      affects:
+        - "Те саме що BIO-HCV-RNA"
+
+  - field: demographics.decompensated_cirrhosis
+    base:
+      short: "Декомпенсований цироз (Child-Pugh B/C) блокує glec/pib і обмежує choice DAA + chemo."
+      why: |
+        Glecaprevir/pibrentasvir contraindicated при Child-Pugh B/C. Sof/vel
+        ± ribavirin — лише вибір. Декомпенсований цироз також знижує
+        переносимість R-CHOP/BR (печінкова токсичність, тромбоцитопенія).
+        Engine розглядає dose-reduction або відкладення active treatment.
+      affects:
+        - "Вибір DAA-режима (sof/vel only, не glec/pib)"
+        - "Можлива відмова від chemoimmunotherapy на користь rituximab-mono"
+        - "Hepatology consult обов'язковий"
+        - "Розгляд orthotopic liver transplant referral при young-fit"
+      sources:
+        - SRC-AASLD-HCV-2023
+        - SRC-CHILD-PUGH-1973
+
+  - field: findings.dominant_nodal_mass_cm
+    base:
+      short: "Bulky disease (≥7 см) — пряма indication для chemo-first навіть при HCV+."
+      why: |
+        Bulky tumor burden не reduce достатньо швидко лише antiviral-ом —
+        ризик progressive симптомів / compression syndrome. Engine
+        переключає на BR-aggressive негайно, з DAA конкурентно або після.
+      affects:
+        - "Override antiviral-first track → BR-aggressive як 1L"
+        - "Прискорений старт terapія (тижні, не місяці)"
+        - "Розгляд debulking radiation якщо локалізована маса"
+      sources:
+        - SRC-ESMO-MZL-2024
+
+  - field: findings.symptomatic_b_symptoms_severe
+    base:
+      short: "Тяжкі B-симптоми — relative indication для chemo навіть без bulky."
+      why: |
+        Severe B-symptoms (T>38°C, drenching night sweats, weight loss >10%
+        за 6 міс) сигналізують aggressive lymphoma biology. Watchful waiting
+        неприйнятний. Engine розглядає BR незалежно від HCV статусу.
+      affects:
+        - "Relative indication для immediate chemo"
+        - "Workup на трансформацію (PET-CT, repeat biopsy найбільшого вузла)"
+      sources:
+        - SRC-ESMO-MZL-2024
+
+  - field: findings.Indolent presentation (non-bulky, asymptomatic or minimally symptomatic)
+    base:
+      short: "Технічне дзеркало для algorithm clause — заповнюється автоматично."
+      why: |
+        Boolean composite для рул-енджин: true ⇔ non-bulky (<7cm) AND no
+        severe B-symptoms. Не клінічно вводиться окремо.
+      affects:
+        - "Дозволяє antiviral-first track при HCV+"
+
+  - field: findings.biopsy_shows_dlbcl
+    base:
+      short: "Трансформація в DLBCL — повна зміна алгоритму з MZL на DLBCL-specific."
+      why: |
+        Histologic transformation indolent → aggressive lymphoma (DLBCL,
+        Richter в CLL) — окрема клінічна сутність. Лікування вже НЕ MZL/CLL,
+        а de novo DLBCL: R-CHOP-21 ± consolidation, потенційно CAR-T у 2L.
+        Prognosis значно гірший.
+      affects:
+        - "Перехід engine на DLBCL algorithm (інша disease entity)"
+        - "Старт R-CHOP-21 × 6 циклів"
+        - "Workup на CNS involvement (CNS-IPI)"
+        - "Раннє обговорення CD19 CAR-T при relapsed/refractory"
+      sources:
+        - SRC-ESMO-DLBCL-2024
+
+  - field: demographics.fit_for_transplant
+    base:
+      short: "Transplant-eligibility — clinical judgment, не вікова межа; визначає 1L architecture у MM."
+      why: |
+        Transplant-eligibility — інтегральна оцінка hematologist (frailty,
+        cardiac/renal, prior treatments, social support), а НЕ просто age
+        cutoff. Eligible пацієнти отримують induction → autoSCT →
+        maintenance; ineligible — continuous induction до progression.
+      affects:
+        - "Вибір induction (VRd/D-VRd → ASCT vs continuous DRd / VRd-lite)"
+        - "Stem-cell collection до melphalan exposure"
+        - "Maintenance strategy (lenalidomide indefinite vs fixed)"
+      sources:
+        - SRC-ESMO-MM-2023
+        - SRC-IMWG-FRAILTY-2015
+
+  - field: biomarkers.BIO-MM-CYTOGENETICS-HR
+    base:
+      short: "High-risk cytogenetics (t(4;14), t(14;16), del(17p), gain1q ≥3) — D-VRd замість VRd."
+      why: |
+        Composite high-risk cytogenetics має значно гірший PFS на VRd alone.
+        Daratumumab-quadruplet (D-VRd, GRIFFIN/PERSEUS) дає значно глибші
+        responses і покращує MRD-negativity rate, з прийнятним safety
+        profile.
+      affects:
+        - "Default 1L induction → D-VRd замість VRd при transplant-eligible"
+        - "Інтенсифікація maintenance (consider Dara-Len замість Len-mono)"
+        - "Запис у early-relapse-risk моніторинг"
+      sources:
+        - SRC-PERSEUS-SONNEVELD-2024
+        - SRC-GRIFFIN-VOORHEES-2023
+        - SRC-ESMO-MM-2023
+
+  - field: findings.creatinine_clearance_ml_min
+    base:
+      short: "CrCl визначає dose-adjustments для lenalidomide, daratumumab, melphalan."
+      why: |
+        Renal impairment (frequent у MM через cast nephropathy) вимагає
+        dose-adjusted lenalidomide (CrCl <60 — 10 mg; <30 — 15 mg q48h або
+        Vd-only). Bortezomib безпечний при будь-якому CrCl. Daratumumab
+        безпечний, але потребує enhanced monitoring перших інфузій.
+      affects:
+        - "Lenalidomide dose (25/15/10 mg по CrCl bands)"
+        - "Hydration / monitoring schedule перших циклів"
+        - "Розгляд plasma exchange при cast nephropathy + light-chain"
+        - "Можлива заміна Len → Pomalidomide (renally safer)"
+      sources:
+        - SRC-ESMO-MM-2023
+        - SRC-IMWG-RENAL-2016
+
+  - field: demographics.pregnancy_status
+    base:
+      short: "Вагітність — абсолютна заборона lenalidomide / pomalidomide / thalidomide (тератогени)."
+      why: |
+        IMiDs (len, pom, thal) — категорія X, абсолютна contraindication при
+        вагітності або можливості завагітніти без contraception. REMS у US
+        вимагає 2 негативних тестів + 2 методів контрацепції. Engine блокує
+        VRd / D-VRd / DRd і fall'ить на bortezomib + dex (Vd) як bridging.
+      affects:
+        - "Hard block на IMiD-containing регімени"
+        - "Default fallback → Vd або CyBorD (cyclophosphamide+bort+dex)"
+        - "OB/GYN consult обов'язковий перед стартом"
+        - "REMS-style enrollment (де доступний)"
+      sources:
+        - SRC-FDA-LENALIDOMIDE-LABEL
+        - SRC-ESMO-MM-2023

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1532,6 +1532,8 @@ let coreBundleLoaded = false;
 const loadedDiseases = new Set();
 let questionnaires = [];     // loaded from /questionnaires.json
 let examples = [];           // loaded from /examples.json
+let criticalExplanations = null;  // loaded from /critical_explanations.json
+                                  // {{ generic: {{field: {{...}}}}, by_disease: {{DIS: {{field: {{...}}}}}} }}
 let activeQuest = null;      // currently selected questionnaire
 let generating = false;      // true while runEngine is mid-flight; blocks
                              // input via <main inert> + overlay so the
@@ -1826,14 +1828,43 @@ function renderForm(quest) {{
       ${{group.description ? `<p class="quest-group-desc">${{escHtml(group.description)}}</p>` : ''}}
     `;
     for (const q of group.questions || []) {{
-      groupEl.appendChild(renderQuestion(q));
+      groupEl.appendChild(renderQuestion(q, quest.disease_id));
     }}
     questGroups.appendChild(groupEl);
   }}
   updateRunBtnEnabled();
 }}
 
-function renderQuestion(q) {{
+// Lookup explanation for a critical field, preferring per-disease override
+// over generic. Returns null if no entry — caller renders no button.
+function getCriticalExplanation(field, diseaseId) {{
+  if (!criticalExplanations || !field) return null;
+  const byDisease = (criticalExplanations.by_disease || {{}})[diseaseId] || {{}};
+  if (byDisease[field]) return byDisease[field];
+  const generic = (criticalExplanations.generic || {{}})[field];
+  return generic || null;
+}}
+
+function renderCriticalExplanationPanel(exp) {{
+  const affects = (exp.affects || []).map(a => `<li>${{escHtml(a)}}</li>`).join('');
+  const sources = (exp.sources || [])
+    .map(s => `<span class="why-crit-source">${{escHtml(s)}}</span>`)
+    .join('');
+  const why = (exp.why || '').trim();
+  const whyHtml = why
+    ? why.split(/\\n\\s*\\n/).map(p => `<p>${{escHtml(p)}}</p>`).join('')
+    : '';
+  return `
+    <div class="why-crit-panel" hidden>
+      ${{exp.short ? `<p class="why-crit-short">${{escHtml(exp.short)}}</p>` : ''}}
+      ${{whyHtml ? `<div class="why-crit-section"><h5>Чому це критично</h5>${{whyHtml}}</div>` : ''}}
+      ${{affects ? `<div class="why-crit-section"><h5>Як впливає на план</h5><ul>${{affects}}</ul></div>` : ''}}
+      ${{sources ? `<div class="why-crit-section"><h5>Джерела</h5><div class="why-crit-sources">${{sources}}</div></div>` : ''}}
+    </div>
+  `;
+}}
+
+function renderQuestion(q, diseaseId) {{
   const wrap = document.createElement('div');
   wrap.className = 'quest-q';
   wrap.dataset.field = q.field;
@@ -1842,6 +1873,11 @@ function renderQuestion(q) {{
   const fieldId = 'fld-' + q.field.replace(/[^A-Za-z0-9]/g, '_');
 
   const triggers = (q.triggers || []).map(t => `<span class="trigger-pill">${{escHtml(t)}}</span>`).join('');
+  const criticalExp = impact === 'critical' ? getCriticalExplanation(q.field, diseaseId) : null;
+  const whyBtnHtml = criticalExp
+    ? `<button type="button" class="why-crit-btn" aria-expanded="false" aria-controls="${{fieldId}}-why">Чому критично?</button>`
+    : '';
+  const whyPanelHtml = criticalExp ? renderCriticalExplanationPanel(criticalExp) : '';
 
   let inputHtml = '';
   const placeholder = q.range_min !== undefined && q.range_max !== undefined
@@ -1879,12 +1915,27 @@ function renderQuestion(q) {{
     <div class="quest-q-head">
       <label for="${{fieldId}}" class="quest-q-label">${{escHtml(q.label)}}</label>
       <span class="impact-pill impact-${{impact}}">${{IMPACT_LABEL[impact] || impact}}</span>
+      ${{whyBtnHtml}}
     </div>
     ${{inputHtml}}
     ${{q.units ? `<span class="quest-units">${{escHtml(q.units)}}</span>` : ''}}
     ${{q.helper ? `<p class="quest-helper">${{escHtml(q.helper)}}</p>` : ''}}
     ${{triggers ? `<div class="quest-triggers">${{triggers}}</div>` : ''}}
+    ${{whyPanelHtml}}
   `;
+
+  // Wire why-critical toggle (if rendered).
+  const whyBtn = wrap.querySelector('.why-crit-btn');
+  const whyPanel = wrap.querySelector('.why-crit-panel');
+  if (whyBtn && whyPanel) {{
+    whyPanel.id = fieldId + '-why';
+    whyBtn.addEventListener('click', () => {{
+      const open = whyPanel.hasAttribute('hidden');
+      if (open) whyPanel.removeAttribute('hidden');
+      else whyPanel.setAttribute('hidden', '');
+      whyBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }});
+  }}
 
   // Apply default value
   const inp = wrap.querySelector('input,select');
@@ -2711,12 +2762,18 @@ function yieldToBrowser(ms) {{
 // ── Boot ──────────────────────────────────────────────────────────────────
 async function loadAssets() {{
   setStatus('Завантажую опитувальники…');
-  const [qResp, exResp] = await Promise.all([
+  const [qResp, exResp, ceResp] = await Promise.all([
     fetch('/questionnaires.json'),
     fetch('/examples.json'),
+    fetch('/critical_explanations.json').catch(() => null),
   ]);
   questionnaires = await qResp.json();
   examples = await exResp.json();
+  try {{
+    criticalExplanations = ceResp && ceResp.ok ? await ceResp.json() : null;
+  }} catch (_) {{
+    criticalExplanations = null;
+  }}
 
   // Disease selector
   diseaseSelect.innerHTML = '<option value="">— оберіть —</option>';

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -476,6 +476,88 @@ def bundle_questionnaires(output_dir: Path) -> dict:
     return {"path": "questionnaires.json", "count": len(payload)}
 
 
+def bundle_critical_explanations(output_dir: Path) -> dict:
+    """Expand critical_field_explanations.yaml (base + per_disease) into
+    a flat lookup at docs/critical_explanations.json so try.html can do
+    O(1) lookup by (disease_id, field) without runtime merging.
+
+    Coverage gate: every (disease_id, field) marked impact='critical' in
+    a questionnaire must resolve. Build fails loudly otherwise — keeps
+    new questionnaires from silently shipping unexplained critical fields.
+    """
+    src = REPO_ROOT / "knowledge_base" / "hosted" / "content" / "critical_field_explanations.yaml"
+    qsrc = REPO_ROOT / "knowledge_base" / "hosted" / "content" / "questionnaires"
+    if not src.is_file():
+        return {"path": "critical_explanations.json", "count": 0, "skipped": True}
+    import yaml as _yaml
+    doc = _yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+    entries = doc.get("entries") or []
+    generic: dict = {}
+    by_disease: dict = {}
+    for ent in entries:
+        field = ent.get("field")
+        base = ent.get("base") or {}
+        if not field or not base:
+            continue
+        generic[field] = {
+            "short": base.get("short", ""),
+            "why": base.get("why", ""),
+            "affects": list(base.get("affects") or []),
+            "sources": list(base.get("sources") or []),
+        }
+        for did, override in (ent.get("per_disease") or {}).items():
+            merged = dict(generic[field])
+            if "short" in override:
+                merged["short"] = override["short"]
+            if "why" in override:
+                merged["why"] = override["why"]
+            if "why_addendum" in override:
+                merged["why"] = (merged["why"].rstrip() + "\n\n" + override["why_addendum"]).strip()
+            if "affects" in override:
+                merged["affects"] = list(override["affects"])
+            if "affects_addendum" in override:
+                merged["affects"] = list(merged["affects"]) + [override["affects_addendum"]]
+            if "sources" in override:
+                merged["sources"] = list(override["sources"])
+            by_disease.setdefault(did, {})[field] = merged
+
+    needed: set = set()
+    if qsrc.is_dir():
+        for path in sorted(qsrc.glob("*.yaml")):
+            try:
+                qd = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            except Exception:
+                continue
+            did = qd.get("disease_id")
+            for g in qd.get("groups") or []:
+                for q in g.get("questions") or []:
+                    if q.get("impact") == "critical":
+                        needed.add((did, q.get("field")))
+    unresolved = [
+        (d, f) for d, f in needed
+        if f not in generic and f not in (by_disease.get(d) or {})
+    ]
+    if unresolved:
+        raise RuntimeError(
+            "critical_field_explanations: missing entries for "
+            + ", ".join(f"{d}/{f}" for d, f in sorted(unresolved))
+        )
+
+    payload = {
+        "version": doc.get("version", "0.1"),
+        "status": doc.get("status", "draft_pending_review"),
+        "generic": generic,
+        "by_disease": by_disease,
+    }
+    out = output_dir / "critical_explanations.json"
+    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return {
+        "path": "critical_explanations.json",
+        "fields": len(generic),
+        "disease_overrides": sum(len(v) for v in by_disease.values()),
+    }
+
+
 # ── Landing page (index.html) ─────────────────────────────────────────────
 
 
@@ -5964,6 +6046,7 @@ def build_site(output_dir: Path) -> dict:
 
     examples_payload = bundle_examples(output_dir)
     questionnaires_payload = bundle_questionnaires(output_dir)
+    critical_explanations_payload = bundle_critical_explanations(output_dir)
     disease_coverage_payload = bundle_disease_coverage(output_dir)
 
     return {
@@ -5975,6 +6058,7 @@ def build_site(output_dir: Path) -> dict:
         "service_worker": sw_payload,
         "examples_payload": examples_payload,
         "questionnaires_payload": questionnaires_payload,
+        "critical_explanations_payload": critical_explanations_payload,
         "disease_coverage_payload": disease_coverage_payload,
         "landing_assets": landing_assets,
     }

--- a/tests/test_critical_field_explanations.py
+++ b/tests/test_critical_field_explanations.py
@@ -1,0 +1,92 @@
+"""Coverage + structure checks for critical_field_explanations.yaml.
+
+Guards two things:
+
+1. Every (disease_id, field) marked impact='critical' in any questionnaire
+   resolves to either a per-disease override or a base entry. Adding a new
+   critical field to a questionnaire without a corresponding explanation
+   fails CI here, not silently in production.
+
+2. Each entry has the required shape (short, why, affects).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parent.parent
+QDIR = REPO / "knowledge_base" / "hosted" / "content" / "questionnaires"
+EXPL = REPO / "knowledge_base" / "hosted" / "content" / "critical_field_explanations.yaml"
+
+
+def _load_explanations() -> dict:
+    return yaml.safe_load(EXPL.read_text(encoding="utf-8")) or {}
+
+
+def _critical_pairs_in_questionnaires() -> set[tuple[str, str]]:
+    pairs: set[tuple[str, str]] = set()
+    for path in sorted(QDIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        did = data.get("disease_id")
+        for group in data.get("groups") or []:
+            for q in group.get("questions") or []:
+                if q.get("impact") == "critical":
+                    pairs.add((did, q.get("field")))
+    return pairs
+
+
+def test_explanations_file_loads_and_has_entries():
+    doc = _load_explanations()
+    assert "entries" in doc
+    assert isinstance(doc["entries"], list)
+    assert len(doc["entries"]) > 0
+
+
+def test_each_entry_has_required_shape():
+    doc = _load_explanations()
+    for ent in doc["entries"]:
+        field = ent.get("field")
+        assert field, f"entry missing field: {ent}"
+        base = ent.get("base") or {}
+        assert base.get("short"), f"{field}: base.short required"
+        assert base.get("why"), f"{field}: base.why required"
+        affects = base.get("affects") or []
+        assert isinstance(affects, list) and len(affects) >= 1, (
+            f"{field}: base.affects must be a non-empty list"
+        )
+
+
+def test_every_critical_field_pair_resolves():
+    """Coverage gate: each (disease_id, field) flagged impact=critical in a
+    questionnaire must resolve to a per_disease override or base entry.
+    """
+    doc = _load_explanations()
+    base_fields = {e["field"] for e in doc["entries"]}
+    per_disease: dict[str, set[str]] = {}
+    for ent in doc["entries"]:
+        for did, _ in (ent.get("per_disease") or {}).items():
+            per_disease.setdefault(did, set()).add(ent["field"])
+
+    needed = _critical_pairs_in_questionnaires()
+    unresolved = [
+        (d, f) for d, f in needed
+        if f not in base_fields and f not in per_disease.get(d, set())
+    ]
+    assert not unresolved, (
+        "critical_field_explanations.yaml missing entries for: "
+        + ", ".join(f"{d}/{f}" for d, f in sorted(unresolved))
+    )
+
+
+def test_per_disease_overrides_reference_known_fields():
+    """An override block must hang off a base entry — a per_disease key
+    cannot exist without a sibling base."""
+    doc = _load_explanations()
+    for ent in doc["entries"]:
+        if ent.get("per_disease"):
+            assert ent.get("base"), (
+                f"{ent.get('field')}: per_disease without base"
+            )


### PR DESCRIPTION
## Summary

Adds a per-field disclosure on /try.html: each `impact='critical'` question now has a small "Чому критично?" button next to its impact pill. Click reveals a panel with the headline, full reasoning, the concrete decisions the field changes, and KB Source IDs.

Backed by a single source-of-truth YAML (`critical_field_explanations.yaml`) using a `base + per_disease` shape. 19 base entries + 11 per-disease overrides cover all **271 critical (disease, field) pairs across 65 questionnaires** — per-field updates touch one record, not 65.

## Two commits (review-friendly split)

1. **`feat(kb): critical_field_explanations.yaml + bundler`** — KB content + `bundle_critical_explanations()` in build_site + coverage test (4 tests, all green). `status: draft_pending_review` per CHARTER §6.1 (dev-mode exemption).

2. **`feat(try): "Чому критично?" disclosure ...`** — UI: `getCriticalExplanation()` lookup, panel renderer, button toggle with `aria-expanded`, CSS for collapsible panel.

## Why base + per_disease (not 271 hand-written records)

Single source of truth: when ESMO/NCCN updates ECOG criteria, one YAML record changes — not 65. Build fails loudly if a future questionnaire adds a critical field without an explanation entry.

## Test plan

- [x] Coverage test: every critical (disease, field) resolves (`tests/test_critical_field_explanations.py`, 4 PASS)
- [x] Existing questionnaire regression: `tests/test_questionnaire.py` (10 PASS)
- [x] Bundler verifies coverage at build time (raises if a pair is missing)
- [ ] Manual UI smoke: load /try.html, pick a disease, click "Чому критично?" on age/ECOG/HBsAg fields
- [ ] Clinical co-lead review of explanation copy (gated by §6.1; dev-mode exemption applies for v0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)