### PR TITLE
Prepare PR21-23 triage for merge

### DIFF
--- a/contributions/citation-semantic-verify-v2/triage-queue-action-maintainer_review.md
+++ b/contributions/citation-semantic-verify-v2/triage-queue-action-maintainer_review.md
@@ -1,0 +1,9932 @@
+# Triage Queue: citation-semantic-verify-v2
+
+**Filter:** status=`None`, action=`maintainer_review`
+
+**Total rows:** 345
+
+---
+
+## 1/345: CV914-0003 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-CLL`
+**File:** `bma_tp53_mut_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:65`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib monotherapy' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinations includes 'acalabrutinib monotherapy', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 2/345: CV914-0004 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-CLL`
+**File:** `bma_tp53_mut_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:66`
+
+**Audit finding text:**
+```
+recommended_combination 'zanubrutinib monotherapy' contains drug name(s) ['zanubrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinations includes 'zanubrutinib monotherapy', but regulatory_approval does not mention zanubrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 3/345: CV914-0005 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-CLL`
+**File:** `bma_tp53_mut_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:67`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab (CLL14)' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab (CLL14)', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 4/345: CV914-0006 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-CLL`
+**File:** `bma_tp53_mut_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:68`
+
+**Audit finding text:**
+```
+recommended_combination 'BTKi + venetoclax (CAPTIVATE / GLOW)' contains drug name(s) ['btki', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinations includes 'BTKi + venetoclax (CAPTIVATE / GLOW)', but regulatory_approval does not mention venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 5/345: CV914-0010 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-P210-BALL`
+**File:** `bma_bcr_abl1_p210_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:74`
+
+**Audit finding text:**
+```
+recommended_combination 'ponatinib + hyper-CVAD' contains drug name(s) ['hyper-cvad'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcr_abl1_p210_ball.yaml: recommended_combinations includes 'ponatinib + hyper-CVAD', but regulatory_approval does not mention hyper-cvad. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 6/345: CV914-0011 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-P210-BALL`
+**File:** `bma_bcr_abl1_p210_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:75`
+
+**Audit finding text:**
+```
+recommended_combination 'dasatinib + blinatumomab' contains drug name(s) ['blinatumomab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcr_abl1_p210_ball.yaml: recommended_combinations includes 'dasatinib + blinatumomab', but regulatory_approval does not mention blinatumomab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 7/345: CV914-0012 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-OVARIAN`
+**File:** `bma_brca1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:78`
+
+**Audit finding text:**
+```
+trial ''SOLO1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca1_germline_ovarian.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 8/345: CV914-0014 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-OVARIAN`
+**File:** `bma_brca1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:80`
+
+**Audit finding text:**
+```
+trial ''ARIEL3'' mentioned but no matching source citation (looked for substrings: [''ARIEL3''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ARIEL3' to existing source SRC-ARIEL3-COLEMAN-2017 at knowledge_base/hosted/content/sources/src_ariel3_coleman_2017.yaml. The source title is 'Rucaparib maintenance treatment for recurrent ovarian carcinoma after response to platinum therapy (ARIEL3): a randomised, double-blind, placebo-controlled, phase 3 trial'; source notes identify the trial/source context as: 'ARIEL3 phase 3: rucaparib 600 mg PO BID maintenance vs placebo in platinum-sensitive recurrent ovarian after CR/PR to most recent platinum, ≥2 prior platinum lines. BRCA-mut: mPFS 16.6 vs 5.4 mo (HR 0.23); HRD+ (BRCA + LOH-high): 13.6 vs 5.4 mo (HR 0.32); ITT all-comers: 10.8 vs 5.4 mo (HR 0.36). Established rucaparib as third PARPi maintenance option for pl'. Current entity locator knowledge_base/hosted/content/...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32440-6/fulltext failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 9/345: CV914-0016 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-OVARIAN`
+**File:** `bma_brca1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:82`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (PAOLA-1, HRD+)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (PAOLA-1, HRD+)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 10/345: CV914-0020 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
+**File:** `bma_brca1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:88`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + abiraterone + prednisone (1L)' contains drug name(s) ['prednisone'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_germline_prostate.yaml: recommended_combinations includes 'olaparib + abiraterone + prednisone (1L)', but regulatory_approval does not mention prednisone. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 11/345: CV914-0021 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
+**File:** `bma_brca1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:89`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib + abiraterone + prednisone (1L)' contains drug name(s) ['prednisone'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_germline_prostate.yaml: recommended_combinations includes 'niraparib + abiraterone + prednisone (1L)', but regulatory_approval does not mention prednisone. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 12/345: CV914-0023 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-BREAST`
+**File:** `bma_brca2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:93`
+
+**Audit finding text:**
+```
+trial ''OLYMPIAD'' mentioned but no matching source citation (looked for substrings: [''OLYMPIAD'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'OLYMPIAD' to existing source SRC-OLYMPIAD-ROBSON-2017 at knowledge_base/hosted/content/sources/src_olympiad_robson_2017.yaml. The source title is 'Olaparib for Metastatic Breast Cancer in Patients with a Germline BRCA Mutation'; source notes identify the trial/source context as: 'OlympiAD phase-3: olaparib 300 mg PO BID vs physician-choice single-agent chemo (capecitabine, eribulin, vinorelbine) in germline BRCA1/2-mutant HER2- metastatic breast (≤2 prior chemo lines for metastatic disease; HR+ subset must have progressed on ≥1 endocrine line). Median PFS 7.0 vs 4.2 mo (HR 0.58, p<0.001); ORR 60% vs 29%; OS not significantly improved'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca2_germline_breast.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1706450 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 13/345: CV914-0024 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-BREAST`
+**File:** `bma_brca2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:94`
+
+**Audit finding text:**
+```
+trial ''EMBRACA'' mentioned but no matching source citation (looked for substrings: [''EMBRACA'', ''TALAZOPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'EMBRACA' to existing source SRC-EMBRACA-LITTON-2018 at knowledge_base/hosted/content/sources/src_embraca_litton_2018.yaml. The source title is 'Talazoparib in Patients with Advanced Breast Cancer and a Germline BRCA Mutation'; source notes identify the trial/source context as: 'EMBRACA phase-3: talazoparib 1 mg PO daily vs physician-choice single-agent chemo in germline BRCA1/2-mutant HER2- metastatic breast (≤3 prior cytotoxic regimens). Median PFS 8.6 vs 5.6 mo (HR 0.54, p<0.001); ORR 62.6% vs 27.2%. Anemia G3+ (39%) more pronounced than with olaparib; nausea, fatigue, alopecia common. Established talazoparib as alternative PARPi'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca2_germline_breast.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1802905 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 14/345: CV914-0026 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-BREAST`
+**File:** `bma_brca2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:96`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (TNBC)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_germline_breast.yaml: recommended_combinations includes 'platinum-based chemo (TNBC)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 15/345: CV914-0031 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-PROSTATE`
+**File:** `bma_brca2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:103`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib monotherapy' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_germline_prostate.yaml: recommended_combinations includes 'rucaparib monotherapy', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 16/345: CV914-0035 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EGFR-C797S-NSCLC`
+**File:** `bma_egfr_c797s_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:109`
+
+**Audit finding text:**
+```
+recommended_combination 'amivantamab + carboplatin + pemetrexed (MARIPOSA-2)' contains drug name(s) ['carboplatin', 'pemetrexed'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_egfr_c797s_nsclc.yaml: recommended_combinations includes 'amivantamab + carboplatin + pemetrexed (MARIPOSA-2)', but regulatory_approval does not mention carboplatin, pemetrexed. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 17/345: CV914-0036 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EGFR-C797S-NSCLC`
+**File:** `bma_egfr_c797s_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:110`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-doublet chemotherapy' contains drug name(s) ['platinum-doublet'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_egfr_c797s_nsclc.yaml: recommended_combinations includes 'platinum-doublet chemotherapy', but regulatory_approval does not mention platinum-doublet. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 18/345: CV914-0037 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-EGFR-EX19DEL-NSCLC`
+**File:** `bma_egfr_ex19del_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:113`
+
+**Audit finding text:**
+```
+trial ''FLAURA'' mentioned but no matching source citation (looked for substrings: [''FLAURA'', ''OSIMERTINIB'', ''AURA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'FLAURA' to existing source SRC-FLAURA-SORIA-2018 at knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml. The source title is 'Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer'; source notes identify the trial/source context as: 'FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs standard-of-care 1st-gen EGFR-TKI (gefitinib or erlotinib) in treatment-naive EGFR-mutated (exon 19 del / L858R) advanced NSCLC. Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final OS analysis (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS PFS markedly improved (HR 0.48). Estab'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_egfr_ex19del_nsclc.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1713137 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 19/345: CV914-0040 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EGFR-EX19DEL-NSCLC`
+**File:** `bma_egfr_ex19del_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:116`
+
+**Audit finding text:**
+```
+recommended_combination 'osimertinib + pemetrexed/platinum (FLAURA2 regimen)' contains drug name(s) ['pemetrexed'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_egfr_ex19del_nsclc.yaml: recommended_combinations includes 'osimertinib + pemetrexed/platinum (FLAURA2 regimen)', but regulatory_approval does not mention pemetrexed. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 20/345: CV914-0041 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EGFR-EX19DEL-NSCLC`
+**File:** `bma_egfr_ex19del_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:117`
+
+**Audit finding text:**
+```
+recommended_combination 'amivantamab + lazertinib (MARIPOSA, 1L alternative)' contains drug name(s) ['amivantamab', 'lazertinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_egfr_ex19del_nsclc.yaml: recommended_combinations includes 'amivantamab + lazertinib (MARIPOSA, 1L alternative)', but regulatory_approval does not mention amivantamab, lazertinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 21/345: CV914-0042 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-EGFR-L858R-NSCLC`
+**File:** `bma_egfr_l858r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:120`
+
+**Audit finding text:**
+```
+trial ''FLAURA'' mentioned but no matching source citation (looked for substrings: [''FLAURA'', ''OSIMERTINIB'', ''AURA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'FLAURA' to existing source SRC-FLAURA-SORIA-2018 at knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml. The source title is 'Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer'; source notes identify the trial/source context as: 'FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs standard-of-care 1st-gen EGFR-TKI (gefitinib or erlotinib) in treatment-naive EGFR-mutated (exon 19 del / L858R) advanced NSCLC. Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final OS analysis (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS PFS markedly improved (HR 0.48). Estab'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_egfr_l858r_nsclc.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1713137 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 22/345: CV914-0046 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EGFR-L858R-NSCLC`
+**File:** `bma_egfr_l858r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:124`
+
+**Audit finding text:**
+```
+recommended_combination 'osimertinib + pemetrexed/platinum (FLAURA2)' contains drug name(s) ['pemetrexed'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_egfr_l858r_nsclc.yaml: recommended_combinations includes 'osimertinib + pemetrexed/platinum (FLAURA2)', but regulatory_approval does not mention pemetrexed. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 23/345: CV914-0050 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
+**File:** `bma_mlh1_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:130`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_germline_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 24/345: CV914-0051 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
+**File:** `bma_mlh1_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:131`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_germline_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 25/345: CV914-0055 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
+**File:** `bma_mlh1_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:137`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_somatic_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 26/345: CV914-0056 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
+**File:** `bma_mlh1_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:138`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_somatic_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 27/345: CV914-0060 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:144`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_germline_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 28/345: CV914-0061 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:145`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_germline_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 29/345: CV914-0065 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:151`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_somatic_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 30/345: CV914-0066 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:152`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_somatic_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 31/345: CV914-0070 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh6_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:158`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_germline_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 32/345: CV914-0071 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh6_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:159`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_germline_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 33/345: CV914-0075 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh6_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:165`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_somatic_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 34/345: CV914-0076 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh6_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:166`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_somatic_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 35/345: CV914-0079 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
+**File:** `bma_notch1_activating_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:171`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab (CLL14)' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab (CLL14)', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 36/345: CV914-0080 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
+**File:** `bma_notch1_activating_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:172`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib monotherapy' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_cll.yaml: recommended_combinations includes 'acalabrutinib monotherapy', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 37/345: CV914-0081 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
+**File:** `bma_notch1_activating_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:173`
+
+**Audit finding text:**
+```
+recommended_combination 'zanubrutinib monotherapy' contains drug name(s) ['zanubrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_cll.yaml: recommended_combinations includes 'zanubrutinib monotherapy', but regulatory_approval does not mention zanubrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 38/345: CV914-0085 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_pms2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:179`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_germline_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 39/345: CV914-0086 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_pms2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:180`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_germline_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 40/345: CV914-0090 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_pms2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:186`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_somatic_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L advanced dMMR, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 41/345: CV914-0091 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_pms2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:187`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_somatic_endometrial.yaml: recommended_combinations includes 'pembrolizumab + carbo/paclitaxel (1L advanced, NRG-GY018)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 42/345: CV914-0093 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
+**File:** `bma_rad51b_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:191`
+
+**Audit finding text:**
+```
+trial ''ARIEL3'' mentioned but no matching source citation (looked for substrings: [''ARIEL3''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ARIEL3' to existing source SRC-ARIEL3-COLEMAN-2017 at knowledge_base/hosted/content/sources/src_ariel3_coleman_2017.yaml. The source title is 'Rucaparib maintenance treatment for recurrent ovarian carcinoma after response to platinum therapy (ARIEL3): a randomised, double-blind, placebo-controlled, phase 3 trial'; source notes identify the trial/source context as: 'ARIEL3 phase 3: rucaparib 600 mg PO BID maintenance vs placebo in platinum-sensitive recurrent ovarian after CR/PR to most recent platinum, ≥2 prior platinum lines. BRCA-mut: mPFS 16.6 vs 5.4 mo (HR 0.23); HRD+ (BRCA + LOH-high): 13.6 vs 5.4 mo (HR 0.32); ITT all-comers: 10.8 vs 5.4 mo (HR 0.36). Established rucaparib as third PARPi maintenance option for pl'. Current entity locator knowledge_base/hosted/content/...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32440-6/fulltext failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 43/345: CV914-0094 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
+**File:** `bma_rad51b_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:192`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib maintenance' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_germline_ovarian.yaml: recommended_combinations includes 'niraparib maintenance', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 44/345: CV914-0095 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
+**File:** `bma_rad51b_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:193`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 45/345: CV914-0096 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
+**File:** `bma_rad51b_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:194`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib maintenance' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_germline_ovarian.yaml: recommended_combinations includes 'rucaparib maintenance', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 46/345: CV914-0098 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
+**File:** `bma_rad51c_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:198`
+
+**Audit finding text:**
+```
+trial ''ARIEL3'' mentioned but no matching source citation (looked for substrings: [''ARIEL3''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ARIEL3' to existing source SRC-ARIEL3-COLEMAN-2017 at knowledge_base/hosted/content/sources/src_ariel3_coleman_2017.yaml. The source title is 'Rucaparib maintenance treatment for recurrent ovarian carcinoma after response to platinum therapy (ARIEL3): a randomised, double-blind, placebo-controlled, phase 3 trial'; source notes identify the trial/source context as: 'ARIEL3 phase 3: rucaparib 600 mg PO BID maintenance vs placebo in platinum-sensitive recurrent ovarian after CR/PR to most recent platinum, ≥2 prior platinum lines. BRCA-mut: mPFS 16.6 vs 5.4 mo (HR 0.23); HRD+ (BRCA + LOH-high): 13.6 vs 5.4 mo (HR 0.32); ITT all-comers: 10.8 vs 5.4 mo (HR 0.36). Established rucaparib as third PARPi maintenance option for pl'. Current entity locator knowledge_base/hosted/content/...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32440-6/fulltext failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 47/345: CV914-0100 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
+**File:** `bma_rad51c_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:200`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 48/345: CV914-0101 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
+**File:** `bma_rad51c_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:201`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib maintenance' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_germline_ovarian.yaml: recommended_combinations includes 'rucaparib maintenance', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 49/345: CV914-0103 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
+**File:** `bma_rad51d_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:205`
+
+**Audit finding text:**
+```
+trial ''ARIEL3'' mentioned but no matching source citation (looked for substrings: [''ARIEL3''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ARIEL3' to existing source SRC-ARIEL3-COLEMAN-2017 at knowledge_base/hosted/content/sources/src_ariel3_coleman_2017.yaml. The source title is 'Rucaparib maintenance treatment for recurrent ovarian carcinoma after response to platinum therapy (ARIEL3): a randomised, double-blind, placebo-controlled, phase 3 trial'; source notes identify the trial/source context as: 'ARIEL3 phase 3: rucaparib 600 mg PO BID maintenance vs placebo in platinum-sensitive recurrent ovarian after CR/PR to most recent platinum, ≥2 prior platinum lines. BRCA-mut: mPFS 16.6 vs 5.4 mo (HR 0.23); HRD+ (BRCA + LOH-high): 13.6 vs 5.4 mo (HR 0.32); ITT all-comers: 10.8 vs 5.4 mo (HR 0.36). Established rucaparib as third PARPi maintenance option for pl'. Current entity locator knowledge_base/hosted/content/...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32440-6/fulltext failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 50/345: CV914-0105 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
+**File:** `bma_rad51d_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:207`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 51/345: CV914-0106 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
+**File:** `bma_rad51d_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:208`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib maintenance' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_germline_ovarian.yaml: recommended_combinations includes 'rucaparib maintenance', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 52/345: CV914-0108 - access_blocked -> maintainer_review
+
+**Entity:** `IND-OVARIAN-MAINT-BEV`
+**File:** `ind_ovarian_maint_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:212`
+
+**Audit finding text:**
+```
+trial ''SOLO-1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO-1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/indications/ind_ovarian_maint_bev.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 53/345: CV914-0115 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ALK-FUSION-ALCL`
+**File:** `bma_alk_fusion_alcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:221`
+
+**Audit finding text:**
+```
+recommended_combination 'brentuximab vedotin + cyclophosphamide/doxorubicin/prednisone (BV-CHP, 1L)' contains drug name(s) ['cyclophosphamide', 'doxorubicin', 'prednisone'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_alk_fusion_alcl.yaml: recommended_combinations includes 'brentuximab vedotin + cyclophosphamide/doxorubicin/prednisone (BV-CHP, 1L)', but regulatory_approval does not mention cyclophosphamide, doxorubicin, prednisone. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 54/345: CV914-0123 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-CLL`
+**File:** `bma_bcl2_expression_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:233`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + ibrutinib (CAPTIVATE / GLOW)' contains drug name(s) ['ibrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_cll.yaml: recommended_combinations includes 'venetoclax + ibrutinib (CAPTIVATE / GLOW)', but regulatory_approval does not mention ibrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 55/345: CV914-0125 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-BREAST`
+**File:** `bma_brca1_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:237`
+
+**Audit finding text:**
+```
+trial ''OLYMPIAD'' mentioned but no matching source citation (looked for substrings: [''OLYMPIAD'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'OLYMPIAD' to existing source SRC-OLYMPIAD-ROBSON-2017 at knowledge_base/hosted/content/sources/src_olympiad_robson_2017.yaml. The source title is 'Olaparib for Metastatic Breast Cancer in Patients with a Germline BRCA Mutation'; source notes identify the trial/source context as: 'OlympiAD phase-3: olaparib 300 mg PO BID vs physician-choice single-agent chemo (capecitabine, eribulin, vinorelbine) in germline BRCA1/2-mutant HER2- metastatic breast (≤2 prior chemo lines for metastatic disease; HR+ subset must have progressed on ≥1 endocrine line). Median PFS 7.0 vs 4.2 mo (HR 0.58, p<0.001); ORR 60% vs 29%; OS not significantly improved'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca1_germline_breast.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1706450 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 56/345: CV914-0126 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA1-GERMLINE-BREAST`
+**File:** `bma_brca1_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:238`
+
+**Audit finding text:**
+```
+trial ''EMBRACA'' mentioned but no matching source citation (looked for substrings: [''EMBRACA'', ''TALAZOPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'EMBRACA' to existing source SRC-EMBRACA-LITTON-2018 at knowledge_base/hosted/content/sources/src_embraca_litton_2018.yaml. The source title is 'Talazoparib in Patients with Advanced Breast Cancer and a Germline BRCA Mutation'; source notes identify the trial/source context as: 'EMBRACA phase-3: talazoparib 1 mg PO daily vs physician-choice single-agent chemo in germline BRCA1/2-mutant HER2- metastatic breast (≤3 prior cytotoxic regimens). Median PFS 8.6 vs 5.6 mo (HR 0.54, p<0.001); ORR 62.6% vs 27.2%. Anemia G3+ (39%) more pronounced than with olaparib; nausea, fatigue, alopecia common. Established talazoparib as alternative PARPi'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca1_germline_breast.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1802905 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 57/345: CV914-0128 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-OVARIAN`
+**File:** `bma_brca2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:242`
+
+**Audit finding text:**
+```
+trial ''SOLO1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca2_germline_ovarian.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 58/345: CV914-0129 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-OVARIAN`
+**File:** `bma_brca2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:243`
+
+**Audit finding text:**
+```
+trial ''ARIEL3'' mentioned but no matching source citation (looked for substrings: [''ARIEL3''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ARIEL3' to existing source SRC-ARIEL3-COLEMAN-2017 at knowledge_base/hosted/content/sources/src_ariel3_coleman_2017.yaml. The source title is 'Rucaparib maintenance treatment for recurrent ovarian carcinoma after response to platinum therapy (ARIEL3): a randomised, double-blind, placebo-controlled, phase 3 trial'; source notes identify the trial/source context as: 'ARIEL3 phase 3: rucaparib 600 mg PO BID maintenance vs placebo in platinum-sensitive recurrent ovarian after CR/PR to most recent platinum, ≥2 prior platinum lines. BRCA-mut: mPFS 16.6 vs 5.4 mo (HR 0.23); HRD+ (BRCA + LOH-high): 13.6 vs 5.4 mo (HR 0.32); ITT all-comers: 10.8 vs 5.4 mo (HR 0.36). Established rucaparib as third PARPi maintenance option for pl'. Current entity locator knowledge_base/hosted/content/...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32440-6/fulltext failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 59/345: CV914-0131 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-OVARIAN`
+**File:** `bma_brca2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:245`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (PAOLA-1)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (PAOLA-1)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 60/345: CV914-0134 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CCND1-T1114-MCL`
+**File:** `bma_ccnd1_t1114_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:250`
+
+**Audit finding text:**
+```
+recommended_combination 'BR or R-CHOP/R-DHAP + autoSCT (1L fit, TP53-WT)' contains drug name(s) ['r-chop', 'r-dhap', 'autosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_ccnd1_t1114_mcl.yaml: recommended_combinations includes 'BR or R-CHOP/R-DHAP + autoSCT (1L fit, TP53-WT)', but regulatory_approval does not mention r-chop, r-dhap, autosct. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 61/345: CV914-0135 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CCND1-T1114-MCL`
+**File:** `bma_ccnd1_t1114_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:251`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + ibrutinib (R/R)' contains drug name(s) ['venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_ccnd1_t1114_mcl.yaml: recommended_combinations includes 'venetoclax + ibrutinib (R/R)', but regulatory_approval does not mention venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 62/345: CV914-0138 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FGFR2-MUTATION-ENDOMETRIAL`
+**File:** `bma_fgfr2_mutation_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:256`
+
+**Audit finding text:**
+```
+recommended_combination 'pemigatinib (basket trial / NCI-MATCH for FGFR2-mutant endometrial)' contains drug name(s) ['pemigatinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fgfr2_mutation_endometrial.yaml: recommended_combinations includes 'pemigatinib (basket trial / NCI-MATCH for FGFR2-mutant endometrial)', but regulatory_approval does not mention pemigatinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 63/345: CV914-0139 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FGFR2-MUTATION-ENDOMETRIAL`
+**File:** `bma_fgfr2_mutation_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:257`
+
+**Audit finding text:**
+```
+recommended_combination 'erdafitinib (basket trial)' contains drug name(s) ['erdafitinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fgfr2_mutation_endometrial.yaml: recommended_combinations includes 'erdafitinib (basket trial)', but regulatory_approval does not mention erdafitinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 64/345: CV914-0141 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FLT3-ITD-AML`
+**File:** `bma_flt3_itd_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:261`
+
+**Audit finding text:**
+```
+recommended_combination 'midostaurin + 7+3 induction + HiDAC consolidation + midostaurin maintenance' contains drug name(s) ['hidac'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_flt3_itd_aml.yaml: recommended_combinations includes 'midostaurin + 7+3 induction + HiDAC consolidation + midostaurin maintenance', but regulatory_approval does not mention hidac. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 65/345: CV914-0142 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FLT3-ITD-AML`
+**File:** `bma_flt3_itd_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:262`
+
+**Audit finding text:**
+```
+recommended_combination 'quizartinib + 7+3 induction + HiDAC consolidation + quizartinib maintenance (FLT3-ITD specifically)' contains drug name(s) ['hidac'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_flt3_itd_aml.yaml: recommended_combinations includes 'quizartinib + 7+3 induction + HiDAC consolidation + quizartinib maintenance (FLT3-ITD specifically)', but regulatory_approval does not mention hidac. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 66/345: CV914-0143 - unclear -> maintainer_review
+
+**Entity:** `BMA-FLT3-ITD-AML`
+**File:** `bma_flt3_itd_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:263`
+
+**Audit finding text:**
+```
+recommended_combination 'allo-SCT in CR1 (high-allelic-ratio FLT3-ITD or other adverse-risk features)' contains drug name(s) ['allo-sct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_flt3_itd_aml.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 67/345: CV914-0147 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KRAS-G12C-PDAC`
+**File:** `bma_kras_g12c_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:269`
+
+**Audit finding text:**
+```
+recommended_combination 'adagrasib monotherapy' contains drug name(s) ['adagrasib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kras_g12c_pdac.yaml: recommended_combinations includes 'adagrasib monotherapy', but regulatory_approval does not mention adagrasib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 68/345: CV914-0149 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-PALB2-GERMLINE-OVARIAN`
+**File:** `bma_palb2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:273`
+
+**Audit finding text:**
+```
+trial ''ARIEL3'' mentioned but no matching source citation (looked for substrings: [''ARIEL3''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ARIEL3' to existing source SRC-ARIEL3-COLEMAN-2017 at knowledge_base/hosted/content/sources/src_ariel3_coleman_2017.yaml. The source title is 'Rucaparib maintenance treatment for recurrent ovarian carcinoma after response to platinum therapy (ARIEL3): a randomised, double-blind, placebo-controlled, phase 3 trial'; source notes identify the trial/source context as: 'ARIEL3 phase 3: rucaparib 600 mg PO BID maintenance vs placebo in platinum-sensitive recurrent ovarian after CR/PR to most recent platinum, ≥2 prior platinum lines. BRCA-mut: mPFS 16.6 vs 5.4 mo (HR 0.23); HRD+ (BRCA + LOH-high): 13.6 vs 5.4 mo (HR 0.32); ITT all-comers: 10.8 vs 5.4 mo (HR 0.36). Established rucaparib as third PARPi maintenance option for pl'. Current entity locator knowledge_base/hosted/content/...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32440-6/fulltext failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 69/345: CV914-0151 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-GERMLINE-OVARIAN`
+**File:** `bma_palb2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:275`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib maintenance' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_germline_ovarian.yaml: recommended_combinations includes 'rucaparib maintenance', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 70/345: CV914-0161 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MCL`
+**File:** `bma_tp53_mut_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:291`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab (1L)' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab (1L)', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 71/345: CV914-0162 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MCL`
+**File:** `bma_tp53_mut_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:292`
+
+**Audit finding text:**
+```
+recommended_combination 'ibrutinib + rituximab + venetoclax (R/R)' contains drug name(s) ['ibrutinib', 'rituximab', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mcl.yaml: recommended_combinations includes 'ibrutinib + rituximab + venetoclax (R/R)', but regulatory_approval does not mention ibrutinib, rituximab, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 72/345: CV914-0163 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MCL`
+**File:** `bma_tp53_mut_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:293`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T brexu-cel (R/R)' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_mut_mcl.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 73/345: CV914-0174 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BARD1-GERMLINE-OVARIAN`
+**File:** `bma_bard1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:310`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bard1_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 74/345: CV914-0177 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-E255K-CML`
+**File:** `bma_bcr_abl1_e255k_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:315`
+
+**Audit finding text:**
+```
+recommended_combination 'asciminib monotherapy (in multi-TKI failure)' contains drug name(s) ['asciminib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcr_abl1_e255k_cml.yaml: recommended_combinations includes 'asciminib monotherapy (in multi-TKI failure)', but regulatory_approval does not mention asciminib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 75/345: CV914-0180 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-F317L-BALL`
+**File:** `bma_bcr_abl1_f317l_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:320`
+
+**Audit finding text:**
+```
+recommended_combination 'ponatinib + blinatumomab' contains drug name(s) ['blinatumomab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcr_abl1_f317l_ball.yaml: recommended_combinations includes 'ponatinib + blinatumomab', but regulatory_approval does not mention blinatumomab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 76/345: CV914-0183 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-T315I-BALL`
+**File:** `bma_bcr_abl1_t315i_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:325`
+
+**Audit finding text:**
+```
+recommended_combination 'ponatinib + blinatumomab (chemo-free)' contains drug name(s) ['blinatumomab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcr_abl1_t315i_ball.yaml: recommended_combinations includes 'ponatinib + blinatumomab (chemo-free)', but regulatory_approval does not mention blinatumomab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 77/345: CV914-0184 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-T315I-CML`
+**File:** `bma_bcr_abl1_t315i_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:328`
+
+**Audit finding text:**
+```
+trial ''ASCEMBL'' mentioned but no matching source citation (looked for substrings: [''ASCEMBL'', ''ASCIMINIB'', ''REA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ASCEMBL' to existing source SRC-ASCEMBL-REA-2021 at knowledge_base/hosted/content/sources/src_ascembl_rea_2021.yaml. The source title is 'Asciminib in Chronic Myeloid Leukemia after ABL Kinase Inhibitor Failure'; source notes identify the trial/source context as: 'ASCEMBL phase-3 RCT: asciminib 40 mg BID vs bosutinib 500 mg daily in CML-CP after ≥2 prior TKIs (n=233). Primary endpoint MMR at 24 weeks 25.5% vs 13.2% (difference 12.2%, p=0.029). Better tolerability than bosutinib. Established asciminib as 3L+ standard for CML-CP post-multi-TKI failure (T315I-negative).'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_bcr_abl1_t315i_cml.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://ashpublications.org/blood/article/138/21/2031/477248 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 78/345: CV914-0187 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600E-CRC`
+**File:** `bma_braf_v600e_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:333`
+
+**Audit finding text:**
+```
+trial ''BEACON'' mentioned but no matching source citation (looked for substrings: [''BEACON'', ''ENCORAFENIB'', ''KOPETZ''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'BEACON' to existing source SRC-BEACON-CRC-KOPETZ-2019 at knowledge_base/hosted/content/sources/src_beacon_crc_kopetz_2019.yaml. The source title is 'Encorafenib, Binimetinib, and Cetuximab in BRAF V600E-Mutated Colorectal Cancer'; source notes identify the trial/source context as: 'BEACON CRC phase-3 (NCT02928224): encorafenib 300 mg PO daily + binimetinib 45 mg BID + cetuximab vs encorafenib + cetuximab vs control (FOLFIRI/irinotecan + cetuximab) in BRAF V600E-mutated metastatic CRC after 1–2 prior lines. Triplet mOS 9.0 vs 5.4 mo (HR 0.52, p<0.001); ORR 26% vs 2%. Doublet (enco+cetux) mOS 8.4 mo, HR 0.60. Established BRAFi + EGFRi (±'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_braf_v600e_crc.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908075 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 79/345: CV914-0188 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600E-CRC`
+**File:** `bma_braf_v600e_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:334`
+
+**Audit finding text:**
+```
+trial ''BEACON-CRC'' mentioned but no matching source citation (looked for substrings: [''BEACON'', ''ENCORAFENIB'', ''KOPETZ''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'BEACON-CRC' to existing source SRC-BEACON-CRC-KOPETZ-2019 at knowledge_base/hosted/content/sources/src_beacon_crc_kopetz_2019.yaml. The source title is 'Encorafenib, Binimetinib, and Cetuximab in BRAF V600E-Mutated Colorectal Cancer'; source notes identify the trial/source context as: 'BEACON CRC phase-3 (NCT02928224): encorafenib 300 mg PO daily + binimetinib 45 mg BID + cetuximab vs encorafenib + cetuximab vs control (FOLFIRI/irinotecan + cetuximab) in BRAF V600E-mutated metastatic CRC after 1–2 prior lines. Triplet mOS 9.0 vs 5.4 mo (HR 0.52, p<0.001); ORR 26% vs 2%. Doublet (enco+cetux) mOS 8.4 mo, HR 0.60. Established BRAFi + EGFRi (±'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_braf_v600e_crc.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908075 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 80/345: CV914-0191 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600E-HCL`
+**File:** `bma_braf_v600e_hcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:339`
+
+**Audit finding text:**
+```
+recommended_combination 'vemurafenib + rituximab (consolidation / R/R)' contains drug name(s) ['rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_braf_v600e_hcl.yaml: recommended_combinations includes 'vemurafenib + rituximab (consolidation / R/R)', but regulatory_approval does not mention rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 81/345: CV914-0192 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600E-HCL`
+**File:** `bma_braf_v600e_hcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:340`
+
+**Audit finding text:**
+```
+recommended_combination 'dabrafenib + trametinib (alternative)' contains drug name(s) ['dabrafenib', 'trametinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_braf_v600e_hcl.yaml: recommended_combinations includes 'dabrafenib + trametinib (alternative)', but regulatory_approval does not mention dabrafenib, trametinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 82/345: CV914-0198 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600K-MELANOMA`
+**File:** `bma_braf_v600k_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:350`
+
+**Audit finding text:**
+```
+recommended_combination 'vemurafenib + cobimetinib' contains drug name(s) ['vemurafenib', 'cobimetinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_braf_v600k_melanoma.yaml: recommended_combinations includes 'vemurafenib + cobimetinib', but regulatory_approval does not mention vemurafenib, cobimetinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 83/345: CV914-0199 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA1-SOMATIC-OVARIAN`
+**File:** `bma_brca1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:353`
+
+**Audit finding text:**
+```
+trial ''SOLO1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca1_somatic_ovarian.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 84/345: CV914-0201 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-SOMATIC-OVARIAN`
+**File:** `bma_brca1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:355`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (PAOLA-1)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (PAOLA-1)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 85/345: CV914-0203 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-SOMATIC-PROSTATE`
+**File:** `bma_brca1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:359`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib + abiraterone (1L)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_somatic_prostate.yaml: recommended_combinations includes 'niraparib + abiraterone (1L)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 86/345: CV914-0204 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-SOMATIC-PROSTATE`
+**File:** `bma_brca1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:360`
+
+**Audit finding text:**
+```
+recommended_combination 'talazoparib + enzalutamide (1L)' contains drug name(s) ['talazoparib', 'enzalutamide'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_somatic_prostate.yaml: recommended_combinations includes 'talazoparib + enzalutamide (1L)', but regulatory_approval does not mention talazoparib, enzalutamide. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 87/345: CV914-0205 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-BRCA2-SOMATIC-OVARIAN`
+**File:** `bma_brca2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:363`
+
+**Audit finding text:**
+```
+trial ''SOLO1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_brca2_somatic_ovarian.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 88/345: CV914-0207 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-SOMATIC-OVARIAN`
+**File:** `bma_brca2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:365`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (PAOLA-1)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (PAOLA-1)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 89/345: CV914-0209 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-SOMATIC-PROSTATE`
+**File:** `bma_brca2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:369`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib + abiraterone (1L)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_somatic_prostate.yaml: recommended_combinations includes 'niraparib + abiraterone (1L)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 90/345: CV914-0210 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-SOMATIC-PROSTATE`
+**File:** `bma_brca2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:370`
+
+**Audit finding text:**
+```
+recommended_combination 'talazoparib + enzalutamide (1L)' contains drug name(s) ['talazoparib', 'enzalutamide'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_somatic_prostate.yaml: recommended_combinations includes 'talazoparib + enzalutamide (1L)', but regulatory_approval does not mention talazoparib, enzalutamide. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 91/345: CV914-0212 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRIP1-GERMLINE-OVARIAN`
+**File:** `bma_brip1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:374`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brip1_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 92/345: CV914-0213 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRIP1-GERMLINE-OVARIAN`
+**File:** `bma_brip1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:375`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brip1_germline_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 93/345: CV914-0216 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EGFR-EX20INS-NSCLC`
+**File:** `bma_egfr_ex20ins_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:380`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-doublet chemotherapy (alternative)' contains drug name(s) ['platinum-doublet'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_egfr_ex20ins_nsclc.yaml: recommended_combinations includes 'platinum-doublet chemotherapy (alternative)', but regulatory_approval does not mention platinum-doublet. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 94/345: CV914-0217 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-EPCAM-GERMLINE-CRC`
+**File:** `bma_epcam_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:383`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_epcam_ge...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 95/345: CV914-0219 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EPCAM-GERMLINE-CRC`
+**File:** `bma_epcam_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:385`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + ipilimumab (2L+, CheckMate-142)' contains drug name(s) ['nivolumab', 'ipilimumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_epcam_germline_crc.yaml: recommended_combinations includes 'nivolumab + ipilimumab (2L+, CheckMate-142)', but regulatory_approval does not mention nivolumab, ipilimumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 96/345: CV914-0222 - unsupported -> maintainer_review
+
+**Entity:** `BMA-EPCAM-GERMLINE-ENDOMETRIAL`
+**File:** `bma_epcam_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:390`
+
+**Audit finding text:**
+```
+recommended_combination 'dostarlimab + carbo/paclitaxel (1L, RUBY)' contains drug name(s) ['carbo', 'paclitaxel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_epcam_germline_endometrial.yaml: recommended_combinations includes 'dostarlimab + carbo/paclitaxel (1L, RUBY)', but regulatory_approval does not mention carbo, paclitaxel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 97/345: CV914-0231 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FLT3-D835-AML`
+**File:** `bma_flt3_d835_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:405`
+
+**Audit finding text:**
+```
+recommended_combination 'midostaurin + 7+3 + HiDAC consolidation + midostaurin maintenance' contains drug name(s) ['hidac'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_flt3_d835_aml.yaml: recommended_combinations includes 'midostaurin + 7+3 + HiDAC consolidation + midostaurin maintenance', but regulatory_approval does not mention hidac. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 98/345: CV914-0234 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FLT3-F691L-AML`
+**File:** `bma_flt3_f691l_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:410`
+
+**Audit finding text:**
+```
+recommended_combination 'salvage chemo + allo-SCT (preferred when fit)' contains drug name(s) ['salvage', 'allo-sct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_flt3_f691l_aml.yaml: recommended_combinations includes 'salvage chemo + allo-SCT (preferred when fit)', but regulatory_approval does not mention salvage. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 99/345: CV914-0236 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132C-AML`
+**File:** `bma_idh1_r132c_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:414`
+
+**Audit finding text:**
+```
+recommended_combination 'olutasidenib' contains drug name(s) ['olutasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132c_aml.yaml: recommended_combinations includes 'olutasidenib', but regulatory_approval does not mention olutasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 100/345: CV914-0237 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132C-AML`
+**File:** `bma_idh1_r132c_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:415`
+
+**Audit finding text:**
+```
+recommended_combination 'ivosidenib + azacitidine' contains drug name(s) ['azacitidine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132c_aml.yaml: recommended_combinations includes 'ivosidenib + azacitidine', but regulatory_approval does not mention azacitidine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 101/345: CV914-0246 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-GERMLINE-GASTRIC`
+**File:** `bma_mlh1_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:430`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_germline_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 102/345: CV914-0249 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-SOMATIC-GASTRIC`
+**File:** `bma_mlh1_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:435`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_somatic_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 103/345: CV914-0252 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-GASTRIC`
+**File:** `bma_msh2_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:440`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_germline_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 104/345: CV914-0255 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-GASTRIC`
+**File:** `bma_msh2_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:445`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_somatic_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 105/345: CV914-0258 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-GASTRIC`
+**File:** `bma_msh6_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:450`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_germline_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 106/345: CV914-0261 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-GASTRIC`
+**File:** `bma_msh6_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:455`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_somatic_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 107/345: CV914-0264 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-HCV-MZL`
+**File:** `bma_myd88_l265p_hcv_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:460`
+
+**Audit finding text:**
+```
+recommended_combination 'zanubrutinib (FDA-approved R/R MZL - not MYD88-selected)' contains drug name(s) ['zanubrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_hcv_mzl.yaml: recommended_combinations includes 'zanubrutinib (FDA-approved R/R MZL - not MYD88-selected)', but regulatory_approval does not mention zanubrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 108/345: CV914-0267 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-NODAL-MZL`
+**File:** `bma_myd88_l265p_nodal_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:465`
+
+**Audit finding text:**
+```
+recommended_combination 'zanubrutinib (FDA-approved R/R MZL - not MYD88-selected)' contains drug name(s) ['zanubrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_nodal_mzl.yaml: recommended_combinations includes 'zanubrutinib (FDA-approved R/R MZL - not MYD88-selected)', but regulatory_approval does not mention zanubrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 109/345: CV914-0270 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-SPLENIC-MZL`
+**File:** `bma_myd88_l265p_splenic_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:470`
+
+**Audit finding text:**
+```
+recommended_combination 'zanubrutinib (FDA-approved R/R MZL - not MYD88-selected)' contains drug name(s) ['zanubrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_splenic_mzl.yaml: recommended_combinations includes 'zanubrutinib (FDA-approved R/R MZL - not MYD88-selected)', but regulatory_approval does not mention zanubrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 110/345: CV914-0273 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-GASTRIC`
+**File:** `bma_pms2_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:475`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_germline_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 111/345: CV914-0276 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-GASTRIC`
+**File:** `bma_pms2_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:480`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)' contains drug name(s) ['folfox', 'capeox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_somatic_gastric.yaml: recommended_combinations includes 'nivolumab + FOLFOX/CapeOX (1L MSI-H gastric, CheckMate-649)', but regulatory_approval does not mention folfox, capeox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 112/345: CV914-0288 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-BREAST`
+**File:** `bma_tp53_mut_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:500`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual TNBC algorithm (KEYNOTE-522)' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_mut_breast.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 113/345: CV914-0313 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-SOMATIC-PROSTATE`
+**File:** `bma_atm_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:545`
+
+**Audit finding text:**
+```
+recommended_combination 'talazoparib + enzalutamide (1L, HRR-mut)' contains drug name(s) ['talazoparib', 'enzalutamide'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_somatic_prostate.yaml: recommended_combinations includes 'talazoparib + enzalutamide (1L, HRR-mut)', but regulatory_approval does not mention talazoparib, enzalutamide. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 114/345: CV914-0317 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCR-ABL1-P190-BALL`
+**File:** `bma_bcr_abl1_p190_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:553`
+
+**Audit finding text:**
+```
+recommended_combination 'ponatinib + hyper-CVAD (1L)' contains drug name(s) ['hyper-cvad'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcr_abl1_p190_ball.yaml: recommended_combinations includes 'ponatinib + hyper-CVAD (1L)', but regulatory_approval does not mention hyper-cvad. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 115/345: CV914-0331 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CHEK2-GERMLINE-PROSTATE`
+**File:** `bma_chek2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:581`
+
+**Audit finding text:**
+```
+recommended_combination 'talazoparib + enzalutamide (HRR-mutated 1L)' contains drug name(s) ['talazoparib', 'enzalutamide'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_chek2_germline_prostate.yaml: recommended_combinations includes 'talazoparib + enzalutamide (HRR-mutated 1L)', but regulatory_approval does not mention talazoparib, enzalutamide. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 116/345: CV914-0333 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CHEK2-SOMATIC-PROSTATE`
+**File:** `bma_chek2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:585`
+
+**Audit finding text:**
+```
+recommended_combination 'talazoparib + enzalutamide (HRR-mutated 1L)' contains drug name(s) ['talazoparib', 'enzalutamide'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_chek2_somatic_prostate.yaml: recommended_combinations includes 'talazoparib + enzalutamide (HRR-mutated 1L)', but regulatory_approval does not mention talazoparib, enzalutamide. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 117/345: CV914-0343 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132G-AML`
+**File:** `bma_idh1_r132g_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:605`
+
+**Audit finding text:**
+```
+recommended_combination 'olutasidenib' contains drug name(s) ['olutasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132g_aml.yaml: recommended_combinations includes 'olutasidenib', but regulatory_approval does not mention olutasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 118/345: CV914-0349 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132L-AML`
+**File:** `bma_idh1_r132l_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:617`
+
+**Audit finding text:**
+```
+recommended_combination 'olutasidenib' contains drug name(s) ['olutasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132l_aml.yaml: recommended_combinations includes 'olutasidenib', but regulatory_approval does not mention olutasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 119/345: CV914-0351 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132S-AML`
+**File:** `bma_idh1_r132s_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:621`
+
+**Audit finding text:**
+```
+recommended_combination 'olutasidenib' contains drug name(s) ['olutasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132s_aml.yaml: recommended_combinations includes 'olutasidenib', but regulatory_approval does not mention olutasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 120/345: CV914-0357 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-EXON11-GIST`
+**File:** `bma_kit_exon11_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:633`
+
+**Audit finding text:**
+```
+recommended_combination ''imatinib 400 mg/day adjuvant 3 yr (high-risk resected: >=3 cm + mitoses >=5/50 HPF, or rupture, or non-gastric primary)'' contains drug name(s) [''day''] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_exon11_gist.yaml: recommended_combinations includes 'imatinib 400 mg/day adjuvant 3 yr (high-risk resected: >=3 cm + mitoses >=5/50 HPF, or rupture, or non-gastric primary)', but regulatory_approval does not mention day. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 121/345: CV914-0361 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-EXON9-GIST`
+**File:** `bma_kit_exon9_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:641`
+
+**Audit finding text:**
+```
+recommended_combination 'imatinib 800 mg/day split BID (1L advanced/metastatic exon 9)' contains drug name(s) ['day'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_exon9_gist.yaml: recommended_combinations includes 'imatinib 800 mg/day split BID (1L advanced/metastatic exon 9)', but regulatory_approval does not mention day. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 122/345: CV914-0365 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MET-AMP-NSCLC`
+**File:** `bma_met_amp_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:649`
+
+**Audit finding text:**
+```
+recommended_combination 'amivantamab + lazertinib (post-EGFR-TKI MET-amp resistance, MARIPOSA-2 / SAVANNAH context)' contains drug name(s) ['amivantamab', 'lazertinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_met_amp_nsclc.yaml: recommended_combinations includes 'amivantamab + lazertinib (post-EGFR-TKI MET-amp resistance, MARIPOSA-2 / SAVANNAH context)', but regulatory_approval does not mention amivantamab, lazertinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 123/345: CV914-0370 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-MLH1-GERMLINE-CRC`
+**File:** `bma_mlh1_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:660`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_ger...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 124/345: CV914-0373 - unclear -> maintainer_review
+
+**Entity:** `BMA-MLH1-GERMLINE-OVARIAN`
+**File:** `bma_mlh1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:665`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_mlh1_germline_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 125/345: CV914-0375 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-GERMLINE-PROSTATE`
+**File:** `bma_mlh1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:669`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 126/345: CV914-0376 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-MLH1-SOMATIC-CRC`
+**File:** `bma_mlh1_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:672`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_som...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 127/345: CV914-0379 - unclear -> maintainer_review
+
+**Entity:** `BMA-MLH1-SOMATIC-OVARIAN`
+**File:** `bma_mlh1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:677`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_mlh1_somatic_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 128/345: CV914-0381 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MLH1-SOMATIC-PROSTATE`
+**File:** `bma_mlh1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:681`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_mlh1_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 129/345: CV914-0382 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-CRC`
+**File:** `bma_msh2_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:684`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_msh2_ger...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 130/345: CV914-0385 - unclear -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-OVARIAN`
+**File:** `bma_msh2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:689`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_msh2_germline_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 131/345: CV914-0387 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-PROSTATE`
+**File:** `bma_msh2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:693`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 132/345: CV914-0388 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-CRC`
+**File:** `bma_msh2_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:696`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_msh2_som...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 133/345: CV914-0391 - unclear -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-OVARIAN`
+**File:** `bma_msh2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:701`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_msh2_somatic_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 134/345: CV914-0393 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-PROSTATE`
+**File:** `bma_msh2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:705`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 135/345: CV914-0394 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-CRC`
+**File:** `bma_msh6_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:708`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_msh6_ger...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 136/345: CV914-0397 - unclear -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-OVARIAN`
+**File:** `bma_msh6_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:713`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_msh6_germline_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 137/345: CV914-0399 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-PROSTATE`
+**File:** `bma_msh6_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:717`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 138/345: CV914-0400 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-CRC`
+**File:** `bma_msh6_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:720`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_msh6_som...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 139/345: CV914-0403 - unclear -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-OVARIAN`
+**File:** `bma_msh6_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:725`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_msh6_somatic_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 140/345: CV914-0405 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-PROSTATE`
+**File:** `bma_msh6_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:729`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 141/345: CV914-0406 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-CRC`
+**File:** `bma_pms2_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:732`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_pms2_ger...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 142/345: CV914-0409 - unclear -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-OVARIAN`
+**File:** `bma_pms2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:737`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_pms2_germline_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 143/345: CV914-0411 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-PROSTATE`
+**File:** `bma_pms2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:741`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 144/345: CV914-0412 - access_blocked -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-CRC`
+**File:** `bma_pms2_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:744`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/biomarker_actionability/bma_pms2_som...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 145/345: CV914-0415 - unclear -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-OVARIAN`
+**File:** `bma_pms2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:749`
+
+**Audit finding text:**
+```
+recommended_combination 'standard EOC therapy by HRD/BRCA status' contains drug name(s) ['brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_pms2_somatic_ovarian.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 146/345: CV914-0417 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-PROSTATE`
+**File:** `bma_pms2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:753`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 147/345: CV914-0426 - access_blocked -> maintainer_review
+
+**Entity:** `IND-APL-1L-ATRA-ATO-IDA`
+**File:** `ind_apl_1l_atra_ato_ida.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:772`
+
+**Audit finding text:**
+```
+trial ''APL0406'' mentioned but no matching source citation (looked for substrings: [''APL0406'', ''PETHEMA'', ''LOCOCO''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'APL0406' to existing source SRC-APL0406-LOCOCO-2013 at knowledge_base/hosted/content/sources/src_apl0406_lococo_2013.yaml. The source title is 'Retinoic acid and arsenic trioxide for acute promyelocytic leukemia'; source notes identify the trial/source context as: 'APL0406 phase-3 RCT: ATRA + ATO vs ATRA + chemotherapy (AIDA) in low/intermediate-risk APL (WBC ≤10). 2-y EFS 97% vs 86%, OS 99% vs 91%. Established chemotherapy-free ATRA+ATO as standard for low-risk APL.'. Current entity locator knowledge_base/hosted/content/indications/ind_apl_1l_atra_ato_ida.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1300874 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 148/345: CV914-0428 - access_blocked -> maintainer_review
+
+**Entity:** `IND-BREAST-BRCA-POS-MET-PARPI`
+**File:** `ind_breast_brca_pos_met_parpi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:776`
+
+**Audit finding text:**
+```
+trial ''OLYMPIAD'' mentioned but no matching source citation (looked for substrings: [''OLYMPIAD'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'OLYMPIAD' to existing source SRC-OLYMPIAD-ROBSON-2017 at knowledge_base/hosted/content/sources/src_olympiad_robson_2017.yaml. The source title is 'Olaparib for Metastatic Breast Cancer in Patients with a Germline BRCA Mutation'; source notes identify the trial/source context as: 'OlympiAD phase-3: olaparib 300 mg PO BID vs physician-choice single-agent chemo (capecitabine, eribulin, vinorelbine) in germline BRCA1/2-mutant HER2- metastatic breast (≤2 prior chemo lines for metastatic disease; HR+ subset must have progressed on ≥1 endocrine line). Median PFS 7.0 vs 4.2 mo (HR 0.58, p<0.001); ORR 60% vs 29%; OS not significantly improved'. Current entity locator knowledge_base/hosted/content/indications/ind_breast_brca_pos_met_parpi.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1706450 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 149/345: CV914-0429 - access_blocked -> maintainer_review
+
+**Entity:** `IND-BREAST-BRCA-POS-MET-PARPI`
+**File:** `ind_breast_brca_pos_met_parpi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:777`
+
+**Audit finding text:**
+```
+trial ''EMBRACA'' mentioned but no matching source citation (looked for substrings: [''EMBRACA'', ''TALAZOPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'EMBRACA' to existing source SRC-EMBRACA-LITTON-2018 at knowledge_base/hosted/content/sources/src_embraca_litton_2018.yaml. The source title is 'Talazoparib in Patients with Advanced Breast Cancer and a Germline BRCA Mutation'; source notes identify the trial/source context as: 'EMBRACA phase-3: talazoparib 1 mg PO daily vs physician-choice single-agent chemo in germline BRCA1/2-mutant HER2- metastatic breast (≤3 prior cytotoxic regimens). Median PFS 8.6 vs 5.6 mo (HR 0.54, p<0.001); ORR 62.6% vs 27.2%. Anemia G3+ (39%) more pronounced than with olaparib; nausea, fatigue, alopecia common. Established talazoparib as alternative PARPi'. Current entity locator knowledge_base/hosted/content/indications/ind_breast_brca_pos_met_parpi.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1802905 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 150/345: CV914-0447 - access_blocked -> maintainer_review
+
+**Entity:** `IND-FL-1L-BR`
+**File:** `ind_fl_1l_br.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:813`
+
+**Audit finding text:**
+```
+trial ''PRIMA'' mentioned but no matching source citation (looked for substrings: [''PRIMA'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PRIMA'. Prior candidate SRC-DIPSS-PLUS-GANGAT-2011 failed strict trial-name verification. Existing trial-specific source SRC-PRIMA-GONZALEZ-MARTIN-2019 at knowledge_base/hosted/content/sources/src_prima_gonzalez_martin_2019.yaml matches by source id/title ('Niraparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'), but its URL is publisher-blocked/subscription-gated for this run; maintainer should review before mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-DIPSS-PLUS-GANGAT-2011 rejected; remapped to trial-specific existing source SRC-PRIMA-GONZALEZ-MARTIN-2019 because the trial name appears in source id/title.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 151/345: CV914-0456 - access_blocked -> maintainer_review
+
+**Entity:** `IND-NSCLC-EGFR-MAINT-OSIMERTINIB`
+**File:** `ind_nsclc_egfr_maint_osimertinib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:832`
+
+**Audit finding text:**
+```
+trial ''FLAURA'' mentioned but no matching source citation (looked for substrings: [''FLAURA'', ''OSIMERTINIB'', ''AURA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'FLAURA' to existing source SRC-FLAURA-SORIA-2018 at knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml. The source title is 'Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer'; source notes identify the trial/source context as: 'FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs standard-of-care 1st-gen EGFR-TKI (gefitinib or erlotinib) in treatment-naive EGFR-mutated (exon 19 del / L858R) advanced NSCLC. Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final OS analysis (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS PFS markedly improved (HR 0.48). Estab'. Current entity locator knowledge_base/hosted/content/indications/ind_nsclc_egfr_maint_osimertinib.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1713137 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 152/345: CV914-0462 - access_blocked -> maintainer_review
+
+**Entity:** `IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-NEG`
+**File:** `ind_ovarian_advanced_1l_carbo_pacli_hrd_neg.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:844`
+
+**Audit finding text:**
+```
+trial ''PRIMA'' mentioned but no matching source citation (looked for substrings: [''PRIMA'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PRIMA'. Prior candidate SRC-DIPSS-PLUS-GANGAT-2011 failed strict trial-name verification. Existing trial-specific source SRC-PRIMA-GONZALEZ-MARTIN-2019 at knowledge_base/hosted/content/sources/src_prima_gonzalez_martin_2019.yaml matches by source id/title ('Niraparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'), but its URL is publisher-blocked/subscription-gated for this run; maintainer should review before mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-DIPSS-PLUS-GANGAT-2011 rejected; remapped to trial-specific existing source SRC-PRIMA-GONZALEZ-MARTIN-2019 because the trial name appears in source id/title.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 153/345: CV914-0464 - access_blocked -> maintainer_review
+
+**Entity:** `IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-OLAP`
+**File:** `ind_ovarian_advanced_1l_carbo_pacli_hrd_olap.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:848`
+
+**Audit finding text:**
+```
+trial ''SOLO-1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO-1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/indications/ind_ovarian_advanced_1l_carbo_pacli_hrd_olap.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 154/345: CV914-0466 - access_blocked -> maintainer_review
+
+**Entity:** `IND-OVARIAN-MAINTENANCE-OLAPARIB`
+**File:** `ind_ovarian_maintenance_olaparib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:852`
+
+**Audit finding text:**
+```
+trial ''SOLO-1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO-1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/indications/ind_ovarian_maintenance_olaparib.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 155/345: CV914-0493 - access_blocked -> maintainer_review
+
+**Entity:** `REG-OLAPARIB-BREAST`
+**File:** `reg_olaparib_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:905`
+
+**Audit finding text:**
+```
+trial ''OLYMPIAD'' mentioned but no matching source citation (looked for substrings: [''OLYMPIAD'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'OLYMPIAD' to existing source SRC-OLYMPIAD-ROBSON-2017 at knowledge_base/hosted/content/sources/src_olympiad_robson_2017.yaml. The source title is 'Olaparib for Metastatic Breast Cancer in Patients with a Germline BRCA Mutation'; source notes identify the trial/source context as: 'OlympiAD phase-3: olaparib 300 mg PO BID vs physician-choice single-agent chemo (capecitabine, eribulin, vinorelbine) in germline BRCA1/2-mutant HER2- metastatic breast (≤2 prior chemo lines for metastatic disease; HR+ subset must have progressed on ≥1 endocrine line). Median PFS 7.0 vs 4.2 mo (HR 0.58, p<0.001); ORR 60% vs 29%; OS not significantly improved'. Current entity locator knowledge_base/hosted/content/regimens/reg_olaparib_breast.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1706450 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 156/345: CV914-0494 - access_blocked -> maintainer_review
+
+**Entity:** `REG-OLAPARIB-MAINT-OVARIAN`
+**File:** `olaparib_maintenance_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:908`
+
+**Audit finding text:**
+```
+trial ''SOLO-1'' mentioned but no matching source citation (looked for substrings: [''SOLO'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'SOLO-1' to existing source SRC-SOLO1-MOORE-2018 at knowledge_base/hosted/content/sources/src_solo1_moore_2018.yaml. The source title is 'Maintenance Olaparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'; source notes identify the trial/source context as: 'SOLO-1 phase-3 (NCT01844986): olaparib 300 mg PO BID maintenance for up to 2 years vs placebo in BRCA1/2-mutant advanced ovarian cancer in CR/PR after 1L platinum-based chemo. Median PFS not reached vs 13.8 mo (HR 0.30, p<0.001); 3-year PFS 60% vs 27%. 7-year update (DiSilvestro JCO 2023) showed durable PFS/OS benefit. Established olaparib as 1L maintenance '. Current entity locator knowledge_base/hosted/content/regimens/olaparib_maintenance_ovarian.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1810858 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 157/345: CV914-0496 - access_blocked -> maintainer_review
+
+**Entity:** `REG-OSIMERTINIB-NSCLC`
+**File:** `reg_osimertinib_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:912`
+
+**Audit finding text:**
+```
+trial ''FLAURA'' mentioned but no matching source citation (looked for substrings: [''FLAURA'', ''OSIMERTINIB'', ''AURA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'FLAURA' to existing source SRC-FLAURA-SORIA-2018 at knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml. The source title is 'Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer'; source notes identify the trial/source context as: 'FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs standard-of-care 1st-gen EGFR-TKI (gefitinib or erlotinib) in treatment-naive EGFR-mutated (exon 19 del / L858R) advanced NSCLC. Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final OS analysis (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS PFS markedly improved (HR 0.48). Estab'. Current entity locator knowledge_base/hosted/content/regimens/reg_osimertinib_nsclc.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1713137 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 158/345: CV914-0504 - access_blocked -> maintainer_review
+
+**Entity:** `REG-SACITUZUMAB`
+**File:** `reg_sacituzumab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:928`
+
+**Audit finding text:**
+```
+trial ''ASCENT'' mentioned but no matching source citation (looked for substrings: [''ASCENT'', ''SACITUZUMAB''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'ASCENT' to existing source SRC-ASCENT-BARDIA-2021 at knowledge_base/hosted/content/sources/src_ascent_bardia_2021.yaml. The source title is 'Sacituzumab Govitecan in Metastatic Triple-Negative Breast Cancer'; source notes identify the trial/source context as: 'ASCENT phase-3: sacituzumab govitecan 10 mg/kg IV days 1, 8 q3w vs physician-choice single-agent chemo (eribulin, vinorelbine, capecitabine, gemcitabine) in metastatic TNBC pretreated with ≥2 prior chemo lines (≥1 in metastatic setting). Brain-mets- negative cohort (n=468): median PFS 5.6 vs 1.7 mo (HR 0.41, p<0.001); median OS 12.1 vs 6.7 mo (HR 0.48, p<0.0'. Current entity locator knowledge_base/hosted/content/regimens/reg_sacituzumab.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2028485 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 159/345: CV914-0508 - access_blocked -> maintainer_review
+
+**Entity:** `REG-TDXD-METASTATIC`
+**File:** `reg_tdxd_metastatic.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:936`
+
+**Audit finding text:**
+```
+trial ''DESTINY-Breast03'' mentioned but no matching source citation (looked for substrings: [''DESTINY-BREAST03'', ''TDXD'', ''TRASTUZUMAB-DERUXTECAN''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'DESTINY-Breast03' to existing source SRC-DESTINY-BREAST03-CORTES-2022 at knowledge_base/hosted/content/sources/src_destiny_breast03_cortes_2022.yaml. The source title is 'Trastuzumab Deruxtecan versus Trastuzumab Emtansine for Breast Cancer'; source notes identify the trial/source context as: 'DESTINY-Breast03 phase-3: T-DXd 5.4 mg/kg q3w vs T-DM1 3.6 mg/kg q3w in HER2+ metastatic breast pretreated with trastuzumab + taxane. Median PFS 28.8 vs 6.8 mo by BICR (HR 0.33, p<0.001); 12-mo PFS 75.8% vs 34.1%; ORR 79% vs 34%. ILD any-grade 10.5%, G3+ 0.8%. Established T-DXd as preferred 2L for HER2+ metastatic post-THP, superior to T-DM1. NOTE: task brie'. Current entity locator knowledge_base/hosted/content/regimens/reg_tdxd_metastatic.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2115022 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 160/345: CV914-0509 - access_blocked -> maintainer_review
+
+**Entity:** `REG-TDXD-METASTATIC`
+**File:** `reg_tdxd_metastatic.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:937`
+
+**Audit finding text:**
+```
+trial ''DESTINY-Breast04'' mentioned but no matching source citation (looked for substrings: [''DESTINY-BREAST04'', ''TDXD'', ''TRASTUZUMAB-DERUXTECAN''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'DESTINY-Breast04' to existing source SRC-DESTINY-BREAST04-MODI-2022 at knowledge_base/hosted/content/sources/src_destiny_breast04_modi_2022.yaml. The source title is 'Trastuzumab Deruxtecan in Previously Treated HER2-Low Advanced Breast Cancer'; source notes identify the trial/source context as: 'DESTINY-Breast04 phase-3: T-DXd 5.4 mg/kg q3w vs physician-choice chemo in HER2-low (IHC 1+ or IHC 2+/ISH-) advanced breast pretreated with 1-2 prior chemo lines for metastatic disease (HR+ cohort had to have progressed on endocrine ± CDK4/6i first). HR+ cohort (n=494): median PFS 10.1 vs 5.4 mo (HR 0.51, p<0.001); median OS 23.9 vs 17.5 mo (HR 0.64, p=0.003'. Current entity locator knowledge_base/hosted/content/regimens/reg_tdxd_metastatic.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2203690 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 161/345: CV914-0557 - access_blocked -> maintainer_review
+
+**Entity:** `IND-B-ALL-POST-CONSOLIDATION-POMP-MAINTENANCE`
+**File:** `ind_b_all_post_consolidation_pomp_maintenance.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1077`
+
+**Audit finding text:**
+```
+trial ''QUAZAR'' mentioned but no matching source citation (looked for substrings: [''QUAZAR'', ''ORAL-AZA'', ''CC-486''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'QUAZAR' to existing source SRC-QUAZAR-WEI-2020 at knowledge_base/hosted/content/sources/src_quazar_wei_2020.yaml. The source title is 'Oral azacitidine maintenance therapy for acute myeloid leukemia in first remission (QUAZAR AML-001)'; source notes identify the trial/source context as: 'QUAZAR AML-001 phase-3: oral azacitidine (CC-486 / Onureg) 300 mg PO daily × 14 d / 28-d cycle vs placebo as maintenance after CR/CRi post-induction ± consolidation in AML patients ≥55 years not eligible for HCT. Median OS 24.7 vs 14.8 months (HR 0.69; p<0.001), median RFS 10.2 vs 4.8 months. FDA-approved Sep 2020. Established oral azacitidine as standard of'. Current entity locator knowledge_base/hosted/content/indications/ind_b_all_post_consolidation_pomp_maintenance.yaml does not cite th...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2004444 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 162/345: CV914-0560 - access_blocked -> maintainer_review
+
+**Entity:** `IND-BREAST-HER2-POS-MET-2L-TDXD`
+**File:** `ind_breast_her2_pos_met_2l_tdxd.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1086`
+
+**Audit finding text:**
+```
+trial ''DESTINY-Breast03'' mentioned but no matching source citation (looked for substrings: [''DESTINY-BREAST03'', ''TDXD'', ''TRASTUZUMAB-DERUXTECAN''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'DESTINY-Breast03' to existing source SRC-DESTINY-BREAST03-CORTES-2022 at knowledge_base/hosted/content/sources/src_destiny_breast03_cortes_2022.yaml. The source title is 'Trastuzumab Deruxtecan versus Trastuzumab Emtansine for Breast Cancer'; source notes identify the trial/source context as: 'DESTINY-Breast03 phase-3: T-DXd 5.4 mg/kg q3w vs T-DM1 3.6 mg/kg q3w in HER2+ metastatic breast pretreated with trastuzumab + taxane. Median PFS 28.8 vs 6.8 mo by BICR (HR 0.33, p<0.001); 12-mo PFS 75.8% vs 34.1%; ORR 79% vs 34%. ILD any-grade 10.5%, G3+ 0.8%. Established T-DXd as preferred 2L for HER2+ metastatic post-THP, superior to T-DM1. NOTE: task brie'. Current entity locator knowledge_base/hosted/content/indications/ind_breast_her2_pos_met_2l_tdxd.yaml does not cite this sourc...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2115022 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 163/345: CV914-0569 - access_blocked -> maintainer_review
+
+**Entity:** `IND-CRC-METASTATIC-1L-MSI-H-PEMBRO`
+**File:** `ind_crc_metastatic_1l_msi_h_pembro.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1113`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/indications/ind_crc_metastatic_1l_ms...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 164/345: CV914-0571 - access_blocked -> maintainer_review
+
+**Entity:** `IND-CRC-METASTATIC-2L-BRAF-BEACON`
+**File:** `ind_crc_metastatic_2l_braf_beacon.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1119`
+
+**Audit finding text:**
+```
+trial ''BEACON'' mentioned but no matching source citation (looked for substrings: [''BEACON'', ''ENCORAFENIB'', ''KOPETZ''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'BEACON' to existing source SRC-BEACON-CRC-KOPETZ-2019 at knowledge_base/hosted/content/sources/src_beacon_crc_kopetz_2019.yaml. The source title is 'Encorafenib, Binimetinib, and Cetuximab in BRAF V600E-Mutated Colorectal Cancer'; source notes identify the trial/source context as: 'BEACON CRC phase-3 (NCT02928224): encorafenib 300 mg PO daily + binimetinib 45 mg BID + cetuximab vs encorafenib + cetuximab vs control (FOLFIRI/irinotecan + cetuximab) in BRAF V600E-mutated metastatic CRC after 1–2 prior lines. Triplet mOS 9.0 vs 5.4 mo (HR 0.52, p<0.001); ORR 26% vs 2%. Doublet (enco+cetux) mOS 8.4 mo, HR 0.60. Established BRAFi + EGFRi (±'. Current entity locator knowledge_base/hosted/content/indications/ind_crc_metastatic_2l_braf_beacon.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908075 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 165/345: CV914-0572 - access_blocked -> maintainer_review
+
+**Entity:** `IND-CRC-METASTATIC-2L-FOLFIRI-BEV`
+**File:** `ind_crc_metastatic_2l_folfiri_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1122`
+
+**Audit finding text:**
+```
+trial ''BEACON'' mentioned but no matching source citation (looked for substrings: [''BEACON'', ''ENCORAFENIB'', ''KOPETZ''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'BEACON' to existing source SRC-BEACON-CRC-KOPETZ-2019 at knowledge_base/hosted/content/sources/src_beacon_crc_kopetz_2019.yaml. The source title is 'Encorafenib, Binimetinib, and Cetuximab in BRAF V600E-Mutated Colorectal Cancer'; source notes identify the trial/source context as: 'BEACON CRC phase-3 (NCT02928224): encorafenib 300 mg PO daily + binimetinib 45 mg BID + cetuximab vs encorafenib + cetuximab vs control (FOLFIRI/irinotecan + cetuximab) in BRAF V600E-mutated metastatic CRC after 1–2 prior lines. Triplet mOS 9.0 vs 5.4 mo (HR 0.52, p<0.001); ORR 26% vs 2%. Doublet (enco+cetux) mOS 8.4 mo, HR 0.60. Established BRAFi + EGFRi (±'. Current entity locator knowledge_base/hosted/content/indications/ind_crc_metastatic_2l_folfiri_bev.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908075 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 166/345: CV914-0573 - access_blocked -> maintainer_review
+
+**Entity:** `IND-CRC-METASTATIC-3L-TAS102-BEV`
+**File:** `ind_crc_metastatic_3l_tas102_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1125`
+
+**Audit finding text:**
+```
+trial ''BEACON'' mentioned but no matching source citation (looked for substrings: [''BEACON'', ''ENCORAFENIB'', ''KOPETZ''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'BEACON' to existing source SRC-BEACON-CRC-KOPETZ-2019 at knowledge_base/hosted/content/sources/src_beacon_crc_kopetz_2019.yaml. The source title is 'Encorafenib, Binimetinib, and Cetuximab in BRAF V600E-Mutated Colorectal Cancer'; source notes identify the trial/source context as: 'BEACON CRC phase-3 (NCT02928224): encorafenib 300 mg PO daily + binimetinib 45 mg BID + cetuximab vs encorafenib + cetuximab vs control (FOLFIRI/irinotecan + cetuximab) in BRAF V600E-mutated metastatic CRC after 1–2 prior lines. Triplet mOS 9.0 vs 5.4 mo (HR 0.52, p<0.001); ORR 26% vs 2%. Doublet (enco+cetux) mOS 8.4 mo, HR 0.60. Established BRAFi + EGFRi (±'. Current entity locator knowledge_base/hosted/content/indications/ind_crc_metastatic_3l_tas102_bev.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908075 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 167/345: CV914-0581 - access_blocked -> maintainer_review
+
+**Entity:** `IND-FL-POST-INDUCTION-RITUXIMAB-MAINTENANCE`
+**File:** `ind_fl_post_induction_rituximab_maintenance.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1149`
+
+**Audit finding text:**
+```
+trial ''PRIMA'' mentioned but no matching source citation (looked for substrings: [''PRIMA'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PRIMA'. Prior candidate SRC-DIPSS-PLUS-GANGAT-2011 failed strict trial-name verification. Existing trial-specific source SRC-PRIMA-GONZALEZ-MARTIN-2019 at knowledge_base/hosted/content/sources/src_prima_gonzalez_martin_2019.yaml matches by source id/title ('Niraparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'), but its URL is publisher-blocked/subscription-gated for this run; maintainer should review before mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-DIPSS-PLUS-GANGAT-2011 rejected; remapped to trial-specific existing source SRC-PRIMA-GONZALEZ-MARTIN-2019 because the trial name appears in source id/title.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 168/345: CV914-0585 - access_blocked -> maintainer_review
+
+**Entity:** `IND-MDS-LR-1L-ESA`
+**File:** `ind_mds_lr_1l_esa.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1161`
+
+**Audit finding text:**
+```
+trial ''COMMANDS'' mentioned but no matching source citation (looked for substrings: [''COMMANDS''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'COMMANDS' to existing source SRC-COMMANDS-FENAUX-2020 at knowledge_base/hosted/content/sources/src_command_fenaux_2020.yaml. The source title is 'Luspatercept in Patients with Lower-Risk Myelodysplastic Syndromes'; source notes identify the trial/source context as: 'MEDALIST phase-3 RCT: luspatercept vs placebo in lower-risk MDS with ring sideroblasts and RBC transfusion dependence. RBC transfusion independence ≥8 wk 38% vs 13%. Established luspatercept as 2L (post-ESA failure) in LR-MDS-RS. The COMMANDS trial later established luspatercept as 1L; this MEDALIST entry is the foundational regulatory pivot.'. Current entity locator knowledge_base/hosted/content/indications/ind_mds_lr_1l_esa.yaml already cites this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908892 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 169/345: CV914-0586 - access_blocked -> maintainer_review
+
+**Entity:** `IND-MELANOMA-METASTATIC-1L-NIVO-IPI`
+**File:** `ind_melanoma_metastatic_1l_nivo_ipi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1164`
+
+**Audit finding text:**
+```
+trial ''CheckMate-067'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-067'', ''CHECKMATE067''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'CheckMate-067' to existing source SRC-CHECKMATE-067-LARKIN-2019 at knowledge_base/hosted/content/sources/src_checkmate_067_larkin_2019.yaml. The source title is 'Five-Year Survival with Combined Nivolumab and Ipilimumab in Advanced Melanoma'; source notes identify the trial/source context as: 'CheckMate-067 phase 3 (NCT01844505): nivolumab + ipilimumab vs nivolumab vs ipilimumab in untreated unresectable/metastatic melanoma. 5-year OS 52% (combo) vs 44% (nivo) vs 26% (ipi); mOS >60 mo (combo) vs 36.9 mo (nivo) vs 19.9 mo (ipi). 7.5-year update (Wolchok 2022): OS 49% (combo). Defines ipi+nivo doublet as 1L standard. Used here as the IO doublet salv'. Current entity locator knowledge_base/hosted/content/indications/ind_melanoma_metastatic_1l_nivo_ipi.yaml does not cite this s...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1910836 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 170/345: CV914-0587 - access_blocked -> maintainer_review
+
+**Entity:** `IND-MELANOMA-NIVO-MAINT`
+**File:** `ind_melanoma_nivo_maint.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1167`
+
+**Audit finding text:**
+```
+trial ''CheckMate-067'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-067'', ''CHECKMATE067''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'CheckMate-067' to existing source SRC-CHECKMATE-067-LARKIN-2019 at knowledge_base/hosted/content/sources/src_checkmate_067_larkin_2019.yaml. The source title is 'Five-Year Survival with Combined Nivolumab and Ipilimumab in Advanced Melanoma'; source notes identify the trial/source context as: 'CheckMate-067 phase 3 (NCT01844505): nivolumab + ipilimumab vs nivolumab vs ipilimumab in untreated unresectable/metastatic melanoma. 5-year OS 52% (combo) vs 44% (nivo) vs 26% (ipi); mOS >60 mo (combo) vs 36.9 mo (nivo) vs 19.9 mo (ipi). 7.5-year update (Wolchok 2022): OS 49% (combo). Defines ipi+nivo doublet as 1L standard. Used here as the IO doublet salv'. Current entity locator knowledge_base/hosted/content/indications/ind_melanoma_nivo_maint.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1910836 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 171/345: CV914-0594 - access_blocked -> maintainer_review
+
+**Entity:** `IND-NSCLC-EGFR-MUT-MET-1L`
+**File:** `ind_nsclc_egfr_mut_met_1l.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1188`
+
+**Audit finding text:**
+```
+trial ''FLAURA'' mentioned but no matching source citation (looked for substrings: [''FLAURA'', ''OSIMERTINIB'', ''AURA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'FLAURA' to existing source SRC-FLAURA-SORIA-2018 at knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml. The source title is 'Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer'; source notes identify the trial/source context as: 'FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs standard-of-care 1st-gen EGFR-TKI (gefitinib or erlotinib) in treatment-naive EGFR-mutated (exon 19 del / L858R) advanced NSCLC. Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final OS analysis (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS PFS markedly improved (HR 0.48). Estab'. Current entity locator knowledge_base/hosted/content/indications/ind_nsclc_egfr_mut_met_1l.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1713137 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 172/345: CV914-0619 - access_blocked -> maintainer_review
+
+**Entity:** `REG-AZA-MDS-HR`
+**File:** `azacitidine_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1263`
+
+**Audit finding text:**
+```
+trial ''VIALE-A'' mentioned but no matching source citation (looked for substrings: [''VIALE-A'', ''VIALEA'', ''VEN-AZA''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'VIALE-A' to existing source SRC-VIALE-A-DINARDO-2020 at knowledge_base/hosted/content/sources/src_viale_a_dinardo_2020.yaml. The source title is 'Azacitidine and Venetoclax in Previously Untreated Acute Myeloid Leukemia'; source notes identify the trial/source context as: 'VIALE-A pivotal phase-3 RCT: ven + aza vs aza alone in newly-diagnosed AML unfit for intensive chemo. Median OS 14.7 vs 9.6 mo (HR 0.66). Established ven+aza as 1L standard for unfit AML.'. Current entity locator knowledge_base/hosted/content/regimens/azacitidine_mds_hr.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2012971 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 173/345: CV914-0627 - access_blocked -> maintainer_review
+
+**Entity:** `REG-ENCORAFENIB-CETUXIMAB`
+**File:** `encorafenib_cetuximab_beacon.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1287`
+
+**Audit finding text:**
+```
+trial ''BEACON'' mentioned but no matching source citation (looked for substrings: [''BEACON'', ''ENCORAFENIB'', ''KOPETZ''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'BEACON' to existing source SRC-BEACON-CRC-KOPETZ-2019 at knowledge_base/hosted/content/sources/src_beacon_crc_kopetz_2019.yaml. The source title is 'Encorafenib, Binimetinib, and Cetuximab in BRAF V600E-Mutated Colorectal Cancer'; source notes identify the trial/source context as: 'BEACON CRC phase-3 (NCT02928224): encorafenib 300 mg PO daily + binimetinib 45 mg BID + cetuximab vs encorafenib + cetuximab vs control (FOLFIRI/irinotecan + cetuximab) in BRAF V600E-mutated metastatic CRC after 1–2 prior lines. Triplet mOS 9.0 vs 5.4 mo (HR 0.52, p<0.001); ORR 26% vs 2%. Doublet (enco+cetux) mOS 8.4 mo, HR 0.60. Established BRAFi + EGFRi (±'. Current entity locator knowledge_base/hosted/content/regimens/encorafenib_cetuximab_beacon.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908075 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 174/345: CV914-0630 - access_blocked -> maintainer_review
+
+**Entity:** `REG-ESA-MDS-LR`
+**File:** `esa_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1296`
+
+**Audit finding text:**
+```
+trial ''COMMANDS'' mentioned but no matching source citation (looked for substrings: [''COMMANDS''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'COMMANDS' to existing source SRC-COMMANDS-FENAUX-2020 at knowledge_base/hosted/content/sources/src_command_fenaux_2020.yaml. The source title is 'Luspatercept in Patients with Lower-Risk Myelodysplastic Syndromes'; source notes identify the trial/source context as: 'MEDALIST phase-3 RCT: luspatercept vs placebo in lower-risk MDS with ring sideroblasts and RBC transfusion dependence. RBC transfusion independence ≥8 wk 38% vs 13%. Established luspatercept as 2L (post-ESA failure) in LR-MDS-RS. The COMMANDS trial later established luspatercept as 1L; this MEDALIST entry is the foundational regulatory pivot.'. Current entity locator knowledge_base/hosted/content/regimens/esa_mds_lr.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1908892 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 175/345: CV914-0635 - access_blocked -> maintainer_review
+
+**Entity:** `REG-NIVO-IPI-MELANOMA`
+**File:** `reg_nivo_ipi_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1311`
+
+**Audit finding text:**
+```
+trial ''CheckMate-067'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-067'', ''CHECKMATE067''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'CheckMate-067' to existing source SRC-CHECKMATE-067-LARKIN-2019 at knowledge_base/hosted/content/sources/src_checkmate_067_larkin_2019.yaml. The source title is 'Five-Year Survival with Combined Nivolumab and Ipilimumab in Advanced Melanoma'; source notes identify the trial/source context as: 'CheckMate-067 phase 3 (NCT01844505): nivolumab + ipilimumab vs nivolumab vs ipilimumab in untreated unresectable/metastatic melanoma. 5-year OS 52% (combo) vs 44% (nivo) vs 26% (ipi); mOS >60 mo (combo) vs 36.9 mo (nivo) vs 19.9 mo (ipi). 7.5-year update (Wolchok 2022): OS 49% (combo). Defines ipi+nivo doublet as 1L standard. Used here as the IO doublet salv'. Current entity locator knowledge_base/hosted/content/regimens/reg_nivo_ipi_melanoma.yaml does not cite this source.
+
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa1910836 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 176/345: CV914-0642 - access_blocked -> maintainer_review
+
+**Entity:** `REG-PEMBROLIZUMAB-MSI-MONO`
+**File:** `pembrolizumab_msi_mono.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1332`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-177'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-177'', ''KEYNOTE177''])
+
+```
+
+**Verification rationale:**
+```
+Resolved trial 'KEYNOTE-177' to existing source SRC-KEYNOTE-177-ANDRE-2020 at knowledge_base/hosted/content/sources/src_keynote177_andre_2020.yaml. The source title is 'Pembrolizumab versus Chemotherapy for Microsatellite Instability-High/Mismatch Repair-Deficient Metastatic Colorectal Cancer'; source notes identify the trial/source context as: 'KEYNOTE-177 phase-3 (NCT02563002): pembrolizumab 200 mg IV q3w vs investigator-choice 1L chemo (mFOLFOX6 or FOLFIRI ± bevacizumab/ cetuximab) in untreated MSI-H/dMMR metastatic CRC. mPFS 16.5 vs 8.2 mo (HR 0.60, p=0.0002); ORR 43.8% vs 33.1%. Final OS analysis (Diaz 2022, Lancet Oncol) crossed without statistical significance due to high crossover (60%). Est'. Current entity locator knowledge_base/hosted/content/regimens/pembrolizumab_msi_mono.yaml...[truncated]
+```
+
+**Notes:** URL reachability check on https://www.nejm.org/doi/full/10.1056/NEJMoa2017699 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Existing source candidate found but not present in current entity citation list; maintainer should add/map it if accepted.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 177/345: CV914-0645 - access_blocked -> maintainer_review
+
+**Entity:** `REG-RITUXIMAB-MAINTENANCE-FL`
+**File:** `reg_rituximab_maintenance_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1341`
+
+**Audit finding text:**
+```
+trial ''PRIMA'' mentioned but no matching source citation (looked for substrings: [''PRIMA'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PRIMA'. Prior candidate SRC-DIPSS-PLUS-GANGAT-2011 failed strict trial-name verification. Existing trial-specific source SRC-PRIMA-GONZALEZ-MARTIN-2019 at knowledge_base/hosted/content/sources/src_prima_gonzalez_martin_2019.yaml matches by source id/title ('Niraparib in Patients with Newly Diagnosed Advanced Ovarian Cancer'), but its URL is publisher-blocked/subscription-gated for this run; maintainer should review before mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-DIPSS-PLUS-GANGAT-2011 rejected; remapped to trial-specific existing source SRC-PRIMA-GONZALEZ-MARTIN-2019 because the trial name appears in source id/title.
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 178/345: CV914-0654 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1366`
+
+**Audit finding text:**
+```
+recommended_combination 'BR or R-CHOP or O-CHOP/O-Benda (1L per FLIPI/burden)' contains drug name(s) ['r-chop', 'o-chop', 'o-benda'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_fl.yaml: recommended_combinations includes 'BR or R-CHOP or O-CHOP/O-Benda (1L per FLIPI/burden)', but regulatory_approval does not mention r-chop, o-chop, o-benda. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 179/345: CV914-0655 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1367`
+
+**Audit finding text:**
+```
+recommended_combination 'tazemetostat (EZH2-mut R/R)' contains drug name(s) ['tazemetostat'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_fl.yaml: recommended_combinations includes 'tazemetostat (EZH2-mut R/R)', but regulatory_approval does not mention tazemetostat. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 180/345: CV914-0656 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1368`
+
+**Audit finding text:**
+```
+recommended_combination 'mosunetuzumab / axi-cel (R/R 3L+)' contains drug name(s) ['mosunetuzumab', 'axi-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_fl.yaml: recommended_combinations includes 'mosunetuzumab / axi-cel (R/R 3L+)', but regulatory_approval does not mention mosunetuzumab, axi-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 181/345: CV914-0658 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-AML`
+**File:** `bma_tp53_mut_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1372`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax (palliative, R/R)' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax (palliative, R/R)', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 182/345: CV914-0659 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-AML`
+**File:** `bma_tp53_mut_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1373`
+
+**Audit finding text:**
+```
+recommended_combination 'decitabine 10-day' contains drug name(s) ['decitabine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_aml.yaml: recommended_combinations includes 'decitabine 10-day', but regulatory_approval does not mention decitabine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 183/345: CV914-0660 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-AML`
+**File:** `bma_tp53_mut_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1374`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_mut_aml.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 184/345: CV914-0662 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-DLBCL-NOS`
+**File:** `bma_bcl2_expression_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1378`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP / pola-R-CHP per usual algorithm' contains drug name(s) ['r-chop', 'pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_dlbcl_nos.yaml: recommended_combinations includes 'R-CHOP / pola-R-CHP per usual algorithm', but regulatory_approval does not mention r-chop, pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 185/345: CV914-0663 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-DLBCL-NOS`
+**File:** `bma_bcl2_expression_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1379`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + R-CHOP (trial; CAVALLI)' contains drug name(s) ['venetoclax', 'r-chop'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_dlbcl_nos.yaml: recommended_combinations includes 'venetoclax + R-CHOP (trial; CAVALLI)', but regulatory_approval does not mention venetoclax, r-chop. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 186/345: CV914-0665 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCA-GERMLINE-OVARIAN`
+**File:** `bma_fanca_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1383`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fanca_germline_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 187/345: CV914-0666 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCA-GERMLINE-OVARIAN`
+**File:** `bma_fanca_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1384`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fanca_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 188/345: CV914-0668 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCL-GERMLINE-OVARIAN`
+**File:** `bma_fancl_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1388`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fancl_germline_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 189/345: CV914-0669 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCL-GERMLINE-OVARIAN`
+**File:** `bma_fancl_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1389`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fancl_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 190/345: CV914-0671 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-NLPBL`
+**File:** `bma_myc_rearrangement_nlpbl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1393`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP' contains drug name(s) ['r-chop'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_nlpbl.yaml: recommended_combinations includes 'R-CHOP', but regulatory_approval does not mention r-chop. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 191/345: CV914-0672 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-NLPBL`
+**File:** `bma_myc_rearrangement_nlpbl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1394`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (if HGBL-DH)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_nlpbl.yaml: recommended_combinations includes 'DA-EPOCH-R (if HGBL-DH)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 192/345: CV914-0674 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-DLBCL-NOS`
+**File:** `bma_tp53_mut_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1398`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (1L; not TP53-selected)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP (1L; not TP53-selected)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 193/345: CV914-0675 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-DLBCL-NOS`
+**File:** `bma_tp53_mut_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1399`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T axi-cel / liso-cel (2L+)' contains drug name(s) ['car-t', 'liso-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_dlbcl_nos.yaml: recommended_combinations includes 'CAR-T axi-cel / liso-cel (2L+)', but regulatory_approval does not mention liso-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 194/345: CV914-0677 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MDS-HR`
+**File:** `bma_tp53_mut_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1403`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration (preferred curative path despite poor outcomes)' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_mut_mds_hr.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 195/345: CV914-0678 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MDS-HR`
+**File:** `bma_tp53_mut_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1404`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax (palliative; modest CR but non-durable)' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax (palliative; modest CR but non-durable)', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 196/345: CV914-0680 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-AML`
+**File:** `bma_tp53_r175h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1408`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 197/345: CV914-0681 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-AML`
+**File:** `bma_tp53_r175h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1409`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r175h_aml.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 198/345: CV914-0683 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-CLL`
+**File:** `bma_tp53_r175h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1413`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 199/345: CV914-0684 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-CLL`
+**File:** `bma_tp53_r175h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1414`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 200/345: CV914-0686 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-DLBCL-NOS`
+**File:** `bma_tp53_r175h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1418`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 201/345: CV914-0687 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-DLBCL-NOS`
+**File:** `bma_tp53_r175h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1419`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T 2L+' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r175h_dlbcl_nos.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 202/345: CV914-0689 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MDS-HR`
+**File:** `bma_tp53_r175h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1423`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 203/345: CV914-0690 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MDS-HR`
+**File:** `bma_tp53_r175h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1424`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r175h_mds_hr.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 204/345: CV914-0692 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-AML`
+**File:** `bma_tp53_r248q_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1428`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 205/345: CV914-0693 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-AML`
+**File:** `bma_tp53_r248q_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1429`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r248q_aml.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 206/345: CV914-0695 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-CLL`
+**File:** `bma_tp53_r248q_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1433`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 207/345: CV914-0696 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-CLL`
+**File:** `bma_tp53_r248q_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1434`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 208/345: CV914-0698 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-DLBCL-NOS`
+**File:** `bma_tp53_r248q_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1438`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 209/345: CV914-0699 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-DLBCL-NOS`
+**File:** `bma_tp53_r248q_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1439`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T 2L+' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r248q_dlbcl_nos.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 210/345: CV914-0701 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MDS-HR`
+**File:** `bma_tp53_r248q_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1443`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 211/345: CV914-0702 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MDS-HR`
+**File:** `bma_tp53_r248q_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1444`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r248q_mds_hr.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 212/345: CV914-0704 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-AML`
+**File:** `bma_tp53_r273h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1448`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 213/345: CV914-0705 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-AML`
+**File:** `bma_tp53_r273h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1449`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r273h_aml.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 214/345: CV914-0707 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-CLL`
+**File:** `bma_tp53_r273h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1453`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 215/345: CV914-0708 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-CLL`
+**File:** `bma_tp53_r273h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1454`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 216/345: CV914-0710 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-DLBCL-NOS`
+**File:** `bma_tp53_r273h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1458`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 217/345: CV914-0711 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-DLBCL-NOS`
+**File:** `bma_tp53_r273h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1459`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T 2L+' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r273h_dlbcl_nos.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 218/345: CV914-0713 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MDS-HR`
+**File:** `bma_tp53_r273h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1463`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 219/345: CV914-0714 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MDS-HR`
+**File:** `bma_tp53_r273h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1464`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r273h_mds_hr.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 220/345: CV914-0716 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-AML`
+**File:** `bma_tp53_r282w_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1468`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 221/345: CV914-0717 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-AML`
+**File:** `bma_tp53_r282w_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1469`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r282w_aml.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 222/345: CV914-0719 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-CLL`
+**File:** `bma_tp53_r282w_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1473`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 223/345: CV914-0720 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-CLL`
+**File:** `bma_tp53_r282w_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1474`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 224/345: CV914-0722 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-DLBCL-NOS`
+**File:** `bma_tp53_r282w_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1478`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 225/345: CV914-0723 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-DLBCL-NOS`
+**File:** `bma_tp53_r282w_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1479`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T 2L+' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r282w_dlbcl_nos.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 226/345: CV914-0725 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MDS-HR`
+**File:** `bma_tp53_r282w_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1483`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 227/345: CV914-0726 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MDS-HR`
+**File:** `bma_tp53_r282w_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1484`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r282w_mds_hr.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 228/345: CV914-0728 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-FL`
+**File:** `bma_bcl2_expression_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1488`
+
+**Audit finding text:**
+```
+recommended_combination 'BR / R-CHOP / O-Benda per FLIPI / burden' contains drug name(s) ['r-chop', 'o-benda', 'burden'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_fl.yaml: recommended_combinations includes 'BR / R-CHOP / O-Benda per FLIPI / burden', but regulatory_approval does not mention r-chop, o-benda, burden. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 229/345: CV914-0730 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-MCL`
+**File:** `bma_bcl2_expression_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1492`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + acalabrutinib (trials)' contains drug name(s) ['venetoclax', 'acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_mcl.yaml: recommended_combinations includes 'venetoclax + acalabrutinib (trials)', but regulatory_approval does not mention venetoclax, acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 230/345: CV914-0732 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_bcl2_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1496`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP / pola-R-CHP per usual DLBCL algorithm' contains drug name(s) ['r-chop', 'pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'R-CHOP / pola-R-CHP per usual DLBCL algorithm', but regulatory_approval does not mention r-chop, pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 231/345: CV914-0734 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600E-MM`
+**File:** `bma_braf_v600e_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1500`
+
+**Audit finding text:**
+```
+recommended_combination 'vemurafenib (case-report level)' contains drug name(s) ['vemurafenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_braf_v600e_mm.yaml: recommended_combinations includes 'vemurafenib (case-report level)', but regulatory_approval does not mention vemurafenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 232/345: CV914-0736 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-MELANOMA`
+**File:** `bma_brca2_germline_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1504`
+
+**Audit finding text:**
+```
+recommended_combination 'standard melanoma therapy by stage/biomarker (ICI, BRAFi+MEKi if BRAF V600)' contains drug name(s) ['biomarker'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_germline_melanoma.yaml: recommended_combinations includes 'standard melanoma therapy by stage/biomarker (ICI, BRAFi+MEKi if BRAF V600)', but regulatory_approval does not mention biomarker. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 233/345: CV914-0738 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CHEK1-SOMATIC-OVARIAN`
+**File:** `bma_chek1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1508`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_chek1_somatic_ovarian.yaml: recommended_combinations includes 'platinum-based chemo', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 234/345: CV914-0740 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132G-GBM`
+**File:** `bma_idh1_r132g_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1512`
+
+**Audit finding text:**
+```
+recommended_combination 'vorasidenib' contains drug name(s) ['vorasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132g_gbm.yaml: recommended_combinations includes 'vorasidenib', but regulatory_approval does not mention vorasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 235/345: CV914-0742 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132H-MDS-HR`
+**File:** `bma_idh1_r132h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1516`
+
+**Audit finding text:**
+```
+recommended_combination 'ivosidenib + azacitidine (trial)' contains drug name(s) ['ivosidenib', 'azacitidine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132h_mds_hr.yaml: recommended_combinations includes 'ivosidenib + azacitidine (trial)', but regulatory_approval does not mention ivosidenib, azacitidine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 236/345: CV914-0744 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132H-MDS-LR`
+**File:** `bma_idh1_r132h_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1520`
+
+**Audit finding text:**
+```
+recommended_combination 'ivosidenib + azacitidine (trial)' contains drug name(s) ['ivosidenib', 'azacitidine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132h_mds_lr.yaml: recommended_combinations includes 'ivosidenib + azacitidine (trial)', but regulatory_approval does not mention ivosidenib, azacitidine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 237/345: CV914-0746 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132L-GBM`
+**File:** `bma_idh1_r132l_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1524`
+
+**Audit finding text:**
+```
+recommended_combination 'vorasidenib' contains drug name(s) ['vorasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132l_gbm.yaml: recommended_combinations includes 'vorasidenib', but regulatory_approval does not mention vorasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 238/345: CV914-0748 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132S-GBM`
+**File:** `bma_idh1_r132s_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1528`
+
+**Audit finding text:**
+```
+recommended_combination 'vorasidenib' contains drug name(s) ['vorasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132s_gbm.yaml: recommended_combinations includes 'vorasidenib', but regulatory_approval does not mention vorasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 239/345: CV914-0750 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-G12-MELANOMA`
+**File:** `bma_nras_g12_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1532`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD1-based ICI' contains drug name(s) ['anti-pd1-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_g12_melanoma.yaml: recommended_combinations includes 'anti-PD1-based ICI', but regulatory_approval does not mention anti-pd1-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 240/345: CV914-0752 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-G13-MELANOMA`
+**File:** `bma_nras_g13_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1536`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD1-based ICI' contains drug name(s) ['anti-pd1-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_g13_melanoma.yaml: recommended_combinations includes 'anti-PD1-based ICI', but regulatory_approval does not mention anti-pd1-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 241/345: CV914-0754 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-ENDOMETRIAL`
+**File:** `bma_pik3ca_hotspot_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1540`
+
+**Audit finding text:**
+```
+recommended_combination 'everolimus + letrozole' contains drug name(s) ['everolimus', 'letrozole'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_hotspot_endometrial.yaml: recommended_combinations includes 'everolimus + letrozole', but regulatory_approval does not mention everolimus, letrozole. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 242/345: CV914-0756 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-NSCLC`
+**File:** `bma_tp53_mut_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1544`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual NSCLC algorithm based on driver' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_mut_nsclc.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 243/345: CV914-0758 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-BREAST`
+**File:** `bma_tp53_r175h_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1548`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual breast algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r175h_breast.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 244/345: CV914-0760 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-NSCLC`
+**File:** `bma_tp53_r175h_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1552`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual NSCLC algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r175h_nsclc.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 245/345: CV914-0762 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-BREAST`
+**File:** `bma_tp53_r248q_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1556`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual breast algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r248q_breast.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 246/345: CV914-0764 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-NSCLC`
+**File:** `bma_tp53_r248q_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1560`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual NSCLC algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r248q_nsclc.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 247/345: CV914-0766 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-BREAST`
+**File:** `bma_tp53_r273h_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1564`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual breast algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r273h_breast.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 248/345: CV914-0768 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-NSCLC`
+**File:** `bma_tp53_r273h_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1568`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual NSCLC algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r273h_nsclc.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 249/345: CV914-0770 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-BREAST`
+**File:** `bma_tp53_r282w_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1572`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual breast algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r282w_breast.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 250/345: CV914-0772 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-NSCLC`
+**File:** `bma_tp53_r282w_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1576`
+
+**Audit finding text:**
+```
+recommended_combination 'per usual NSCLC algorithm' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_r282w_nsclc.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 251/345: CV914-0820 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1720`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd (1L transplant-eligible)' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mm.yaml: recommended_combinations includes 'D-VRd (1L transplant-eligible)', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 252/345: CV914-0821 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1721`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd (1L transplant-ineligible)' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mm.yaml: recommended_combinations includes 'Dara-Rd (1L transplant-ineligible)', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 253/345: CV914-0822 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1722`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel (R/R)' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel (R/R)', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 254/345: CV914-0823 - unclear -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1723`
+
+**Audit finding text:**
+```
+recommended_combination 'alloSCT consideration in young high-risk' contains drug name(s) ['allosct'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_tp53_mut_mm.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 255/345: CV914-0824 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-HGBL-DH`
+**File:** `bma_bcl2_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1726`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'DA-EPOCH-R', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 256/345: CV914-0825 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-HGBL-DH`
+**File:** `bma_bcl2_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1727`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 257/345: CV914-0826 - unclear -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-HGBL-DH`
+**File:** `bma_bcl2_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1728`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T (R/R)' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_bcl2_rearrangement_hgbl_dh.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 258/345: CV914-0827 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-BURKITT`
+**File:** `bma_myc_rearrangement_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1731`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (low/intermediate-risk Burkitt)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_burkitt.yaml: recommended_combinations includes 'DA-EPOCH-R (low/intermediate-risk Burkitt)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 259/345: CV914-0828 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-BURKITT`
+**File:** `bma_myc_rearrangement_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1732`
+
+**Audit finding text:**
+```
+recommended_combination 'CODOX-M/IVAC + rituximab (high-risk/CNS+)' contains drug name(s) ['codox-m', 'ivac', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_burkitt.yaml: recommended_combinations includes 'CODOX-M/IVAC + rituximab (high-risk/CNS+)', but regulatory_approval does not mention codox-m, ivac, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 260/345: CV914-0829 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-BURKITT`
+**File:** `bma_myc_rearrangement_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1733`
+
+**Audit finding text:**
+```
+recommended_combination 'R-hyperCVAD (alternative)' contains drug name(s) ['r-hypercvad'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_burkitt.yaml: recommended_combinations includes 'R-hyperCVAD (alternative)', but regulatory_approval does not mention r-hypercvad. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 261/345: CV914-0830 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_myc_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1736`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP (1L standard)' contains drug name(s) ['r-chop'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'R-CHOP (1L standard)', but regulatory_approval does not mention r-chop. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 262/345: CV914-0831 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_myc_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1737`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (POLARIX)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP (POLARIX)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 263/345: CV914-0832 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_myc_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1738`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (intensification consideration)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'DA-EPOCH-R (intensification consideration)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 264/345: CV914-0833 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-FL`
+**File:** `bma_myc_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1741`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_fl.yaml: recommended_combinations includes 'DA-EPOCH-R', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 265/345: CV914-0834 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-FL`
+**File:** `bma_myc_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1742`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_fl.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 266/345: CV914-0835 - unclear -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-FL`
+**File:** `bma_myc_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1743`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T 2L+' contains drug name(s) ['car-t'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_myc_rearrangement_fl.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 267/345: CV914-0836 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-HGBL-DH`
+**File:** `bma_myc_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1746`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (1L preferred)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'DA-EPOCH-R (1L preferred)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 268/345: CV914-0837 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-HGBL-DH`
+**File:** `bma_myc_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1747`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (1L alternative)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'pola-R-CHP (1L alternative)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 269/345: CV914-0838 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-HGBL-DH`
+**File:** `bma_myc_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1748`
+
+**Audit finding text:**
+```
+recommended_combination 'axi-cel / liso-cel (2L+)' contains drug name(s) ['axi-cel', 'liso-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'axi-cel / liso-cel (2L+)', but regulatory_approval does not mention axi-cel, liso-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 270/345: CV914-0839 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-T-ALL`
+**File:** `bma_notch1_activating_t_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1751`
+
+**Audit finding text:**
+```
+recommended_combination 'per CALGB-10403 / GMALL / BFM-inspired regimen (1L)' contains drug name(s) ['per', 'gmall', 'bfm-inspired'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_t_all.yaml: recommended_combinations includes 'per CALGB-10403 / GMALL / BFM-inspired regimen (1L)', but regulatory_approval does not mention gmall, bfm-inspired. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 271/345: CV914-0840 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-T-ALL`
+**File:** `bma_notch1_activating_t_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1752`
+
+**Audit finding text:**
+```
+recommended_combination 'nelarabine (R/R T-ALL)' contains drug name(s) ['nelarabine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_t_all.yaml: recommended_combinations includes 'nelarabine (R/R T-ALL)', but regulatory_approval does not mention nelarabine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 272/345: CV914-0841 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-T-ALL`
+**File:** `bma_notch1_activating_t_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1753`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + navitoclax (early-phase trials)' contains drug name(s) ['venetoclax', 'navitoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_t_all.yaml: recommended_combinations includes 'venetoclax + navitoclax (early-phase trials)', but regulatory_approval does not mention venetoclax, navitoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 273/345: CV914-0842 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-OVARIAN`
+**File:** `bma_palb2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1756`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib maintenance' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_ovarian.yaml: recommended_combinations includes 'niraparib maintenance', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 274/345: CV914-0843 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-OVARIAN`
+**File:** `bma_palb2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1757`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib maintenance (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib maintenance (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 275/345: CV914-0844 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-OVARIAN`
+**File:** `bma_palb2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1758`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 276/345: CV914-0845 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON20-BREAST`
+**File:** `bma_pik3ca_exon20_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1761`
+
+**Audit finding text:**
+```
+recommended_combination 'alpelisib + fulvestrant' contains drug name(s) ['alpelisib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon20_breast.yaml: recommended_combinations includes 'alpelisib + fulvestrant', but regulatory_approval does not mention alpelisib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 277/345: CV914-0846 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON20-BREAST`
+**File:** `bma_pik3ca_exon20_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1762`
+
+**Audit finding text:**
+```
+recommended_combination 'inavolisib + palbociclib + fulvestrant' contains drug name(s) ['inavolisib', 'palbociclib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon20_breast.yaml: recommended_combinations includes 'inavolisib + palbociclib + fulvestrant', but regulatory_approval does not mention inavolisib, palbociclib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 278/345: CV914-0847 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON20-BREAST`
+**File:** `bma_pik3ca_exon20_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1763`
+
+**Audit finding text:**
+```
+recommended_combination 'capivasertib + fulvestrant' contains drug name(s) ['capivasertib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon20_breast.yaml: recommended_combinations includes 'capivasertib + fulvestrant', but regulatory_approval does not mention capivasertib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 279/345: CV914-0848 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON9-BREAST`
+**File:** `bma_pik3ca_exon9_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1766`
+
+**Audit finding text:**
+```
+recommended_combination 'alpelisib + fulvestrant' contains drug name(s) ['alpelisib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon9_breast.yaml: recommended_combinations includes 'alpelisib + fulvestrant', but regulatory_approval does not mention alpelisib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 280/345: CV914-0849 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON9-BREAST`
+**File:** `bma_pik3ca_exon9_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1767`
+
+**Audit finding text:**
+```
+recommended_combination 'inavolisib + palbociclib + fulvestrant' contains drug name(s) ['inavolisib', 'palbociclib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon9_breast.yaml: recommended_combinations includes 'inavolisib + palbociclib + fulvestrant', but regulatory_approval does not mention inavolisib, palbociclib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 281/345: CV914-0850 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON9-BREAST`
+**File:** `bma_pik3ca_exon9_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1768`
+
+**Audit finding text:**
+```
+recommended_combination 'capivasertib + fulvestrant' contains drug name(s) ['capivasertib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon9_breast.yaml: recommended_combinations includes 'capivasertib + fulvestrant', but regulatory_approval does not mention capivasertib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 282/345: CV914-0851 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-SOMATIC-OVARIAN`
+**File:** `bma_rad51b_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1771`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 283/345: CV914-0852 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-SOMATIC-OVARIAN`
+**File:** `bma_rad51b_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1772`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 284/345: CV914-0853 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-SOMATIC-OVARIAN`
+**File:** `bma_rad51b_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1773`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 285/345: CV914-0854 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-SOMATIC-OVARIAN`
+**File:** `bma_rad51c_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1776`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 286/345: CV914-0855 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-SOMATIC-OVARIAN`
+**File:** `bma_rad51c_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1777`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 287/345: CV914-0856 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-SOMATIC-OVARIAN`
+**File:** `bma_rad51c_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1778`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 288/345: CV914-0857 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-SOMATIC-OVARIAN`
+**File:** `bma_rad51d_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1781`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 289/345: CV914-0858 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-SOMATIC-OVARIAN`
+**File:** `bma_rad51d_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1782`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 290/345: CV914-0859 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-SOMATIC-OVARIAN`
+**File:** `bma_rad51d_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1783`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 291/345: CV914-0860 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MM`
+**File:** `bma_tp53_r175h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1786`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 292/345: CV914-0861 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MM`
+**File:** `bma_tp53_r175h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1787`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 293/345: CV914-0862 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MM`
+**File:** `bma_tp53_r175h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1788`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 294/345: CV914-0863 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MM`
+**File:** `bma_tp53_r248q_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1791`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 295/345: CV914-0864 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MM`
+**File:** `bma_tp53_r248q_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1792`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 296/345: CV914-0865 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MM`
+**File:** `bma_tp53_r248q_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1793`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 297/345: CV914-0866 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MM`
+**File:** `bma_tp53_r273h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1796`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 298/345: CV914-0867 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MM`
+**File:** `bma_tp53_r273h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1797`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 299/345: CV914-0868 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MM`
+**File:** `bma_tp53_r273h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1798`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 300/345: CV914-0869 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MM`
+**File:** `bma_tp53_r282w_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1801`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 301/345: CV914-0870 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MM`
+**File:** `bma_tp53_r282w_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1802`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 302/345: CV914-0871 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MM`
+**File:** `bma_tp53_r282w_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1803`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 303/345: CV914-0872 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-GERMLINE-BREAST`
+**File:** `bma_atm_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1806`
+
+**Audit finding text:**
+```
+recommended_combination 'standard breast therapy by HR/HER2' contains drug name(s) ['her2'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_germline_breast.yaml: recommended_combinations includes 'standard breast therapy by HR/HER2', but regulatory_approval does not mention her2. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 304/345: CV914-0873 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-GERMLINE-BREAST`
+**File:** `bma_atm_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1807`
+
+**Audit finding text:**
+```
+recommended_combination 'enhanced screening (annual MRI)' contains drug name(s) ['enhanced'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_germline_breast.yaml: recommended_combinations includes 'enhanced screening (annual MRI)', but regulatory_approval does not mention enhanced. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 305/345: CV914-0874 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BARD1-SOMATIC-OVARIAN`
+**File:** `bma_bard1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1810`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bard1_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 306/345: CV914-0875 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BARD1-SOMATIC-OVARIAN`
+**File:** `bma_bard1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1811`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bard1_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 307/345: CV914-0876 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRIP1-SOMATIC-OVARIAN`
+**File:** `bma_brip1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1814`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brip1_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 308/345: CV914-0877 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRIP1-SOMATIC-OVARIAN`
+**File:** `bma_brip1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1815`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brip1_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 309/345: CV914-0878 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-MUTATION-AML`
+**File:** `bma_kit_mutation_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1818`
+
+**Audit finding text:**
+```
+recommended_combination 'standard 7+3 + HiDAC consolidation (CBF-AML backbone)' contains drug name(s) ['hidac'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_mutation_aml.yaml: recommended_combinations includes 'standard 7+3 + HiDAC consolidation (CBF-AML backbone)', but regulatory_approval does not mention hidac. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 310/345: CV914-0879 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-MUTATION-AML`
+**File:** `bma_kit_mutation_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1819`
+
+**Audit finding text:**
+```
+recommended_combination 'avapritinib (D816V-AML, basket trial)' contains drug name(s) ['avapritinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_mutation_aml.yaml: recommended_combinations includes 'avapritinib (D816V-AML, basket trial)', but regulatory_approval does not mention avapritinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 311/345: CV914-0880 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-DLBCL-NOS`
+**File:** `bma_myd88_l265p_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1822`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (1L; POLARIX - not MYD88-selected but consider)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP (1L; POLARIX - not MYD88-selected but consider)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 312/345: CV914-0881 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-DLBCL-NOS`
+**File:** `bma_myd88_l265p_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1823`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T axi-cel / liso-cel (R/R)' contains drug name(s) ['car-t', 'liso-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_dlbcl_nos.yaml: recommended_combinations includes 'CAR-T axi-cel / liso-cel (R/R)', but regulatory_approval does not mention liso-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 313/345: CV914-0882 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-PCNSL`
+**File:** `bma_myd88_l265p_pcnsl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1826`
+
+**Audit finding text:**
+```
+recommended_combination 'ibrutinib + HD-MTX-based regimens (trial)' contains drug name(s) ['ibrutinib', 'hd-mtx-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_pcnsl.yaml: recommended_combinations includes 'ibrutinib + HD-MTX-based regimens (trial)', but regulatory_approval does not mention ibrutinib, hd-mtx-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 314/345: CV914-0883 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-PCNSL`
+**File:** `bma_myd88_l265p_pcnsl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1827`
+
+**Audit finding text:**
+```
+recommended_combination 'MTX-based induction -> consolidation per usual PCNSL algorithm' contains drug name(s) ['mtx-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_pcnsl.yaml: recommended_combinations includes 'MTX-based induction -> consolidation per usual PCNSL algorithm', but regulatory_approval does not mention mtx-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 315/345: CV914-0884 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-OVARIAN`
+**File:** `bma_tp53_mut_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1830`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli (1L HGSOC)' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli (1L HGSOC)', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 316/345: CV914-0885 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-OVARIAN`
+**File:** `bma_tp53_mut_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1831`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib maintenance (BRCA-WT/HRD-test)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_ovarian.yaml: recommended_combinations includes 'niraparib maintenance (BRCA-WT/HRD-test)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 317/345: CV914-0886 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MCL`
+**File:** `bma_tp53_r175h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1834`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 318/345: CV914-0887 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MCL`
+**File:** `bma_tp53_r175h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1835`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 319/345: CV914-0888 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-OVARIAN`
+**File:** `bma_tp53_r175h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1838`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 320/345: CV914-0889 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-OVARIAN`
+**File:** `bma_tp53_r175h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1839`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 321/345: CV914-0890 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MCL`
+**File:** `bma_tp53_r248q_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1842`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 322/345: CV914-0891 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MCL`
+**File:** `bma_tp53_r248q_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1843`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 323/345: CV914-0892 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-OVARIAN`
+**File:** `bma_tp53_r248q_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1846`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 324/345: CV914-0893 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-OVARIAN`
+**File:** `bma_tp53_r248q_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1847`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 325/345: CV914-0894 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MCL`
+**File:** `bma_tp53_r273h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1850`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 326/345: CV914-0895 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MCL`
+**File:** `bma_tp53_r273h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1851`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 327/345: CV914-0896 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-OVARIAN`
+**File:** `bma_tp53_r273h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1854`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 328/345: CV914-0897 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-OVARIAN`
+**File:** `bma_tp53_r273h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1855`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 329/345: CV914-0898 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MCL`
+**File:** `bma_tp53_r282w_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1858`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 330/345: CV914-0899 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MCL`
+**File:** `bma_tp53_r282w_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1859`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 331/345: CV914-0900 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-OVARIAN`
+**File:** `bma_tp53_r282w_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1862`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 332/345: CV914-0901 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-OVARIAN`
+**File:** `bma_tp53_r282w_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1863`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 333/345: CV914-0902 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-GERMLINE-PDAC`
+**File:** `bma_atm_germline_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1866`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX or gem-cis (platinum induction)' contains drug name(s) ['folfirinox', 'gem-cis'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_germline_pdac.yaml: recommended_combinations includes 'FOLFIRINOX or gem-cis (platinum induction)', but regulatory_approval does not mention folfirinox, gem-cis. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 334/345: CV914-0903 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-SOMATIC-PDAC`
+**File:** `bma_atm_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1869`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX (platinum-based)' contains drug name(s) ['folfirinox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_somatic_pdac.yaml: recommended_combinations includes 'FOLFIRINOX (platinum-based)', but regulatory_approval does not mention folfirinox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 335/345: CV914-0904 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-SOMATIC-PDAC`
+**File:** `bma_brca1_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1872`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (FOLFIRINOX preferred)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_somatic_pdac.yaml: recommended_combinations includes 'platinum-based chemo (FOLFIRINOX preferred)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 336/345: CV914-0905 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-SOMATIC-PDAC`
+**File:** `bma_brca2_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1875`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (FOLFIRINOX)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_somatic_pdac.yaml: recommended_combinations includes 'platinum-based chemo (FOLFIRINOX)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 337/345: CV914-0906 - unclear -> maintainer_review
+
+**Entity:** `BMA-CCND1-IHC-MCL`
+**File:** `bma_ccnd1_ihc_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1878`
+
+**Audit finding text:**
+```
+recommended_combination 'per DIS-MCL algorithm (BTKi-centric)' contains drug name(s) ['per'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Checked current entity file bma_ccnd1_ihc_mcl.yaml for 'recommended_combination value from audit'. The flagged token(s) are generic, already present, or not safely interpretable as drug names from the audit text alone. No cited source_id exists in v1, so source-level support remains unclear.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 338/345: CV914-0907 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CCND1-T1114-MM`
+**File:** `bma_ccnd1_t1114_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1881`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + carfilzomib + dex (NCT trials)' contains drug name(s) ['venetoclax', 'carfilzomib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_ccnd1_t1114_mm.yaml: recommended_combinations includes 'venetoclax + carfilzomib + dex (NCT trials)', but regulatory_approval does not mention venetoclax, carfilzomib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 339/345: CV914-0908 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CHEK2-GERMLINE-BREAST`
+**File:** `bma_chek2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1884`
+
+**Audit finding text:**
+```
+recommended_combination 'enhanced screening (annual MRI from age 40)' contains drug name(s) ['enhanced'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_chek2_germline_breast.yaml: recommended_combinations includes 'enhanced screening (annual MRI from age 40)', but regulatory_approval does not mention enhanced. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 340/345: CV914-0909 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-MUTATION-MELANOMA`
+**File:** `bma_kit_mutation_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1887`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD-1 \xB1 anti-CTLA-4 (1L irrespective of KIT status)' contains drug name(s) ['anti-pd-1'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_mutation_melanoma.yaml: recommended_combinations includes 'anti-PD-1 \\xB1 anti-CTLA-4 (1L irrespective of KIT status)', but regulatory_approval does not mention anti-pd-1. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 341/345: CV914-0910 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-Q61K-MELANOMA`
+**File:** `bma_nras_q61k_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1890`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD1-based ICI' contains drug name(s) ['anti-pd1-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_q61k_melanoma.yaml: recommended_combinations includes 'anti-PD1-based ICI', but regulatory_approval does not mention anti-pd1-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 342/345: CV914-0911 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-Q61R-MELANOMA`
+**File:** `bma_nras_q61r_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1893`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + ipilimumab (1L preferred)' contains drug name(s) ['nivolumab', 'ipilimumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_q61r_melanoma.yaml: recommended_combinations includes 'nivolumab + ipilimumab (1L preferred)', but regulatory_approval does not mention nivolumab, ipilimumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 343/345: CV914-0912 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-GERMLINE-BREAST`
+**File:** `bma_palb2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1896`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (TNBC)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_germline_breast.yaml: recommended_combinations includes 'platinum-based chemo (TNBC)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 344/345: CV914-0913 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-GERMLINE-PDAC`
+**File:** `bma_palb2_germline_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1899`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX (platinum induction)' contains drug name(s) ['folfirinox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_germline_pdac.yaml: recommended_combinations includes 'FOLFIRINOX (platinum induction)', but regulatory_approval does not mention folfirinox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 345/345: CV914-0914 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-PDAC`
+**File:** `bma_palb2_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1902`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX' contains drug name(s) ['folfirinox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_pdac.yaml: recommended_combinations includes 'FOLFIRINOX', but regulatory_approval does not mention folfirinox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---

--- a/contributions/citation-semantic-verify-v2/triage-queue-action-replace_source.md
+++ b/contributions/citation-semantic-verify-v2/triage-queue-action-replace_source.md
@@ -1,6 +1,6 @@
 # Triage Queue: citation-semantic-verify-v2
 
-**Filter:** status=`supported`, action=`None`
+**Filter:** status=`None`, action=`replace_source`
 
 **Total rows:** 121
 

--- a/contributions/citation-semantic-verify-v2/triage-queue-action-revise_claim.md
+++ b/contributions/citation-semantic-verify-v2/triage-queue-action-revise_claim.md
@@ -1,0 +1,3479 @@
+# Triage Queue: citation-semantic-verify-v2
+
+**Filter:** status=`None`, action=`revise_claim`
+
+**Total rows:** 124
+
+---
+
+## 1/124: CV914-0002 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-CLL`
+**File:** `bma_tp53_mut_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:64`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_cll.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 2/124: CV914-0009 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-P210-BALL`
+**File:** `bma_bcr_abl1_p210_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:73`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_p210_ball.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 3/124: CV914-0034 - access_blocked -> revise_claim
+
+**Entity:** `BMA-EGFR-C797S-NSCLC`
+**File:** `bma_egfr_c797s_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:108`
+
+**Audit finding text:**
+```
+ESCAT IIB typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level 'R2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_egfr_c797s_nsclc.yaml has escat_tier='IIB' and a legacy OncoKB-derived evidence level 'R2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 4/124: CV914-0078 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
+**File:** `bma_notch1_activating_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:170`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_notch1_activating_cll.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 5/124: CV914-0114 - access_blocked -> revise_claim
+
+**Entity:** `BMA-ALK-FUSION-ALCL`
+**File:** `bma_alk_fusion_alcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:220`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_alk_fusion_alcl.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 6/124: CV914-0176 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-E255K-CML`
+**File:** `bma_bcr_abl1_e255k_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:314`
+
+**Audit finding text:**
+```
+ESCAT IB typically maps to OncoKB {1,2} but entity declares OncoKB level 'R2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_e255k_cml.yaml has escat_tier='IB' and a legacy OncoKB-derived evidence level 'R2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 7/124: CV914-0179 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-F317L-BALL`
+**File:** `bma_bcr_abl1_f317l_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:319`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level 'R2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_f317l_ball.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level 'R2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 8/124: CV914-0182 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-T315I-BALL`
+**File:** `bma_bcr_abl1_t315i_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:324`
+
+**Audit finding text:**
+```
+ESCAT IA typically maps to OncoKB {1} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_t315i_ball.yaml has escat_tier='IA' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 9/124: CV914-0186 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-T315I-CML`
+**File:** `bma_bcr_abl1_t315i_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:330`
+
+**Audit finding text:**
+```
+ESCAT IA typically maps to OncoKB {1} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_t315i_cml.yaml has escat_tier='IA' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 10/124: CV914-0233 - access_blocked -> revise_claim
+
+**Entity:** `BMA-FLT3-F691L-AML`
+**File:** `bma_flt3_f691l_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:409`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_flt3_f691l_aml.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 11/124: CV914-0263 - access_blocked -> revise_claim
+
+**Entity:** `BMA-MYD88-L265P-HCV-MZL`
+**File:** `bma_myd88_l265p_hcv_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:459`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_myd88_l265p_hcv_mzl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 12/124: CV914-0266 - access_blocked -> revise_claim
+
+**Entity:** `BMA-MYD88-L265P-NODAL-MZL`
+**File:** `bma_myd88_l265p_nodal_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:464`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_myd88_l265p_nodal_mzl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 13/124: CV914-0269 - access_blocked -> revise_claim
+
+**Entity:** `BMA-MYD88-L265P-SPLENIC-MZL`
+**File:** `bma_myd88_l265p_splenic_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:469`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_myd88_l265p_splenic_mzl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 14/124: CV914-0285 - access_blocked -> revise_claim
+
+**Entity:** `BMA-ROS1-G2032R-NSCLC`
+**File:** `bma_ros1_g2032r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:495`
+
+**Audit finding text:**
+```
+ESCAT IB typically maps to OncoKB {1,2} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_ros1_g2032r_nsclc.yaml has escat_tier='IB' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 15/124: CV914-0287 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-BREAST`
+**File:** `bma_tp53_mut_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:499`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_breast.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 16/124: CV914-0309 - access_blocked -> revise_claim
+
+**Entity:** `BMA-ALK-G1202R-NSCLC`
+**File:** `bma_alk_g1202r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:537`
+
+**Audit finding text:**
+```
+ESCAT IB typically maps to OncoKB {1,2} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_alk_g1202r_nsclc.yaml has escat_tier='IB' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 17/124: CV914-0311 - access_blocked -> revise_claim
+
+**Entity:** `BMA-ALK-L1196M-NSCLC`
+**File:** `bma_alk_l1196m_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:541`
+
+**Audit finding text:**
+```
+ESCAT IB typically maps to OncoKB {1,2} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_alk_l1196m_nsclc.yaml has escat_tier='IB' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 18/124: CV914-0315 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-F317L-CML`
+**File:** `bma_bcr_abl1_f317l_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:549`
+
+**Audit finding text:**
+```
+ESCAT IB typically maps to OncoKB {1,2} but entity declares OncoKB level 'R2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_f317l_cml.yaml has escat_tier='IB' and a legacy OncoKB-derived evidence level 'R2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 19/124: CV914-0321 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCR-ABL1-V299L-CML`
+**File:** `bma_bcr_abl1_v299l_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:561`
+
+**Audit finding text:**
+```
+ESCAT IB typically maps to OncoKB {1,2} but entity declares OncoKB level 'R2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcr_abl1_v299l_cml.yaml has escat_tier='IB' and a legacy OncoKB-derived evidence level 'R2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 20/124: CV914-0323 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-GBM`
+**File:** `bma_braf_v600e_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:565`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_gbm.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 21/124: CV914-0325 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-OVARIAN`
+**File:** `bma_braf_v600e_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:569`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_ovarian.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 22/124: CV914-0327 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-PDAC`
+**File:** `bma_braf_v600e_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:573`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_pdac.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 23/124: CV914-0329 - access_blocked -> revise_claim
+
+**Entity:** `BMA-CHEK1-SOMATIC-PROSTATE`
+**File:** `bma_chek1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:577`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_chek1_somatic_prostate.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 24/124: CV914-0341 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132C-GBM`
+**File:** `bma_idh1_r132c_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:601`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132c_gbm.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 25/124: CV914-0347 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132H-GBM`
+**File:** `bma_idh1_r132h_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:613`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132h_gbm.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 26/124: CV914-0353 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH2-R172K-AITL`
+**File:** `bma_idh2_r172k_aitl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:625`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh2_r172k_aitl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 27/124: CV914-0355 - access_blocked -> revise_claim
+
+**Entity:** `BMA-KIT-D816V-GIST`
+**File:** `bma_kit_d816v_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:629`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level 'R1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_kit_d816v_gist.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level 'R1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 28/124: CV914-0359 - access_blocked -> revise_claim
+
+**Entity:** `BMA-KIT-EXON13-17-GIST`
+**File:** `bma_kit_exon13_17_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:637`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '1
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_kit_exon13_17_gist.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '1'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 29/124: CV914-0363 - access_blocked -> revise_claim
+
+**Entity:** `BMA-KRAS-G12C-OVARIAN`
+**File:** `bma_kras_g12c_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:645`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_kras_g12c_ovarian.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 30/124: CV914-0367 - access_blocked -> revise_claim
+
+**Entity:** `BMA-MET-AMP-RCC-PAPILLARY`
+**File:** `bma_met_amp_rcc_papillary.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:653`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_met_amp_rcc_papillary.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 31/124: CV914-0653 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1365`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcl2_rearrangement_fl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 32/124: CV914-0657 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-AML`
+**File:** `bma_tp53_mut_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1371`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_aml.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 33/124: CV914-0661 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCL2-EXPRESSION-DLBCL-NOS`
+**File:** `bma_bcl2_expression_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1377`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcl2_expression_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 34/124: CV914-0664 - access_blocked -> revise_claim
+
+**Entity:** `BMA-FANCA-GERMLINE-OVARIAN`
+**File:** `bma_fanca_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1382`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_fanca_germline_ovarian.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 35/124: CV914-0667 - access_blocked -> revise_claim
+
+**Entity:** `BMA-FANCL-GERMLINE-OVARIAN`
+**File:** `bma_fancl_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1387`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_fancl_germline_ovarian.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 36/124: CV914-0670 - access_blocked -> revise_claim
+
+**Entity:** `BMA-MYC-REARRANGEMENT-NLPBL`
+**File:** `bma_myc_rearrangement_nlpbl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1392`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_myc_rearrangement_nlpbl.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 37/124: CV914-0673 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-DLBCL-NOS`
+**File:** `bma_tp53_mut_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1397`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 38/124: CV914-0676 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-MDS-HR`
+**File:** `bma_tp53_mut_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1402`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 39/124: CV914-0679 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R175H-AML`
+**File:** `bma_tp53_r175h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1407`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r175h_aml.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 40/124: CV914-0682 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R175H-CLL`
+**File:** `bma_tp53_r175h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1412`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r175h_cll.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 41/124: CV914-0685 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R175H-DLBCL-NOS`
+**File:** `bma_tp53_r175h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1417`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r175h_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 42/124: CV914-0688 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R175H-MDS-HR`
+**File:** `bma_tp53_r175h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1422`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r175h_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 43/124: CV914-0691 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R248Q-AML`
+**File:** `bma_tp53_r248q_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1427`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r248q_aml.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 44/124: CV914-0694 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R248Q-CLL`
+**File:** `bma_tp53_r248q_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1432`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r248q_cll.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 45/124: CV914-0697 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R248Q-DLBCL-NOS`
+**File:** `bma_tp53_r248q_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1437`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r248q_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 46/124: CV914-0700 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R248Q-MDS-HR`
+**File:** `bma_tp53_r248q_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1442`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r248q_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 47/124: CV914-0703 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R273H-AML`
+**File:** `bma_tp53_r273h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1447`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r273h_aml.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 48/124: CV914-0706 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R273H-CLL`
+**File:** `bma_tp53_r273h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1452`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r273h_cll.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 49/124: CV914-0709 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R273H-DLBCL-NOS`
+**File:** `bma_tp53_r273h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1457`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r273h_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 50/124: CV914-0712 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R273H-MDS-HR`
+**File:** `bma_tp53_r273h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1462`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r273h_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 51/124: CV914-0715 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R282W-AML`
+**File:** `bma_tp53_r282w_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1467`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r282w_aml.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 52/124: CV914-0718 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R282W-CLL`
+**File:** `bma_tp53_r282w_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1472`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3A
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r282w_cll.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3A'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 53/124: CV914-0721 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R282W-DLBCL-NOS`
+**File:** `bma_tp53_r282w_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1477`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r282w_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 54/124: CV914-0724 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R282W-MDS-HR`
+**File:** `bma_tp53_r282w_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1482`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r282w_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 55/124: CV914-0727 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCL2-EXPRESSION-FL`
+**File:** `bma_bcl2_expression_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1487`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcl2_expression_fl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 56/124: CV914-0729 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCL2-EXPRESSION-MCL`
+**File:** `bma_bcl2_expression_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1491`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcl2_expression_mcl.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 57/124: CV914-0731 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_bcl2_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1495`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bcl2_rearrangement_dlbcl_nos.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 58/124: CV914-0733 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-MM`
+**File:** `bma_braf_v600e_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1499`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_mm.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 59/124: CV914-0735 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRCA2-GERMLINE-MELANOMA`
+**File:** `bma_brca2_germline_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1503`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_brca2_germline_melanoma.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 60/124: CV914-0737 - access_blocked -> revise_claim
+
+**Entity:** `BMA-CHEK1-SOMATIC-OVARIAN`
+**File:** `bma_chek1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1507`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_chek1_somatic_ovarian.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 61/124: CV914-0739 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132G-GBM`
+**File:** `bma_idh1_r132g_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1511`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132g_gbm.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 62/124: CV914-0741 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132H-MDS-HR`
+**File:** `bma_idh1_r132h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1515`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132h_mds_hr.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 63/124: CV914-0743 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132H-MDS-LR`
+**File:** `bma_idh1_r132h_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1519`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132h_mds_lr.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 64/124: CV914-0745 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132L-GBM`
+**File:** `bma_idh1_r132l_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1523`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132l_gbm.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 65/124: CV914-0747 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH1-R132S-GBM`
+**File:** `bma_idh1_r132s_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1527`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh1_r132s_gbm.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 66/124: CV914-0749 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-G12-MELANOMA`
+**File:** `bma_nras_g12_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1531`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_g12_melanoma.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 67/124: CV914-0751 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-G13-MELANOMA`
+**File:** `bma_nras_g13_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1535`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_g13_melanoma.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 68/124: CV914-0753 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-ENDOMETRIAL`
+**File:** `bma_pik3ca_hotspot_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1539`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_endometrial.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 69/124: CV914-0755 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-NSCLC`
+**File:** `bma_tp53_mut_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1543`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 70/124: CV914-0757 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R175H-BREAST`
+**File:** `bma_tp53_r175h_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1547`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r175h_breast.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 71/124: CV914-0759 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R175H-NSCLC`
+**File:** `bma_tp53_r175h_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1551`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r175h_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 72/124: CV914-0761 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R248Q-BREAST`
+**File:** `bma_tp53_r248q_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1555`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r248q_breast.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 73/124: CV914-0763 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R248Q-NSCLC`
+**File:** `bma_tp53_r248q_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1559`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r248q_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 74/124: CV914-0765 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R273H-BREAST`
+**File:** `bma_tp53_r273h_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1563`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r273h_breast.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 75/124: CV914-0767 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R273H-NSCLC`
+**File:** `bma_tp53_r273h_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1567`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r273h_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 76/124: CV914-0769 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R282W-BREAST`
+**File:** `bma_tp53_r282w_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1571`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r282w_breast.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 77/124: CV914-0771 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-R282W-NSCLC`
+**File:** `bma_tp53_r282w_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1575`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_r282w_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 78/124: CV914-0773 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BARD1-SOMATIC-BREAST`
+**File:** `bma_bard1_somatic_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1579`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_bard1_somatic_breast.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 79/124: CV914-0774 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-CLASS3-NSCLC`
+**File:** `bma_braf_class3_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1582`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_class3_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 80/124: CV914-0775 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-AML`
+**File:** `bma_braf_v600e_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1585`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_aml.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 81/124: CV914-0776 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-CLL`
+**File:** `bma_braf_v600e_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1588`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_cll.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 82/124: CV914-0777 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRAF-V600E-HCC`
+**File:** `bma_braf_v600e_hcc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1591`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_braf_v600e_hcc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 83/124: CV914-0778 - access_blocked -> revise_claim
+
+**Entity:** `BMA-BRIP1-GERMLINE-BREAST`
+**File:** `bma_brip1_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1594`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_brip1_germline_breast.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 84/124: CV914-0779 - access_blocked -> revise_claim
+
+**Entity:** `BMA-EGFR-MUTATION-GBM`
+**File:** `bma_egfr_mutation_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1597`
+
+**Audit finding text:**
+```
+ESCAT X typically maps to OncoKB {} but entity declares OncoKB level '4
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_egfr_mutation_gbm.yaml has escat_tier='X' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 85/124: CV914-0780 - access_blocked -> revise_claim
+
+**Entity:** `BMA-FGFR1-AMP-NSCLC-SQUAMOUS`
+**File:** `bma_fgfr1_amp_nsclc_squamous.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1600`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_fgfr1_amp_nsclc_squamous.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 86/124: CV914-0781 - access_blocked -> revise_claim
+
+**Entity:** `BMA-FGFR3-MUTATION-MM`
+**File:** `bma_fgfr3_mutation_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1603`
+
+**Audit finding text:**
+```
+ESCAT X typically maps to OncoKB {} but entity declares OncoKB level '4
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_fgfr3_mutation_mm.yaml has escat_tier='X' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 87/124: CV914-0782 - access_blocked -> revise_claim
+
+**Entity:** `BMA-FLT3-ITD-B-ALL`
+**File:** `bma_flt3_itd_b_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1606`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_flt3_itd_b_all.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 88/124: CV914-0783 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH2-R140Q-AITL`
+**File:** `bma_idh2_r140q_aitl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1609`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh2_r140q_aitl.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 89/124: CV914-0784 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH2-R140Q-MDS-HR`
+**File:** `bma_idh2_r140q_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1612`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh2_r140q_mds_hr.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 90/124: CV914-0785 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH2-R140Q-MDS-LR`
+**File:** `bma_idh2_r140q_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1615`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh2_r140q_mds_lr.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 91/124: CV914-0786 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH2-R172K-MDS-HR`
+**File:** `bma_idh2_r172k_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1618`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh2_r172k_mds_hr.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 92/124: CV914-0787 - access_blocked -> revise_claim
+
+**Entity:** `BMA-IDH2-R172K-MDS-LR`
+**File:** `bma_idh2_r172k_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1621`
+
+**Audit finding text:**
+```
+ESCAT IIA typically maps to OncoKB {3,3A,3B} but entity declares OncoKB level '2
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_idh2_r172k_mds_lr.yaml has escat_tier='IIA' and a legacy OncoKB-derived evidence level '2'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 93/124: CV914-0788 - access_blocked -> revise_claim
+
+**Entity:** `BMA-KRAS-G12C-ENDOMETRIAL`
+**File:** `bma_kras_g12c_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1624`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_kras_g12c_endometrial.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 94/124: CV914-0789 - access_blocked -> revise_claim
+
+**Entity:** `BMA-KRAS-G12C-GASTRIC`
+**File:** `bma_kras_g12c_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1627`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_kras_g12c_gastric.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 95/124: CV914-0790 - access_blocked -> revise_claim
+
+**Entity:** `BMA-KRAS-G12D-OVARIAN`
+**File:** `bma_kras_g12d_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1630`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_kras_g12d_ovarian.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 96/124: CV914-0791 - access_blocked -> revise_claim
+
+**Entity:** `BMA-MET-AMP-GASTRIC`
+**File:** `bma_met_amp_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1633`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_met_amp_gastric.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 97/124: CV914-0792 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-MCL`
+**File:** `bma_notch1_activating_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1636`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_notch1_activating_mcl.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 98/124: CV914-0793 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-G12-MDS-HR`
+**File:** `bma_nras_g12_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1639`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_g12_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 99/124: CV914-0794 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-G12-MDS-LR`
+**File:** `bma_nras_g12_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1642`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_g12_mds_lr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 100/124: CV914-0795 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-G13-MDS-HR`
+**File:** `bma_nras_g13_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1645`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_g13_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 101/124: CV914-0796 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-G13-MDS-LR`
+**File:** `bma_nras_g13_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1648`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_g13_mds_lr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 102/124: CV914-0797 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-Q61R-MDS-HR`
+**File:** `bma_nras_q61r_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1651`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_q61r_mds_hr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 103/124: CV914-0798 - access_blocked -> revise_claim
+
+**Entity:** `BMA-NRAS-Q61R-MDS-LR`
+**File:** `bma_nras_q61r_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1654`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_nras_q61r_mds_lr.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 104/124: CV914-0799 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-CERVICAL`
+**File:** `bma_pik3ca_hotspot_cervical.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1657`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_cervical.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 105/124: CV914-0800 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-ESOPHAGEAL`
+**File:** `bma_pik3ca_hotspot_esophageal.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1660`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_esophageal.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 106/124: CV914-0801 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-GASTRIC`
+**File:** `bma_pik3ca_hotspot_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1663`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_gastric.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 107/124: CV914-0802 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-NSCLC`
+**File:** `bma_pik3ca_hotspot_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1666`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_nsclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 108/124: CV914-0803 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-PROSTATE`
+**File:** `bma_pik3ca_hotspot_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1669`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_prostate.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 109/124: CV914-0804 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-RCC`
+**File:** `bma_pik3ca_hotspot_rcc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1672`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_rcc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 110/124: CV914-0805 - access_blocked -> revise_claim
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-UROTHELIAL`
+**File:** `bma_pik3ca_hotspot_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1675`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_pik3ca_hotspot_urothelial.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 111/124: CV914-0806 - access_blocked -> revise_claim
+
+**Entity:** `BMA-RAD51B-GERMLINE-BREAST`
+**File:** `bma_rad51b_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1678`
+
+**Audit finding text:**
+```
+ESCAT IIIA typically maps to OncoKB {4} but entity declares OncoKB level '3B
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_rad51b_germline_breast.yaml has escat_tier='IIIA' and a legacy OncoKB-derived evidence level '3B'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 112/124: CV914-0807 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-CERVICAL`
+**File:** `bma_tp53_mut_cervical.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1681`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_cervical.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 113/124: CV914-0808 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-CRC`
+**File:** `bma_tp53_mut_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1684`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_crc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 114/124: CV914-0809 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-ENDOMETRIAL`
+**File:** `bma_tp53_mut_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1687`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_endometrial.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 115/124: CV914-0810 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-ESOPHAGEAL`
+**File:** `bma_tp53_mut_esophageal.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1690`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_esophageal.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 116/124: CV914-0811 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-GASTRIC`
+**File:** `bma_tp53_mut_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1693`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_gastric.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 117/124: CV914-0812 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-GBM`
+**File:** `bma_tp53_mut_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1696`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_gbm.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 118/124: CV914-0813 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-HCC`
+**File:** `bma_tp53_mut_hcc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1699`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_hcc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 119/124: CV914-0814 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-MELANOMA`
+**File:** `bma_tp53_mut_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1702`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_melanoma.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 120/124: CV914-0815 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-PDAC`
+**File:** `bma_tp53_mut_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1705`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_pdac.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 121/124: CV914-0816 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-PROSTATE`
+**File:** `bma_tp53_mut_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1708`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_prostate.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 122/124: CV914-0817 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-RCC`
+**File:** `bma_tp53_mut_rcc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1711`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_rcc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 123/124: CV914-0818 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-SCLC`
+**File:** `bma_tp53_mut_sclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1714`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_sclc.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---
+
+## 124/124: CV914-0819 - access_blocked -> revise_claim
+
+**Entity:** `BMA-TP53-MUT-UROTHELIAL`
+**File:** `bma_tp53_mut_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1717`
+
+**Audit finding text:**
+```
+unknown ESCAT tier 'IIIB' (cannot validate against OncoKB level '4')
+
+```
+
+**Verification rationale:**
+```
+Current entity file bma_tp53_mut_urothelial.yaml has escat_tier='IIIB' and a legacy OncoKB-derived evidence level '4'. OncoKB is banned/not fetchable for this pilot, so the level mapping cannot be source-verified; the row should stay in maintainer review and not be treated as supported.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] dismiss (paywalled banned source; current claim acceptable)
+- [ ] file source_stub for alternative source
+- [ ] escalate
+
+---

--- a/contributions/citation-semantic-verify-v2/triage-queue-action-source_stub_needed.md
+++ b/contributions/citation-semantic-verify-v2/triage-queue-action-source_stub_needed.md
@@ -1,0 +1,9403 @@
+# Triage Queue: citation-semantic-verify-v2
+
+**Filter:** status=`None`, action=`source_stub_needed`
+
+**Total rows:** 324
+
+---
+
+## 1/324: CV914-0007 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-P210-BALL`
+**File:** `bma_bcr_abl1_p210_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:71`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_bcr_abl1_p210_ball.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 2/324: CV914-0008 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-P210-BALL`
+**File:** `bma_bcr_abl1_p210_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:72`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_p210_ball.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 3/324: CV914-0013 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-OVARIAN`
+**File:** `bma_brca1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:79`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_brca1_germline_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 4/324: CV914-0015 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-OVARIAN`
+**File:** `bma_brca1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:81`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca1_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 5/324: CV914-0017 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
+**File:** `bma_brca1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:85`
+
+**Audit finding text:**
+```
+trial ''PROpel'' mentioned but no matching source citation (looked for substrings: [''PROPEL'', ''OLAPARIB-PROST''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_brca1_germline_prostate.yaml and the hosted source registry for trial 'PROpel', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 6/324: CV914-0018 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
+**File:** `bma_brca1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:86`
+
+**Audit finding text:**
+```
+trial ''MAGNITUDE'' mentioned but no matching source citation (looked for substrings: [''MAGNITUDE'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MAGNITUDE'. Prior candidate SRC-CHECKMATE-649-JANJIGIAN-2022 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CHECKMATE-649-JANJIGIAN-2022 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 7/324: CV914-0019 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
+**File:** `bma_brca1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:87`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (5) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca1_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 8/324: CV914-0022 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-BREAST`
+**File:** `bma_brca2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:92`
+
+**Audit finding text:**
+```
+trial ''OLYMPIA'' mentioned but no matching source citation (looked for substrings: [''OLYMPIA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'OLYMPIA'. Prior candidate SRC-OLYMPIAD-ROBSON-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-OLYMPIAD-ROBSON-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 9/324: CV914-0025 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-BREAST`
+**File:** `bma_brca2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:95`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (3) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca2_germline_breast.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 10/324: CV914-0027 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-PROSTATE`
+**File:** `bma_brca2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:99`
+
+**Audit finding text:**
+```
+trial ''PROpel'' mentioned but no matching source citation (looked for substrings: [''PROPEL'', ''OLAPARIB-PROST''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_brca2_germline_prostate.yaml and the hosted source registry for trial 'PROpel', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 11/324: CV914-0028 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-PROSTATE`
+**File:** `bma_brca2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:100`
+
+**Audit finding text:**
+```
+trial ''MAGNITUDE'' mentioned but no matching source citation (looked for substrings: [''MAGNITUDE'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MAGNITUDE'. Prior candidate SRC-CHECKMATE-649-JANJIGIAN-2022 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CHECKMATE-649-JANJIGIAN-2022 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 12/324: CV914-0029 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-PROSTATE`
+**File:** `bma_brca2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:101`
+
+**Audit finding text:**
+```
+trial ''TALAPRO-2'' mentioned but no matching source citation (looked for substrings: [''TALAPRO'', ''TALAZOPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_brca2_germline_prostate.yaml and the hosted source registry for trial 'TALAPRO-2', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 13/324: CV914-0030 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-PROSTATE`
+**File:** `bma_brca2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:102`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca2_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 14/324: CV914-0032 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-C797S-NSCLC`
+**File:** `bma_egfr_c797s_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:106`
+
+**Audit finding text:**
+```
+trial ''MARIPOSA'' mentioned but no matching source citation (looked for substrings: [''MARIPOSA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MARIPOSA'. Prior candidate SRC-MARIPOSA2-PASSARO-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-MARIPOSA2-PASSARO-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 15/324: CV914-0033 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-C797S-NSCLC`
+**File:** `bma_egfr_c797s_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:107`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_egfr_c797s_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 16/324: CV914-0039 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-EX19DEL-NSCLC`
+**File:** `bma_egfr_ex19del_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:115`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_egfr_ex19del_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 17/324: CV914-0044 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-L858R-NSCLC`
+**File:** `bma_egfr_l858r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:122`
+
+**Audit finding text:**
+```
+trial ''MARIPOSA'' mentioned but no matching source citation (looked for substrings: [''MARIPOSA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MARIPOSA'. Prior candidate SRC-MARIPOSA2-PASSARO-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-MARIPOSA2-PASSARO-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 18/324: CV914-0045 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-L858R-NSCLC`
+**File:** `bma_egfr_l858r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:123`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_egfr_l858r_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 19/324: CV914-0047 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
+**File:** `bma_mlh1_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:127`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_mlh1_germline_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 20/324: CV914-0048 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
+**File:** `bma_mlh1_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:128`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_mlh1_germline_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 21/324: CV914-0049 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
+**File:** `bma_mlh1_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:129`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_germline_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 22/324: CV914-0052 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
+**File:** `bma_mlh1_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:134`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_mlh1_somatic_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 23/324: CV914-0053 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
+**File:** `bma_mlh1_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:135`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_mlh1_somatic_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 24/324: CV914-0054 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
+**File:** `bma_mlh1_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:136`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_somatic_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 25/324: CV914-0057 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:141`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh2_germline_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 26/324: CV914-0058 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:142`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh2_germline_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 27/324: CV914-0059 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:143`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_germline_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 28/324: CV914-0062 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:148`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh2_somatic_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 29/324: CV914-0063 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:149`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh2_somatic_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 30/324: CV914-0064 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:150`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_somatic_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 31/324: CV914-0067 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh6_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:155`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh6_germline_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 32/324: CV914-0068 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh6_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:156`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh6_germline_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 33/324: CV914-0069 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
+**File:** `bma_msh6_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:157`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_germline_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 34/324: CV914-0072 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh6_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:162`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh6_somatic_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 35/324: CV914-0073 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh6_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:163`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_msh6_somatic_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 36/324: CV914-0074 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
+**File:** `bma_msh6_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:164`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_somatic_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 37/324: CV914-0082 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_pms2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:176`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_pms2_germline_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 38/324: CV914-0083 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_pms2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:177`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_pms2_germline_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 39/324: CV914-0084 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
+**File:** `bma_pms2_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:178`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_germline_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 40/324: CV914-0087 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_pms2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:183`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_pms2_somatic_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 41/324: CV914-0088 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_pms2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:184`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_pms2_somatic_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 42/324: CV914-0089 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
+**File:** `bma_pms2_somatic_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:185`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_somatic_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 43/324: CV914-0092 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
+**File:** `bma_rad51b_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:190`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_rad51b_germline_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 44/324: CV914-0097 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
+**File:** `bma_rad51c_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:197`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_rad51c_germline_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 45/324: CV914-0099 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
+**File:** `bma_rad51c_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:199`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_rad51c_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 46/324: CV914-0102 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
+**File:** `bma_rad51d_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:204`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_rad51d_germline_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 47/324: CV914-0104 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
+**File:** `bma_rad51d_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:206`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_rad51d_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 48/324: CV914-0107 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-MAINT-BEV`
+**File:** `ind_ovarian_maint_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:211`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_maint_bev.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 49/324: CV914-0109 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-MAINT-BEV`
+**File:** `ind_ovarian_maint_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:213`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_maint_bev.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 50/324: CV914-0110 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-MAINT-BEV`
+**File:** `ind_ovarian_maint_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:214`
+
+**Audit finding text:**
+```
+trial ''GOG-218'' mentioned but no matching source citation (looked for substrings: [''GOG-218''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_maint_bev.yaml and the hosted source registry for trial 'GOG-218', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 51/324: CV914-0111 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-MAINT-BEV`
+**File:** `ind_ovarian_maint_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:215`
+
+**Audit finding text:**
+```
+trial ''ICON7'' mentioned but no matching source citation (looked for substrings: [''ICON7''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_maint_bev.yaml and the hosted source registry for trial 'ICON7', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 52/324: CV914-0113 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-FUSION-ALCL`
+**File:** `bma_alk_fusion_alcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:219`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_alk_fusion_alcl.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 53/324: CV914-0117 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-FUSION-NSCLC`
+**File:** `bma_alk_fusion_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:225`
+
+**Audit finding text:**
+```
+trial ''ALINA'' mentioned but no matching source citation (looked for substrings: [''ALINA'', ''ALECTINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_alk_fusion_nsclc.yaml and the hosted source registry for trial 'ALINA', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 54/324: CV914-0119 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-FUSION-NSCLC`
+**File:** `bma_alk_fusion_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:227`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_alk_fusion_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 55/324: CV914-0122 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCL2-EXPRESSION-CLL`
+**File:** `bma_bcl2_expression_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:232`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcl2_expression_cll.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 56/324: CV914-0124 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-BREAST`
+**File:** `bma_brca1_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:236`
+
+**Audit finding text:**
+```
+trial ''OLYMPIA'' mentioned but no matching source citation (looked for substrings: [''OLYMPIA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'OLYMPIA'. Prior candidate SRC-OLYMPIAD-ROBSON-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-OLYMPIAD-ROBSON-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 57/324: CV914-0127 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-BREAST`
+**File:** `bma_brca1_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:239`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (3) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca1_germline_breast.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 58/324: CV914-0130 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-OVARIAN`
+**File:** `bma_brca2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:244`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca2_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 59/324: CV914-0132 - unclear -> source_stub_needed
+
+**Entity:** `BMA-CCND1-T1114-MCL`
+**File:** `bma_ccnd1_t1114_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:248`
+
+**Audit finding text:**
+```
+trial ''TRIANGLE'' mentioned but no matching source citation (looked for substrings: [''TRIANGLE''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'TRIANGLE'. Prior candidate SRC-ESMO-MCL-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 60/324: CV914-0133 - unclear -> source_stub_needed
+
+**Entity:** `BMA-CCND1-T1114-MCL`
+**File:** `bma_ccnd1_t1114_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:249`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (5) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ccnd1_t1114_mcl.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 61/324: CV914-0136 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR2-MUTATION-ENDOMETRIAL`
+**File:** `bma_fgfr2_mutation_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:254`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_fgfr2_mutation_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 62/324: CV914-0137 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR2-MUTATION-ENDOMETRIAL`
+**File:** `bma_fgfr2_mutation_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:255`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_fgfr2_mutation_endometrial.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 63/324: CV914-0140 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FLT3-ITD-AML`
+**File:** `bma_flt3_itd_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:260`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_flt3_itd_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 64/324: CV914-0144 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-PDAC`
+**File:** `bma_kras_g12c_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:266`
+
+**Audit finding text:**
+```
+trial ''CodeBreaK'' mentioned but no matching source citation (looked for substrings: [''CODEBREAK'', ''SOTORASIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CodeBreaK'. Prior candidate SRC-CODEBREAK-300-FAKIH-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CODEBREAK-300-FAKIH-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 65/324: CV914-0146 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-PDAC`
+**File:** `bma_kras_g12c_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:268`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kras_g12c_pdac.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 66/324: CV914-0148 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PALB2-GERMLINE-OVARIAN`
+**File:** `bma_palb2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:272`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_palb2_germline_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 67/324: CV914-0150 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PALB2-GERMLINE-OVARIAN`
+**File:** `bma_palb2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:274`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_palb2_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 68/324: CV914-0155 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RET-FUSION-NSCLC`
+**File:** `bma_ret_fusion_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:281`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ret_fusion_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 69/324: CV914-0159 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RET-KIF5B-NSCLC`
+**File:** `bma_ret_kif5b_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:287`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ret_kif5b_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 70/324: CV914-0160 - unclear -> source_stub_needed
+
+**Entity:** `BMA-TP53-MUT-MCL`
+**File:** `bma_tp53_mut_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:290`
+
+**Audit finding text:**
+```
+trial ''TRIANGLE'' mentioned but no matching source citation (looked for substrings: [''TRIANGLE''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'TRIANGLE'. Prior candidate SRC-ESMO-MCL-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 71/324: CV914-0167 - unclear -> source_stub_needed
+
+**Entity:** `IND-BREAST-HR-POS-MAINT-CDK46I`
+**File:** `ind_breast_hr_pos_maint_cdk46i.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:299`
+
+**Audit finding text:**
+```
+trial ''TROPiCS-02'' mentioned but no matching source citation (looked for substrings: [''TROPICS'', ''SACITUZUMAB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'TROPiCS-02'. Prior candidate SRC-NCCN-BREAST-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-NCCN-BREAST-2025 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 72/324: CV914-0168 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MHSPC-1L-ARPI-DOUBLET`
+**File:** `ind_prostate_mhspc_1l_arpi_doublet.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:302`
+
+**Audit finding text:**
+```
+trial ''LATITUDE'' mentioned but no matching source citation (looked for substrings: [''LATITUDE'', ''ABIRATERONE''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'LATITUDE'. Prior candidate SRC-ESMO-PROSTATE-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-ESMO-PROSTATE-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 73/324: CV914-0169 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MHSPC-1L-ARPI-DOUBLET`
+**File:** `ind_prostate_mhspc_1l_arpi_doublet.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:303`
+
+**Audit finding text:**
+```
+trial ''ENZAMET'' mentioned but no matching source citation (looked for substrings: [''ENZAMET'', ''ENZALUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_prostate_mhspc_1l_arpi_doublet.yaml and the hosted source registry for trial 'ENZAMET', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 74/324: CV914-0170 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MHSPC-1L-ARPI-DOUBLET`
+**File:** `ind_prostate_mhspc_1l_arpi_doublet.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:304`
+
+**Audit finding text:**
+```
+trial ''TITAN'' mentioned but no matching source citation (looked for substrings: [''TITAN'', ''APALUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_prostate_mhspc_1l_arpi_doublet.yaml and the hosted source registry for trial 'TITAN', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 75/324: CV914-0171 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MHSPC-1L-ARPI-DOUBLET`
+**File:** `ind_prostate_mhspc_1l_arpi_doublet.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:305`
+
+**Audit finding text:**
+```
+trial ''ARASENS'' mentioned but no matching source citation (looked for substrings: [''ARASENS'', ''DAROLUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_prostate_mhspc_1l_arpi_doublet.yaml and the hosted source registry for trial 'ARASENS', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 76/324: CV914-0172 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BARD1-GERMLINE-OVARIAN`
+**File:** `bma_bard1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:308`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_bard1_germline_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 77/324: CV914-0173 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BARD1-GERMLINE-OVARIAN`
+**File:** `bma_bard1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:309`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bard1_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 78/324: CV914-0175 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-E255K-CML`
+**File:** `bma_bcr_abl1_e255k_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:313`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_e255k_cml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 79/324: CV914-0178 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-F317L-BALL`
+**File:** `bma_bcr_abl1_f317l_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:318`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_f317l_ball.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 80/324: CV914-0181 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-T315I-BALL`
+**File:** `bma_bcr_abl1_t315i_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:323`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_t315i_ball.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 81/324: CV914-0185 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-T315I-CML`
+**File:** `bma_bcr_abl1_t315i_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:329`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_t315i_cml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 82/324: CV914-0189 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-CRC`
+**File:** `bma_braf_v600e_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:335`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 83/324: CV914-0190 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-HCL`
+**File:** `bma_braf_v600e_hcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:338`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_hcl.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 84/324: CV914-0195 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-MELANOMA`
+**File:** `bma_braf_v600e_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:345`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (3) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_melanoma.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 85/324: CV914-0197 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600K-MELANOMA`
+**File:** `bma_braf_v600k_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:349`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600k_melanoma.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 86/324: CV914-0200 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-SOMATIC-OVARIAN`
+**File:** `bma_brca1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:354`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca1_somatic_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 87/324: CV914-0202 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-SOMATIC-PROSTATE`
+**File:** `bma_brca1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:358`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca1_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 88/324: CV914-0206 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-SOMATIC-OVARIAN`
+**File:** `bma_brca2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:364`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca2_somatic_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 89/324: CV914-0208 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-SOMATIC-PROSTATE`
+**File:** `bma_brca2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:368`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca2_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 90/324: CV914-0211 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRIP1-GERMLINE-OVARIAN`
+**File:** `bma_brip1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:373`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brip1_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 91/324: CV914-0214 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-EX20INS-NSCLC`
+**File:** `bma_egfr_ex20ins_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:378`
+
+**Audit finding text:**
+```
+trial ''PAPILLON'' mentioned but no matching source citation (looked for substrings: [''PAPILLON'', ''AMIVANTAMAB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PAPILLON'. Prior candidate SRC-CHRYSALIS-PARK-2021 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CHRYSALIS-PARK-2021 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 92/324: CV914-0215 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-EX20INS-NSCLC`
+**File:** `bma_egfr_ex20ins_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:379`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_egfr_ex20ins_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 93/324: CV914-0218 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EPCAM-GERMLINE-CRC`
+**File:** `bma_epcam_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:384`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_epcam_germline_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 94/324: CV914-0220 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EPCAM-GERMLINE-ENDOMETRIAL`
+**File:** `bma_epcam_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:388`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_epcam_germline_endometrial.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 95/324: CV914-0221 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EPCAM-GERMLINE-ENDOMETRIAL`
+**File:** `bma_epcam_germline_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:389`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_epcam_germline_endometrial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 96/324: CV914-0223 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR2-MUTATION-UROTHELIAL`
+**File:** `bma_fgfr2_mutation_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:393`
+
+**Audit finding text:**
+```
+trial ''BLC2001'' mentioned but no matching source citation (looked for substrings: [''BLC2001'', ''ERDAFITINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_fgfr2_mutation_urothelial.yaml and the hosted source registry for trial 'BLC2001', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 97/324: CV914-0224 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR2-MUTATION-UROTHELIAL`
+**File:** `bma_fgfr2_mutation_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:394`
+
+**Audit finding text:**
+```
+trial ''THOR'' mentioned but no matching source citation (looked for substrings: [''THOR'', ''ERDAFITINIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'THOR'. Prior candidate SRC-POSEIDON-JOHNSON-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-POSEIDON-JOHNSON-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 98/324: CV914-0225 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR2-MUTATION-UROTHELIAL`
+**File:** `bma_fgfr2_mutation_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:395`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_fgfr2_mutation_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 99/324: CV914-0226 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-TACC3-UROTHELIAL`
+**File:** `bma_fgfr3_tacc3_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:398`
+
+**Audit finding text:**
+```
+trial ''BLC2001'' mentioned but no matching source citation (looked for substrings: [''BLC2001'', ''ERDAFITINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_fgfr3_tacc3_urothelial.yaml and the hosted source registry for trial 'BLC2001', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 100/324: CV914-0227 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-TACC3-UROTHELIAL`
+**File:** `bma_fgfr3_tacc3_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:399`
+
+**Audit finding text:**
+```
+trial ''THOR'' mentioned but no matching source citation (looked for substrings: [''THOR'', ''ERDAFITINIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'THOR'. Prior candidate SRC-POSEIDON-JOHNSON-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-POSEIDON-JOHNSON-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 101/324: CV914-0228 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-TACC3-UROTHELIAL`
+**File:** `bma_fgfr3_tacc3_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:400`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_fgfr3_tacc3_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 102/324: CV914-0229 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FLT3-D835-AML`
+**File:** `bma_flt3_d835_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:403`
+
+**Audit finding text:**
+```
+trial ''MAGNITUDE'' mentioned but no matching source citation (looked for substrings: [''MAGNITUDE'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MAGNITUDE'. Prior candidate SRC-CHECKMATE-649-JANJIGIAN-2022 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CHECKMATE-649-JANJIGIAN-2022 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 103/324: CV914-0230 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FLT3-D835-AML`
+**File:** `bma_flt3_d835_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:404`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_flt3_d835_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 104/324: CV914-0232 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FLT3-F691L-AML`
+**File:** `bma_flt3_f691l_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:408`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 105/324: CV914-0235 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132C-AML`
+**File:** `bma_idh1_r132c_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:413`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132c_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 106/324: CV914-0238 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-CRC`
+**File:** `bma_kras_g12c_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:418`
+
+**Audit finding text:**
+```
+trial ''CodeBreaK'' mentioned but no matching source citation (looked for substrings: [''CODEBREAK'', ''SOTORASIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CodeBreaK'. Prior candidate SRC-CODEBREAK-300-FAKIH-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CODEBREAK-300-FAKIH-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 107/324: CV914-0240 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-CRC`
+**File:** `bma_kras_g12c_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:420`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kras_g12c_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 108/324: CV914-0241 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-NSCLC`
+**File:** `bma_kras_g12c_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:423`
+
+**Audit finding text:**
+```
+trial ''CodeBreaK'' mentioned but no matching source citation (looked for substrings: [''CODEBREAK'', ''SOTORASIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CodeBreaK'. Prior candidate SRC-CODEBREAK-300-FAKIH-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CODEBREAK-300-FAKIH-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 109/324: CV914-0243 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-NSCLC`
+**File:** `bma_kras_g12c_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:425`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kras_g12c_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 110/324: CV914-0245 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-GASTRIC`
+**File:** `bma_mlh1_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:429`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_germline_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 111/324: CV914-0248 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-GASTRIC`
+**File:** `bma_mlh1_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:434`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_somatic_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 112/324: CV914-0251 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-GASTRIC`
+**File:** `bma_msh2_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:439`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_germline_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 113/324: CV914-0254 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-GASTRIC`
+**File:** `bma_msh2_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:444`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_somatic_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 114/324: CV914-0257 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-GASTRIC`
+**File:** `bma_msh6_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:449`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_germline_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 115/324: CV914-0260 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-GASTRIC`
+**File:** `bma_msh6_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:454`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_somatic_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 116/324: CV914-0262 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MYD88-L265P-HCV-MZL`
+**File:** `bma_myd88_l265p_hcv_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:458`
+
+**Audit finding text:**
+```
+trial ''MAGNOLIA'' mentioned but no matching source citation (looked for substrings: [''MAGNOLIA''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_myd88_l265p_hcv_mzl.yaml and the hosted source registry for trial 'MAGNOLIA', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 117/324: CV914-0265 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MYD88-L265P-NODAL-MZL`
+**File:** `bma_myd88_l265p_nodal_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:463`
+
+**Audit finding text:**
+```
+trial ''MAGNOLIA'' mentioned but no matching source citation (looked for substrings: [''MAGNOLIA''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_myd88_l265p_nodal_mzl.yaml and the hosted source registry for trial 'MAGNOLIA', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 118/324: CV914-0268 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MYD88-L265P-SPLENIC-MZL`
+**File:** `bma_myd88_l265p_splenic_mzl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:468`
+
+**Audit finding text:**
+```
+trial ''MAGNOLIA'' mentioned but no matching source citation (looked for substrings: [''MAGNOLIA''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_myd88_l265p_splenic_mzl.yaml and the hosted source registry for trial 'MAGNOLIA', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 119/324: CV914-0272 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-GASTRIC`
+**File:** `bma_pms2_germline_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:474`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_germline_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 120/324: CV914-0275 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-GASTRIC`
+**File:** `bma_pms2_somatic_gastric.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:479`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_somatic_gastric.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 121/324: CV914-0279 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RET-CCDC6-NSCLC`
+**File:** `bma_ret_ccdc6_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:485`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ret_ccdc6_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 122/324: CV914-0282 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RET-FUSION-THYROID-PAPILLARY`
+**File:** `bma_ret_fusion_thyroid_papillary.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:490`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ret_fusion_thyroid_papillary.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 123/324: CV914-0284 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ROS1-G2032R-NSCLC`
+**File:** `bma_ros1_g2032r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:494`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ros1_g2032r_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 124/324: CV914-0286 - unclear -> source_stub_needed
+
+**Entity:** `BMA-TP53-MUT-BREAST`
+**File:** `bma_tp53_mut_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:498`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-522'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-522'', ''KEYNOTE522''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'KEYNOTE-522'. Prior candidate SRC-NCCN-BREAST-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 125/324: CV914-0289 - unclear -> source_stub_needed
+
+**Entity:** `IND-CML-1L-2GEN-TKI`
+**File:** `ind_cml_1l_2gen_tki.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:503`
+
+**Audit finding text:**
+```
+trial ''ENESTnd'' mentioned but no matching source citation (looked for substrings: [''ENESTND'', ''NILOTINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_cml_1l_2gen_tki.yaml and the hosted source registry for trial 'ENESTnd', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 126/324: CV914-0290 - unclear -> source_stub_needed
+
+**Entity:** `IND-CML-1L-2GEN-TKI`
+**File:** `ind_cml_1l_2gen_tki.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:504`
+
+**Audit finding text:**
+```
+trial ''DASISION'' mentioned but no matching source citation (looked for substrings: [''DASISION'', ''DASATINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_cml_1l_2gen_tki.yaml and the hosted source registry for trial 'DASISION', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 127/324: CV914-0291 - unclear -> source_stub_needed
+
+**Entity:** `IND-CML-1L-2GEN-TKI`
+**File:** `ind_cml_1l_2gen_tki.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:505`
+
+**Audit finding text:**
+```
+trial ''BFORE'' mentioned but no matching source citation (looked for substrings: [''BFORE'', ''BOSUTINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_cml_1l_2gen_tki.yaml and the hosted source registry for trial 'BFORE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 128/324: CV914-0292 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO`
+**File:** `ind_endometrial_advanced_1l_pembro_chemo.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:508`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_advanced_1l_pembro_chemo.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 129/324: CV914-0293 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO`
+**File:** `ind_endometrial_advanced_1l_pembro_chemo.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:509`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_advanced_1l_pembro_chemo.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 130/324: CV914-0294 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO`
+**File:** `ind_endometrial_advanced_1l_pembro_chemo.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:510`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_advanced_1l_pembro_chemo.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 131/324: CV914-0297 - unclear -> source_stub_needed
+
+**Entity:** `IND-MTC-ADVANCED-1L-SELPERCATINIB`
+**File:** `ind_mtc_advanced_1l_selpercatinib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:515`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 132/324: CV914-0300 - unclear -> source_stub_needed
+
+**Entity:** `IND-NSCLC-ALK-MAINT-ALECTINIB`
+**File:** `ind_nsclc_alk_maint_alectinib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:520`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_nsclc_alk_maint_alectinib.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 133/324: CV914-0301 - unclear -> source_stub_needed
+
+**Entity:** `REG-2GEN-TKI-CML`
+**File:** `dasatinib_or_nilotinib_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:523`
+
+**Audit finding text:**
+```
+trial ''ENESTnd'' mentioned but no matching source citation (looked for substrings: [''ENESTND'', ''NILOTINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity dasatinib_or_nilotinib_cml.yaml and the hosted source registry for trial 'ENESTnd', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 134/324: CV914-0302 - unclear -> source_stub_needed
+
+**Entity:** `REG-2GEN-TKI-CML`
+**File:** `dasatinib_or_nilotinib_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:524`
+
+**Audit finding text:**
+```
+trial ''DASISION'' mentioned but no matching source citation (looked for substrings: [''DASISION'', ''DASATINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity dasatinib_or_nilotinib_cml.yaml and the hosted source registry for trial 'DASISION', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 135/324: CV914-0303 - unclear -> source_stub_needed
+
+**Entity:** `REG-2GEN-TKI-CML`
+**File:** `dasatinib_or_nilotinib_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:525`
+
+**Audit finding text:**
+```
+trial ''BFORE'' mentioned but no matching source citation (looked for substrings: [''BFORE'', ''BOSUTINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity dasatinib_or_nilotinib_cml.yaml and the hosted source registry for trial 'BFORE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 136/324: CV914-0305 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-EML4-V1-NSCLC`
+**File:** `bma_alk_eml4_v1_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:529`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_alk_eml4_v1_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 137/324: CV914-0307 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-EML4-V3-NSCLC`
+**File:** `bma_alk_eml4_v3_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:533`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_alk_eml4_v3_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 138/324: CV914-0308 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-G1202R-NSCLC`
+**File:** `bma_alk_g1202r_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:536`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_alk_g1202r_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 139/324: CV914-0310 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ALK-L1196M-NSCLC`
+**File:** `bma_alk_l1196m_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:540`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_alk_l1196m_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 140/324: CV914-0312 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ATM-SOMATIC-PROSTATE`
+**File:** `bma_atm_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:544`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_atm_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 141/324: CV914-0314 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-F317L-CML`
+**File:** `bma_bcr_abl1_f317l_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:548`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_f317l_cml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 142/324: CV914-0316 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-P190-BALL`
+**File:** `bma_bcr_abl1_p190_ball.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:552`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_p190_ball.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 143/324: CV914-0318 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-P210-CML`
+**File:** `bma_bcr_abl1_p210_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:556`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_bcr_abl1_p210_cml.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 144/324: CV914-0319 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-P210-CML`
+**File:** `bma_bcr_abl1_p210_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:557`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_p210_cml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 145/324: CV914-0320 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BCR-ABL1-V299L-CML`
+**File:** `bma_bcr_abl1_v299l_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:560`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_bcr_abl1_v299l_cml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 146/324: CV914-0322 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-GBM`
+**File:** `bma_braf_v600e_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:564`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_gbm.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 147/324: CV914-0324 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-OVARIAN`
+**File:** `bma_braf_v600e_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:568`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 148/324: CV914-0326 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-PDAC`
+**File:** `bma_braf_v600e_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:572`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_pdac.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 149/324: CV914-0328 - unclear -> source_stub_needed
+
+**Entity:** `BMA-CHEK1-SOMATIC-PROSTATE`
+**File:** `bma_chek1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:576`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_chek1_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 150/324: CV914-0330 - unclear -> source_stub_needed
+
+**Entity:** `BMA-CHEK2-GERMLINE-PROSTATE`
+**File:** `bma_chek2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:580`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_chek2_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 151/324: CV914-0332 - unclear -> source_stub_needed
+
+**Entity:** `BMA-CHEK2-SOMATIC-PROSTATE`
+**File:** `bma_chek2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:584`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_chek2_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 152/324: CV914-0335 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-T790M-NSCLC`
+**File:** `bma_egfr_t790m_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:589`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_egfr_t790m_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 153/324: CV914-0336 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-R248C-UROTHELIAL`
+**File:** `bma_fgfr3_r248c_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:592`
+
+**Audit finding text:**
+```
+trial ''THOR'' mentioned but no matching source citation (looked for substrings: [''THOR'', ''ERDAFITINIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'THOR'. Prior candidate SRC-POSEIDON-JOHNSON-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-POSEIDON-JOHNSON-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 154/324: CV914-0337 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-R248C-UROTHELIAL`
+**File:** `bma_fgfr3_r248c_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:593`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_fgfr3_r248c_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 155/324: CV914-0338 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-S249C-UROTHELIAL`
+**File:** `bma_fgfr3_s249c_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:596`
+
+**Audit finding text:**
+```
+trial ''THOR'' mentioned but no matching source citation (looked for substrings: [''THOR'', ''ERDAFITINIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'THOR'. Prior candidate SRC-POSEIDON-JOHNSON-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-POSEIDON-JOHNSON-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 156/324: CV914-0339 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-S249C-UROTHELIAL`
+**File:** `bma_fgfr3_s249c_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:597`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_fgfr3_s249c_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 157/324: CV914-0340 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132C-GBM`
+**File:** `bma_idh1_r132c_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:600`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132c_gbm.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 158/324: CV914-0342 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132G-AML`
+**File:** `bma_idh1_r132g_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:604`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132g_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 159/324: CV914-0344 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132H-AML`
+**File:** `bma_idh1_r132h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:608`
+
+**Audit finding text:**
+```
+trial ''AGILE'' mentioned but no matching source citation (looked for substrings: [''AGILE'', ''IVOSIDENIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_idh1_r132h_aml.yaml and the hosted source registry for trial 'AGILE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 160/324: CV914-0345 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132H-AML`
+**File:** `bma_idh1_r132h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:609`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132h_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 161/324: CV914-0346 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132H-GBM`
+**File:** `bma_idh1_r132h_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:612`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132h_gbm.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 162/324: CV914-0348 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132L-AML`
+**File:** `bma_idh1_r132l_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:616`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132l_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 163/324: CV914-0350 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH1-R132S-AML`
+**File:** `bma_idh1_r132s_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:620`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh1_r132s_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 164/324: CV914-0354 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KIT-D816V-GIST`
+**File:** `bma_kit_d816v_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:628`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kit_d816v_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 165/324: CV914-0356 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KIT-EXON11-GIST`
+**File:** `bma_kit_exon11_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:632`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kit_exon11_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 166/324: CV914-0358 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KIT-EXON13-17-GIST`
+**File:** `bma_kit_exon13_17_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:636`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kit_exon13_17_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 167/324: CV914-0360 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KIT-EXON9-GIST`
+**File:** `bma_kit_exon9_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:640`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kit_exon9_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 168/324: CV914-0362 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KRAS-G12C-OVARIAN`
+**File:** `bma_kras_g12c_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:644`
+
+**Audit finding text:**
+```
+trial ''CodeBreaK'' mentioned but no matching source citation (looked for substrings: [''CODEBREAK'', ''SOTORASIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CodeBreaK'. Prior candidate SRC-CODEBREAK-300-FAKIH-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CODEBREAK-300-FAKIH-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 169/324: CV914-0364 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MET-AMP-NSCLC`
+**File:** `bma_met_amp_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:648`
+
+**Audit finding text:**
+```
+trial ''MARIPOSA'' mentioned but no matching source citation (looked for substrings: [''MARIPOSA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MARIPOSA'. Prior candidate SRC-MARIPOSA2-PASSARO-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-MARIPOSA2-PASSARO-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 170/324: CV914-0366 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MET-AMP-RCC-PAPILLARY`
+**File:** `bma_met_amp_rcc_papillary.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:652`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_met_amp_rcc_papillary.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 171/324: CV914-0369 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MET-EX14-NSCLC`
+**File:** `bma_met_ex14_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:657`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_met_ex14_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 172/324: CV914-0371 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-CRC`
+**File:** `bma_mlh1_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:661`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_germline_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 173/324: CV914-0372 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-OVARIAN`
+**File:** `bma_mlh1_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:664`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 174/324: CV914-0374 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-PROSTATE`
+**File:** `bma_mlh1_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:668`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 175/324: CV914-0377 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-CRC`
+**File:** `bma_mlh1_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:673`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_somatic_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 176/324: CV914-0378 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-OVARIAN`
+**File:** `bma_mlh1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:676`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_somatic_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 177/324: CV914-0380 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-PROSTATE`
+**File:** `bma_mlh1_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:680`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 178/324: CV914-0383 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-CRC`
+**File:** `bma_msh2_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:685`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_germline_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 179/324: CV914-0384 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-OVARIAN`
+**File:** `bma_msh2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:688`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 180/324: CV914-0386 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-PROSTATE`
+**File:** `bma_msh2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:692`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 181/324: CV914-0389 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-CRC`
+**File:** `bma_msh2_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:697`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_somatic_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 182/324: CV914-0390 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-OVARIAN`
+**File:** `bma_msh2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:700`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_somatic_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 183/324: CV914-0392 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-PROSTATE`
+**File:** `bma_msh2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:704`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 184/324: CV914-0395 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-CRC`
+**File:** `bma_msh6_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:709`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_germline_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 185/324: CV914-0396 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-OVARIAN`
+**File:** `bma_msh6_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:712`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 186/324: CV914-0398 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-PROSTATE`
+**File:** `bma_msh6_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:716`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 187/324: CV914-0401 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-CRC`
+**File:** `bma_msh6_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:721`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_somatic_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 188/324: CV914-0402 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-OVARIAN`
+**File:** `bma_msh6_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:724`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_somatic_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 189/324: CV914-0404 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-PROSTATE`
+**File:** `bma_msh6_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:728`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 190/324: CV914-0407 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-CRC`
+**File:** `bma_pms2_germline_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:733`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_germline_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 191/324: CV914-0408 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-OVARIAN`
+**File:** `bma_pms2_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:736`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_germline_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 192/324: CV914-0410 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-PROSTATE`
+**File:** `bma_pms2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:740`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 193/324: CV914-0413 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-CRC`
+**File:** `bma_pms2_somatic_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:745`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (4) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_somatic_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 194/324: CV914-0414 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-OVARIAN`
+**File:** `bma_pms2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:748`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_somatic_ovarian.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 195/324: CV914-0416 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-PROSTATE`
+**File:** `bma_pms2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:752`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_somatic_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 196/324: CV914-0419 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RET-C634R-MTC`
+**File:** `bma_ret_c634r_mtc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:757`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ret_c634r_mtc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 197/324: CV914-0421 - unclear -> source_stub_needed
+
+**Entity:** `BMA-RET-M918T-MTC`
+**File:** `bma_ret_m918t_mtc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:761`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ret_m918t_mtc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 198/324: CV914-0423 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ROS1-FUSION-NSCLC`
+**File:** `bma_ros1_fusion_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:765`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ros1_fusion_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 199/324: CV914-0424 - unclear -> source_stub_needed
+
+**Entity:** `IND-ALCL-MAINTENANCE-BV-POST-ASCT`
+**File:** `ind_alcl_maintenance_bv_post_asct.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:768`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_alcl_maintenance_bv_post_asct.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 200/324: CV914-0427 - unclear -> source_stub_needed
+
+**Entity:** `IND-APL-1L-ATRA-ATO-IDA`
+**File:** `ind_apl_1l_atra_ato_ida.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:773`
+
+**Audit finding text:**
+```
+trial ''AIDA'' mentioned but no matching source citation (looked for substrings: [''AIDA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'AIDA'. Prior candidate SRC-ELN-APL-2019 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** URL reachability check on https://ashpublications.org/blood/article/133/15/1630/272971 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Other source candidates: SRC-ESMO-AML-2020, SRC-APL0406-LOCOCO-2013
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 201/324: CV914-0434 - unclear -> source_stub_needed
+
+**Entity:** `IND-BREAST-TNBC-EARLY-NEOADJUVANT`
+**File:** `ind_breast_tnbc_early_neoadjuvant.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:788`
+
+**Audit finding text:**
+```
+trial ''OLYMPIA'' mentioned but no matching source citation (looked for substrings: [''OLYMPIA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'OLYMPIA'. Prior candidate SRC-OLYMPIAD-ROBSON-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-OLYMPIAD-ROBSON-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 202/324: CV914-0435 - unclear -> source_stub_needed
+
+**Entity:** `IND-BREAST-TNBC-EARLY-NEOADJUVANT`
+**File:** `ind_breast_tnbc_early_neoadjuvant.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:789`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-522'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-522'', ''KEYNOTE522''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'KEYNOTE-522'. Prior candidate SRC-NCCN-BREAST-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-NCCN-BREAST-2025 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 203/324: CV914-0440 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-2L-DOSTARLIMAB-DMMR`
+**File:** `ind_endometrial_2l_dostarlimab_dmmr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:800`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_2l_dostarlimab_dmmr.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 204/324: CV914-0441 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-2L-DOSTARLIMAB-DMMR`
+**File:** `ind_endometrial_2l_dostarlimab_dmmr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:801`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_2l_dostarlimab_dmmr.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 205/324: CV914-0442 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-2L-PEMBRO-LENVA-PMMR`
+**File:** `ind_endometrial_2l_pembro_lenva_pmmr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:804`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_2l_pembro_lenva_pmmr.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 206/324: CV914-0443 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-2L-PEMBRO-LENVA-PMMR`
+**File:** `ind_endometrial_2l_pembro_lenva_pmmr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:805`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_2l_pembro_lenva_pmmr.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 207/324: CV914-0444 - unclear -> source_stub_needed
+
+**Entity:** `IND-ESOPH-ADJUVANT-NIVOLUMAB-POST-CROSS`
+**File:** `ind_esoph_adjuvant_nivolumab_post_cross.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:808`
+
+**Audit finding text:**
+```
+trial ''CheckMate-577'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-577'', ''CHECKMATE577''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_esoph_adjuvant_nivolumab_post_cross.yaml and the hosted source registry for trial 'CheckMate-577', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 208/324: CV914-0445 - unclear -> source_stub_needed
+
+**Entity:** `IND-ESOPH-ADJUVANT-NIVOLUMAB-POST-CROSS`
+**File:** `ind_esoph_adjuvant_nivolumab_post_cross.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:809`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 209/324: CV914-0446 - unclear -> source_stub_needed
+
+**Entity:** `IND-FL-1L-BR`
+**File:** `ind_fl_1l_br.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:812`
+
+**Audit finding text:**
+```
+trial ''STIL'' mentioned but no matching source citation (looked for substrings: [''STIL''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_fl_1l_br.yaml and the hosted source registry for trial 'STIL', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 210/324: CV914-0450 - unclear -> source_stub_needed
+
+**Entity:** `IND-MELANOMA-BRAF-METASTATIC-1L-DABRA-TRAME`
+**File:** `ind_melanoma_braf_metastatic_1l_dabra_trame.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:820`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 211/324: CV914-0457 - unclear -> source_stub_needed
+
+**Entity:** `IND-NSCLC-EGFR-MAINT-OSIMERTINIB`
+**File:** `ind_nsclc_egfr_maint_osimertinib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:833`
+
+**Audit finding text:**
+```
+trial ''MARIPOSA'' mentioned but no matching source citation (looked for substrings: [''MARIPOSA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MARIPOSA'. Prior candidate SRC-MARIPOSA2-PASSARO-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-MARIPOSA2-PASSARO-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 212/324: CV914-0463 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-NEG`
+**File:** `ind_ovarian_advanced_1l_carbo_pacli_hrd_neg.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:845`
+
+**Audit finding text:**
+```
+trial ''GOG-218'' mentioned but no matching source citation (looked for substrings: [''GOG-218''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_advanced_1l_carbo_pacli_hrd_neg.yaml and the hosted source registry for trial 'GOG-218', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 213/324: CV914-0465 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-OLAP`
+**File:** `ind_ovarian_advanced_1l_carbo_pacli_hrd_olap.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:849`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_advanced_1l_carbo_pacli_hrd_olap.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 214/324: CV914-0467 - unclear -> source_stub_needed
+
+**Entity:** `IND-OVARIAN-MAINTENANCE-OLAPARIB`
+**File:** `ind_ovarian_maintenance_olaparib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:853`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ovarian_maintenance_olaparib.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 215/324: CV914-0468 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MCRPC-1L-PARPI`
+**File:** `ind_prostate_mcrpc_1l_parpi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:856`
+
+**Audit finding text:**
+```
+trial ''MAGNITUDE'' mentioned but no matching source citation (looked for substrings: [''MAGNITUDE'', ''NIRAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'MAGNITUDE'. Prior candidate SRC-CHECKMATE-649-JANJIGIAN-2022 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CHECKMATE-649-JANJIGIAN-2022 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 216/324: CV914-0469 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MCRPC-1L-PARPI`
+**File:** `ind_prostate_mcrpc_1l_parpi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:857`
+
+**Audit finding text:**
+```
+trial ''TALAPRO-2'' mentioned but no matching source citation (looked for substrings: [''TALAPRO'', ''TALAZOPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_prostate_mcrpc_1l_parpi.yaml and the hosted source registry for trial 'TALAPRO-2', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 217/324: CV914-0471 - unclear -> source_stub_needed
+
+**Entity:** `IND-SCLC-EXTENSIVE-1L`
+**File:** `ind_sclc_extensive_1l.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:861`
+
+**Audit finding text:**
+```
+trial ''IMpower133'' mentioned but no matching source citation (looked for substrings: [''IMPOWER133'', ''ATEZOLIZUMAB-SCLC''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'IMpower133'. Prior candidate SRC-ESMO-SCLC-2021 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-ESMO-SCLC-2021 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 218/324: CV914-0472 - unclear -> source_stub_needed
+
+**Entity:** `IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO`
+**File:** `ind_urothelial_metastatic_1l_ev_pembro.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:864`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_urothelial_metastatic_1l_ev_pembro.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 219/324: CV914-0473 - unclear -> source_stub_needed
+
+**Entity:** `IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO`
+**File:** `ind_urothelial_metastatic_1l_ev_pembro.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:865`
+
+**Audit finding text:**
+```
+trial ''EV-302'' mentioned but no matching source citation (looked for substrings: [''EV-302'', ''EV302'', ''ENFORTUMAB'', ''PADCEV''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_urothelial_metastatic_1l_ev_pembro.yaml and the hosted source registry for trial 'EV-302', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 220/324: CV914-0474 - unclear -> source_stub_needed
+
+**Entity:** `REG-ADT-ABIRATERONE`
+**File:** `reg_adt_abiraterone.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:868`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 221/324: CV914-0475 - unclear -> source_stub_needed
+
+**Entity:** `REG-ADT-ABIRATERONE`
+**File:** `reg_adt_abiraterone.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:869`
+
+**Audit finding text:**
+```
+trial ''LATITUDE'' mentioned but no matching source citation (looked for substrings: [''LATITUDE'', ''ABIRATERONE''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'LATITUDE'. Prior candidate SRC-ESMO-PROSTATE-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 222/324: CV914-0477 - unclear -> source_stub_needed
+
+**Entity:** `REG-ALECTINIB-NSCLC`
+**File:** `reg_alectinib_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:873`
+
+**Audit finding text:**
+```
+trial ''ALINA'' mentioned but no matching source citation (looked for substrings: [''ALINA'', ''ALECTINIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_alectinib_nsclc.yaml and the hosted source registry for trial 'ALINA', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 223/324: CV914-0484 - unclear -> source_stub_needed
+
+**Entity:** `REG-DOSTARLIMAB-MONO-ENDOM`
+**File:** `reg_dostarlimab_mono_endom.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:888`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_dostarlimab_mono_endom.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 224/324: CV914-0485 - unclear -> source_stub_needed
+
+**Entity:** `REG-DOSTARLIMAB-MONO-ENDOM`
+**File:** `reg_dostarlimab_mono_endom.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:889`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_dostarlimab_mono_endom.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 225/324: CV914-0486 - unclear -> source_stub_needed
+
+**Entity:** `REG-EV-PEMBRO-UROTHELIAL`
+**File:** `reg_ev_pembro_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:892`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_ev_pembro_urothelial.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 226/324: CV914-0487 - unclear -> source_stub_needed
+
+**Entity:** `REG-EV-PEMBRO-UROTHELIAL`
+**File:** `reg_ev_pembro_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:893`
+
+**Audit finding text:**
+```
+trial ''EV-302'' mentioned but no matching source citation (looked for substrings: [''EV-302'', ''EV302'', ''ENFORTUMAB'', ''PADCEV''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_ev_pembro_urothelial.yaml and the hosted source registry for trial 'EV-302', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 227/324: CV914-0488 - unclear -> source_stub_needed
+
+**Entity:** `REG-FOLFOX-CETUX`
+**File:** `folfox_cetuximab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:896`
+
+**Audit finding text:**
+```
+trial ''FIRE-3'' mentioned but no matching source citation (looked for substrings: [''FIRE-3''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity folfox_cetuximab.yaml and the hosted source registry for trial 'FIRE-3', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 228/324: CV914-0489 - unclear -> source_stub_needed
+
+**Entity:** `REG-FOLFOX-CETUX`
+**File:** `folfox_cetuximab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:897`
+
+**Audit finding text:**
+```
+trial ''CRYSTAL'' mentioned but no matching source citation (looked for substrings: [''CRYSTAL''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity folfox_cetuximab.yaml and the hosted source registry for trial 'CRYSTAL', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 229/324: CV914-0490 - unclear -> source_stub_needed
+
+**Entity:** `REG-NIVO-ADJUVANT-ESOPH`
+**File:** `nivolumab_adjuvant_esophageal.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:900`
+
+**Audit finding text:**
+```
+trial ''CheckMate-577'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-577'', ''CHECKMATE577''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity nivolumab_adjuvant_esophageal.yaml and the hosted source registry for trial 'CheckMate-577', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 230/324: CV914-0491 - unclear -> source_stub_needed
+
+**Entity:** `REG-NIVO-ADJUVANT-ESOPH`
+**File:** `nivolumab_adjuvant_esophageal.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:901`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-ESMO-ESOPHAGEAL-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-ESMO-ESOPHAGEAL-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 231/324: CV914-0492 - unclear -> source_stub_needed
+
+**Entity:** `REG-OLAPARIB-BREAST`
+**File:** `reg_olaparib_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:904`
+
+**Audit finding text:**
+```
+trial ''OLYMPIA'' mentioned but no matching source citation (looked for substrings: [''OLYMPIA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'OLYMPIA'. Prior candidate SRC-OLYMPIAD-ROBSON-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-OLYMPIAD-ROBSON-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 232/324: CV914-0495 - unclear -> source_stub_needed
+
+**Entity:** `REG-OLAPARIB-MAINT-OVARIAN`
+**File:** `olaparib_maintenance_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:909`
+
+**Audit finding text:**
+```
+trial ''PAOLA-1'' mentioned but no matching source citation (looked for substrings: [''PAOLA'', ''OLAPARIB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity olaparib_maintenance_ovarian.yaml and the hosted source registry for trial 'PAOLA-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 233/324: CV914-0498 - unclear -> source_stub_needed
+
+**Entity:** `REG-PEMBRO-CHEMO-NSCLC-NONSQ`
+**File:** `reg_pembro_chemo_nsclc_nonsq.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:916`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 234/324: CV914-0502 - unclear -> source_stub_needed
+
+**Entity:** `REG-RICE-BURKITT`
+**File:** `reg_rice_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:924`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 235/324: CV914-0505 - unclear -> source_stub_needed
+
+**Entity:** `REG-SACITUZUMAB`
+**File:** `reg_sacituzumab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:929`
+
+**Audit finding text:**
+```
+trial ''TROPiCS-02'' mentioned but no matching source citation (looked for substrings: [''TROPICS'', ''SACITUZUMAB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'TROPiCS-02'. Prior candidate SRC-NCCN-BREAST-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Other source candidates: SRC-ASCENT-BARDIA-2021
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 236/324: CV914-0511 - unclear -> source_stub_needed
+
+**Entity:** `REG-TECLISTAMAB`
+**File:** `reg_teclistamab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:941`
+
+**Audit finding text:**
+```
+trial ''MonumenTAL-1'' mentioned but no matching source citation (looked for substrings: [''MONUMENTAL'', ''TALQUETAMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_teclistamab.yaml and the hosted source registry for trial 'MonumenTAL-1', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 237/324: CV914-0514 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ATM-GERMLINE-PROSTATE`
+**File:** `bma_atm_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:948`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_atm_germline_prostate.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 238/324: CV914-0515 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ATM-LOSS-CLL`
+**File:** `bma_atm_loss_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:951`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_atm_loss_cll.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 239/324: CV914-0516 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRAF-V600E-NSCLC`
+**File:** `bma_braf_v600e_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:954`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_braf_v600e_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 240/324: CV914-0517 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA1-GERMLINE-PDAC`
+**File:** `bma_brca1_germline_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:957`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca1_germline_pdac.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 241/324: CV914-0518 - unclear -> source_stub_needed
+
+**Entity:** `BMA-BRCA2-GERMLINE-PDAC`
+**File:** `bma_brca2_germline_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:960`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_brca2_germline_pdac.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 242/324: CV914-0519 - unclear -> source_stub_needed
+
+**Entity:** `BMA-EGFR-G719X-NSCLC`
+**File:** `bma_egfr_g719x_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:963`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_egfr_g719x_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 243/324: CV914-0522 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FGFR3-Y373C-UROTHELIAL`
+**File:** `bma_fgfr3_y373c_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:972`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_fgfr3_y373c_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 244/324: CV914-0523 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FLT3-D835-AML-RR`
+**File:** `bma_flt3_d835_aml_rr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:975`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_flt3_d835_aml_rr.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 245/324: CV914-0524 - unclear -> source_stub_needed
+
+**Entity:** `BMA-FLT3-ITD-AML-RR`
+**File:** `bma_flt3_itd_aml_rr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:978`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_flt3_itd_aml_rr.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 246/324: CV914-0525 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH2-R140Q-AML`
+**File:** `bma_idh2_r140q_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:981`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh2_r140q_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 247/324: CV914-0526 - unclear -> source_stub_needed
+
+**Entity:** `BMA-IDH2-R172K-AML`
+**File:** `bma_idh2_r172k_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:984`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_idh2_r172k_aml.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 248/324: CV914-0527 - unclear -> source_stub_needed
+
+**Entity:** `BMA-KIT-D816V-MASTOCYTOSIS`
+**File:** `bma_kit_d816v_mastocytosis.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:987`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_kit_d816v_mastocytosis.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 249/324: CV914-0528 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-GERMLINE-UROTHELIAL`
+**File:** `bma_mlh1_germline_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:990`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_germline_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 250/324: CV914-0529 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MLH1-SOMATIC-UROTHELIAL`
+**File:** `bma_mlh1_somatic_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:993`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_mlh1_somatic_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 251/324: CV914-0530 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-GERMLINE-UROTHELIAL`
+**File:** `bma_msh2_germline_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:996`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_germline_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 252/324: CV914-0531 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH2-SOMATIC-UROTHELIAL`
+**File:** `bma_msh2_somatic_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:999`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh2_somatic_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 253/324: CV914-0532 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-GERMLINE-UROTHELIAL`
+**File:** `bma_msh6_germline_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1002`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_germline_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 254/324: CV914-0533 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MSH6-SOMATIC-UROTHELIAL`
+**File:** `bma_msh6_somatic_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1005`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_msh6_somatic_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 255/324: CV914-0534 - unclear -> source_stub_needed
+
+**Entity:** `BMA-MYD88-L265P-WM`
+**File:** `bma_myd88_l265p_wm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1008`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_myd88_l265p_wm.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 256/324: CV914-0535 - unclear -> source_stub_needed
+
+**Entity:** `BMA-NTRK-ETV6-SALIVARY`
+**File:** `bma_ntrk_etv6_salivary.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1011`
+
+**Audit finding text:**
+```
+trial ''STARTRK'' mentioned but no matching source citation (looked for substrings: [''STARTRK''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'STARTRK'. Prior candidate SRC-STARTRK2-DRILON-2020 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-STARTRK2-DRILON-2020 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 257/324: CV914-0536 - unclear -> source_stub_needed
+
+**Entity:** `BMA-NTRK-FUSION-CRC`
+**File:** `bma_ntrk_fusion_crc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1014`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ntrk_fusion_crc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 258/324: CV914-0537 - unclear -> source_stub_needed
+
+**Entity:** `BMA-NTRK-FUSION-IFS`
+**File:** `bma_ntrk_fusion_ifs.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1017`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity bma_ntrk_fusion_ifs.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 259/324: CV914-0538 - unclear -> source_stub_needed
+
+**Entity:** `BMA-NTRK-FUSION-NSCLC`
+**File:** `bma_ntrk_fusion_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1020`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (2) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ntrk_fusion_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 260/324: CV914-0539 - unclear -> source_stub_needed
+
+**Entity:** `BMA-NTRK-FUSION-SALIVARY`
+**File:** `bma_ntrk_fusion_salivary.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1023`
+
+**Audit finding text:**
+```
+trial ''STARTRK'' mentioned but no matching source citation (looked for substrings: [''STARTRK''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'STARTRK'. Prior candidate SRC-STARTRK2-DRILON-2020 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-STARTRK2-DRILON-2020 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 261/324: CV914-0540 - unclear -> source_stub_needed
+
+**Entity:** `BMA-NTRK-FUSION-THYROID-PAPILLARY`
+**File:** `bma_ntrk_fusion_thyroid_papillary.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1026`
+
+**Audit finding text:**
+```
+trial ''STARTRK'' mentioned but no matching source citation (looked for substrings: [''STARTRK''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'STARTRK'. Prior candidate SRC-STARTRK2-DRILON-2020 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-STARTRK2-DRILON-2020 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 262/324: CV914-0541 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PDGFRA-EXON12-GIST`
+**File:** `bma_pdgfra_exon12_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1029`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pdgfra_exon12_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 263/324: CV914-0542 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PDGFRA-EXON14-GIST`
+**File:** `bma_pdgfra_exon14_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1032`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pdgfra_exon14_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 264/324: CV914-0543 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PDGFRA-EXON18-NON-D842-GIST`
+**File:** `bma_pdgfra_exon18_non_d842_gist.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1035`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pdgfra_exon18_non_d842_gist.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 265/324: CV914-0544 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PIK3CA-E542K-BREAST`
+**File:** `bma_pik3ca_e542k_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1038`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pik3ca_e542k_breast.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 266/324: CV914-0545 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PIK3CA-E545K-BREAST`
+**File:** `bma_pik3ca_e545k_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1041`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pik3ca_e545k_breast.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 267/324: CV914-0546 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PIK3CA-H1047L-BREAST`
+**File:** `bma_pik3ca_h1047l_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1044`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pik3ca_h1047l_breast.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 268/324: CV914-0547 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PIK3CA-H1047R-BREAST`
+**File:** `bma_pik3ca_h1047r_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1047`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (3) + EMA approvals listed (2) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pik3ca_h1047r_breast.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 269/324: CV914-0548 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-GERMLINE-UROTHELIAL`
+**File:** `bma_pms2_germline_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1050`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_germline_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 270/324: CV914-0549 - unclear -> source_stub_needed
+
+**Entity:** `BMA-PMS2-SOMATIC-UROTHELIAL`
+**File:** `bma_pms2_somatic_urothelial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1053`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_pms2_somatic_urothelial.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 271/324: CV914-0550 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ROS1-CD74-NSCLC`
+**File:** `bma_ros1_cd74_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1056`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ros1_cd74_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 272/324: CV914-0551 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ROS1-EZR-NSCLC`
+**File:** `bma_ros1_ezr_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1059`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ros1_ezr_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 273/324: CV914-0552 - unclear -> source_stub_needed
+
+**Entity:** `BMA-ROS1-SLC34A2-NSCLC`
+**File:** `bma_ros1_slc34a2_nsclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1062`
+
+**Audit finding text:**
+```
+regulatory_approval cites FDA approvals listed (1) + EMA approvals listed (1) but no FDA/EMA-tagged Source entity is among primary_sources
+
+```
+
+**Verification rationale:**
+```
+Current entity bma_ros1_slc34a2_nsclc.yaml still has regulatory_approval content but no primary/source/evidence source ID containing FDA, EMA, DailyMed, openFDA, or label. Because v1 has source_id=null, no regulatory source could be fetched.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 274/324: CV914-0554 - unclear -> source_stub_needed
+
+**Entity:** `IND-APL-1L-ATRA-ATO`
+**File:** `ind_apl_1l_atra_ato.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1068`
+
+**Audit finding text:**
+```
+trial ''AIDA'' mentioned but no matching source citation (looked for substrings: [''AIDA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'AIDA'. Prior candidate SRC-ELN-APL-2019 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** URL reachability check on https://ashpublications.org/blood/article/133/15/1630/272971 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Other source candidates: SRC-APL0406-LOCOCO-2013, SRC-ESMO-AML-2020
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 275/324: CV914-0555 - unclear -> source_stub_needed
+
+**Entity:** `IND-APL-SALVAGE-ATRA-ATO`
+**File:** `ind_apl_salvage_atra_ato.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1071`
+
+**Audit finding text:**
+```
+trial ''AIDA'' mentioned but no matching source citation (looked for substrings: [''AIDA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'AIDA'. Prior candidate SRC-ELN-APL-2019 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-ELN-APL-2019 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 276/324: CV914-0556 - unclear -> source_stub_needed
+
+**Entity:** `IND-ATLL-2L-MOGAMULIZUMAB`
+**File:** `ind_atll_2l_mogamulizumab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1074`
+
+**Audit finding text:**
+```
+trial ''BRIGHT'' mentioned but no matching source citation (looked for substrings: [''BRIGHT''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_atll_2l_mogamulizumab.yaml and the hosted source registry for trial 'BRIGHT', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 277/324: CV914-0561 - unclear -> source_stub_needed
+
+**Entity:** `IND-BURKITT-2L-RDHAP-ASCT`
+**File:** `ind_burkitt_2l_rdhap_asct.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1089`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 278/324: CV914-0562 - unclear -> source_stub_needed
+
+**Entity:** `IND-BURKITT-2L-RICE-ASCT`
+**File:** `ind_burkitt_2l_rice_asct.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1092`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_burkitt_2l_rice_asct.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 279/324: CV914-0568 - unclear -> source_stub_needed
+
+**Entity:** `IND-CML-3L-ASCIMINIB`
+**File:** `ind_cml_3l_asciminib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1110`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 280/324: CV914-0570 - unclear -> source_stub_needed
+
+**Entity:** `IND-CRC-METASTATIC-1L-RAS-WT-LEFT`
+**File:** `ind_crc_metastatic_1l_ras_wt_left.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1116`
+
+**Audit finding text:**
+```
+trial ''FIRE-3'' mentioned but no matching source citation (looked for substrings: [''FIRE-3''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_crc_metastatic_1l_ras_wt_left.yaml and the hosted source registry for trial 'FIRE-3', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 281/324: CV914-0574 - unclear -> source_stub_needed
+
+**Entity:** `IND-CRC-METASTATIC-MAINT-FOLFIRI-BEV`
+**File:** `ind_crc_metastatic_maint_folfiri_bev.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1128`
+
+**Audit finding text:**
+```
+trial ''PRODIGE'' mentioned but no matching source citation (looked for substrings: [''PRODIGE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_crc_metastatic_maint_folfiri_bev.yaml and the hosted source registry for trial 'PRODIGE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 282/324: CV914-0575 - unclear -> source_stub_needed
+
+**Entity:** `IND-EATL-2L-ICE`
+**File:** `ind_eatl_2l_ice.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1131`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_eatl_2l_ice.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 283/324: CV914-0576 - unclear -> source_stub_needed
+
+**Entity:** `IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO`
+**File:** `ind_endometrial_advanced_1l_dostarlimab_chemo.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1134`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_endometrial_advanced_1l_dostarlimab_chemo.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 284/324: CV914-0577 - unclear -> source_stub_needed
+
+**Entity:** `IND-ESOPH-METASTATIC-2L-NIVO-SQUAMOUS`
+**File:** `ind_esoph_metastatic_2l_nivo_squamous.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1137`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-590'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-590'', ''KEYNOTE590''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_esoph_metastatic_2l_nivo_squamous.yaml and the hosted source registry for trial 'KEYNOTE-590', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 285/324: CV914-0578 - unclear -> source_stub_needed
+
+**Entity:** `IND-ESOPH-RESECTABLE-CROSS-NEOADJUVANT`
+**File:** `ind_esoph_resectable_cross_neoadjuvant.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1140`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 286/324: CV914-0580 - unclear -> source_stub_needed
+
+**Entity:** `IND-FL-3L-MOSUNETUZUMAB`
+**File:** `ind_fl_3l_mosunetuzumab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1146`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_fl_3l_mosunetuzumab.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 287/324: CV914-0583 - unclear -> source_stub_needed
+
+**Entity:** `IND-GBM-NEWLY-DIAGNOSED-STUPP`
+**File:** `ind_gbm_newly_diagnosed_stupp.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1155`
+
+**Audit finding text:**
+```
+trial ''Stupp'' mentioned but no matching source citation (looked for substrings: [''STUPP'', ''TEMOZOLOMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'Stupp'. Prior candidate SRC-EANO-GBM-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-EANO-GBM-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 288/324: CV914-0584 - unclear -> source_stub_needed
+
+**Entity:** `IND-GIST-1L-IMATINIB`
+**File:** `ind_gist_1l_imatinib.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1158`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 289/324: CV914-0590 - unclear -> source_stub_needed
+
+**Entity:** `IND-MTC-ADVANCED-1L-CABOZANTINIB-RET-WT`
+**File:** `ind_mtc_advanced_1l_cabozantinib_ret_wt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1176`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 290/324: CV914-0591 - unclear -> source_stub_needed
+
+**Entity:** `IND-NLPBL-2L-RCHOP-TRANSFORMATION`
+**File:** `ind_nlpbl_2l_rchop_transformation.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1179`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_nlpbl_2l_rchop_transformation.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 291/324: CV914-0592 - unclear -> source_stub_needed
+
+**Entity:** `IND-NMZL-1L-WATCH`
+**File:** `ind_nmzl_1l_watch.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1182`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_nmzl_1l_watch.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 292/324: CV914-0593 - unclear -> source_stub_needed
+
+**Entity:** `IND-NSCLC-2L-DOCETAXEL-RAMUCIRUMAB`
+**File:** `ind_nsclc_2l_docetaxel_ramucirumab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1185`
+
+**Audit finding text:**
+```
+trial ''IMpower150'' mentioned but no matching source citation (looked for substrings: [''IMPOWER150''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_nsclc_2l_docetaxel_ramucirumab.yaml and the hosted source registry for trial 'IMpower150', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 293/324: CV914-0595 - unclear -> source_stub_needed
+
+**Entity:** `IND-NSCLC-KRAS-G12C-MET-2L`
+**File:** `ind_nsclc_kras_g12c_met_2l.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1191`
+
+**Audit finding text:**
+```
+trial ''CodeBreaK'' mentioned but no matching source citation (looked for substrings: [''CODEBREAK'', ''SOTORASIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CodeBreaK'. Prior candidate SRC-CODEBREAK-300-FAKIH-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CODEBREAK-300-FAKIH-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 294/324: CV914-0597 - unclear -> source_stub_needed
+
+**Entity:** `IND-NSCLC-STAGE-III-PACIFIC`
+**File:** `ind_nsclc_stage_iii_pacific.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1197`
+
+**Audit finding text:**
+```
+trial ''PACIFIC'' mentioned but no matching source citation (looked for substrings: [''PACIFIC'', ''DURVALUMAB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PACIFIC'. Prior candidate SRC-NCCN-NSCLC-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-NCCN-NSCLC-2025 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 295/324: CV914-0598 - unclear -> source_stub_needed
+
+**Entity:** `IND-PDAC-METASTATIC-1L-FOLFIRINOX`
+**File:** `ind_pdac_metastatic_1l_folfirinox.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1200`
+
+**Audit finding text:**
+```
+trial ''PRODIGE'' mentioned but no matching source citation (looked for substrings: [''PRODIGE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_pdac_metastatic_1l_folfirinox.yaml and the hosted source registry for trial 'PRODIGE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 296/324: CV914-0600 - unclear -> source_stub_needed
+
+**Entity:** `IND-PROSTATE-MHSPC-1L-TRIPLET`
+**File:** `ind_prostate_mhspc_1l_triplet.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1206`
+
+**Audit finding text:**
+```
+trial ''ARASENS'' mentioned but no matching source citation (looked for substrings: [''ARASENS'', ''DAROLUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_prostate_mhspc_1l_triplet.yaml and the hosted source registry for trial 'ARASENS', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 297/324: CV914-0602 - unclear -> source_stub_needed
+
+**Entity:** `IND-PTCL-2L-PRALATREXATE`
+**File:** `ind_ptcl_2l_pralatrexate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1212`
+
+**Audit finding text:**
+```
+trial ''PROpel'' mentioned but no matching source citation (looked for substrings: [''PROPEL'', ''OLAPARIB-PROST''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_ptcl_2l_pralatrexate.yaml and the hosted source registry for trial 'PROpel', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 298/324: CV914-0603 - unclear -> source_stub_needed
+
+**Entity:** `IND-RCC-METASTATIC-1L-NIVO-IPI`
+**File:** `ind_rcc_metastatic_1l_nivo_ipi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1215`
+
+**Audit finding text:**
+```
+trial ''CheckMate-214'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-214'', ''CHECKMATE214''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_rcc_metastatic_1l_nivo_ipi.yaml and the hosted source registry for trial 'CheckMate-214', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 299/324: CV914-0604 - unclear -> source_stub_needed
+
+**Entity:** `IND-RCC-METASTATIC-1L-PEMBRO-AXI`
+**File:** `ind_rcc_metastatic_1l_pembro_axi.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1218`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-426'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-426'', ''KEYNOTE426''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_rcc_metastatic_1l_pembro_axi.yaml and the hosted source registry for trial 'KEYNOTE-426', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 300/324: CV914-0606 - unclear -> source_stub_needed
+
+**Entity:** `IND-WM-2L-VRD`
+**File:** `ind_wm_2l_vrd.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1224`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity ind_wm_2l_vrd.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 301/324: CV914-0609 - unclear -> source_stub_needed
+
+**Entity:** `REG-ACALABRUTINIB-RITUXIMAB`
+**File:** `acalabrutinib_rituximab.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1233`
+
+**Audit finding text:**
+```
+trial ''SHINE'' mentioned but no matching source citation (looked for substrings: [''SHINE'', ''IBRUTINIB-MCL''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity acalabrutinib_rituximab.yaml and the hosted source registry for trial 'SHINE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 302/324: CV914-0610 - unclear -> source_stub_needed
+
+**Entity:** `REG-ADT-APALUTAMIDE`
+**File:** `reg_adt_apalutamide.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1236`
+
+**Audit finding text:**
+```
+trial ''TITAN'' mentioned but no matching source citation (looked for substrings: [''TITAN'', ''APALUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_adt_apalutamide.yaml and the hosted source registry for trial 'TITAN', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 303/324: CV914-0611 - unclear -> source_stub_needed
+
+**Entity:** `REG-ADT-DAROLUTAMIDE-DOCETAXEL`
+**File:** `reg_adt_darolutamide_docetaxel.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1239`
+
+**Audit finding text:**
+```
+trial ''ARASENS'' mentioned but no matching source citation (looked for substrings: [''ARASENS'', ''DAROLUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_adt_darolutamide_docetaxel.yaml and the hosted source registry for trial 'ARASENS', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 304/324: CV914-0612 - unclear -> source_stub_needed
+
+**Entity:** `REG-ADT-ENZALUTAMIDE`
+**File:** `reg_adt_enzalutamide.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1242`
+
+**Audit finding text:**
+```
+trial ''ENZAMET'' mentioned but no matching source citation (looked for substrings: [''ENZAMET'', ''ENZALUTAMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_adt_enzalutamide.yaml and the hosted source registry for trial 'ENZAMET', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 305/324: CV914-0615 - unclear -> source_stub_needed
+
+**Entity:** `REG-ASCIMINIB-CML`
+**File:** `reg_asciminib_cml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1251`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 306/324: CV914-0616 - unclear -> source_stub_needed
+
+**Entity:** `REG-ATRA-ATO-APL`
+**File:** `atra_ato_apl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1254`
+
+**Audit finding text:**
+```
+trial ''AIDA'' mentioned but no matching source citation (looked for substrings: [''AIDA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'AIDA'. Prior candidate SRC-ELN-APL-2019 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** URL reachability check on https://ashpublications.org/blood/article/133/15/1630/272971 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Other source candidates: SRC-APL0406-LOCOCO-2013, SRC-ESMO-AML-2020
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 307/324: CV914-0617 - unclear -> source_stub_needed
+
+**Entity:** `REG-ATRA-ATO-APL-SALVAGE`
+**File:** `reg_atra_ato_apl_salvage.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1257`
+
+**Audit finding text:**
+```
+trial ''AIDA'' mentioned but no matching source citation (looked for substrings: [''AIDA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'AIDA'. Prior candidate SRC-ELN-APL-2019 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** URL reachability check on https://ashpublications.org/blood/article/133/15/1630/272971 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Other source candidates: SRC-ESMO-AML-2020, SRC-APL0406-LOCOCO-2013
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 308/324: CV914-0618 - unclear -> source_stub_needed
+
+**Entity:** `REG-ATRA-ATO-IDA-APL`
+**File:** `atra_ato_ida_apl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1260`
+
+**Audit finding text:**
+```
+trial ''AIDA'' mentioned but no matching source citation (looked for substrings: [''AIDA''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'AIDA'. Prior candidate SRC-ELN-APL-2019 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** URL reachability check on https://ashpublications.org/blood/article/133/15/1630/272971 failed with 'HTTP Error 403: Forbidden'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Other source candidates: SRC-APL0406-LOCOCO-2013, SRC-ESMO-AML-2020
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 309/324: CV914-0621 - unclear -> source_stub_needed
+
+**Entity:** `REG-CARBO-PACLI-OVARIAN`
+**File:** `carboplatin_paclitaxel_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1269`
+
+**Audit finding text:**
+```
+trial ''GOG-218'' mentioned but no matching source citation (looked for substrings: [''GOG-218''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity carboplatin_paclitaxel_ovarian.yaml and the hosted source registry for trial 'GOG-218', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 310/324: CV914-0622 - unclear -> source_stub_needed
+
+**Entity:** `REG-CARBOPLATIN-PACLITAXEL-WEEKLY`
+**File:** `carboplatin_paclitaxel_weekly.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1272`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-ESMO-ESOPHAGEAL-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-ESMO-ESOPHAGEAL-2024 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 311/324: CV914-0625 - unclear -> source_stub_needed
+
+**Entity:** `REG-DOSTARLIMAB-CARBO-PACLI-ENDOM`
+**File:** `reg_dostarlimab_carbo_pacli_endom.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1281`
+
+**Audit finding text:**
+```
+trial ''RUBY'' mentioned but no matching source citation (looked for substrings: [''RUBY'', ''DOSTARLIMAB''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_dostarlimab_carbo_pacli_endom.yaml and the hosted source registry for trial 'RUBY', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 312/324: CV914-0626 - unclear -> source_stub_needed
+
+**Entity:** `REG-DURVA-CONSOLIDATION-PACIFIC`
+**File:** `reg_durva_consolidation_pacific.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1284`
+
+**Audit finding text:**
+```
+trial ''PACIFIC'' mentioned but no matching source citation (looked for substrings: [''PACIFIC'', ''DURVALUMAB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'PACIFIC'. Prior candidate SRC-NCCN-NSCLC-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Other source candidates: SRC-ESMO-NSCLC-EARLY-2024
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 313/324: CV914-0628 - unclear -> source_stub_needed
+
+**Entity:** `REG-EP-ATEZO-SCLC`
+**File:** `reg_ep_atezo_sclc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1290`
+
+**Audit finding text:**
+```
+trial ''IMpower133'' mentioned but no matching source citation (looked for substrings: [''IMPOWER133'', ''ATEZOLIZUMAB-SCLC''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'IMpower133'. Prior candidate SRC-ESMO-SCLC-2021 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Other source candidates: SRC-NCCN-SCLC-2025
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 314/324: CV914-0631 - unclear -> source_stub_needed
+
+**Entity:** `REG-FOLFIRINOX`
+**File:** `folfirinox.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1299`
+
+**Audit finding text:**
+```
+trial ''PRODIGE'' mentioned but no matching source citation (looked for substrings: [''PRODIGE''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity folfirinox.yaml and the hosted source registry for trial 'PRODIGE', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 315/324: CV914-0636 - unclear -> source_stub_needed
+
+**Entity:** `REG-NIVO-IPI-RCC`
+**File:** `reg_nivo_ipi_rcc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1314`
+
+**Audit finding text:**
+```
+trial ''CheckMate-214'' mentioned but no matching source citation (looked for substrings: [''CHECKMATE-214'', ''CHECKMATE214''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_nivo_ipi_rcc.yaml and the hosted source registry for trial 'CheckMate-214', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 316/324: CV914-0637 - unclear -> source_stub_needed
+
+**Entity:** `REG-PEMBRO-AXI-RCC`
+**File:** `reg_pembro_axi_rcc.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1317`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-426'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-426'', ''KEYNOTE426''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_pembro_axi_rcc.yaml and the hosted source registry for trial 'KEYNOTE-426', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 317/324: CV914-0638 - unclear -> source_stub_needed
+
+**Entity:** `REG-PEMBRO-CARBO-PACLI-ENDOM`
+**File:** `reg_pembro_carbo_pacli_endom.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1320`
+
+**Audit finding text:**
+```
+trial ''NRG-GY018'' mentioned but no matching source citation (looked for substrings: [''GY018'', ''PEMBRO-ENDOM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_pembro_carbo_pacli_endom.yaml and the hosted source registry for trial 'NRG-GY018', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 318/324: CV914-0639 - unclear -> source_stub_needed
+
+**Entity:** `REG-PEMBRO-CHEMO-TNBC-NEOADJUVANT`
+**File:** `reg_pembro_chemo_tnbc_neoadjuvant.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1323`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-522'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-522'', ''KEYNOTE522''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'KEYNOTE-522'. Prior candidate SRC-NCCN-BREAST-2025 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 319/324: CV914-0640 - unclear -> source_stub_needed
+
+**Entity:** `REG-PEMBRO-MONO-ESOPH-2L`
+**File:** `reg_pembro_mono_esoph_2l.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1326`
+
+**Audit finding text:**
+```
+trial ''KEYNOTE-590'' mentioned but no matching source citation (looked for substrings: [''KEYNOTE-590'', ''KEYNOTE590''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_pembro_mono_esoph_2l.yaml and the hosted source registry for trial 'KEYNOTE-590', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 320/324: CV914-0643 - unclear -> source_stub_needed
+
+**Entity:** `REG-PRALATREXATE-PTCL`
+**File:** `reg_pralatrexate_ptcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1335`
+
+**Audit finding text:**
+```
+trial ''PROpel'' mentioned but no matching source citation (looked for substrings: [''PROPEL'', ''OLAPARIB-PROST''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_pralatrexate_ptcl.yaml and the hosted source registry for trial 'PROpel', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 321/324: CV914-0644 - unclear -> source_stub_needed
+
+**Entity:** `REG-RDHAP-BURKITT`
+**File:** `reg_rdhap_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1338`
+
+**Audit finding text:**
+```
+trial ''CROSS'' mentioned but no matching source citation (looked for substrings: [''CROSS''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CROSS'. Prior candidate SRC-IMC-HTLV-2017 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-IMC-HTLV-2017 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 322/324: CV914-0646 - unclear -> source_stub_needed
+
+**Entity:** `REG-SOTORASIB-KRAS`
+**File:** `reg_sotorasib_kras.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1344`
+
+**Audit finding text:**
+```
+trial ''CodeBreaK'' mentioned but no matching source citation (looked for substrings: [''CODEBREAK'', ''SOTORASIB''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'CodeBreaK'. Prior candidate SRC-CODEBREAK-300-FAKIH-2023 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** Strict replace_source repair: previous candidate SRC-CODEBREAK-300-FAKIH-2023 rejected; no specific-trial to guideline/different-trial replacement retained.
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 323/324: CV914-0647 - unclear -> source_stub_needed
+
+**Entity:** `REG-STUPP-TMZ`
+**File:** `stupp_temozolomide.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1347`
+
+**Audit finding text:**
+```
+trial ''Stupp'' mentioned but no matching source citation (looked for substrings: [''STUPP'', ''TEMOZOLOMIDE''])
+
+```
+
+**Verification rationale:**
+```
+Rechecked after maintainer review. Audit names specific trial 'Stupp'. Prior candidate SRC-EANO-GBM-2024 was rejected because the target source id/title does not contain the exact trial name or is a general guideline/different trial. No strict trial-specific hosted Source was found in knowledge_base/hosted/content/sources by source id/title, so this row remains unresolved and needs a trial-specific source stub or maintainer mapping.
+
+```
+
+**Notes:** URL reachability check on https://www.eano.eu/guidelines/ failed with 'HTTP Error 404: Not Found'; row downgraded from supported to access_blocked pending maintainer/source replacement review.       Other source candidates: SRC-NCCN-CNS-2025
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---
+
+## 324/324: CV914-0652 - unclear -> source_stub_needed
+
+**Entity:** `REG-VRD-WM`
+**File:** `reg_vrd_wm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1362`
+
+**Audit finding text:**
+```
+trial ''PARADIGM'' mentioned but no matching source citation (looked for substrings: [''PARADIGM''])
+
+```
+
+**Verification rationale:**
+```
+Investigated current hosted entity reg_vrd_wm.yaml and the hosted source registry for trial 'PARADIGM', but no existing SRC-* record matched the trial name in source id/title. The v1 row has source_id=null, so there is no cited source to fetch; a real source stub or maintainer mapping is still needed.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] keep (genuinely unresolvable; no edit)
+- [ ] file source_stub_needed (attempt to find authoritative source)
+- [ ] revise_claim (narrow the claim wording)
+- [ ] escalate
+
+---

--- a/contributions/citation-semantic-verify-v2/triage-queue-status-unsupported.md
+++ b/contributions/citation-semantic-verify-v2/triage-queue-status-unsupported.md
@@ -2,11 +2,11 @@
 
 **Filter:** status=`unsupported`, action=`None`
 
-**Total rows:** 100
+**Total rows:** 247
 
 ---
 
-## 1/100: CV914-0003 - unsupported -> maintainer_review
+## 1/247: CV914-0003 - unsupported -> maintainer_review
 
 **Entity:** `BMA-TP53-MUT-CLL`
 **File:** `bma_tp53_mut_cll.yaml`
@@ -35,7 +35,7 @@ Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinat
 
 ---
 
-## 2/100: CV914-0004 - unsupported -> maintainer_review
+## 2/247: CV914-0004 - unsupported -> maintainer_review
 
 **Entity:** `BMA-TP53-MUT-CLL`
 **File:** `bma_tp53_mut_cll.yaml`
@@ -64,7 +64,7 @@ Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinat
 
 ---
 
-## 3/100: CV914-0005 - unsupported -> maintainer_review
+## 3/247: CV914-0005 - unsupported -> maintainer_review
 
 **Entity:** `BMA-TP53-MUT-CLL`
 **File:** `bma_tp53_mut_cll.yaml`
@@ -93,7 +93,7 @@ Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinat
 
 ---
 
-## 4/100: CV914-0006 - unsupported -> maintainer_review
+## 4/247: CV914-0006 - unsupported -> maintainer_review
 
 **Entity:** `BMA-TP53-MUT-CLL`
 **File:** `bma_tp53_mut_cll.yaml`
@@ -122,7 +122,7 @@ Verified against current entity file bma_tp53_mut_cll.yaml: recommended_combinat
 
 ---
 
-## 5/100: CV914-0010 - unsupported -> maintainer_review
+## 5/247: CV914-0010 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCR-ABL1-P210-BALL`
 **File:** `bma_bcr_abl1_p210_ball.yaml`
@@ -151,7 +151,7 @@ Verified against current entity file bma_bcr_abl1_p210_ball.yaml: recommended_co
 
 ---
 
-## 6/100: CV914-0011 - unsupported -> maintainer_review
+## 6/247: CV914-0011 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCR-ABL1-P210-BALL`
 **File:** `bma_bcr_abl1_p210_ball.yaml`
@@ -180,7 +180,7 @@ Verified against current entity file bma_bcr_abl1_p210_ball.yaml: recommended_co
 
 ---
 
-## 7/100: CV914-0016 - unsupported -> maintainer_review
+## 7/247: CV914-0016 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA1-GERMLINE-OVARIAN`
 **File:** `bma_brca1_germline_ovarian.yaml`
@@ -209,7 +209,7 @@ Verified against current entity file bma_brca1_germline_ovarian.yaml: recommende
 
 ---
 
-## 8/100: CV914-0020 - unsupported -> maintainer_review
+## 8/247: CV914-0020 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
 **File:** `bma_brca1_germline_prostate.yaml`
@@ -238,7 +238,7 @@ Verified against current entity file bma_brca1_germline_prostate.yaml: recommend
 
 ---
 
-## 9/100: CV914-0021 - unsupported -> maintainer_review
+## 9/247: CV914-0021 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA1-GERMLINE-PROSTATE`
 **File:** `bma_brca1_germline_prostate.yaml`
@@ -267,7 +267,7 @@ Verified against current entity file bma_brca1_germline_prostate.yaml: recommend
 
 ---
 
-## 10/100: CV914-0026 - unsupported -> maintainer_review
+## 10/247: CV914-0026 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA2-GERMLINE-BREAST`
 **File:** `bma_brca2_germline_breast.yaml`
@@ -296,7 +296,7 @@ Verified against current entity file bma_brca2_germline_breast.yaml: recommended
 
 ---
 
-## 11/100: CV914-0031 - unsupported -> maintainer_review
+## 11/247: CV914-0031 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA2-GERMLINE-PROSTATE`
 **File:** `bma_brca2_germline_prostate.yaml`
@@ -325,7 +325,7 @@ Verified against current entity file bma_brca2_germline_prostate.yaml: recommend
 
 ---
 
-## 12/100: CV914-0035 - unsupported -> maintainer_review
+## 12/247: CV914-0035 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EGFR-C797S-NSCLC`
 **File:** `bma_egfr_c797s_nsclc.yaml`
@@ -354,7 +354,7 @@ Verified against current entity file bma_egfr_c797s_nsclc.yaml: recommended_comb
 
 ---
 
-## 13/100: CV914-0036 - unsupported -> maintainer_review
+## 13/247: CV914-0036 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EGFR-C797S-NSCLC`
 **File:** `bma_egfr_c797s_nsclc.yaml`
@@ -383,7 +383,7 @@ Verified against current entity file bma_egfr_c797s_nsclc.yaml: recommended_comb
 
 ---
 
-## 14/100: CV914-0040 - unsupported -> maintainer_review
+## 14/247: CV914-0040 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EGFR-EX19DEL-NSCLC`
 **File:** `bma_egfr_ex19del_nsclc.yaml`
@@ -412,7 +412,7 @@ Verified against current entity file bma_egfr_ex19del_nsclc.yaml: recommended_co
 
 ---
 
-## 15/100: CV914-0041 - unsupported -> maintainer_review
+## 15/247: CV914-0041 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EGFR-EX19DEL-NSCLC`
 **File:** `bma_egfr_ex19del_nsclc.yaml`
@@ -441,7 +441,7 @@ Verified against current entity file bma_egfr_ex19del_nsclc.yaml: recommended_co
 
 ---
 
-## 16/100: CV914-0046 - unsupported -> maintainer_review
+## 16/247: CV914-0046 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EGFR-L858R-NSCLC`
 **File:** `bma_egfr_l858r_nsclc.yaml`
@@ -470,7 +470,7 @@ Verified against current entity file bma_egfr_l858r_nsclc.yaml: recommended_comb
 
 ---
 
-## 17/100: CV914-0050 - unsupported -> maintainer_review
+## 17/247: CV914-0050 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
 **File:** `bma_mlh1_germline_endometrial.yaml`
@@ -499,7 +499,7 @@ Verified against current entity file bma_mlh1_germline_endometrial.yaml: recomme
 
 ---
 
-## 18/100: CV914-0051 - unsupported -> maintainer_review
+## 18/247: CV914-0051 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-GERMLINE-ENDOMETRIAL`
 **File:** `bma_mlh1_germline_endometrial.yaml`
@@ -528,7 +528,7 @@ Verified against current entity file bma_mlh1_germline_endometrial.yaml: recomme
 
 ---
 
-## 19/100: CV914-0055 - unsupported -> maintainer_review
+## 19/247: CV914-0055 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
 **File:** `bma_mlh1_somatic_endometrial.yaml`
@@ -557,7 +557,7 @@ Verified against current entity file bma_mlh1_somatic_endometrial.yaml: recommen
 
 ---
 
-## 20/100: CV914-0056 - unsupported -> maintainer_review
+## 20/247: CV914-0056 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-SOMATIC-ENDOMETRIAL`
 **File:** `bma_mlh1_somatic_endometrial.yaml`
@@ -586,7 +586,7 @@ Verified against current entity file bma_mlh1_somatic_endometrial.yaml: recommen
 
 ---
 
-## 21/100: CV914-0060 - unsupported -> maintainer_review
+## 21/247: CV914-0060 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
 **File:** `bma_msh2_germline_endometrial.yaml`
@@ -615,7 +615,7 @@ Verified against current entity file bma_msh2_germline_endometrial.yaml: recomme
 
 ---
 
-## 22/100: CV914-0061 - unsupported -> maintainer_review
+## 22/247: CV914-0061 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH2-GERMLINE-ENDOMETRIAL`
 **File:** `bma_msh2_germline_endometrial.yaml`
@@ -644,7 +644,7 @@ Verified against current entity file bma_msh2_germline_endometrial.yaml: recomme
 
 ---
 
-## 23/100: CV914-0065 - unsupported -> maintainer_review
+## 23/247: CV914-0065 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
 **File:** `bma_msh2_somatic_endometrial.yaml`
@@ -673,7 +673,7 @@ Verified against current entity file bma_msh2_somatic_endometrial.yaml: recommen
 
 ---
 
-## 24/100: CV914-0066 - unsupported -> maintainer_review
+## 24/247: CV914-0066 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH2-SOMATIC-ENDOMETRIAL`
 **File:** `bma_msh2_somatic_endometrial.yaml`
@@ -702,7 +702,7 @@ Verified against current entity file bma_msh2_somatic_endometrial.yaml: recommen
 
 ---
 
-## 25/100: CV914-0070 - unsupported -> maintainer_review
+## 25/247: CV914-0070 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
 **File:** `bma_msh6_germline_endometrial.yaml`
@@ -731,7 +731,7 @@ Verified against current entity file bma_msh6_germline_endometrial.yaml: recomme
 
 ---
 
-## 26/100: CV914-0071 - unsupported -> maintainer_review
+## 26/247: CV914-0071 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH6-GERMLINE-ENDOMETRIAL`
 **File:** `bma_msh6_germline_endometrial.yaml`
@@ -760,7 +760,7 @@ Verified against current entity file bma_msh6_germline_endometrial.yaml: recomme
 
 ---
 
-## 27/100: CV914-0075 - unsupported -> maintainer_review
+## 27/247: CV914-0075 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
 **File:** `bma_msh6_somatic_endometrial.yaml`
@@ -789,7 +789,7 @@ Verified against current entity file bma_msh6_somatic_endometrial.yaml: recommen
 
 ---
 
-## 28/100: CV914-0076 - unsupported -> maintainer_review
+## 28/247: CV914-0076 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH6-SOMATIC-ENDOMETRIAL`
 **File:** `bma_msh6_somatic_endometrial.yaml`
@@ -818,7 +818,7 @@ Verified against current entity file bma_msh6_somatic_endometrial.yaml: recommen
 
 ---
 
-## 29/100: CV914-0079 - unsupported -> maintainer_review
+## 29/247: CV914-0079 - unsupported -> maintainer_review
 
 **Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
 **File:** `bma_notch1_activating_cll.yaml`
@@ -847,7 +847,7 @@ Verified against current entity file bma_notch1_activating_cll.yaml: recommended
 
 ---
 
-## 30/100: CV914-0080 - unsupported -> maintainer_review
+## 30/247: CV914-0080 - unsupported -> maintainer_review
 
 **Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
 **File:** `bma_notch1_activating_cll.yaml`
@@ -876,7 +876,7 @@ Verified against current entity file bma_notch1_activating_cll.yaml: recommended
 
 ---
 
-## 31/100: CV914-0081 - unsupported -> maintainer_review
+## 31/247: CV914-0081 - unsupported -> maintainer_review
 
 **Entity:** `BMA-NOTCH1-ACTIVATING-CLL`
 **File:** `bma_notch1_activating_cll.yaml`
@@ -905,7 +905,7 @@ Verified against current entity file bma_notch1_activating_cll.yaml: recommended
 
 ---
 
-## 32/100: CV914-0085 - unsupported -> maintainer_review
+## 32/247: CV914-0085 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
 **File:** `bma_pms2_germline_endometrial.yaml`
@@ -934,7 +934,7 @@ Verified against current entity file bma_pms2_germline_endometrial.yaml: recomme
 
 ---
 
-## 33/100: CV914-0086 - unsupported -> maintainer_review
+## 33/247: CV914-0086 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PMS2-GERMLINE-ENDOMETRIAL`
 **File:** `bma_pms2_germline_endometrial.yaml`
@@ -963,7 +963,7 @@ Verified against current entity file bma_pms2_germline_endometrial.yaml: recomme
 
 ---
 
-## 34/100: CV914-0090 - unsupported -> maintainer_review
+## 34/247: CV914-0090 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
 **File:** `bma_pms2_somatic_endometrial.yaml`
@@ -992,7 +992,7 @@ Verified against current entity file bma_pms2_somatic_endometrial.yaml: recommen
 
 ---
 
-## 35/100: CV914-0091 - unsupported -> maintainer_review
+## 35/247: CV914-0091 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PMS2-SOMATIC-ENDOMETRIAL`
 **File:** `bma_pms2_somatic_endometrial.yaml`
@@ -1021,7 +1021,7 @@ Verified against current entity file bma_pms2_somatic_endometrial.yaml: recommen
 
 ---
 
-## 36/100: CV914-0094 - unsupported -> maintainer_review
+## 36/247: CV914-0094 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
 **File:** `bma_rad51b_germline_ovarian.yaml`
@@ -1050,7 +1050,7 @@ Verified against current entity file bma_rad51b_germline_ovarian.yaml: recommend
 
 ---
 
-## 37/100: CV914-0095 - unsupported -> maintainer_review
+## 37/247: CV914-0095 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
 **File:** `bma_rad51b_germline_ovarian.yaml`
@@ -1079,7 +1079,7 @@ Verified against current entity file bma_rad51b_germline_ovarian.yaml: recommend
 
 ---
 
-## 38/100: CV914-0096 - unsupported -> maintainer_review
+## 38/247: CV914-0096 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51B-GERMLINE-OVARIAN`
 **File:** `bma_rad51b_germline_ovarian.yaml`
@@ -1108,7 +1108,7 @@ Verified against current entity file bma_rad51b_germline_ovarian.yaml: recommend
 
 ---
 
-## 39/100: CV914-0100 - unsupported -> maintainer_review
+## 39/247: CV914-0100 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
 **File:** `bma_rad51c_germline_ovarian.yaml`
@@ -1137,7 +1137,7 @@ Verified against current entity file bma_rad51c_germline_ovarian.yaml: recommend
 
 ---
 
-## 40/100: CV914-0101 - unsupported -> maintainer_review
+## 40/247: CV914-0101 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51C-GERMLINE-OVARIAN`
 **File:** `bma_rad51c_germline_ovarian.yaml`
@@ -1166,7 +1166,7 @@ Verified against current entity file bma_rad51c_germline_ovarian.yaml: recommend
 
 ---
 
-## 41/100: CV914-0105 - unsupported -> maintainer_review
+## 41/247: CV914-0105 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
 **File:** `bma_rad51d_germline_ovarian.yaml`
@@ -1195,7 +1195,7 @@ Verified against current entity file bma_rad51d_germline_ovarian.yaml: recommend
 
 ---
 
-## 42/100: CV914-0106 - unsupported -> maintainer_review
+## 42/247: CV914-0106 - unsupported -> maintainer_review
 
 **Entity:** `BMA-RAD51D-GERMLINE-OVARIAN`
 **File:** `bma_rad51d_germline_ovarian.yaml`
@@ -1224,7 +1224,7 @@ Verified against current entity file bma_rad51d_germline_ovarian.yaml: recommend
 
 ---
 
-## 43/100: CV914-0115 - unsupported -> maintainer_review
+## 43/247: CV914-0115 - unsupported -> maintainer_review
 
 **Entity:** `BMA-ALK-FUSION-ALCL`
 **File:** `bma_alk_fusion_alcl.yaml`
@@ -1253,7 +1253,7 @@ Verified against current entity file bma_alk_fusion_alcl.yaml: recommended_combi
 
 ---
 
-## 44/100: CV914-0123 - unsupported -> maintainer_review
+## 44/247: CV914-0123 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCL2-EXPRESSION-CLL`
 **File:** `bma_bcl2_expression_cll.yaml`
@@ -1282,7 +1282,7 @@ Verified against current entity file bma_bcl2_expression_cll.yaml: recommended_c
 
 ---
 
-## 45/100: CV914-0131 - unsupported -> maintainer_review
+## 45/247: CV914-0131 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA2-GERMLINE-OVARIAN`
 **File:** `bma_brca2_germline_ovarian.yaml`
@@ -1311,7 +1311,7 @@ Verified against current entity file bma_brca2_germline_ovarian.yaml: recommende
 
 ---
 
-## 46/100: CV914-0134 - unsupported -> maintainer_review
+## 46/247: CV914-0134 - unsupported -> maintainer_review
 
 **Entity:** `BMA-CCND1-T1114-MCL`
 **File:** `bma_ccnd1_t1114_mcl.yaml`
@@ -1340,7 +1340,7 @@ Verified against current entity file bma_ccnd1_t1114_mcl.yaml: recommended_combi
 
 ---
 
-## 47/100: CV914-0135 - unsupported -> maintainer_review
+## 47/247: CV914-0135 - unsupported -> maintainer_review
 
 **Entity:** `BMA-CCND1-T1114-MCL`
 **File:** `bma_ccnd1_t1114_mcl.yaml`
@@ -1369,7 +1369,7 @@ Verified against current entity file bma_ccnd1_t1114_mcl.yaml: recommended_combi
 
 ---
 
-## 48/100: CV914-0138 - unsupported -> maintainer_review
+## 48/247: CV914-0138 - unsupported -> maintainer_review
 
 **Entity:** `BMA-FGFR2-MUTATION-ENDOMETRIAL`
 **File:** `bma_fgfr2_mutation_endometrial.yaml`
@@ -1398,7 +1398,7 @@ Verified against current entity file bma_fgfr2_mutation_endometrial.yaml: recomm
 
 ---
 
-## 49/100: CV914-0139 - unsupported -> maintainer_review
+## 49/247: CV914-0139 - unsupported -> maintainer_review
 
 **Entity:** `BMA-FGFR2-MUTATION-ENDOMETRIAL`
 **File:** `bma_fgfr2_mutation_endometrial.yaml`
@@ -1427,7 +1427,7 @@ Verified against current entity file bma_fgfr2_mutation_endometrial.yaml: recomm
 
 ---
 
-## 50/100: CV914-0141 - unsupported -> maintainer_review
+## 50/247: CV914-0141 - unsupported -> maintainer_review
 
 **Entity:** `BMA-FLT3-ITD-AML`
 **File:** `bma_flt3_itd_aml.yaml`
@@ -1456,7 +1456,7 @@ Verified against current entity file bma_flt3_itd_aml.yaml: recommended_combinat
 
 ---
 
-## 51/100: CV914-0142 - unsupported -> maintainer_review
+## 51/247: CV914-0142 - unsupported -> maintainer_review
 
 **Entity:** `BMA-FLT3-ITD-AML`
 **File:** `bma_flt3_itd_aml.yaml`
@@ -1485,7 +1485,7 @@ Verified against current entity file bma_flt3_itd_aml.yaml: recommended_combinat
 
 ---
 
-## 52/100: CV914-0147 - unsupported -> maintainer_review
+## 52/247: CV914-0147 - unsupported -> maintainer_review
 
 **Entity:** `BMA-KRAS-G12C-PDAC`
 **File:** `bma_kras_g12c_pdac.yaml`
@@ -1514,7 +1514,7 @@ Verified against current entity file bma_kras_g12c_pdac.yaml: recommended_combin
 
 ---
 
-## 53/100: CV914-0151 - unsupported -> maintainer_review
+## 53/247: CV914-0151 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PALB2-GERMLINE-OVARIAN`
 **File:** `bma_palb2_germline_ovarian.yaml`
@@ -1543,7 +1543,7 @@ Verified against current entity file bma_palb2_germline_ovarian.yaml: recommende
 
 ---
 
-## 54/100: CV914-0161 - unsupported -> maintainer_review
+## 54/247: CV914-0161 - unsupported -> maintainer_review
 
 **Entity:** `BMA-TP53-MUT-MCL`
 **File:** `bma_tp53_mut_mcl.yaml`
@@ -1572,7 +1572,7 @@ Verified against current entity file bma_tp53_mut_mcl.yaml: recommended_combinat
 
 ---
 
-## 55/100: CV914-0162 - unsupported -> maintainer_review
+## 55/247: CV914-0162 - unsupported -> maintainer_review
 
 **Entity:** `BMA-TP53-MUT-MCL`
 **File:** `bma_tp53_mut_mcl.yaml`
@@ -1601,7 +1601,7 @@ Verified against current entity file bma_tp53_mut_mcl.yaml: recommended_combinat
 
 ---
 
-## 56/100: CV914-0174 - unsupported -> maintainer_review
+## 56/247: CV914-0174 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BARD1-GERMLINE-OVARIAN`
 **File:** `bma_bard1_germline_ovarian.yaml`
@@ -1630,7 +1630,7 @@ Verified against current entity file bma_bard1_germline_ovarian.yaml: recommende
 
 ---
 
-## 57/100: CV914-0177 - unsupported -> maintainer_review
+## 57/247: CV914-0177 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCR-ABL1-E255K-CML`
 **File:** `bma_bcr_abl1_e255k_cml.yaml`
@@ -1659,7 +1659,7 @@ Verified against current entity file bma_bcr_abl1_e255k_cml.yaml: recommended_co
 
 ---
 
-## 58/100: CV914-0180 - unsupported -> maintainer_review
+## 58/247: CV914-0180 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCR-ABL1-F317L-BALL`
 **File:** `bma_bcr_abl1_f317l_ball.yaml`
@@ -1688,7 +1688,7 @@ Verified against current entity file bma_bcr_abl1_f317l_ball.yaml: recommended_c
 
 ---
 
-## 59/100: CV914-0183 - unsupported -> maintainer_review
+## 59/247: CV914-0183 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCR-ABL1-T315I-BALL`
 **File:** `bma_bcr_abl1_t315i_ball.yaml`
@@ -1717,7 +1717,7 @@ Verified against current entity file bma_bcr_abl1_t315i_ball.yaml: recommended_c
 
 ---
 
-## 60/100: CV914-0191 - unsupported -> maintainer_review
+## 60/247: CV914-0191 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRAF-V600E-HCL`
 **File:** `bma_braf_v600e_hcl.yaml`
@@ -1746,7 +1746,7 @@ Verified against current entity file bma_braf_v600e_hcl.yaml: recommended_combin
 
 ---
 
-## 61/100: CV914-0192 - unsupported -> maintainer_review
+## 61/247: CV914-0192 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRAF-V600E-HCL`
 **File:** `bma_braf_v600e_hcl.yaml`
@@ -1775,7 +1775,7 @@ Verified against current entity file bma_braf_v600e_hcl.yaml: recommended_combin
 
 ---
 
-## 62/100: CV914-0198 - unsupported -> maintainer_review
+## 62/247: CV914-0198 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRAF-V600K-MELANOMA`
 **File:** `bma_braf_v600k_melanoma.yaml`
@@ -1804,7 +1804,7 @@ Verified against current entity file bma_braf_v600k_melanoma.yaml: recommended_c
 
 ---
 
-## 63/100: CV914-0201 - unsupported -> maintainer_review
+## 63/247: CV914-0201 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA1-SOMATIC-OVARIAN`
 **File:** `bma_brca1_somatic_ovarian.yaml`
@@ -1833,7 +1833,7 @@ Verified against current entity file bma_brca1_somatic_ovarian.yaml: recommended
 
 ---
 
-## 64/100: CV914-0203 - unsupported -> maintainer_review
+## 64/247: CV914-0203 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA1-SOMATIC-PROSTATE`
 **File:** `bma_brca1_somatic_prostate.yaml`
@@ -1862,7 +1862,7 @@ Verified against current entity file bma_brca1_somatic_prostate.yaml: recommende
 
 ---
 
-## 65/100: CV914-0204 - unsupported -> maintainer_review
+## 65/247: CV914-0204 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA1-SOMATIC-PROSTATE`
 **File:** `bma_brca1_somatic_prostate.yaml`
@@ -1891,7 +1891,7 @@ Verified against current entity file bma_brca1_somatic_prostate.yaml: recommende
 
 ---
 
-## 66/100: CV914-0207 - unsupported -> maintainer_review
+## 66/247: CV914-0207 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA2-SOMATIC-OVARIAN`
 **File:** `bma_brca2_somatic_ovarian.yaml`
@@ -1920,7 +1920,7 @@ Verified against current entity file bma_brca2_somatic_ovarian.yaml: recommended
 
 ---
 
-## 67/100: CV914-0209 - unsupported -> maintainer_review
+## 67/247: CV914-0209 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA2-SOMATIC-PROSTATE`
 **File:** `bma_brca2_somatic_prostate.yaml`
@@ -1949,7 +1949,7 @@ Verified against current entity file bma_brca2_somatic_prostate.yaml: recommende
 
 ---
 
-## 68/100: CV914-0210 - unsupported -> maintainer_review
+## 68/247: CV914-0210 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRCA2-SOMATIC-PROSTATE`
 **File:** `bma_brca2_somatic_prostate.yaml`
@@ -1978,7 +1978,7 @@ Verified against current entity file bma_brca2_somatic_prostate.yaml: recommende
 
 ---
 
-## 69/100: CV914-0212 - unsupported -> maintainer_review
+## 69/247: CV914-0212 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRIP1-GERMLINE-OVARIAN`
 **File:** `bma_brip1_germline_ovarian.yaml`
@@ -2007,7 +2007,7 @@ Verified against current entity file bma_brip1_germline_ovarian.yaml: recommende
 
 ---
 
-## 70/100: CV914-0213 - unsupported -> maintainer_review
+## 70/247: CV914-0213 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BRIP1-GERMLINE-OVARIAN`
 **File:** `bma_brip1_germline_ovarian.yaml`
@@ -2036,7 +2036,7 @@ Verified against current entity file bma_brip1_germline_ovarian.yaml: recommende
 
 ---
 
-## 71/100: CV914-0216 - unsupported -> maintainer_review
+## 71/247: CV914-0216 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EGFR-EX20INS-NSCLC`
 **File:** `bma_egfr_ex20ins_nsclc.yaml`
@@ -2065,7 +2065,7 @@ Verified against current entity file bma_egfr_ex20ins_nsclc.yaml: recommended_co
 
 ---
 
-## 72/100: CV914-0219 - unsupported -> maintainer_review
+## 72/247: CV914-0219 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EPCAM-GERMLINE-CRC`
 **File:** `bma_epcam_germline_crc.yaml`
@@ -2094,7 +2094,7 @@ Verified against current entity file bma_epcam_germline_crc.yaml: recommended_co
 
 ---
 
-## 73/100: CV914-0222 - unsupported -> maintainer_review
+## 73/247: CV914-0222 - unsupported -> maintainer_review
 
 **Entity:** `BMA-EPCAM-GERMLINE-ENDOMETRIAL`
 **File:** `bma_epcam_germline_endometrial.yaml`
@@ -2123,7 +2123,7 @@ Verified against current entity file bma_epcam_germline_endometrial.yaml: recomm
 
 ---
 
-## 74/100: CV914-0231 - unsupported -> maintainer_review
+## 74/247: CV914-0231 - unsupported -> maintainer_review
 
 **Entity:** `BMA-FLT3-D835-AML`
 **File:** `bma_flt3_d835_aml.yaml`
@@ -2152,7 +2152,7 @@ Verified against current entity file bma_flt3_d835_aml.yaml: recommended_combina
 
 ---
 
-## 75/100: CV914-0234 - unsupported -> maintainer_review
+## 75/247: CV914-0234 - unsupported -> maintainer_review
 
 **Entity:** `BMA-FLT3-F691L-AML`
 **File:** `bma_flt3_f691l_aml.yaml`
@@ -2181,7 +2181,7 @@ Verified against current entity file bma_flt3_f691l_aml.yaml: recommended_combin
 
 ---
 
-## 76/100: CV914-0236 - unsupported -> maintainer_review
+## 76/247: CV914-0236 - unsupported -> maintainer_review
 
 **Entity:** `BMA-IDH1-R132C-AML`
 **File:** `bma_idh1_r132c_aml.yaml`
@@ -2210,7 +2210,7 @@ Verified against current entity file bma_idh1_r132c_aml.yaml: recommended_combin
 
 ---
 
-## 77/100: CV914-0237 - unsupported -> maintainer_review
+## 77/247: CV914-0237 - unsupported -> maintainer_review
 
 **Entity:** `BMA-IDH1-R132C-AML`
 **File:** `bma_idh1_r132c_aml.yaml`
@@ -2239,7 +2239,7 @@ Verified against current entity file bma_idh1_r132c_aml.yaml: recommended_combin
 
 ---
 
-## 78/100: CV914-0246 - unsupported -> maintainer_review
+## 78/247: CV914-0246 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-GERMLINE-GASTRIC`
 **File:** `bma_mlh1_germline_gastric.yaml`
@@ -2268,7 +2268,7 @@ Verified against current entity file bma_mlh1_germline_gastric.yaml: recommended
 
 ---
 
-## 79/100: CV914-0249 - unsupported -> maintainer_review
+## 79/247: CV914-0249 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-SOMATIC-GASTRIC`
 **File:** `bma_mlh1_somatic_gastric.yaml`
@@ -2297,7 +2297,7 @@ Verified against current entity file bma_mlh1_somatic_gastric.yaml: recommended_
 
 ---
 
-## 80/100: CV914-0252 - unsupported -> maintainer_review
+## 80/247: CV914-0252 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH2-GERMLINE-GASTRIC`
 **File:** `bma_msh2_germline_gastric.yaml`
@@ -2326,7 +2326,7 @@ Verified against current entity file bma_msh2_germline_gastric.yaml: recommended
 
 ---
 
-## 81/100: CV914-0255 - unsupported -> maintainer_review
+## 81/247: CV914-0255 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH2-SOMATIC-GASTRIC`
 **File:** `bma_msh2_somatic_gastric.yaml`
@@ -2355,7 +2355,7 @@ Verified against current entity file bma_msh2_somatic_gastric.yaml: recommended_
 
 ---
 
-## 82/100: CV914-0258 - unsupported -> maintainer_review
+## 82/247: CV914-0258 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH6-GERMLINE-GASTRIC`
 **File:** `bma_msh6_germline_gastric.yaml`
@@ -2384,7 +2384,7 @@ Verified against current entity file bma_msh6_germline_gastric.yaml: recommended
 
 ---
 
-## 83/100: CV914-0261 - unsupported -> maintainer_review
+## 83/247: CV914-0261 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MSH6-SOMATIC-GASTRIC`
 **File:** `bma_msh6_somatic_gastric.yaml`
@@ -2413,7 +2413,7 @@ Verified against current entity file bma_msh6_somatic_gastric.yaml: recommended_
 
 ---
 
-## 84/100: CV914-0264 - unsupported -> maintainer_review
+## 84/247: CV914-0264 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MYD88-L265P-HCV-MZL`
 **File:** `bma_myd88_l265p_hcv_mzl.yaml`
@@ -2442,7 +2442,7 @@ Verified against current entity file bma_myd88_l265p_hcv_mzl.yaml: recommended_c
 
 ---
 
-## 85/100: CV914-0267 - unsupported -> maintainer_review
+## 85/247: CV914-0267 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MYD88-L265P-NODAL-MZL`
 **File:** `bma_myd88_l265p_nodal_mzl.yaml`
@@ -2471,7 +2471,7 @@ Verified against current entity file bma_myd88_l265p_nodal_mzl.yaml: recommended
 
 ---
 
-## 86/100: CV914-0270 - unsupported -> maintainer_review
+## 86/247: CV914-0270 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MYD88-L265P-SPLENIC-MZL`
 **File:** `bma_myd88_l265p_splenic_mzl.yaml`
@@ -2500,7 +2500,7 @@ Verified against current entity file bma_myd88_l265p_splenic_mzl.yaml: recommend
 
 ---
 
-## 87/100: CV914-0273 - unsupported -> maintainer_review
+## 87/247: CV914-0273 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PMS2-GERMLINE-GASTRIC`
 **File:** `bma_pms2_germline_gastric.yaml`
@@ -2529,7 +2529,7 @@ Verified against current entity file bma_pms2_germline_gastric.yaml: recommended
 
 ---
 
-## 88/100: CV914-0276 - unsupported -> maintainer_review
+## 88/247: CV914-0276 - unsupported -> maintainer_review
 
 **Entity:** `BMA-PMS2-SOMATIC-GASTRIC`
 **File:** `bma_pms2_somatic_gastric.yaml`
@@ -2558,7 +2558,7 @@ Verified against current entity file bma_pms2_somatic_gastric.yaml: recommended_
 
 ---
 
-## 89/100: CV914-0313 - unsupported -> maintainer_review
+## 89/247: CV914-0313 - unsupported -> maintainer_review
 
 **Entity:** `BMA-ATM-SOMATIC-PROSTATE`
 **File:** `bma_atm_somatic_prostate.yaml`
@@ -2587,7 +2587,7 @@ Verified against current entity file bma_atm_somatic_prostate.yaml: recommended_
 
 ---
 
-## 90/100: CV914-0317 - unsupported -> maintainer_review
+## 90/247: CV914-0317 - unsupported -> maintainer_review
 
 **Entity:** `BMA-BCR-ABL1-P190-BALL`
 **File:** `bma_bcr_abl1_p190_ball.yaml`
@@ -2616,7 +2616,7 @@ Verified against current entity file bma_bcr_abl1_p190_ball.yaml: recommended_co
 
 ---
 
-## 91/100: CV914-0331 - unsupported -> maintainer_review
+## 91/247: CV914-0331 - unsupported -> maintainer_review
 
 **Entity:** `BMA-CHEK2-GERMLINE-PROSTATE`
 **File:** `bma_chek2_germline_prostate.yaml`
@@ -2645,7 +2645,7 @@ Verified against current entity file bma_chek2_germline_prostate.yaml: recommend
 
 ---
 
-## 92/100: CV914-0333 - unsupported -> maintainer_review
+## 92/247: CV914-0333 - unsupported -> maintainer_review
 
 **Entity:** `BMA-CHEK2-SOMATIC-PROSTATE`
 **File:** `bma_chek2_somatic_prostate.yaml`
@@ -2674,7 +2674,7 @@ Verified against current entity file bma_chek2_somatic_prostate.yaml: recommende
 
 ---
 
-## 93/100: CV914-0343 - unsupported -> maintainer_review
+## 93/247: CV914-0343 - unsupported -> maintainer_review
 
 **Entity:** `BMA-IDH1-R132G-AML`
 **File:** `bma_idh1_r132g_aml.yaml`
@@ -2703,7 +2703,7 @@ Verified against current entity file bma_idh1_r132g_aml.yaml: recommended_combin
 
 ---
 
-## 94/100: CV914-0349 - unsupported -> maintainer_review
+## 94/247: CV914-0349 - unsupported -> maintainer_review
 
 **Entity:** `BMA-IDH1-R132L-AML`
 **File:** `bma_idh1_r132l_aml.yaml`
@@ -2732,7 +2732,7 @@ Verified against current entity file bma_idh1_r132l_aml.yaml: recommended_combin
 
 ---
 
-## 95/100: CV914-0351 - unsupported -> maintainer_review
+## 95/247: CV914-0351 - unsupported -> maintainer_review
 
 **Entity:** `BMA-IDH1-R132S-AML`
 **File:** `bma_idh1_r132s_aml.yaml`
@@ -2761,7 +2761,7 @@ Verified against current entity file bma_idh1_r132s_aml.yaml: recommended_combin
 
 ---
 
-## 96/100: CV914-0357 - unsupported -> maintainer_review
+## 96/247: CV914-0357 - unsupported -> maintainer_review
 
 **Entity:** `BMA-KIT-EXON11-GIST`
 **File:** `bma_kit_exon11_gist.yaml`
@@ -2790,7 +2790,7 @@ Verified against current entity file bma_kit_exon11_gist.yaml: recommended_combi
 
 ---
 
-## 97/100: CV914-0361 - unsupported -> maintainer_review
+## 97/247: CV914-0361 - unsupported -> maintainer_review
 
 **Entity:** `BMA-KIT-EXON9-GIST`
 **File:** `bma_kit_exon9_gist.yaml`
@@ -2819,7 +2819,7 @@ Verified against current entity file bma_kit_exon9_gist.yaml: recommended_combin
 
 ---
 
-## 98/100: CV914-0365 - unsupported -> maintainer_review
+## 98/247: CV914-0365 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MET-AMP-NSCLC`
 **File:** `bma_met_amp_nsclc.yaml`
@@ -2848,7 +2848,7 @@ Verified against current entity file bma_met_amp_nsclc.yaml: recommended_combina
 
 ---
 
-## 99/100: CV914-0375 - unsupported -> maintainer_review
+## 99/247: CV914-0375 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-GERMLINE-PROSTATE`
 **File:** `bma_mlh1_germline_prostate.yaml`
@@ -2877,7 +2877,7 @@ Verified against current entity file bma_mlh1_germline_prostate.yaml: recommende
 
 ---
 
-## 100/100: CV914-0381 - unsupported -> maintainer_review
+## 100/247: CV914-0381 - unsupported -> maintainer_review
 
 **Entity:** `BMA-MLH1-SOMATIC-PROSTATE`
 **File:** `bma_mlh1_somatic_prostate.yaml`
@@ -2892,6 +2892,4269 @@ recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 20
 **Verification rationale:**
 ```
 Verified against current entity file bma_mlh1_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 101/247: CV914-0387 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-GERMLINE-PROSTATE`
+**File:** `bma_msh2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:693`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 102/247: CV914-0393 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH2-SOMATIC-PROSTATE`
+**File:** `bma_msh2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:705`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh2_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 103/247: CV914-0399 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-GERMLINE-PROSTATE`
+**File:** `bma_msh6_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:717`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 104/247: CV914-0405 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MSH6-SOMATIC-PROSTATE`
+**File:** `bma_msh6_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:729`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_msh6_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 105/247: CV914-0411 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-GERMLINE-PROSTATE`
+**File:** `bma_pms2_germline_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:741`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_germline_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 106/247: CV914-0417 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PMS2-SOMATIC-PROSTATE`
+**File:** `bma_pms2_somatic_prostate.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:753`
+
+**Audit finding text:**
+```
+recommended_combination 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane' contains drug name(s) ['taxane'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pms2_somatic_prostate.yaml: recommended_combinations includes 'pembrolizumab monotherapy (pan-tumor MSI-H/dMMR, FDA 2017) in mCRPC after NHA/taxane', but regulatory_approval does not mention taxane. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 107/247: CV914-0654 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1366`
+
+**Audit finding text:**
+```
+recommended_combination 'BR or R-CHOP or O-CHOP/O-Benda (1L per FLIPI/burden)' contains drug name(s) ['r-chop', 'o-chop', 'o-benda'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_fl.yaml: recommended_combinations includes 'BR or R-CHOP or O-CHOP/O-Benda (1L per FLIPI/burden)', but regulatory_approval does not mention r-chop, o-chop, o-benda. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 108/247: CV914-0655 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1367`
+
+**Audit finding text:**
+```
+recommended_combination 'tazemetostat (EZH2-mut R/R)' contains drug name(s) ['tazemetostat'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_fl.yaml: recommended_combinations includes 'tazemetostat (EZH2-mut R/R)', but regulatory_approval does not mention tazemetostat. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 109/247: CV914-0656 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-FL`
+**File:** `bma_bcl2_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1368`
+
+**Audit finding text:**
+```
+recommended_combination 'mosunetuzumab / axi-cel (R/R 3L+)' contains drug name(s) ['mosunetuzumab', 'axi-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_fl.yaml: recommended_combinations includes 'mosunetuzumab / axi-cel (R/R 3L+)', but regulatory_approval does not mention mosunetuzumab, axi-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 110/247: CV914-0658 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-AML`
+**File:** `bma_tp53_mut_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1372`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax (palliative, R/R)' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax (palliative, R/R)', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 111/247: CV914-0659 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-AML`
+**File:** `bma_tp53_mut_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1373`
+
+**Audit finding text:**
+```
+recommended_combination 'decitabine 10-day' contains drug name(s) ['decitabine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_aml.yaml: recommended_combinations includes 'decitabine 10-day', but regulatory_approval does not mention decitabine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 112/247: CV914-0662 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-DLBCL-NOS`
+**File:** `bma_bcl2_expression_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1378`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP / pola-R-CHP per usual algorithm' contains drug name(s) ['r-chop', 'pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_dlbcl_nos.yaml: recommended_combinations includes 'R-CHOP / pola-R-CHP per usual algorithm', but regulatory_approval does not mention r-chop, pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 113/247: CV914-0663 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-DLBCL-NOS`
+**File:** `bma_bcl2_expression_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1379`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + R-CHOP (trial; CAVALLI)' contains drug name(s) ['venetoclax', 'r-chop'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_dlbcl_nos.yaml: recommended_combinations includes 'venetoclax + R-CHOP (trial; CAVALLI)', but regulatory_approval does not mention venetoclax, r-chop. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 114/247: CV914-0665 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCA-GERMLINE-OVARIAN`
+**File:** `bma_fanca_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1383`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fanca_germline_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 115/247: CV914-0666 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCA-GERMLINE-OVARIAN`
+**File:** `bma_fanca_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1384`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fanca_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 116/247: CV914-0668 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCL-GERMLINE-OVARIAN`
+**File:** `bma_fancl_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1388`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fancl_germline_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 117/247: CV914-0669 - unsupported -> maintainer_review
+
+**Entity:** `BMA-FANCL-GERMLINE-OVARIAN`
+**File:** `bma_fancl_germline_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1389`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_fancl_germline_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 118/247: CV914-0671 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-NLPBL`
+**File:** `bma_myc_rearrangement_nlpbl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1393`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP' contains drug name(s) ['r-chop'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_nlpbl.yaml: recommended_combinations includes 'R-CHOP', but regulatory_approval does not mention r-chop. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 119/247: CV914-0672 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-NLPBL`
+**File:** `bma_myc_rearrangement_nlpbl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1394`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (if HGBL-DH)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_nlpbl.yaml: recommended_combinations includes 'DA-EPOCH-R (if HGBL-DH)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 120/247: CV914-0674 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-DLBCL-NOS`
+**File:** `bma_tp53_mut_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1398`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (1L; not TP53-selected)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP (1L; not TP53-selected)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 121/247: CV914-0675 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-DLBCL-NOS`
+**File:** `bma_tp53_mut_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1399`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T axi-cel / liso-cel (2L+)' contains drug name(s) ['car-t', 'liso-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_dlbcl_nos.yaml: recommended_combinations includes 'CAR-T axi-cel / liso-cel (2L+)', but regulatory_approval does not mention liso-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 122/247: CV914-0678 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MDS-HR`
+**File:** `bma_tp53_mut_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1404`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax (palliative; modest CR but non-durable)' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax (palliative; modest CR but non-durable)', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 123/247: CV914-0680 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-AML`
+**File:** `bma_tp53_r175h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1408`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 124/247: CV914-0683 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-CLL`
+**File:** `bma_tp53_r175h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1413`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 125/247: CV914-0684 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-CLL`
+**File:** `bma_tp53_r175h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1414`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 126/247: CV914-0686 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-DLBCL-NOS`
+**File:** `bma_tp53_r175h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1418`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 127/247: CV914-0689 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MDS-HR`
+**File:** `bma_tp53_r175h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1423`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 128/247: CV914-0692 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-AML`
+**File:** `bma_tp53_r248q_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1428`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 129/247: CV914-0695 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-CLL`
+**File:** `bma_tp53_r248q_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1433`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 130/247: CV914-0696 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-CLL`
+**File:** `bma_tp53_r248q_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1434`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 131/247: CV914-0698 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-DLBCL-NOS`
+**File:** `bma_tp53_r248q_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1438`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 132/247: CV914-0701 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MDS-HR`
+**File:** `bma_tp53_r248q_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1443`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 133/247: CV914-0704 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-AML`
+**File:** `bma_tp53_r273h_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1448`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 134/247: CV914-0707 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-CLL`
+**File:** `bma_tp53_r273h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1453`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 135/247: CV914-0708 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-CLL`
+**File:** `bma_tp53_r273h_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1454`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 136/247: CV914-0710 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-DLBCL-NOS`
+**File:** `bma_tp53_r273h_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1458`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 137/247: CV914-0713 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MDS-HR`
+**File:** `bma_tp53_r273h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1463`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 138/247: CV914-0716 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-AML`
+**File:** `bma_tp53_r282w_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1468`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_aml.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 139/247: CV914-0719 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-CLL`
+**File:** `bma_tp53_r282w_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1473`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib' contains drug name(s) ['acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_cll.yaml: recommended_combinations includes 'acalabrutinib', but regulatory_approval does not mention acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 140/247: CV914-0720 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-CLL`
+**File:** `bma_tp53_r282w_cll.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1474`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + obinutuzumab' contains drug name(s) ['venetoclax', 'obinutuzumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_cll.yaml: recommended_combinations includes 'venetoclax + obinutuzumab', but regulatory_approval does not mention venetoclax, obinutuzumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 141/247: CV914-0722 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-DLBCL-NOS`
+**File:** `bma_tp53_r282w_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1478`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 142/247: CV914-0725 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MDS-HR`
+**File:** `bma_tp53_r282w_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1483`
+
+**Audit finding text:**
+```
+recommended_combination 'azacitidine + venetoclax' contains drug name(s) ['azacitidine', 'venetoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mds_hr.yaml: recommended_combinations includes 'azacitidine + venetoclax', but regulatory_approval does not mention azacitidine, venetoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 143/247: CV914-0728 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-FL`
+**File:** `bma_bcl2_expression_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1488`
+
+**Audit finding text:**
+```
+recommended_combination 'BR / R-CHOP / O-Benda per FLIPI / burden' contains drug name(s) ['r-chop', 'o-benda', 'burden'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_fl.yaml: recommended_combinations includes 'BR / R-CHOP / O-Benda per FLIPI / burden', but regulatory_approval does not mention r-chop, o-benda, burden. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 144/247: CV914-0730 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-EXPRESSION-MCL`
+**File:** `bma_bcl2_expression_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1492`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + acalabrutinib (trials)' contains drug name(s) ['venetoclax', 'acalabrutinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_expression_mcl.yaml: recommended_combinations includes 'venetoclax + acalabrutinib (trials)', but regulatory_approval does not mention venetoclax, acalabrutinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 145/247: CV914-0732 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_bcl2_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1496`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP / pola-R-CHP per usual DLBCL algorithm' contains drug name(s) ['r-chop', 'pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'R-CHOP / pola-R-CHP per usual DLBCL algorithm', but regulatory_approval does not mention r-chop, pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 146/247: CV914-0734 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRAF-V600E-MM`
+**File:** `bma_braf_v600e_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1500`
+
+**Audit finding text:**
+```
+recommended_combination 'vemurafenib (case-report level)' contains drug name(s) ['vemurafenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_braf_v600e_mm.yaml: recommended_combinations includes 'vemurafenib (case-report level)', but regulatory_approval does not mention vemurafenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 147/247: CV914-0736 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-GERMLINE-MELANOMA`
+**File:** `bma_brca2_germline_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1504`
+
+**Audit finding text:**
+```
+recommended_combination 'standard melanoma therapy by stage/biomarker (ICI, BRAFi+MEKi if BRAF V600)' contains drug name(s) ['biomarker'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_germline_melanoma.yaml: recommended_combinations includes 'standard melanoma therapy by stage/biomarker (ICI, BRAFi+MEKi if BRAF V600)', but regulatory_approval does not mention biomarker. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 148/247: CV914-0738 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CHEK1-SOMATIC-OVARIAN`
+**File:** `bma_chek1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1508`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_chek1_somatic_ovarian.yaml: recommended_combinations includes 'platinum-based chemo', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 149/247: CV914-0740 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132G-GBM`
+**File:** `bma_idh1_r132g_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1512`
+
+**Audit finding text:**
+```
+recommended_combination 'vorasidenib' contains drug name(s) ['vorasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132g_gbm.yaml: recommended_combinations includes 'vorasidenib', but regulatory_approval does not mention vorasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 150/247: CV914-0742 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132H-MDS-HR`
+**File:** `bma_idh1_r132h_mds_hr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1516`
+
+**Audit finding text:**
+```
+recommended_combination 'ivosidenib + azacitidine (trial)' contains drug name(s) ['ivosidenib', 'azacitidine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132h_mds_hr.yaml: recommended_combinations includes 'ivosidenib + azacitidine (trial)', but regulatory_approval does not mention ivosidenib, azacitidine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 151/247: CV914-0744 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132H-MDS-LR`
+**File:** `bma_idh1_r132h_mds_lr.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1520`
+
+**Audit finding text:**
+```
+recommended_combination 'ivosidenib + azacitidine (trial)' contains drug name(s) ['ivosidenib', 'azacitidine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132h_mds_lr.yaml: recommended_combinations includes 'ivosidenib + azacitidine (trial)', but regulatory_approval does not mention ivosidenib, azacitidine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 152/247: CV914-0746 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132L-GBM`
+**File:** `bma_idh1_r132l_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1524`
+
+**Audit finding text:**
+```
+recommended_combination 'vorasidenib' contains drug name(s) ['vorasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132l_gbm.yaml: recommended_combinations includes 'vorasidenib', but regulatory_approval does not mention vorasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 153/247: CV914-0748 - unsupported -> maintainer_review
+
+**Entity:** `BMA-IDH1-R132S-GBM`
+**File:** `bma_idh1_r132s_gbm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1528`
+
+**Audit finding text:**
+```
+recommended_combination 'vorasidenib' contains drug name(s) ['vorasidenib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_idh1_r132s_gbm.yaml: recommended_combinations includes 'vorasidenib', but regulatory_approval does not mention vorasidenib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 154/247: CV914-0750 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-G12-MELANOMA`
+**File:** `bma_nras_g12_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1532`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD1-based ICI' contains drug name(s) ['anti-pd1-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_g12_melanoma.yaml: recommended_combinations includes 'anti-PD1-based ICI', but regulatory_approval does not mention anti-pd1-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 155/247: CV914-0752 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-G13-MELANOMA`
+**File:** `bma_nras_g13_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1536`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD1-based ICI' contains drug name(s) ['anti-pd1-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_g13_melanoma.yaml: recommended_combinations includes 'anti-PD1-based ICI', but regulatory_approval does not mention anti-pd1-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 156/247: CV914-0754 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-HOTSPOT-ENDOMETRIAL`
+**File:** `bma_pik3ca_hotspot_endometrial.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1540`
+
+**Audit finding text:**
+```
+recommended_combination 'everolimus + letrozole' contains drug name(s) ['everolimus', 'letrozole'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_hotspot_endometrial.yaml: recommended_combinations includes 'everolimus + letrozole', but regulatory_approval does not mention everolimus, letrozole. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 157/247: CV914-0820 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1720`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd (1L transplant-eligible)' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mm.yaml: recommended_combinations includes 'D-VRd (1L transplant-eligible)', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 158/247: CV914-0821 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1721`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd (1L transplant-ineligible)' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mm.yaml: recommended_combinations includes 'Dara-Rd (1L transplant-ineligible)', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 159/247: CV914-0822 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-MM`
+**File:** `bma_tp53_mut_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1722`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel (R/R)' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel (R/R)', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 160/247: CV914-0824 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-HGBL-DH`
+**File:** `bma_bcl2_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1726`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'DA-EPOCH-R', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 161/247: CV914-0825 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BCL2-REARRANGEMENT-HGBL-DH`
+**File:** `bma_bcl2_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1727`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bcl2_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 162/247: CV914-0827 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-BURKITT`
+**File:** `bma_myc_rearrangement_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1731`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (low/intermediate-risk Burkitt)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_burkitt.yaml: recommended_combinations includes 'DA-EPOCH-R (low/intermediate-risk Burkitt)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 163/247: CV914-0828 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-BURKITT`
+**File:** `bma_myc_rearrangement_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1732`
+
+**Audit finding text:**
+```
+recommended_combination 'CODOX-M/IVAC + rituximab (high-risk/CNS+)' contains drug name(s) ['codox-m', 'ivac', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_burkitt.yaml: recommended_combinations includes 'CODOX-M/IVAC + rituximab (high-risk/CNS+)', but regulatory_approval does not mention codox-m, ivac, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 164/247: CV914-0829 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-BURKITT`
+**File:** `bma_myc_rearrangement_burkitt.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1733`
+
+**Audit finding text:**
+```
+recommended_combination 'R-hyperCVAD (alternative)' contains drug name(s) ['r-hypercvad'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_burkitt.yaml: recommended_combinations includes 'R-hyperCVAD (alternative)', but regulatory_approval does not mention r-hypercvad. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 165/247: CV914-0830 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_myc_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1736`
+
+**Audit finding text:**
+```
+recommended_combination 'R-CHOP (1L standard)' contains drug name(s) ['r-chop'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'R-CHOP (1L standard)', but regulatory_approval does not mention r-chop. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 166/247: CV914-0831 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_myc_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1737`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (POLARIX)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP (POLARIX)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 167/247: CV914-0832 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-DLBCL-NOS`
+**File:** `bma_myc_rearrangement_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1738`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (intensification consideration)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_dlbcl_nos.yaml: recommended_combinations includes 'DA-EPOCH-R (intensification consideration)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 168/247: CV914-0833 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-FL`
+**File:** `bma_myc_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1741`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_fl.yaml: recommended_combinations includes 'DA-EPOCH-R', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 169/247: CV914-0834 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-FL`
+**File:** `bma_myc_rearrangement_fl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1742`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_fl.yaml: recommended_combinations includes 'pola-R-CHP', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 170/247: CV914-0836 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-HGBL-DH`
+**File:** `bma_myc_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1746`
+
+**Audit finding text:**
+```
+recommended_combination 'DA-EPOCH-R (1L preferred)' contains drug name(s) ['da-epoch-r'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'DA-EPOCH-R (1L preferred)', but regulatory_approval does not mention da-epoch-r. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 171/247: CV914-0837 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-HGBL-DH`
+**File:** `bma_myc_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1747`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (1L alternative)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'pola-R-CHP (1L alternative)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 172/247: CV914-0838 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYC-REARRANGEMENT-HGBL-DH`
+**File:** `bma_myc_rearrangement_hgbl_dh.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1748`
+
+**Audit finding text:**
+```
+recommended_combination 'axi-cel / liso-cel (2L+)' contains drug name(s) ['axi-cel', 'liso-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myc_rearrangement_hgbl_dh.yaml: recommended_combinations includes 'axi-cel / liso-cel (2L+)', but regulatory_approval does not mention axi-cel, liso-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 173/247: CV914-0839 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-T-ALL`
+**File:** `bma_notch1_activating_t_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1751`
+
+**Audit finding text:**
+```
+recommended_combination 'per CALGB-10403 / GMALL / BFM-inspired regimen (1L)' contains drug name(s) ['per', 'gmall', 'bfm-inspired'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_t_all.yaml: recommended_combinations includes 'per CALGB-10403 / GMALL / BFM-inspired regimen (1L)', but regulatory_approval does not mention gmall, bfm-inspired. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 174/247: CV914-0840 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-T-ALL`
+**File:** `bma_notch1_activating_t_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1752`
+
+**Audit finding text:**
+```
+recommended_combination 'nelarabine (R/R T-ALL)' contains drug name(s) ['nelarabine'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_t_all.yaml: recommended_combinations includes 'nelarabine (R/R T-ALL)', but regulatory_approval does not mention nelarabine. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 175/247: CV914-0841 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NOTCH1-ACTIVATING-T-ALL`
+**File:** `bma_notch1_activating_t_all.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1753`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + navitoclax (early-phase trials)' contains drug name(s) ['venetoclax', 'navitoclax'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_notch1_activating_t_all.yaml: recommended_combinations includes 'venetoclax + navitoclax (early-phase trials)', but regulatory_approval does not mention venetoclax, navitoclax. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 176/247: CV914-0842 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-OVARIAN`
+**File:** `bma_palb2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1756`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib maintenance' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_ovarian.yaml: recommended_combinations includes 'niraparib maintenance', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 177/247: CV914-0843 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-OVARIAN`
+**File:** `bma_palb2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1757`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib maintenance (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib maintenance (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 178/247: CV914-0844 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-OVARIAN`
+**File:** `bma_palb2_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1758`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab (HRD-positive)' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab (HRD-positive)', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 179/247: CV914-0845 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON20-BREAST`
+**File:** `bma_pik3ca_exon20_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1761`
+
+**Audit finding text:**
+```
+recommended_combination 'alpelisib + fulvestrant' contains drug name(s) ['alpelisib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon20_breast.yaml: recommended_combinations includes 'alpelisib + fulvestrant', but regulatory_approval does not mention alpelisib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 180/247: CV914-0846 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON20-BREAST`
+**File:** `bma_pik3ca_exon20_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1762`
+
+**Audit finding text:**
+```
+recommended_combination 'inavolisib + palbociclib + fulvestrant' contains drug name(s) ['inavolisib', 'palbociclib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon20_breast.yaml: recommended_combinations includes 'inavolisib + palbociclib + fulvestrant', but regulatory_approval does not mention inavolisib, palbociclib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 181/247: CV914-0847 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON20-BREAST`
+**File:** `bma_pik3ca_exon20_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1763`
+
+**Audit finding text:**
+```
+recommended_combination 'capivasertib + fulvestrant' contains drug name(s) ['capivasertib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon20_breast.yaml: recommended_combinations includes 'capivasertib + fulvestrant', but regulatory_approval does not mention capivasertib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 182/247: CV914-0848 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON9-BREAST`
+**File:** `bma_pik3ca_exon9_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1766`
+
+**Audit finding text:**
+```
+recommended_combination 'alpelisib + fulvestrant' contains drug name(s) ['alpelisib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon9_breast.yaml: recommended_combinations includes 'alpelisib + fulvestrant', but regulatory_approval does not mention alpelisib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 183/247: CV914-0849 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON9-BREAST`
+**File:** `bma_pik3ca_exon9_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1767`
+
+**Audit finding text:**
+```
+recommended_combination 'inavolisib + palbociclib + fulvestrant' contains drug name(s) ['inavolisib', 'palbociclib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon9_breast.yaml: recommended_combinations includes 'inavolisib + palbociclib + fulvestrant', but regulatory_approval does not mention inavolisib, palbociclib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 184/247: CV914-0850 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PIK3CA-EXON9-BREAST`
+**File:** `bma_pik3ca_exon9_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1768`
+
+**Audit finding text:**
+```
+recommended_combination 'capivasertib + fulvestrant' contains drug name(s) ['capivasertib', 'fulvestrant'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_pik3ca_exon9_breast.yaml: recommended_combinations includes 'capivasertib + fulvestrant', but regulatory_approval does not mention capivasertib, fulvestrant. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 185/247: CV914-0851 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-SOMATIC-OVARIAN`
+**File:** `bma_rad51b_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1771`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 186/247: CV914-0852 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-SOMATIC-OVARIAN`
+**File:** `bma_rad51b_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1772`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 187/247: CV914-0853 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51B-SOMATIC-OVARIAN`
+**File:** `bma_rad51b_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1773`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51b_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 188/247: CV914-0854 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-SOMATIC-OVARIAN`
+**File:** `bma_rad51c_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1776`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 189/247: CV914-0855 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-SOMATIC-OVARIAN`
+**File:** `bma_rad51c_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1777`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 190/247: CV914-0856 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51C-SOMATIC-OVARIAN`
+**File:** `bma_rad51c_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1778`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51c_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 191/247: CV914-0857 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-SOMATIC-OVARIAN`
+**File:** `bma_rad51d_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1781`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 192/247: CV914-0858 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-SOMATIC-OVARIAN`
+**File:** `bma_rad51d_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1782`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 193/247: CV914-0859 - unsupported -> maintainer_review
+
+**Entity:** `BMA-RAD51D-SOMATIC-OVARIAN`
+**File:** `bma_rad51d_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1783`
+
+**Audit finding text:**
+```
+recommended_combination 'rucaparib (LOH-high)' contains drug name(s) ['rucaparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_rad51d_somatic_ovarian.yaml: recommended_combinations includes 'rucaparib (LOH-high)', but regulatory_approval does not mention rucaparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 194/247: CV914-0860 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MM`
+**File:** `bma_tp53_r175h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1786`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 195/247: CV914-0861 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MM`
+**File:** `bma_tp53_r175h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1787`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 196/247: CV914-0862 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MM`
+**File:** `bma_tp53_r175h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1788`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 197/247: CV914-0863 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MM`
+**File:** `bma_tp53_r248q_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1791`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 198/247: CV914-0864 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MM`
+**File:** `bma_tp53_r248q_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1792`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 199/247: CV914-0865 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MM`
+**File:** `bma_tp53_r248q_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1793`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 200/247: CV914-0866 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MM`
+**File:** `bma_tp53_r273h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1796`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 201/247: CV914-0867 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MM`
+**File:** `bma_tp53_r273h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1797`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 202/247: CV914-0868 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MM`
+**File:** `bma_tp53_r273h_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1798`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 203/247: CV914-0869 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MM`
+**File:** `bma_tp53_r282w_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1801`
+
+**Audit finding text:**
+```
+recommended_combination 'D-VRd' contains drug name(s) ['d-vrd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mm.yaml: recommended_combinations includes 'D-VRd', but regulatory_approval does not mention d-vrd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 204/247: CV914-0870 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MM`
+**File:** `bma_tp53_r282w_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1802`
+
+**Audit finding text:**
+```
+recommended_combination 'Dara-Rd' contains drug name(s) ['dara-rd'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mm.yaml: recommended_combinations includes 'Dara-Rd', but regulatory_approval does not mention dara-rd. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 205/247: CV914-0871 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MM`
+**File:** `bma_tp53_r282w_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1803`
+
+**Audit finding text:**
+```
+recommended_combination 'ide-cel / cilta-cel' contains drug name(s) ['ide-cel', 'cilta-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mm.yaml: recommended_combinations includes 'ide-cel / cilta-cel', but regulatory_approval does not mention ide-cel, cilta-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 206/247: CV914-0872 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-GERMLINE-BREAST`
+**File:** `bma_atm_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1806`
+
+**Audit finding text:**
+```
+recommended_combination 'standard breast therapy by HR/HER2' contains drug name(s) ['her2'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_germline_breast.yaml: recommended_combinations includes 'standard breast therapy by HR/HER2', but regulatory_approval does not mention her2. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 207/247: CV914-0873 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-GERMLINE-BREAST`
+**File:** `bma_atm_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1807`
+
+**Audit finding text:**
+```
+recommended_combination 'enhanced screening (annual MRI)' contains drug name(s) ['enhanced'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_germline_breast.yaml: recommended_combinations includes 'enhanced screening (annual MRI)', but regulatory_approval does not mention enhanced. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 208/247: CV914-0874 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BARD1-SOMATIC-OVARIAN`
+**File:** `bma_bard1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1810`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bard1_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 209/247: CV914-0875 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BARD1-SOMATIC-OVARIAN`
+**File:** `bma_bard1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1811`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_bard1_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 210/247: CV914-0876 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRIP1-SOMATIC-OVARIAN`
+**File:** `bma_brip1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1814`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib (HRD-positive)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brip1_somatic_ovarian.yaml: recommended_combinations includes 'niraparib (HRD-positive)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 211/247: CV914-0877 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRIP1-SOMATIC-OVARIAN`
+**File:** `bma_brip1_somatic_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1815`
+
+**Audit finding text:**
+```
+recommended_combination 'olaparib + bevacizumab' contains drug name(s) ['olaparib', 'bevacizumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brip1_somatic_ovarian.yaml: recommended_combinations includes 'olaparib + bevacizumab', but regulatory_approval does not mention olaparib, bevacizumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 212/247: CV914-0878 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-MUTATION-AML`
+**File:** `bma_kit_mutation_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1818`
+
+**Audit finding text:**
+```
+recommended_combination 'standard 7+3 + HiDAC consolidation (CBF-AML backbone)' contains drug name(s) ['hidac'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_mutation_aml.yaml: recommended_combinations includes 'standard 7+3 + HiDAC consolidation (CBF-AML backbone)', but regulatory_approval does not mention hidac. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 213/247: CV914-0879 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-MUTATION-AML`
+**File:** `bma_kit_mutation_aml.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1819`
+
+**Audit finding text:**
+```
+recommended_combination 'avapritinib (D816V-AML, basket trial)' contains drug name(s) ['avapritinib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_mutation_aml.yaml: recommended_combinations includes 'avapritinib (D816V-AML, basket trial)', but regulatory_approval does not mention avapritinib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 214/247: CV914-0880 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-DLBCL-NOS`
+**File:** `bma_myd88_l265p_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1822`
+
+**Audit finding text:**
+```
+recommended_combination 'pola-R-CHP (1L; POLARIX - not MYD88-selected but consider)' contains drug name(s) ['pola-r-chp'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_dlbcl_nos.yaml: recommended_combinations includes 'pola-R-CHP (1L; POLARIX - not MYD88-selected but consider)', but regulatory_approval does not mention pola-r-chp. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 215/247: CV914-0881 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-DLBCL-NOS`
+**File:** `bma_myd88_l265p_dlbcl_nos.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1823`
+
+**Audit finding text:**
+```
+recommended_combination 'CAR-T axi-cel / liso-cel (R/R)' contains drug name(s) ['car-t', 'liso-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_dlbcl_nos.yaml: recommended_combinations includes 'CAR-T axi-cel / liso-cel (R/R)', but regulatory_approval does not mention liso-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 216/247: CV914-0882 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-PCNSL`
+**File:** `bma_myd88_l265p_pcnsl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1826`
+
+**Audit finding text:**
+```
+recommended_combination 'ibrutinib + HD-MTX-based regimens (trial)' contains drug name(s) ['ibrutinib', 'hd-mtx-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_pcnsl.yaml: recommended_combinations includes 'ibrutinib + HD-MTX-based regimens (trial)', but regulatory_approval does not mention ibrutinib, hd-mtx-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 217/247: CV914-0883 - unsupported -> maintainer_review
+
+**Entity:** `BMA-MYD88-L265P-PCNSL`
+**File:** `bma_myd88_l265p_pcnsl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1827`
+
+**Audit finding text:**
+```
+recommended_combination 'MTX-based induction -> consolidation per usual PCNSL algorithm' contains drug name(s) ['mtx-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_myd88_l265p_pcnsl.yaml: recommended_combinations includes 'MTX-based induction -> consolidation per usual PCNSL algorithm', but regulatory_approval does not mention mtx-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 218/247: CV914-0884 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-OVARIAN`
+**File:** `bma_tp53_mut_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1830`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli (1L HGSOC)' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli (1L HGSOC)', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 219/247: CV914-0885 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-MUT-OVARIAN`
+**File:** `bma_tp53_mut_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1831`
+
+**Audit finding text:**
+```
+recommended_combination 'niraparib maintenance (BRCA-WT/HRD-test)' contains drug name(s) ['niraparib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_mut_ovarian.yaml: recommended_combinations includes 'niraparib maintenance (BRCA-WT/HRD-test)', but regulatory_approval does not mention niraparib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 220/247: CV914-0886 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MCL`
+**File:** `bma_tp53_r175h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1834`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 221/247: CV914-0887 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-MCL`
+**File:** `bma_tp53_r175h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1835`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 222/247: CV914-0888 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-OVARIAN`
+**File:** `bma_tp53_r175h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1838`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 223/247: CV914-0889 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R175H-OVARIAN`
+**File:** `bma_tp53_r175h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1839`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r175h_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 224/247: CV914-0890 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MCL`
+**File:** `bma_tp53_r248q_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1842`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 225/247: CV914-0891 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-MCL`
+**File:** `bma_tp53_r248q_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1843`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 226/247: CV914-0892 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-OVARIAN`
+**File:** `bma_tp53_r248q_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1846`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 227/247: CV914-0893 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R248Q-OVARIAN`
+**File:** `bma_tp53_r248q_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1847`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r248q_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 228/247: CV914-0894 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MCL`
+**File:** `bma_tp53_r273h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1850`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 229/247: CV914-0895 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-MCL`
+**File:** `bma_tp53_r273h_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1851`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 230/247: CV914-0896 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-OVARIAN`
+**File:** `bma_tp53_r273h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1854`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 231/247: CV914-0897 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R273H-OVARIAN`
+**File:** `bma_tp53_r273h_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1855`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r273h_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 232/247: CV914-0898 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MCL`
+**File:** `bma_tp53_r282w_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1858`
+
+**Audit finding text:**
+```
+recommended_combination 'acalabrutinib + rituximab' contains drug name(s) ['acalabrutinib', 'rituximab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mcl.yaml: recommended_combinations includes 'acalabrutinib + rituximab', but regulatory_approval does not mention acalabrutinib, rituximab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 233/247: CV914-0899 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-MCL`
+**File:** `bma_tp53_r282w_mcl.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1859`
+
+**Audit finding text:**
+```
+recommended_combination 'brexu-cel' contains drug name(s) ['brexu-cel'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_mcl.yaml: recommended_combinations includes 'brexu-cel', but regulatory_approval does not mention brexu-cel. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 234/247: CV914-0900 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-OVARIAN`
+**File:** `bma_tp53_r282w_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1862`
+
+**Audit finding text:**
+```
+recommended_combination 'bevacizumab + carbo/pacli' contains drug name(s) ['bevacizumab', 'carbo', 'pacli'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_ovarian.yaml: recommended_combinations includes 'bevacizumab + carbo/pacli', but regulatory_approval does not mention bevacizumab, carbo, pacli. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 235/247: CV914-0901 - unsupported -> maintainer_review
+
+**Entity:** `BMA-TP53-R282W-OVARIAN`
+**File:** `bma_tp53_r282w_ovarian.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1863`
+
+**Audit finding text:**
+```
+recommended_combination 'PARPi maintenance per HRD/BRCA' contains drug name(s) ['parpi', 'brca'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_tp53_r282w_ovarian.yaml: recommended_combinations includes 'PARPi maintenance per HRD/BRCA', but regulatory_approval does not mention parpi. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 236/247: CV914-0902 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-GERMLINE-PDAC`
+**File:** `bma_atm_germline_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1866`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX or gem-cis (platinum induction)' contains drug name(s) ['folfirinox', 'gem-cis'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_germline_pdac.yaml: recommended_combinations includes 'FOLFIRINOX or gem-cis (platinum induction)', but regulatory_approval does not mention folfirinox, gem-cis. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 237/247: CV914-0903 - unsupported -> maintainer_review
+
+**Entity:** `BMA-ATM-SOMATIC-PDAC`
+**File:** `bma_atm_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1869`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX (platinum-based)' contains drug name(s) ['folfirinox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_atm_somatic_pdac.yaml: recommended_combinations includes 'FOLFIRINOX (platinum-based)', but regulatory_approval does not mention folfirinox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 238/247: CV914-0904 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA1-SOMATIC-PDAC`
+**File:** `bma_brca1_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1872`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (FOLFIRINOX preferred)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca1_somatic_pdac.yaml: recommended_combinations includes 'platinum-based chemo (FOLFIRINOX preferred)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 239/247: CV914-0905 - unsupported -> maintainer_review
+
+**Entity:** `BMA-BRCA2-SOMATIC-PDAC`
+**File:** `bma_brca2_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1875`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (FOLFIRINOX)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_brca2_somatic_pdac.yaml: recommended_combinations includes 'platinum-based chemo (FOLFIRINOX)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 240/247: CV914-0907 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CCND1-T1114-MM`
+**File:** `bma_ccnd1_t1114_mm.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1881`
+
+**Audit finding text:**
+```
+recommended_combination 'venetoclax + carfilzomib + dex (NCT trials)' contains drug name(s) ['venetoclax', 'carfilzomib'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_ccnd1_t1114_mm.yaml: recommended_combinations includes 'venetoclax + carfilzomib + dex (NCT trials)', but regulatory_approval does not mention venetoclax, carfilzomib. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 241/247: CV914-0908 - unsupported -> maintainer_review
+
+**Entity:** `BMA-CHEK2-GERMLINE-BREAST`
+**File:** `bma_chek2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1884`
+
+**Audit finding text:**
+```
+recommended_combination 'enhanced screening (annual MRI from age 40)' contains drug name(s) ['enhanced'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_chek2_germline_breast.yaml: recommended_combinations includes 'enhanced screening (annual MRI from age 40)', but regulatory_approval does not mention enhanced. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 242/247: CV914-0909 - unsupported -> maintainer_review
+
+**Entity:** `BMA-KIT-MUTATION-MELANOMA`
+**File:** `bma_kit_mutation_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1887`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD-1 \xB1 anti-CTLA-4 (1L irrespective of KIT status)' contains drug name(s) ['anti-pd-1'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_kit_mutation_melanoma.yaml: recommended_combinations includes 'anti-PD-1 \\xB1 anti-CTLA-4 (1L irrespective of KIT status)', but regulatory_approval does not mention anti-pd-1. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 243/247: CV914-0910 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-Q61K-MELANOMA`
+**File:** `bma_nras_q61k_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1890`
+
+**Audit finding text:**
+```
+recommended_combination 'anti-PD1-based ICI' contains drug name(s) ['anti-pd1-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_q61k_melanoma.yaml: recommended_combinations includes 'anti-PD1-based ICI', but regulatory_approval does not mention anti-pd1-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 244/247: CV914-0911 - unsupported -> maintainer_review
+
+**Entity:** `BMA-NRAS-Q61R-MELANOMA`
+**File:** `bma_nras_q61r_melanoma.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1893`
+
+**Audit finding text:**
+```
+recommended_combination 'nivolumab + ipilimumab (1L preferred)' contains drug name(s) ['nivolumab', 'ipilimumab'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_nras_q61r_melanoma.yaml: recommended_combinations includes 'nivolumab + ipilimumab (1L preferred)', but regulatory_approval does not mention nivolumab, ipilimumab. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 245/247: CV914-0912 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-GERMLINE-BREAST`
+**File:** `bma_palb2_germline_breast.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1896`
+
+**Audit finding text:**
+```
+recommended_combination 'platinum-based chemo (TNBC)' contains drug name(s) ['platinum-based'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_germline_breast.yaml: recommended_combinations includes 'platinum-based chemo (TNBC)', but regulatory_approval does not mention platinum-based. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 246/247: CV914-0913 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-GERMLINE-PDAC`
+**File:** `bma_palb2_germline_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1899`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX (platinum induction)' contains drug name(s) ['folfirinox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_germline_pdac.yaml: recommended_combinations includes 'FOLFIRINOX (platinum induction)', but regulatory_approval does not mention folfirinox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
+
+```
+
+**Notes:** ""
+
+
+**Maintainer action:**
+- [ ] revise claim (edit the entity field to match what source actually says)
+- [ ] replace_source (find correct cited Source)
+- [ ] dismiss (audit was wrong; claim is fine as-is)
+- [ ] escalate to Co-Lead
+
+---
+
+## 247/247: CV914-0914 - unsupported -> maintainer_review
+
+**Entity:** `BMA-PALB2-SOMATIC-PDAC`
+**File:** `bma_palb2_somatic_pdac.yaml`
+**Claim locator:** `docs/reviews/citation-verification-2026-04-27.md:1902`
+
+**Audit finding text:**
+```
+recommended_combination 'FOLFIRINOX' contains drug name(s) ['folfirinox'] not appearing in regulatory_approval text (may be legitimate combination-component naming OR off-label not flagged)
+
+```
+
+**Verification rationale:**
+```
+Verified against current entity file bma_palb2_somatic_pdac.yaml: recommended_combinations includes 'FOLFIRINOX', but regulatory_approval does not mention folfirinox. This supports the audit concern that the recommendation/regulatory wording is not source-aligned and needs maintainer review rather than bulk edit.
 
 ```
 

--- a/docs/reviews/tasktorrent-pr21-23-execution-2026-04-28.md
+++ b/docs/reviews/tasktorrent-pr21-23-execution-2026-04-28.md
@@ -1,0 +1,73 @@
+# TaskTorrent PR #21/#22/#23 execution log (2026-04-28)
+
+Start time: 2026-04-28 15:57:16 +03:00.
+
+Synced baseline: `origin/master @ 5859cf4c` (`Merge pull request #22 from romeo111/chore/post-pilot-verify-and-apply`).
+
+## Scope limits
+
+- Work only in the clean `OpenOnco_master_sync` worktree.
+- Do not modify the older dirty `OpenOnco_work` worktree.
+- Do not promote new claim-bearing clinical content without CHARTER section 6.1 review/signoff.
+- PR #21, #22, and #23 are already merged; this pass executes mechanical validation, re-verification, and maintainer-facing triage follow-ups.
+
+## PR status at start
+
+- PR #21: merged. Remaining chunks landed as sidecars; claim-bearing application remains gated by Co-Lead review.
+- PR #22: merged. `civic-bma-reconstruct-all` was applied to hosted BMA content after deterministic re-verify.
+- PR #23: merged. `citation-semantic-verify-v2` report landed; follow-up work is triage and source-replacement/action queues.
+
+## Execution results
+
+### Sync
+
+- Synced `romeo111/OpenOnco` to `origin/master @ 5859cf4c`.
+- Created a clean worktree at `C:\Users\805\task_torrent\OpenOnco_master_sync`.
+- Created execution branch `codex/execute-pr21-23`.
+- Left the older `OpenOnco_work` worktree untouched because it had unrelated local modifications.
+
+### Validation
+
+- `git fetch origin --prune`: PASS; branch baseline still matches `origin/master @ 5859cf4c`.
+- `python -m scripts.tasktorrent.validate_contributions --all`: PASS for all 8 chunks.
+- `python -m knowledge_base.validation.loader knowledge_base/hosted/content`: PASS; loaded 2414 hosted entities and resolved references.
+- Loader warnings remain: 36 contract warnings, mostly draft redflags requiring clinical review plus three one-source warnings.
+- `python -m scripts.tasktorrent.reverify_bma_civic`: PASS; 399/399 BMA sidecars match the CIViC snapshot.
+- `python -m scripts.tasktorrent.reverify_citation_replace_source citation-semantic-verify-v2`: PASS; 121 replace-source rows, 0 missing target sources, 0 trial/title mismatches.
+
+### PR #21 follow-up state
+
+- `bma-drafting-gap-diseases`: 23 sidecars, all `review_existing_hosted_draft`, all `pending_clinical_signoff`; 5 blocker items remain.
+- `redflag-indication-coverage-fill`: 33 sidecars, all `review_existing_hosted_draft`, all `pending_clinical_signoff`; 10 blocker items remain.
+- `source-stub-ingest-batch`: 40 source sidecars, all `review_existing_stub`; 12 are `pending_clinical_signoff`, 28 have no explicit review status.
+- Six source-stub contribution sidecars still contain `TODO: confirm citation`: `SRC-ASCO-BTC-2023`, `SRC-ATA-ATC-2021`, `SRC-ATA-THYROID-2015`, `SRC-EANO-LGG-2024`, `SRC-ESMO-BTC-2023`, and `SRC-ESMO-HNSCC-2020`.
+- Hosted sources still contain multiple `TODO: confirm citation` titles. These are source-quality blockers, not mechanical-validation failures.
+
+### PR #22 follow-up state
+
+- CIViC BMA reverify remains clean after sync: 399 sidecars rechecked against the 2026-04-25 CIViC snapshot.
+- No BMA content changes were needed in this pass.
+
+### PR #23 follow-up state
+
+- Regenerated maintainer triage queues without row limits by status:
+  - `contributions/citation-semantic-verify-v2/triage-queue-status-supported.md`: 121 supported rows, all replace-source candidates.
+  - `contributions/citation-semantic-verify-v2/triage-queue-status-unsupported.md`: 247 unsupported rows, all maintainer-review candidates.
+- Generated full maintainer triage queues by action:
+  - `contributions/citation-semantic-verify-v2/triage-queue-action-replace_source.md`: 121 rows.
+  - `contributions/citation-semantic-verify-v2/triage-queue-action-maintainer_review.md`: 345 rows.
+  - `contributions/citation-semantic-verify-v2/triage-queue-action-revise_claim.md`: 124 rows.
+  - `contributions/citation-semantic-verify-v2/triage-queue-action-source_stub_needed.md`: 324 rows.
+- Re-ran trial extraction:
+  - `source_stub_needed` rows: 324.
+  - Unique extracted trials: 47.
+  - Rows without extractable trial: 153.
+  - Existing report path: `contributions/citation-semantic-verify-v2/trials-needing-source-ingest.md`.
+
+## Remaining guarded work
+
+- Merge-ready technical state: validation, KB loading, CIViC reverify, and citation replace-source reverify are green.
+- Governance state: remaining blockers are not schema/test failures; they are clinical/source-review queues that must remain explicit for reviewer action.
+- Do not bulk-apply the 121 replace-source candidates without maintainer acceptance; one example (`VISION`) can resolve to the wrong oncology trial name across domains.
+- Do not promote #21 claim-bearing BMA/redflag/indication drafts until PR-level review or clinical signoff resolves the explicit blocker reports.
+- Source-stub TODOs should be resolved by checking primary source pages/metadata and licensing notes before editing hosted source titles or citation identifiers.


### PR DESCRIPTION
## Summary
- Regenerate full citation-semantic-verify-v2 triage queues without row limits.
- Add action-based maintainer queues for replace_source, maintainer_review, revise_claim, and source_stub_needed.
- Add PR #21/#22/#23 execution log with sync baseline, validation results, limits, and remaining governed review queues.

## Validation
- PASS: python -m scripts.tasktorrent.validate_contributions --all
- PASS: python -m knowledge_base.validation.loader knowledge_base/hosted/content
- PASS: python -m scripts.tasktorrent.reverify_bma_civic
- PASS: python -m scripts.tasktorrent.reverify_citation_replace_source citation-semantic-verify-v2
- PASS: git diff --cached --check before commit

## Governance notes
- No claim-bearing hosted YAML was promoted in this PR.
- Remaining #21 blockers are clinical/source-review queues, not schema failures.
- Replace-source rows are prepared for maintainer action; they are not bulk-applied.