### PR TITLE
feat(tasktorrent): L-19 claim coordination — bots, docs, schema

### DIFF
--- a/.github/ISSUE_TEMPLATE/tasktorrent-chunk-task.md
+++ b/.github/ISSUE_TEMPLATE/tasktorrent-chunk-task.md
@@ -27,6 +27,28 @@ assignees: ""
 
 `tasktorrent/<chunk-id>`
 
+## Claim Method
+
+<!-- Pick one (must match chunk-spec):
+     - formal-issue → contributor comments to claim, maintainer assigns within 24h SLA
+     - trusted-agent-wip-branch-first → pre-authorized agent pushes empty WIP commit immediately
+-->
+
+claim_method:
+
+## How to claim
+
+For `formal-issue`:
+- Comment: `I'd like to take this chunk.`
+- Maintainer assigns within 24h. If not assigned, auto-released by bot.
+- One contributor per chunk.
+
+For `trusted-agent-wip-branch-first`:
+- Push empty WIP commit to `tasktorrent/<chunk-id>` on origin IMMEDIATELY when starting.
+- That branch on origin is the visible lock — other agents see it and don't duplicate.
+
+**Stale-claim auto-release:** if no branch activity for 14 days, bot drops assignee + relabels `status-active`.
+
 ## Sidecar Output Path
 
 ```

--- a/.github/workflows/tasktorrent-claim-bots.yml
+++ b/.github/workflows/tasktorrent-claim-bots.yml
@@ -1,0 +1,71 @@
+name: TaskTorrent Claim Coordination Bots
+
+# L-19 implementation:
+#   - claim-sla-bot (hourly): auto-release issues whose claim was not
+#     assigned within 24h
+#   - stale-claim-bot (daily): auto-release issues with assignee set but
+#     no activity on the `tasktorrent/<chunk-id>` branch for 14+ days
+
+on:
+  schedule:
+    # Hourly: SLA check
+    - cron: "0 * * * *"
+    # Daily 04:00 UTC: stale-claim sweep
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run mode (don't actually unassign / comment)"
+        required: false
+        default: "false"
+        type: choice
+        options: ["true", "false"]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  claim-sla-check:
+    # Runs hourly — quick check for unassigned-too-long claims
+    if: github.event.schedule == '0 * * * *' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run claim-SLA bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m scripts.tasktorrent.check_claim_sla $DRY_RUN_FLAG
+
+  stale-claim-sweep:
+    # Runs daily — slower sweep across all assigned issues
+    if: github.event.schedule == '0 4 * * *' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run stale-claim bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          python -m scripts.tasktorrent.auto_release_stale_claims $DRY_RUN_FLAG

--- a/docs/contributing/CONTRIBUTOR_QUICKSTART.md
+++ b/docs/contributing/CONTRIBUTOR_QUICKSTART.md
@@ -26,17 +26,30 @@ python --version    # 3.12.x or higher; on Windows: py -V:3.12
    <https://github.com/romeo111/OpenOnco/issues?q=is%3Aissue+is%3Aopen+label%3Achunk-task+label%3Astatus-active>
 2. Read the chunk-task issue. It links to the full chunk spec at
    `https://github.com/romeo111/task_torrent/blob/main/chunks/openonco/<chunk-id>.md`.
-3. Comment on the issue: `I'd like to take this chunk.` Wait up to 24 hours for the maintainer to assign you. Only one contributor per chunk.
+3. Note the chunk's **`claim_method`** — declared in the spec. Two values:
+   - `formal-issue`: comment on issue → maintainer assigns. Step 3 below.
+   - `trusted-agent-wip-branch-first`: skip issue claim, push WIP branch immediately. Step 3 below describes this.
+4. For `formal-issue` chunks: comment on the issue: `I'd like to take this chunk.` Wait up to 24 hours for the maintainer to assign you. **24h SLA** — if not assigned, the chunk auto-releases.
 
-If no chunks are `status-active`, the pilot is at its concurrency cap (2 active). Subscribe to the repo or check back.
+If no chunks are `status-active`, all slots are taken or queued. Subscribe to the repo or check back.
 
-## 3. Branch (1 min)
+## 3. Branch + WIP-push (1 min)
+
+For both claim methods:
 
 ```bash
-git checkout -b tasktorrent/<chunk-id>      # e.g. tasktorrent/civic-bma-reconstruct-all
+git checkout -b tasktorrent/<chunk-id>      # e.g. tasktorrent/escat-tier-audit
+git commit --allow-empty -m "wip: starting <chunk-id>"
+git push -u origin tasktorrent/<chunk-id>
 ```
 
+**The empty WIP-push is mandatory for `trusted-agent-wip-branch-first` chunks** — it broadcasts your claim immediately, before you do significant local work. Other trusted agents see the branch on origin and don't duplicate.
+
+For `formal-issue` chunks: WIP-push is recommended even though the issue assignee is the primary lock. Two layers of visibility = better coordination.
+
 The branch name matters — CI looks for the `tasktorrent/` prefix.
+
+**Stale-claim auto-release:** if you don't push commits to your branch for 14 days, a bot will release your claim (drop assignee, re-open the slot). If you need more time, comment on the issue with an ETA before the bot fires.
 
 ## 4. Read the agent prompt (10 min)
 

--- a/docs/contributing/HELP_WANTED.md
+++ b/docs/contributing/HELP_WANTED.md
@@ -39,14 +39,41 @@ chunks open as previous ones close.
 
 Quick summary of the flow:
 
-1. **Pick** an open `[Chunk]` issue with label `status-active` and no assignee. Comment to claim. Maintainer assigns you within 24 hours.
+1. **Pick** an open `[Chunk]` issue with label `status-active` and no assignee. Comment to claim. Maintainer assigns you within 24 hours (auto-released after 24h if not assigned).
 2. **Read** [`CONTRIBUTOR_QUICKSTART.md`](CONTRIBUTOR_QUICKSTART.md) end-to-end.
-3. **Branch** as `tasktorrent/<chunk-id>`.
+3. **Branch** as `tasktorrent/<chunk-id>` AND **immediately push the empty branch to origin** (WIP-branch-first rule, see below).
 4. **Run** your AI tool with the chunk's `AGENT_PROMPT_*.md` content. Output goes into `contributions/<chunk-id>/`.
 5. **Self-validate**: `python -m scripts.tasktorrent.validate_contributions <chunk-id>` — must say `PASS`.
 6. **Open PR** against `master`. CI auto-runs; maintainer reviews when CI green.
 7. **Iterate** force-pushing if maintainer requests changes.
 8. **PR merges** when accepted. Maintainer-run upsert promotes sidecars into hosted content after Clinical Co-Lead signoff (CHARTER §6.1) where applicable.
+
+## Two claim methods (per chunk-spec)
+
+Each chunk-spec declares one of two `claim_method` values. Use the method declared in the chunk you're taking.
+
+### `formal-issue` (for open contributors)
+
+The standard flow described in steps 1–8 above. Comment on issue → maintainer assigns → assignee field locks the slot. Other contributors see the assigned issue and don't duplicate.
+
+**24h SLA:** if maintainer doesn't assign within 24 hours of your claim comment, the chunk auto-releases (a bot drops the claim label). You can re-claim or another contributor can take it.
+
+### `trusted-agent-wip-branch-first` (for pre-authorized contributor agents)
+
+Maintainer pre-authorizes the contributor (e.g. their own Codex or a known partner agent). No formal issue-claim ceremony.
+
+**Critical:** push a minimal/empty WIP commit to `tasktorrent/<chunk-id>` on origin **immediately** when you start, BEFORE doing significant local work. This branch on origin = the visible lock.
+
+```bash
+git checkout -b tasktorrent/<chunk-id>
+git commit --allow-empty -m "wip: starting <chunk-id>"
+git push -u origin tasktorrent/<chunk-id>
+# now do the actual work; force-push or new commits later
+```
+
+The WIP-branch-first rule prevents the "invisible window" between local-work-start and first-push from causing two trusted agents to duplicate the chunk. Without it, a 2-hour local session of agent A blocks nothing from origin's perspective; agent B starts the same chunk in parallel.
+
+**Stale-claim auto-release:** chunk-task issues with `assignee` set + no commits to `tasktorrent/<chunk-id>` for 14 days are auto-released by a bot (drops assignee, re-labels `status-active`). If you fall behind, comment on the issue with an ETA before the bot fires.
 
 ## Reference output: the PoC sidecar
 

--- a/docs/contributing/MAINTAINER_CHUNK_OPENING.md
+++ b/docs/contributing/MAINTAINER_CHUNK_OPENING.md
@@ -1,0 +1,98 @@
+# Maintainer Checklist: Opening a Chunk-Task Issue
+
+Before opening a `[Chunk]` issue with `status-active` label (which makes the chunk claimable by contributors), walk this checklist. Skipping steps risks parallel-work duplication, manifest collisions, or contributor confusion.
+
+## 1. Is the chunk-spec ready?
+
+Open `chunks/openonco/<chunk-id>.md` in `task_torrent` repo. Confirm:
+
+- [ ] Status is `queued` (not `completed`/`active`)
+- [ ] Economic Profile filled with `break_even_test: PASS` or `MARGINAL` — **never open `FAIL` chunks**
+- [ ] `claim_method` declared (`formal-issue` or `trusted-agent-wip-branch-first`)
+- [ ] Manifest is concrete (real entity IDs / file ranges, not placeholder)
+- [ ] Re-verification spec is real (sample %, expert role, trust threshold)
+
+If anything is missing, fix the chunk-spec first.
+
+## 2. Cross-chunk manifest overlap check
+
+If the chunk's manifest overlaps with another currently-active chunk's manifest, two contributors may collide on the same entity. Run:
+
+```bash
+# Save the new chunk's manifest to a temp file
+cat > /tmp/new_manifest.txt <<EOF
+<paste the manifest IDs, one per line>
+EOF
+
+# Run overlap check against existing active chunks
+python -m scripts.tasktorrent.check_manifest_overlap <new-chunk-id> /tmp/new_manifest.txt
+```
+
+Expected output:
+
+```
+No overlap. Safe to open the new chunk-task issue.
+```
+
+If overlap detected:
+
+```
+OVERLAP with contributions/<other-chunk-id>/ (N entities):
+  - <BMA-ID-1>
+  - <BMA-ID-2>
+  ...
+Overlap detected. Resolve before opening the new chunk-task issue.
+```
+
+**Resolution options:**
+
+- Wait for the conflicting chunk to close, then re-check.
+- Re-scope the new chunk's manifest to avoid the overlap.
+- If both must run in parallel, coordinate so they touch DIFFERENT fields of the same entity (e.g. one chunk modifies `evidence_sources`, another modifies `notes`) — and document that in both chunk-specs.
+
+## 3. Open the issue
+
+```bash
+gh issue create --label "chunk-task,status-active,<topic-labels>" \
+  --title "[Chunk] <chunk-id> — <one-line scope>" \
+  --body-file path/to/issue-body.md
+```
+
+Issue body template at `.github/ISSUE_TEMPLATE/tasktorrent-chunk-task.md` — fill out every section. The chunk's full spec is at `task_torrent/chunks/openonco/<chunk-id>.md`; link to it from the issue.
+
+## 4. After opening
+
+- For `formal-issue` chunks: wait for first claim comment. Assign within 24h or the bot auto-releases.
+- For `trusted-agent-wip-branch-first` chunks: notify the pre-authorized agent via DM/secondary channel. They'll push a WIP branch immediately when starting.
+- Add to active-chunks dashboard / shelf listing if you maintain one.
+
+## 5. Active-cap check
+
+Active-cap is currently 10 (per `task_torrent/docs/openonco-pilot-workflow.md`). Before opening, check current active count:
+
+```bash
+gh issue list --label "chunk-task,status-active" --state open | wc -l
+```
+
+If at cap, hold the open until a slot frees.
+
+## When chunks close
+
+When a chunk's PR merges (sidecars in `contributions/`):
+
+1. Close the chunk-task issue with a comment linking to the merged PR
+2. Update chunk-spec status to `completed` (back in task_torrent)
+3. Active-cap decrements; new chunk can be promoted
+
+When chunk's content gets applied to hosted/content (Co-Lead signoff happens):
+
+4. Run `application_status: applied` tracking (see PR #15 / improvement plan §9)
+
+## Notes for the bot maintainer
+
+The two bots in `.github/workflows/tasktorrent-claim-bots.yml`:
+
+- **claim-sla-bot** (hourly): auto-releases formal-issue claims unassigned > 24h
+- **stale-claim-bot** (daily): auto-releases assignees with no branch activity > 14 days
+
+Both have `workflow_dispatch` for manual trigger with `dry_run: true` to test without side effects.

--- a/scripts/tasktorrent/auto_release_stale_claims.py
+++ b/scripts/tasktorrent/auto_release_stale_claims.py
@@ -1,0 +1,144 @@
+"""Auto-release stale chunk claims (14 days no activity).
+
+Run by a GitHub Action on schedule (daily). For each open `[Chunk]` issue
+with `chunk-task` label AND assignee set:
+
+1. Check if `tasktorrent/<chunk-id>` branch exists on origin.
+2. Find the most recent commit on that branch (or the issue's most recent
+   activity if no branch).
+3. If activity > 14 days old → comment + drop assignee + relabel
+   `status-active`.
+
+Usage:
+    python -m scripts.tasktorrent.auto_release_stale_claims [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+STALE_DAYS = 14
+CHUNK_ID_RE = re.compile(r"\[Chunk\]\s*(\S+)")
+
+
+def _gh(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if result.stdout.strip().startswith(("{", "[")):
+        return json.loads(result.stdout)
+    return result.stdout
+
+
+def _list_assigned_chunk_issues() -> list[dict]:
+    issues = _gh([
+        "issue", "list",
+        "--label", "chunk-task",
+        "--state", "open",
+        "--json", "number,title,assignees,labels,updatedAt",
+        "--limit", "100",
+    ])
+    return [i for i in issues if i.get("assignees")]
+
+
+def _extract_chunk_id(title: str) -> str | None:
+    """Issue titles look like '[Chunk] civic-bma-reconstruct-all (NSCLC subset)' —
+    extract the chunk-id (first token after [Chunk])."""
+    m = CHUNK_ID_RE.search(title or "")
+    if m:
+        return m.group(1).rstrip(".:,;")
+    return None
+
+
+def _branch_last_activity(chunk_id: str) -> dt.datetime | None:
+    """Return the timestamp of the latest commit on origin/tasktorrent/<chunk-id>,
+    or None if branch missing."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/:owner/:repo/commits",
+             "-X", "GET",
+             "-f", f"sha=tasktorrent/{chunk_id}",
+             "-f", "per_page=1",
+             "--jq", ".[0].commit.committer.date"],
+            capture_output=True, text=True, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if result.returncode != 0:
+        return None
+    iso = result.stdout.strip().strip('"')
+    if not iso:
+        return None
+    try:
+        return dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _is_stale(activity_at: dt.datetime, now: dt.datetime) -> bool:
+    return (now - activity_at).days >= STALE_DAYS
+
+
+def _release_stale(issue: dict, last_activity: dt.datetime, dry_run: bool) -> None:
+    number = issue["number"]
+    assignees = [a["login"] for a in issue.get("assignees", [])]
+    msg = (
+        f"🤖 **Auto-released by stale-claim-bot.** Last activity on "
+        f"`tasktorrent/<chunk-id>` was {last_activity.isoformat()} "
+        f"({STALE_DAYS}+ days ago). Dropping assignee(s) {', '.join('@' + a for a in assignees)} "
+        f"and re-labeling `status-active`.\n\n"
+        f"If you still want this chunk, claim again. If you've made progress "
+        f"locally but didn't push, push your WIP commits — that resets the timer."
+    )
+    if dry_run:
+        print(f"[dry-run] would release #{number}: {msg[:100]}...")
+        return
+    _gh(["issue", "comment", str(number), "--body", msg])
+    for assignee in assignees:
+        _gh(["issue", "edit", str(number), "--remove-assignee", assignee])
+    _gh(["issue", "edit", str(number), "--add-label", "status-active"])
+    print(f"released #{number}: stale {STALE_DAYS}+ days")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    issues = _list_assigned_chunk_issues()
+    print(f"Reviewing {len(issues)} assigned chunk-task issues...")
+
+    now = dt.datetime.now(dt.timezone.utc)
+    released = 0
+    for issue in issues:
+        chunk_id = _extract_chunk_id(issue.get("title", ""))
+        if not chunk_id:
+            continue
+        last_branch = _branch_last_activity(chunk_id)
+        if last_branch is None:
+            # No branch on origin — fall back to issue activity
+            try:
+                last = dt.datetime.fromisoformat(issue["updatedAt"].replace("Z", "+00:00"))
+            except (KeyError, ValueError):
+                continue
+        else:
+            last = last_branch
+        if _is_stale(last, now):
+            _release_stale(issue, last, args.dry_run)
+            released += 1
+
+    print(f"\nReleased {released} stale claim(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tasktorrent/check_claim_sla.py
+++ b/scripts/tasktorrent/check_claim_sla.py
@@ -1,0 +1,132 @@
+"""Check 24h claim SLA on TaskTorrent chunk-task issues.
+
+Run by a GitHub Action on schedule (hourly). For each open `[Chunk]` issue
+with `chunk-task` label:
+
+1. Find the most recent comment containing a claim phrase
+   ("I'd like to take this chunk", "claiming", etc.).
+2. Check whether the issue has an `assignee` set.
+3. If a claim was made > 24h ago AND no assignee was set → comment that
+   the chunk is auto-released and re-label `status-active`.
+
+This handles the open-contributor flow where maintainer didn't assign in
+time. Trusted-agent flow is unaffected (those use WIP-branch-first, not
+issue-comment claims).
+
+Usage:
+    python -m scripts.tasktorrent.check_claim_sla [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+SLA_HOURS = 24
+CLAIM_PHRASES = [
+    r"\bI'd like to take\b",
+    r"\bI'd like to claim\b",
+    r"\bI'll take this chunk\b",
+    r"\bclaiming this chunk\b",
+    r"\btaking this chunk\b",
+]
+CLAIM_RE = re.compile("|".join(CLAIM_PHRASES), re.IGNORECASE)
+
+
+def _gh(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if result.stdout.strip().startswith(("{", "[")):
+        return json.loads(result.stdout)
+    return result.stdout
+
+
+def _list_chunk_issues() -> list[dict]:
+    return _gh([
+        "issue", "list",
+        "--label", "chunk-task",
+        "--state", "open",
+        "--json", "number,title,assignees,labels",
+        "--limit", "100",
+    ])
+
+
+def _get_comments(issue_number: int) -> list[dict]:
+    return _gh([
+        "issue", "view", str(issue_number),
+        "--json", "comments",
+    ])["comments"]
+
+
+def _is_past_sla(comment_iso: str, now: dt.datetime) -> bool:
+    t = dt.datetime.fromisoformat(comment_iso.replace("Z", "+00:00"))
+    return (now - t).total_seconds() > SLA_HOURS * 3600
+
+
+def _release_for_sla(issue_number: int, claimer_login: str, claim_at: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"[dry-run] would release issue #{issue_number}: SLA breach for {claimer_login}@{claim_at}")
+        return
+    _gh([
+        "issue", "comment", str(issue_number),
+        "--body", (
+            f"🤖 **Auto-released by claim-SLA-bot.** Claim by @{claimer_login} "
+            f"at {claim_at} was not assigned within {SLA_HOURS}h. "
+            f"Re-released to `status-active` — anyone can claim again.\n\n"
+            f"@{claimer_login}, if you still want this chunk, comment again."
+        ),
+    ])
+    print(f"released issue #{issue_number}: SLA breach (claimer @{claimer_login})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    issues = _list_chunk_issues()
+    print(f"Reviewing {len(issues)} open chunk-task issues...")
+
+    now = dt.datetime.now(dt.timezone.utc)
+    released = 0
+    for issue in issues:
+        if issue.get("assignees"):
+            continue  # already assigned, no SLA breach
+        labels = [l["name"] for l in issue.get("labels", [])]
+        if "status-active" not in labels:
+            continue
+        comments = _get_comments(issue["number"])
+        # Find the most recent claim phrase
+        latest_claim = None
+        for c in comments:
+            if CLAIM_RE.search(c.get("body", "") or ""):
+                latest_claim = c
+        if not latest_claim:
+            continue
+        claim_at = latest_claim.get("createdAt")
+        if not claim_at:
+            continue
+        if _is_past_sla(claim_at, now):
+            _release_for_sla(
+                issue["number"],
+                latest_claim.get("author", {}).get("login", "unknown"),
+                claim_at,
+                args.dry_run,
+            )
+            released += 1
+
+    print(f"\nReleased {released} SLA-breached claim(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements L-19 sub-proposals (b)+(c)+(e). Companion to task_torrent PR #18 (which carries (a)+(d) schema/docs).

**Problem:** parallel-work risk. Current claim flow has gaps:
- 24h assignment SLA not enforced
- Stale claims block slots indefinitely  
- Cross-chunk manifest overlap not checked at issue-open
- Trusted-agent local-work-start to first-push window invisible

**Solution:**

| Sub | What | Location |
|---|---|---|
| (a) | WIP-branch-first rule | HELP_WANTED.md + CONTRIBUTOR_QUICKSTART.md |
| (b) | Stale-claim auto-release (14d) | scripts/tasktorrent/auto_release_stale_claims.py + workflow |
| (c) | Cross-chunk overlap check | docs/contributing/MAINTAINER_CHUNK_OPENING.md (manual maintainer step) |
| (d) | claim_method schema | (in task_torrent PR #18) |
| (e) | 24h assignment SLA | scripts/tasktorrent/check_claim_sla.py + workflow |

**Bots:**
- `claim-sla-bot` — hourly cron, releases unassigned-too-long claims
- `stale-claim-bot` — daily cron, releases assigned-but-stale claims
- Both support `workflow_dispatch` with `dry_run: true` for testing

**Permissions:** `issues: write, contents: read` — bots can comment/unassign/relabel only.

**Test plan:**
- [ ] Manually run `workflow_dispatch` with `dry_run: true` after merge to validate bots find no false positives on existing issues.
- [ ] After first scheduled run (~1h after merge), check workflow output for `Released N` count = 0 (no real stale claims yet).
- [ ] When a real chunk gets claimed, verify SLA timer behavior end-to-end.