### PR TITLE
feat(kb): coverage matrix generator + strategy doc

### DIFF
--- a/docs/kb-coverage-matrix.md
+++ b/docs/kb-coverage-matrix.md
@@ -1,0 +1,200 @@
+# KB Coverage Matrix
+
+_Generated_: 2026-04-28 20:56 UTC
+
+Auto-generated from `knowledge_base/hosted/content/` by `scripts/kb_coverage_matrix.py`. **Do not edit by hand** — re-run the script. The strategy doc that explains how to read this is [`kb-coverage-strategy.md`](kb-coverage-strategy.md).
+
+## Top-level KPIs
+
+| Entity | Count |
+|---|---:|
+| Diseases | 65 |
+| Biomarker_actionability (BMA) | 399 |
+| Indications | 302 |
+| Red flags | 426 |
+| Drugs | 216 |
+| Regimens | 244 |
+| Sources | 269 |
+| Biomarkers | 111 |
+| Algorithms | 110 |
+| Questionnaires | 65 |
+| **Total entities** | **2142** |
+
+## Quality scores
+
+| Axis | Numerator | Denominator | Score |
+|---|---:|---:|---:|
+| BMA with ESCAT tier | 399 | 399 | 100% |
+| BMA with CIViC evidence_sources | 295 | 399 | 74% |
+| BMA UA-signed-off | 0 | 399 | 0% |
+| BMA UA pending review | 398 | 399 | 100% |
+| Indications with expected_outcomes | 302 | 302 | 100% |
+| Indications with NCCN category | 302 | 302 | 100% |
+| RF with sources | 426 | 426 | 100% |
+| RF with last_reviewed | 394 | 426 | 92% |
+| Sources with license declared | 240 | 269 | 89% |
+| Sources current_as_of <365d | 27 | 269 | 10% |
+| Drugs UA-registered | 151 | 216 | 70% |
+| Drugs NSZU-reimbursed | 132 | 216 | 61% |
+
+## ESCAT tier distribution (across 399 BMAs)
+
+| Tier | Count | % |
+|---|---:|---:|
+| IA | 135 | 34% |
+| IB | 47 | 12% |
+| IIA | 52 | 13% |
+| IIB | 18 | 5% |
+| IIIA | 53 | 13% |
+| IIIB | 61 | 15% |
+| IV | 31 | 8% |
+| V | 0 | 0% |
+| X | 2 | 1% |
+| (unset) | 0 | 0% |
+
+## Per-disease coverage matrix
+
+Sorted by (BMA + IND + RF) descending. Diseases with 0 across all axes are listed under "Coverage gaps" below.
+
+| Disease | Archetype | Subtypes | BMA | ESCAT% | CIViC% | UA✓ | IND | Outcomes% | NCCN% | RF | RF cats | Regimens | Sources | Quest |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|
+| Non-small cell lung cancer (NSCLC) | biomarker_driven | 10 | 36 | 100% | 94% | 0% | 28 | 100% | 100% | 22 | 5 | 20 | 20 | ✓ |
+| Breast cancer (invasive) (BREAST) | biomarker_driven | — | 36 | 100% | 86% | 0% | 20 | 100% | 100% | 11 | 5 | 13 | 11 | ✓ |
+| Ovarian carcinoma (high-grade serous predominant) (OVARIAN) | biomarker_driven | — | 39 | 100% | 67% | 0% | 15 | 100% | 100% | 11 | 5 | 11 | 10 | ✓ |
+| Colorectal carcinoma (CRC) (CRC) | stage_driven | — | 27 | 100% | 59% | 0% | 18 | 100% | 100% | 8 | 5 | 12 | 2 | ✓ |
+| Acute Myeloid Leukemia (non-APL) (AML) | risk_stratified | — | 24 | 100% | 96% | 0% | 11 | 100% | 100% | 12 | 5 | 6 | 6 | ✓ |
+| Prostate adenocarcinoma (PROSTATE) | line_of_therapy_sequential | — | 20 | 100% | 45% | 0% | 5 | 100% | 100% | 9 | 6 | 5 | 3 | ✓ |
+| Diffuse Large B-Cell Lymphoma, NOS (DLBCL-NOS) | risk_stratified | — | 13 | 100% | 85% | 0% | 9 | 100% | 100% | 11 | 6 | 4 | 2 | ✓ |
+| Multiple Myeloma (MM) | risk_stratified | — | 10 | 100% | 80% | 0% | 7 | 100% | 100% | 12 | 6 | 5 | 3 | ✓ |
+| Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma (CLL) | risk_stratified | — | 10 | 100% | 70% | 0% | 6 | 100% | 100% | 12 | 7 | 5 | 3 | ✓ |
+| Cutaneous melanoma (MELANOMA) | biomarker_driven | 4 | 11 | 100% | 100% | 0% | 9 | 100% | 100% | 8 | 5 | 6 | 6 | ✓ |
+| Gastric / GEJ adenocarcinoma (GASTRIC) | stage_driven | — | 15 | 100% | 40% | 0% | 5 | 100% | 100% | 6 | 5 | 5 | 2 | ✓ |
+| Mantle Cell Lymphoma (MCL) | risk_stratified | — | 11 | 100% | 55% | 0% | 6 | 100% | 100% | 8 | 5 | 6 | 3 | ✓ |
+| Endometrial carcinoma (ENDOMETRIAL) | biomarker_driven | 4 | 15 | 100% | 40% | 0% | 4 | 100% | 100% | 5 | 5 | 4 | 2 | ✓ |
+| Pancreatic ductal adenocarcinoma (PDAC) (PDAC) | stage_driven | — | 16 | 100% | 94% | 0% | 3 | 100% | 100% | 5 | 5 | 3 | 2 | ✓ |
+| Myelodysplastic Syndromes — Higher-Risk (IPSS-R high / very high; includes MDS-EB) (MDS-HR) | risk_stratified | — | 11 | 100% | 100% | 0% | 3 | 100% | 100% | 9 | 6 | 3 | 3 | ✓ |
+| Urothelial carcinoma (bladder + upper tract) (UROTHELIAL) | line_of_therapy_sequential | — | 15 | 100% | 47% | 0% | 2 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| B-Lymphoblastic Leukemia / Lymphoma (B-ALL) | biomarker_driven | — | 6 | 100% | 100% | 0% | 6 | 100% | 100% | 7 | 5 | 5 | 4 | ✓ |
+| Chronic Myeloid Leukemia (BCR-ABL1) (CML) | etiologically_driven | — | 5 | 100% | 100% | 0% | 5 | 100% | 100% | 9 | 6 | 5 | 3 | ✓ |
+| Follicular Lymphoma (FL) | risk_stratified | — | 4 | 100% | 25% | 0% | 7 | 100% | 100% | 8 | 6 | 6 | 2 | ✓ |
+| Myelodysplastic Syndromes — Lower-Risk (IPSS-R very low / low / intermediate) (MDS-LR) | risk_stratified | — | 6 | 100% | 100% | 0% | 4 | 100% | 100% | 8 | 6 | 4 | 3 | ✓ |
+| Gastrointestinal stromal tumor (GIST) (GIST) | biomarker_driven | — | 9 | 100% | 33% | 0% | 2 | 100% | 100% | 5 | 5 | 2 | 4 | ✓ |
+| Glioblastoma (IDH-WT, WHO grade 4) (GBM) | stage_driven | — | 9 | 100% | 89% | 0% | 1 | 100% | 100% | 5 | 5 | 1 | 2 | ✓ |
+| Angioimmunoblastic T-Cell Lymphoma / Nodal TFH-cell lymphoma (AITL) | risk_stratified | — | 2 | 100% | 100% | 0% | 5 | 100% | 100% | 7 | 5 | 5 | 2 | ✓ |
+| Hepatocellular carcinoma (HCC) (HCC) | stage_driven | — | 5 | 100% | 100% | 0% | 3 | 100% | 100% | 6 | 5 | 3 | 2 | ✓ |
+| Primary Myelofibrosis (DIPSS-Plus stratified) (PMF) | risk_stratified | — | 2 | 100% | 50% | 0% | 5 | 100% | 100% | 7 | 6 | 4 | 4 | ✓ |
+| Acute Promyelocytic Leukemia (PML-RARA) (APL) | molecularly_defined_emergency | — | 0 | — | — | — | 4 | 100% | 100% | 9 | 6 | 4 | 3 | ✓ |
+| Classical Hodgkin Lymphoma (CHL) | stage_driven | — | 1 | 100% | 0% | 0% | 7 | 100% | 100% | 5 | 5 | 5 | 2 | ✓ |
+| Polycythemia Vera (PV) | risk_stratified | — | 1 | 100% | 100% | 0% | 6 | 100% | 100% | 6 | 5 | 4 | 3 | ✓ |
+| Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma (WM) | biomarker_driven | — | 2 | 100% | 50% | 0% | 5 | 100% | 100% | 6 | 5 | 5 | 2 | ✓ |
+| Anaplastic Large Cell Lymphoma (systemic) (ALCL) | biomarker_driven | — | 2 | 100% | 50% | 0% | 5 | 100% | 100% | 5 | 5 | 5 | 2 | ✓ |
+| Burkitt Lymphoma (BURKITT) | biomarker_driven | — | 1 | 100% | 100% | 0% | 5 | 100% | 100% | 6 | 5 | 5 | 2 | ✓ |
+| Esophageal carcinoma (squamous + adeno) (ESOPHAGEAL) | stage_driven | — | 3 | 100% | 67% | 0% | 4 | 100% | 100% | 5 | 5 | 4 | 2 | ✓ |
+| High-Grade B-Cell Lymphoma with MYC and BCL2 and/or BCL6 rearrangements (double-hit / triple-hit) (HGBL-DH) | biomarker_driven | — | 2 | 100% | 50% | 0% | 3 | 100% | 100% | 7 | 5 | 3 | 2 | ✓ |
+| Renal cell carcinoma (RCC) | biomarker_driven | — | 3 | 100% | 67% | 0% | 4 | 100% | 100% | 5 | 5 | 3 | 2 | ✓ |
+| T-Lymphoblastic Leukemia / Lymphoma (T-ALL) | risk_stratified | — | 2 | 100% | 100% | 0% | 2 | 100% | 100% | 8 | 5 | 2 | 4 | ✓ |
+| Essential Thrombocythemia (ET) | risk_stratified | — | 2 | 100% | 50% | 0% | 3 | 100% | 100% | 6 | 5 | 2 | 3 | ✓ |
+| Cervical carcinoma (squamous predominant + adeno) (CERVICAL) | etiologically_driven | — | 2 | 100% | 100% | 0% | 2 | 100% | 100% | 6 | 5 | 1 | 2 | ✓ |
+| Cholangiocarcinoma (bile duct cancer) (CHOLANGIOCARCINOMA) | stage_driven | — | 4 | 100% | 100% | 0% | 1 | 100% | 100% | 5 | 5 | 1 | 4 | ✓ |
+| Mycosis Fungoides / Sézary Syndrome (MF-SEZARY) | stage_driven | — | 0 | — | — | — | 5 | 100% | 100% | 5 | 5 | 4 | 2 | ✓ |
+| Nodal Marginal Zone Lymphoma (NODAL-MZL) | risk_stratified | — | 1 | 100% | 100% | 0% | 4 | 100% | 100% | 5 | 5 | 3 | 2 | ✓ |
+| Primary Diffuse Large B-Cell Lymphoma of the CNS (PCNSL) | stage_driven | — | 1 | 100% | 100% | 0% | 3 | 100% | 100% | 6 | 5 | 3 | 3 | ✓ |
+| Primary Mediastinal (Thymic) Large B-Cell Lymphoma (PMBCL) | risk_stratified | — | 0 | — | — | — | 3 | 100% | 100% | 7 | 5 | 3 | 2 | ✓ |
+| Small cell lung cancer (SCLC) | stage_driven | — | 1 | 100% | 100% | 0% | 2 | 100% | 100% | 7 | 5 | 2 | 2 | ✓ |
+| Adult T-Cell Leukemia/Lymphoma (ATLL) | etiologically_driven | — | 0 | — | — | — | 3 | 100% | 100% | 6 | 5 | 3 | 3 | ✓ |
+| Hairy Cell Leukemia (HCL) | biomarker_driven | — | 1 | 100% | 100% | 0% | 3 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| HCV-associated Marginal Zone Lymphoma (HCV-MZL) | etiologically_driven | — | 1 | 100% | 100% | 0% | 3 | 100% | 100% | 5 | 5 | 3 | 4 | ✓ |
+| Medullary thyroid carcinoma (MTC) (MTC) | biomarker_driven | — | 2 | 100% | 100% | 0% | 2 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| Nodular Lymphocyte-Predominant B-cell Lymphoma (formerly NLPHL) (NLPBL) | stage_driven | — | 1 | 100% | 100% | 0% | 3 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| Peripheral T-Cell Lymphoma, Not Otherwise Specified (PTCL-NOS) | risk_stratified | — | 0 | — | — | — | 4 | 100% | 100% | 5 | 5 | 4 | 2 | ✓ |
+| Post-Transplant Lymphoproliferative Disorder (PTLD) | stage_driven | — | 1 | 100% | 100% | 0% | 3 | 100% | 100% | 5 | 5 | 3 | 2 | ✓ |
+| Salivary gland carcinoma (SALIVARY) | biomarker_driven | — | 2 | 100% | 0% | 0% | 1 | 100% | 100% | 6 | 5 | 1 | 4 | ✓ |
+| Splenic Marginal Zone Lymphoma (SPLENIC-MZL) | etiologically_driven | — | 1 | 100% | 100% | 0% | 3 | 100% | 100% | 5 | 5 | 3 | 2 | ✓ |
+| Advanced systemic mastocytosis (AdvSM) (MASTOCYTOSIS) | biomarker_driven | — | 1 | 100% | 100% | 0% | 2 | 100% | 100% | 5 | 5 | 2 | 4 | ✓ |
+| Extranodal NK/T-Cell Lymphoma, Nasal Type (NK-T-NASAL) | etiologically_driven | — | 0 | — | — | — | 3 | 100% | 100% | 5 | 5 | 3 | 2 | ✓ |
+| Anaplastic thyroid carcinoma (ATC) (THYROID-ANAPLASTIC) | biomarker_driven | — | 1 | 100% | 100% | 0% | 1 | 100% | 100% | 6 | 5 | 1 | 2 | ✓ |
+| Papillary thyroid carcinoma (PTC) (THYROID-PAPILLARY) | stage_driven | — | 2 | 100% | 50% | 0% | 1 | 100% | 100% | 5 | 5 | 1 | 2 | ✓ |
+| Enteropathy-Associated T-Cell Lymphoma (EATL) | etiologically_driven | — | 0 | — | — | — | 2 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| Low-grade glioma (LGG, WHO grade 2 — IDH-mutant) (GLIOMA-LOW-GRADE) | biomarker_driven | — | 0 | — | — | — | 1 | 100% | 100% | 6 | 5 | 0 | 4 | ✓ |
+| Head and neck squamous cell carcinoma (HNSCC) (HNSCC) | etiologically_driven | — | 0 | — | — | — | 2 | 100% | 100% | 5 | 5 | 2 | 4 | ✓ |
+| Hepatosplenic T-Cell Lymphoma (HSTCL) | biomarker_driven | — | 0 | — | — | — | 2 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| Infantile fibrosarcoma (IFS) (IFS) | biomarker_driven | — | 1 | 100% | 0% | 0% | 1 | 100% | 100% | 5 | 5 | 1 | 2 | ✓ |
+| Malignant peripheral nerve sheath tumor (MPNST) (MPNST) | biomarker_driven | — | 0 | — | — | — | 1 | 100% | 100% | 6 | 5 | 1 | 2 | ✓ |
+| T-Cell Prolymphocytic Leukemia (T-PLL) | biomarker_driven | — | 0 | — | — | — | 2 | 100% | 100% | 5 | 5 | 2 | 2 | ✓ |
+| Chondrosarcoma (CHONDROSARCOMA) | stage_driven | — | 0 | — | — | — | 1 | 100% | 100% | 5 | 5 | 1 | 4 | ✓ |
+| Inflammatory myofibroblastic tumor (IMT) (IMT) | biomarker_driven | — | 0 | — | — | — | 1 | 100% | 100% | 5 | 5 | 1 | 2 | ✓ |
+
+## Coverage gaps
+
+### Diseases with **zero BMA** (14)
+
+| Disease | Archetype | IND | RF |
+|---|---|---:|---:|
+| Acute Promyelocytic Leukemia (PML-RARA) (DIS-APL) | molecularly_defined_emergency | 4 | 9 |
+| Adult T-Cell Leukemia/Lymphoma (DIS-ATLL) | etiologically_driven | 3 | 6 |
+| Chondrosarcoma (DIS-CHONDROSARCOMA) | stage_driven | 1 | 5 |
+| Enteropathy-Associated T-Cell Lymphoma (DIS-EATL) | etiologically_driven | 2 | 5 |
+| Low-grade glioma (LGG, WHO grade 2 — IDH-mutant) (DIS-GLIOMA-LOW-GRADE) | biomarker_driven | 1 | 6 |
+| Head and neck squamous cell carcinoma (HNSCC) (DIS-HNSCC) | etiologically_driven | 2 | 5 |
+| Hepatosplenic T-Cell Lymphoma (DIS-HSTCL) | biomarker_driven | 2 | 5 |
+| Inflammatory myofibroblastic tumor (IMT) (DIS-IMT) | biomarker_driven | 1 | 5 |
+| Mycosis Fungoides / Sézary Syndrome (DIS-MF-SEZARY) | stage_driven | 5 | 5 |
+| Malignant peripheral nerve sheath tumor (MPNST) (DIS-MPNST) | biomarker_driven | 1 | 6 |
+| Extranodal NK/T-Cell Lymphoma, Nasal Type (DIS-NK-T-NASAL) | etiologically_driven | 3 | 5 |
+| Primary Mediastinal (Thymic) Large B-Cell Lymphoma (DIS-PMBCL) | risk_stratified | 3 | 7 |
+| Peripheral T-Cell Lymphoma, Not Otherwise Specified (DIS-PTCL-NOS) | risk_stratified | 4 | 5 |
+| T-Cell Prolymphocytic Leukemia (DIS-T-PLL) | biomarker_driven | 2 | 5 |
+
+### Diseases with **thin BMA coverage (1-2 entries)** (25)
+
+| Disease | BMA |
+|---|---:|
+| Burkitt Lymphoma (DIS-BURKITT) | 1 |
+| Hairy Cell Leukemia (DIS-HCL) | 1 |
+| HCV-associated Marginal Zone Lymphoma (DIS-HCV-MZL) | 1 |
+| Classical Hodgkin Lymphoma (DIS-CHL) | 1 |
+| Infantile fibrosarcoma (IFS) (DIS-IFS) | 1 |
+| Advanced systemic mastocytosis (AdvSM) (DIS-MASTOCYTOSIS) | 1 |
+| Nodular Lymphocyte-Predominant B-cell Lymphoma (formerly NLPHL) (DIS-NLPBL) | 1 |
+| Nodal Marginal Zone Lymphoma (DIS-NODAL-MZL) | 1 |
+| Primary Diffuse Large B-Cell Lymphoma of the CNS (DIS-PCNSL) | 1 |
+| Post-Transplant Lymphoproliferative Disorder (DIS-PTLD) | 1 |
+| Polycythemia Vera (DIS-PV) | 1 |
+| Small cell lung cancer (DIS-SCLC) | 1 |
+| Splenic Marginal Zone Lymphoma (DIS-SPLENIC-MZL) | 1 |
+| Anaplastic thyroid carcinoma (ATC) (DIS-THYROID-ANAPLASTIC) | 1 |
+| Angioimmunoblastic T-Cell Lymphoma / Nodal TFH-cell lymphoma (DIS-AITL) | 2 |
+| Anaplastic Large Cell Lymphoma (systemic) (DIS-ALCL) | 2 |
+| Cervical carcinoma (squamous predominant + adeno) (DIS-CERVICAL) | 2 |
+| Essential Thrombocythemia (DIS-ET) | 2 |
+| High-Grade B-Cell Lymphoma with MYC and BCL2 and/or BCL6 rearrangements (double-hit / triple-hit) (DIS-HGBL-DH) | 2 |
+| Medullary thyroid carcinoma (MTC) (DIS-MTC) | 2 |
+| Primary Myelofibrosis (DIPSS-Plus stratified) (DIS-PMF) | 2 |
+| Salivary gland carcinoma (DIS-SALIVARY) | 2 |
+| T-Lymphoblastic Leukemia / Lymphoma (DIS-T-ALL) | 2 |
+| Papillary thyroid carcinoma (PTC) (DIS-THYROID-PAPILLARY) | 2 |
+| Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma (DIS-WM) | 2 |
+
+### Diseases with **zero red-flags** (0)
+
+
+### Diseases with **zero indications** (0)
+
+
+### Diseases with **no questionnaire** (0)
+
+
+## Quality gaps
+
+- **0** BMAs without ESCAT tier
+- **104** BMAs without CIViC evidence_sources
+- **0** indications without `expected_outcomes` block
+- **0** redflags without `sources` block
+
+---
+
+## How to act on this matrix
+
+Each new TaskTorrent chunk should reference a specific cell or gap and state how it advances coverage. Example chunk-spec preamble: _"This chunk advances `Per-disease matrix > breast_cancer > IND-Outcomes%` from 60% to 95% by adding expected_outcomes to 12 missing indications."_
+
+Re-run this script after each KB-mutating PR is applied. Schedule weekly via cron once the strategy doc lands.

--- a/docs/kb-coverage-strategy.md
+++ b/docs/kb-coverage-strategy.md
@@ -1,0 +1,181 @@
+# KB Coverage Strategy
+
+**Status:** v0.1 draft, 2026-04-28. Lives alongside the auto-generated [`kb-coverage-matrix.md`](kb-coverage-matrix.md) which is the live snapshot of where we are. This doc explains _how to read it, where v1.0 ends, and how chunks should reference it._
+
+## What this is for
+
+OpenOnco's KB grew opportunistically — gap → chunk → fill → next gap. That works while the maintainer can hold the entire shape of the KB in their head. We're past that point: 2,142 entities across 10 types, 65 diseases × 5 quality axes = 325 cells of state, plus three orthogonal audit dimensions.
+
+This strategy doc + the matrix together answer four questions that the chunk shelf alone cannot:
+
+1. **Where are we now?** (`kb-coverage-matrix.md` — auto-generated)
+2. **Where are we going?** (target state, this doc)
+3. **What's the next highest-leverage chunk?** (gap × priority weight, this doc)
+4. **Are we converging?** (matrix-over-time diff, future cron)
+
+Without it, "база майже готова" is unfalsifiable. With it, "DLBCL row is at 8/12 cells; 4 to go" is an honest statement of progress.
+
+## How chunks reference this
+
+Every new chunk-spec (per `tasktorrent` v0.4 schema) should reference the matrix in its **Mission** section. Pattern:
+
+> _This chunk advances **`kb-coverage-matrix.md > Per-disease matrix > glioma-low-grade > BMA`** from 0 to ≥3 by adding actionability records for IDH1/IDH2/MGMT/1p19q/BRAF V600E in low-grade glioma._
+
+The chunk-spec linter does not enforce this (yet) — it's a writing discipline. Without it, chunks tend to drift toward "what's quick" rather than "what closes a known gap."
+
+## Three classes of work, three distinct queues
+
+The matrix surfaces three orthogonal axes; each generates its own queue. They should not compete for the same shelf slot.
+
+### Queue A — Coverage-fill
+
+**Driver:** the matrix's gap sections (zero-BMA, thin-BMA, no-RF, etc.)
+
+**Metric:** entity count ↑ for a specific disease × axis cell.
+
+**Examples already done:**
+- `bma-drafting-gap-diseases` (+23 BMA drafts staged, awaiting Co-Lead signoff)
+- `redflag-indication-coverage-fill` (+33 RF entries staged)
+- `source-stub-ingest-batch` (+40 source stubs staged)
+- `trial-source-ingest-pubmed` (+25 SRC, merged 2026-04-28 via PR #29)
+
+**Examples next:**
+- 14 zero-BMA diseases need ≥3 BMAs each (~42 new BMA records). Priority on UA-frequent rare lymphomas (PTCL-NOS, NK/T-Nasal, MF-Sezary).
+- 25 thin-BMA diseases need 2-3 more each (~60 BMA records).
+- HNSCC (zero BMA, etiologically_driven) — needs HPV-positive vs HPV-negative actionability split + EGFR amplification.
+
+**Risk profile:** low. Chunks here are scriptable + verifiable.
+
+### Queue B — Audit + remediate
+
+**Driver:** the matrix's quality columns (ESCAT%, CIViC%, UA✓ signoff %) and prior audit reports (citation-verify-v2 793 actionable rows; rec-wording 870; ua-translation 1858).
+
+**Metric:** error count ↓, or quality % ↑, in the matrix's quality columns.
+
+**Pattern:** comes in pairs. Audit chunk (cheap, ~1 Drop) generates a triage queue. Remediation chunk (expensive, depends on triage volume) acts on the queue.
+
+**Examples already done (audit half):**
+- citation-verify v1 + v2 — 793 actionable rows surfaced, no remediation chunk run yet
+- rec-wording-audit-claim-bearing — 870 findings (229 critical), no remediation
+- ua-translation-review-batch — 1858 findings (200 critical), no remediation
+- escat-tier-audit (B2 subset) — 16 overclaim / 22 underclaim / 12 correct on 50/399 sample. Full audit not yet run; subset alone projects ~120 overclaim + ~175 underclaim across 399.
+
+**Examples next:**
+- ESCAT-tier-audit full chunk (~830k tokens) — confirms B2 projection on remaining 349 BMAs.
+- citation-verify-v2 remediation chunk — process the 793-row triage queue.
+- rec-wording remediation — start with 229 critical only.
+
+**Risk profile:** medium. Triage steps are mechanical; remediation requires expert read-through. Co-Lead queue depth matters.
+
+### Queue C — Schema-evolution
+
+**Driver:** decision to add a new field, relationship, or enrichment block across an existing entity type.
+
+**Metric:** % of entity_type populated with new field Y ↑.
+
+**Examples already done:**
+- `civic-bma-reconstruct-all` (399 BMAs gained `evidence_sources` block; oncokb_lookup → actionability_lookup migration)
+- The new `volume_impact` block on volume-mutating chunks (Proposal #18)
+
+**Examples next:**
+- Add `cost_estimate` / `cost_actual` fields to chunk-spec + `_contribution_meta.yaml` (per owner decision 2026-04-28).
+- Add `line_of_therapy_evidence_source` to all 302 indications (currently `evidence_level` is set but not tied to a specific RCT citation).
+- Add `tasktorrent_version` to all sidecars (per L-21).
+- Add ESMO ESCAT references explicitly when reconstruction work surfaces them.
+
+**Risk profile:** front-loaded. Get the schema right (Pydantic, validators), then mass-fill is mechanical.
+
+## v1.0 target state — what "done" looks like
+
+Concrete, falsifiable numbers per axis. Below is a draft proposal; numbers may need clinical-co-lead calibration before adoption.
+
+### Per-disease coverage targets
+
+For each of 65 diseases:
+
+| Axis | v1.0 target | Current bar |
+|---|---|---|
+| BMA | ≥3 records covering top biomarker classes | 14 diseases at 0; 25 at 1-2 |
+| Indications | ≥1 first-line + ≥1 advanced/relapsed line | All 65 ≥1 ✓ |
+| Red-flags | 5-type matrix coverage (organ-dysfunction / infection / pregnancy / age / prior-therapy) | All 65 ≥1; 5-type completeness varies |
+| Questionnaire | 1 disease-specific questionnaire | All 65 ✓ |
+| Source-citation density | ≥2 distinct sources cited from BMA + IND combined | varies; not yet measured per cell |
+
+### Per-entity-type quality targets
+
+| Entity | Current | v1.0 target |
+|---|---|---|
+| BMA UA-signed-off | 0% | 100% (bottleneck: Co-Lead queue) |
+| BMA with CIViC evidence | 74% | 95%+ (recover the 104 legacy BMAs) |
+| BMA with valid ESCAT tier | 100% | 100% **and ≥85% verified** (B2 audit shows nominal 100% has ~10% overclaim risk) |
+| Indications with `expected_outcomes` | 100% | 100% **and ≥90% citation-traceable** to a specific RCT |
+| Sources `current_as_of <365d` | 10% | ≥60% (243 of 269 sources currently >1y stale-by-date) |
+| Sources with license declared | 89% | 100% (29 sources need license backfill) |
+| Drugs UA-registered | 70% | 75%+ (15 percentage points to gain via НСЗУ + DEC.gov.ua sync) |
+| RF with `last_reviewed` | 92% | 100% (32 RFs need recheck-and-stamp) |
+
+### Living-data targets (continuous)
+
+| Source | Refresh cadence | Status |
+|---|---|---|
+| CIViC nightly snapshot | monthly via CI | ✅ landed (commit `0b53a5c`) |
+| NCCN guideline updates | per-disease, ~6-monthly | ❌ no automation |
+| FDA approvals | weekly | ❌ no automation |
+| Trial pivotal-readout monitoring | monthly | ❌ no automation |
+| UA-registration registry sync | quarterly | ❌ manual |
+| CTCAE v5 reference | annual | ✅ static |
+
+## What we don't yet measure (and should)
+
+The current matrix covers presence-of-field. It doesn't yet measure:
+
+1. **Citation density per claim** — how many independent sources back each clinical recommendation. Distribution histogram per entity type.
+2. **Recency of cited evidence** — % of citations from <2020 / 2020-2024 / 2024+. Beyond source's `current_as_of`, the citations themselves age.
+3. **Coverage of trial readouts per regimen** — out of 244 regimens, how many have an attached `expected_outcomes` block (median OS, ORR, CR rate). Hint: probably <50% — trial-outcome ingestion is a future Queue-C chunk.
+4. **Toxicity-profile completeness per regimen** — CTCAE v5 grading per regimen.
+5. **UA epidemiology weighting** — which 14 zero-BMA diseases are most common in Ukrainian patient population? (Requires one-off pull from МОЗ/НСЗУ statistics.) Without this weighting, "fill all 14" is a 6-month chunk batch; with it, "fill the 4 most common first" is 2 weeks.
+6. **Per-disease patient-scenario coverage** — out of N reference cases (anonymized), what % can the engine fully process given current KB state?
+
+These six are deferred to v0.2 of this strategy doc. Acknowledging the gap honestly is more useful than measuring fake completeness.
+
+## How to use this doc + matrix
+
+### For maintainers picking the next chunk
+
+1. Open `kb-coverage-matrix.md`
+2. Look at `Coverage gaps` and `Quality gaps` sections
+3. Pick a cell that:
+   - Has high gap-magnitude (zero or low %)
+   - Has UA-population priority (rare lymphomas if epidemiology-weighted; otherwise volume)
+   - Has scriptable methodology (don't open chunks where the work would be one expert reading 5 papers)
+4. Open chunk-spec referencing the specific cell
+
+### For contributors (Codex, Claude, others)
+
+1. Read the chunk-spec
+2. Check the chunk-spec's Mission references the matrix cell
+3. After execution, the maintainer re-runs `scripts/kb_coverage_matrix.py` and the matrix moves
+
+### For governance (CHARTER, Co-Lead)
+
+1. Quarterly review of matrix-over-time diff
+2. v1.0 targets above are negotiable — bring proposed adjustments to Co-Lead signoff PR
+
+## Re-running the matrix
+
+```bash
+C:/Python312/python.exe -m scripts.kb_coverage_matrix
+git diff docs/kb-coverage-matrix.md     # see what moved
+```
+
+Output is read-only against `knowledge_base/hosted/content/`. The script does not mutate KB data.
+
+**Cadence (proposed):**
+- After every PR that touches `knowledge_base/hosted/content/` (post-merge maintainer step; could be a CI job)
+- Weekly cron, posting the diff to a `kb-state` GitHub Discussion or similar
+
+## Document hygiene
+
+- `kb-coverage-matrix.md` is **machine-generated**. Do not edit. Re-run the script.
+- This doc (`kb-coverage-strategy.md`) is **human-edited**. Update v1.0 targets when Co-Lead reviews them; update queue examples as chunks land/fail.
+- When the matrix changes meaning (new column added, definition changed), this doc must be updated in the same PR.

--- a/docs/reviews/cross-repo-task_torrent-sync-plan-2026-04-28.md
+++ b/docs/reviews/cross-repo-task_torrent-sync-plan-2026-04-28.md
@@ -1,0 +1,292 @@
+# Cross-Repo task_torrent Sync Plan — координація змін з OpenOnco workstreams
+
+**Дата:** 2026-04-28
+**Статус:** план узгоджено, до coding не приступали
+**Тригер:** "треба буде оновити спільні файли із task_torrent" — користувач підтвердив, що OpenOnco workstreams (`feat/regimen-phases-refactor`, `feat/citation-verifier`, `feat/one-prompt-onboarding`) потребують узгоджених змін у `romeo111/task_torrent` repo.
+
+## 1. Прийняті рішення (з попередньої розмови)
+
+| # | Питання | Відповідь |
+|---|---|---|
+| 1 | Доступ до task_torrent | **1b — Claude продукує patches/diffs; user застосовує PR-ами** (немає write-access) |
+| 2 | Прочитати їх improvement plan? | ✅ Зроблено — див. §3 |
+| 3 | Versioning handshake | **"Always latest, fail loud"** — без semver-pinning, без `tasktorrent_version` поля, без `.tasktorrent.yaml`. Validators читають raw `main`; mismatch → loud error, не silent accept. (Trade-off: multi-consumer-future простіший за #21, але solo-maintainer у v0.1 не платить ціну ceremonии.) |
+| 4 | Single source of truth контракту | **Sync-rule:** у обох репо з automated drift-detection |
+
+## 2. Recon — що в task_torrent (фактично прочитано)
+
+### 2.1. Структура repo
+
+```
+romeo111/task_torrent/
+├── chunks/openonco/         12 chunk specs + README.md (shelf index)
+├── docs/                     11 docs, ключові:
+│   ├── chunk-system.md       Schema definition
+│   ├── safety-rules.md       Безпекові правила
+│   ├── openonco-pilot-workflow.md
+│   ├── protocol-v0.4-design.md (17KB) — protocol design
+│   └── tasktorrent-improvement-plan.md (26KB) — LIVING DOC
+├── skills/                   3 skill specs (biomarker-extraction, citation-verification, drug-evidence-mapping)
+└── tasktorrent/
+    ├── lint_chunk_spec.py    13.7 KB — primary contract enforcement
+    └── config.py
+```
+
+### 2.2. `lint_chunk_spec.py` v0.4 — обов'язкові секції chunk-spec
+
+```python
+REQUIRED_SECTIONS = (
+    "Status", "Topic Labels", "Mission", "Economic Profile",
+    "Drop Estimate", "Required Skill", "Allowed Sources",
+    "Manifest", "Output Format", "Acceptance Criteria",
+    "Rejection Criteria", "Claim Method",
+)
+# Conditional:
+#   MARGINAL chunks → expected_violations field
+#   Volume-mutating chunks → volume_impact declaration
+```
+
+Ці 12 sections — **canonical contract**, не issue-body parsing. Наш `next_chunk.py` має парсити CHUNK SPEC, не issue body. Issue body — лише UI-summary з посиланням на spec.
+
+### 2.3. Existing `tasktorrent-improvement-plan.md` — 21 numbered Proposals
+
+Living document із 12 lessons (L-1..L-21) + 21 numbered Proposals по 3 Tiers. **Більшість того, що я б пропонував, уже там.** Особливо критично:
+
+- **L-21 / Proposal #21**: cross-repo version pinning — точно те, що я мав запропонувати у Q3
+- **L-19 / Proposal #19**: claim coordination hardening — уже implemented (recent OpenOnco PRs #25)
+- **L-13 / Proposal #13**: citation-verify validator gate — overlaps з нашим citation-verifier
+- **L-2/L-12 / Proposal #2/#12**: permissive validator — частково implemented (PRs #16-#20)
+- **L-18 / Proposal #18**: volume-impact declaration — в чергі
+
+## 3. Map: наші workstreams ↔ їхні existing Proposals
+
+Жоден з наших OpenOnco workstreams не вимагає **нових** TaskTorrent proposals. Ми extend-имо існуючі або implement-имо запропоноване.
+
+| OpenOnco workstream | Existing TaskTorrent Proposal(s) | Що ми додаємо понад |
+|---|---|---|
+| `feat/regimen-phases-refactor` | #18 (volume_impact) — relevant if rebuilds all regimens | Reference до `Regimen.phases` shape у chunk-spec template для майбутніх regimen-creating chunks |
+| `feat/citation-verifier` | #13 (citation-verify validator gate) — partial overlap | New optional chunk-spec field: `Verifier Threshold` (e.g., "≥85% claims pass Anthropic Citations API"). Skill `citation-verification.md` update з Citations API + CoVe |
+| `feat/one-prompt-onboarding` | #19 (claim coordination — implemented), #7 (branch-name CI gate). **NOT adopting #21** (per Q3 = always-latest-fail-loud) | New required fields: `Severity` (low/medium/high stakes) + `Min Contributor Tier` (rejected/new/established/trusted). Static `index.json` for `next_chunk.py`. Public landing tied to verifier-in-CI gate |
+
+### 3.1. Що з нашого додаємо як NEW Proposals для their living doc
+
+Три речі, які НЕ входять у поточні 21 Proposal — варто запропонувати maintainer-у task_torrent для додавання:
+
+| Proposal-кандидат | Зміст | Ціна |
+|---|---|---|
+| **#22 Severity + Min-Tier фіолд** | `Severity: low\|medium\|high` + `Min Contributor Tier: new\|established\|trusted` у chunk-spec. Linter validates. Дозволяє tier-based gating (див. `one-prompt-onboarding-plan-2026-04-28` §8.1) | ~½ день |
+| **#23 Verifier Threshold field** | Опціональний `Verifier Threshold` у chunk-spec для chunks, що включають citation-verification. Linter перевіряє наявність для chunks із `topic_label: citation-verify`. Default = 85% if not specified | ~¼ день |
+| **#24 Cross-repo contract sync** | Published canonical contract doc, sync mechanism: (a) у task_torrent — `docs/cross-repo-contract.md` (canonical); (b) у OpenOnco — `docs/contributing/cross-repo-contract.md` із frontmatter `synced_from: task_torrent@main#docs/cross-repo-contract.md` (per Q3 = always-latest, no tag); (c) CI на обох репо — daily job hash-compare (LF-normalized); mismatch → issue в обох | ~1 день |
+
+**Ці 3 я подам як patch до їхнього `tasktorrent-improvement-plan.md` як L-22/L-23/L-24 + Proposal #22/#23/#24.**
+
+## 4. File-by-file changes у task_torrent
+
+### 4.1. From `feat/regimen-phases-refactor` (мінімальний)
+
+| Файл у task_torrent | Зміна | Effort |
+|---|---|---|
+| `chunks/openonco/_template.md` (якщо існує — інакше не торкаємось) | Reference до `Regimen.phases` shape | ¼ год |
+| `skills/drug-evidence-mapping.md` | Додати приклад phases-aware drafting | ½ год |
+| _НЕ_ змінюємо `lint_chunk_spec.py` | Phases — це OpenOnco-side schema, не task_torrent-level | — |
+
+**Загалом: <1 година.** Phases-refactor — внутрішня OpenOnco справа.
+
+### 4.2. From `feat/citation-verifier`
+
+| Файл у task_torrent | Зміна | Effort |
+|---|---|---|
+| `tasktorrent/lint_chunk_spec.py` | Add conditional check: chunks з `Topic Labels: citation-verify` мусять мати `Verifier Threshold` секцію | 2-3 год |
+| `skills/citation-verification.md` | Update: Anthropic Citations API as canonical verifier, CoVe як fallback, two-agent disagreement-as-flag pattern | 1-2 год |
+| `docs/safety-rules.md` | Add §"Citation grounding verification" — verifier як obligatory pre-merge gate | 1 год |
+| `chunks/openonco/citation-*.md` (3 файли: `citation-semantic-verify-v2`, `citation-verify-914-audit`, possibly future) | Add `## Verifier Threshold` section | 2 год |
+| `docs/tasktorrent-improvement-plan.md` | Add L-22 + Proposal #22 (Verifier Threshold field) | ½ год |
+
+**Загалом: ~1 день.**
+
+### 4.3. From `feat/one-prompt-onboarding` ⚠️ найбільший impact
+
+| Файл у task_torrent | Зміна | Effort |
+|---|---|---|
+| `tasktorrent/lint_chunk_spec.py` | Add `Severity` + `Min Contributor Tier` to REQUIRED_SECTIONS. Validation: Severity ∈ {low, medium, high}; Min Tier ∈ {new, established, trusted} | ½ день |
+| `chunks/openonco/*.md` (всі 12) | Audit на consistency. Add `Severity` + `Min Tier` per chunk. Best guess defaults: source-stub/UA-translation = low/new; BMA/indication = medium/established; regimen/charter = high/trusted | 1 день |
+| `chunks/openonco/README.md` | Add `Severity` + `Min Tier` columns у shelf-index table | ½ год |
+| `docs/openonco-pilot-workflow.md` | Update workflow: tier-system + onboarding-via-bootstrap-script reference | 1 год |
+| `docs/chunk-system.md` | Update Schema with `Severity` + `Min Tier` fields | 1 год |
+| **NEW**: `docs/cross-repo-contract.md` | Single source of truth — schema+versioning+sync rules. Reference у обох репо | 2-3 год |
+| Optional: `chunks/openonco/index.json` (auto-generated) | Static published JSON for fast `next_chunk.py` parse without GitHub API rate-limits. CI rebuilds on chunk-spec change | 2-3 год |
+| `docs/tasktorrent-improvement-plan.md` | Add L-22/L-23/L-24 + Proposal #22/#23/#24 | 1 год |
+
+**Загалом: ~2.5-3 дні.**
+
+### 4.4. Від нас — sync-rule mechanism (Q4 рішення)
+
+| Файл | Repo | Що |
+|---|---|---|
+| `docs/cross-repo-contract.md` | task_torrent | **Canonical**. Schema, versioning, sync rules. Frozen per release tag |
+| `docs/contributing/cross-repo-contract.md` | OpenOnco | **Mirror**. Frontmatter: `synced_from: task_torrent@main#docs/cross-repo-contract.md` (per Q3 — always main, no tag). Identical content otherwise |
+| `.github/workflows/cross-repo-sync-check.yml` | Both repos | Daily CI: `gh api raw` обидва файли, hash-compare (LF-normalized). Mismatch → auto-create issue в обох репо із diff |
+| _**НЕ створюємо** `.tasktorrent.yaml`_ | — | Per Q3 = always-latest. Без version pin |
+
+**Загалом: ~1 день для sync mechanism.** Implements Q4 рішення.
+
+## 5. Schema versioning approach: "Always latest, fail loud" (per Q3)
+
+**Не adopt-имо Proposal #21.** Користувач обрав простіший підхід для solo-maintainer / one-consumer scenario.
+
+### 5.1. Як це працює
+
+```
+- task_torrent НЕ тегує semver releases
+- task_torrent НЕ публікує `_contribution_meta.yaml.tasktorrent_version` поле
+- OpenOnco НЕ створює `.tasktorrent.yaml`
+- Усі URL у issue-templates referen `main` HEAD, не release tag
+- Validators читають raw raw.githubusercontent.com/.../main/... як завжди
+
+КОЛИ schemas drift (наприклад, task_torrent додає required field):
+  - lint_chunk_spec.py @ task_torrent main fails closed on existing chunk specs
+  - OR OpenOnco validator fails clean із чітким error:
+    "chunk-spec at task_torrent/main has section X that this validator
+     doesn't understand. Please update OpenOnco validator: see commit Y in task_torrent."
+  - Mismatch видно одразу при першому запуску, не silent
+```
+
+### 5.2. Все одно бамп — у CHANGELOG, не у version tag
+
+Breaking changes (наші 3 нові required sections — Severity, Min Tier, Verifier Threshold) landing у task_torrent `main` як звичайні merge commits + entry у `docs/CHANGELOG.md`:
+
+```
+## 2026-04-30 — Cross-repo sync v1
++ Severity required section у chunk-spec (per OpenOnco onboarding plan §8.1)
++ Min Contributor Tier required section (per OpenOnco onboarding plan §8.1)
++ Verifier Threshold conditional for citation-* chunks
+- Existing 12 OpenOnco chunks backfilled with defaults
+
+Breaking: lint_chunk_spec.py rejects pre-this-commit chunk specs.
+```
+
+### 5.3. Trade-off, який ми приймаємо
+
+| Що отримуємо | Що ризикуємо |
+|---|---|
+| Швидка ітерація, нульовий ceremony cost | Multi-consumer adoption у майбутньому потребує retroactive versioning |
+| Один файл `CHANGELOG.md` замість release-tags + migration tables | Time-travel debugging тільки через git log, не через checkout v0.X |
+| Менше boilerplate в OpenOnco валідаторі | Якщо хтось fork-не TaskTorrent для іншого проєкту — їм доведеться додавати pinning самим |
+
+**Цей trade-off виправданий поки:** TaskTorrent — solo-maintainer проєкт із одним consumer (OpenOnco). Якщо приходить N=2-й consumer — переоцінюємо.
+
+## 6. Coordination protocol (per Q1 = patches-not-direct-write)
+
+Я не маю write-access у task_torrent. Worflow:
+
+```
+1. У OpenOnco repo, я створюю:
+   contributions/task_torrent_patches/
+   ├── README.md                          # Index + apply order
+   ├── 0001-add-severity-fields.patch    # git format-patch style
+   ├── 0002-add-verifier-threshold.patch
+   ├── 0003-cross-repo-contract.patch
+   └── ...
+
+2. Кожен patch — git format-patch стиль:
+   - From: Claude (via maintainer)
+   - Subject: line
+   - Diff
+   - Self-contained (one logical change)
+
+3. Maintainer (ти):
+   - cd ~/task_torrent
+   - git checkout -b feat/cross-repo-sync (без version у назві — per Q3)
+   - git am ~/cancer-autoresearch/contributions/task_torrent_patches/*.patch
+   - git push, open PR у task_torrent
+
+4. Після merge у task_torrent:
+   - Add CHANGELOG.md entry (breaking changes описано)
+   - НЕ робимо: semver tag, .tasktorrent.yaml у OpenOnco — per Q3
+   - Run sync-check CI (для cross-repo-contract.md hash-compare)
+```
+
+Альтернатива (Q1=1a в майбутньому): дати мені contributor-permission — спрощує flow, але user не вибрав це.
+
+## 7. Sequencing — узгоджено з OpenOnco refactor train
+
+```
+ФАЗА 0: Pre-conditions
+└─ OpenOnco PR #3, #5, #29 закриті (поточний стан, ще open)
+
+ФАЗА 1: Schema-side у OpenOnco (PR1)
+└─ feat/regimen-phases-refactor: schema + loader auto-wrap
+   → task_torrent untouched (per §4.1)
+
+ФАЗА 2: Render + manual migration у OpenOnco (PR2)
+└─ feat/regimen-phases-refactor: render + 18 YAML
+   → task_torrent untouched
+
+ФАЗА 3: TaskTorrent schema sync — НОВИЙ ETAP
+├─ Patches у contributions/task_torrent_patches/ готові
+├─ Maintainer apply через git am, push to main
+├─ CHANGELOG.md entry для breaking changes
+└─ Sync-check CI active у обох (для cross-repo-contract.md)
+   (НЕ робимо: semver tag, .tasktorrent.yaml, version field — per Q3)
+
+ФАЗА 4: feat/citation-verifier (паралельно з ФАЗА 5)
+├─ OpenOnco-side: Citations API verifier script + CI
+└─ task_torrent-side: per §4.2 (skill update + safety-rules)
+
+ФАЗА 5: feat/one-prompt-onboarding scripts (паралельно з ФАЗА 4)
+├─ OpenOnco-side: next_chunk.py + bootstrap + tier system
+└─ task_torrent-side: per §4.3 (Severity + Min Tier audit)
+
+ФАЗА 6: GA gate (per onboarding plan §6)
+└─ Public landing flip коли verifier у CI + ≥3 active chunks
+```
+
+ФАЗА 3 — **новий блокер** перед ФАЗА 4-5. Без нових fields у task_torrent main (Severity, Min Tier, Verifier Threshold) наші scripts (next_chunk.py, citation-verifier extensions) будуть посилатись на ще-не-існуючі поля. Це і є "fail loud" поведінка з Q3 — validators крикнуть, не silent-accept.
+
+## 8. Effort consolidated
+
+| Workstream | OpenOnco-side | task_torrent-side (patches) | Maintainer apply | Разом |
+|---|---|---|---|---|
+| regimen-phases-refactor | 5.5 днів (schema+render+18 YAML) | <1 година | <½ год | ≈5.5 днів |
+| citation-verifier | 2-3 дні | 1 день | ½-1 день | ≈4-5 днів |
+| one-prompt-onboarding | 5.75 днів (з tier system) | 2.5-3 дні | 1-2 дні | ≈9-11 днів |
+| Sync-rule mechanism | ½ день | ½ день | ½ день | ≈1.5 дні |
+| **Загалом** | **~14-15 днів** | **~5-6 днів** | **~2-3 дні** | **~21-24 днів elapsed** |
+
+Раніше попередня оцінка для one-prompt onboarding plan була "13-15 днів elapsed for GA". Тепер з task_torrent integration — **21-24 дні**. Maintainer-apply час (2-3 дні) — це **bottleneck**, не coding.
+
+## 9. Open questions (нові, що з'явились після recon)
+
+1. **Чи оновлюємо `protocol-v0.4-design.md` (17KB)?** — Цей файл я не читав детально. Якщо там вже описаний trust model + schema-evolution, наш sync-rule може overlap. Треба прочитати перед написанням patches.
+2. **Hash-compare у sync-check CI — чи приймається noise від line-ending differences (CRLF vs LF)?** Windows-collaborators (як user) можуть випадково пушити CRLF. Сanonicalize обидва — read-and-normalize before hash.
+3. **Який тип patches генерую — `git format-patch` (за commit) чи `git diff > patches/X.patch` (cumulative)?** Перший зручніше для review, другий для bulk-apply. Я б голосував за format-patch.
+4. **Чи запускаємо ФАЗА 3 (task_torrent schema sync) ДО `feat/citation-verifier` та `feat/one-prompt-onboarding`, чи паралельно?** Я виклав sequentially у §7. Альтернатива — паралельно з coding на OpenOnco-side. Ризик паралельного: OpenOnco scripts можуть посилатись на нові поля, що ще не landed → "fail loud" спрацює, але прибуде шум у CI під час coding-вікна. Sequentially чистіше.
+
+## 10. Cross-references
+
+- **Цей repo:**
+  - `docs/reviews/regimen-phases-refactor-plan-2026-04-28.md`
+  - `docs/reviews/one-prompt-onboarding-plan-2026-04-28.md` (особливо §8.1 для tier system)
+- **task_torrent repo:**
+  - `docs/tasktorrent-improvement-plan.md` (живий документ, 21 Proposals)
+  - `docs/protocol-v0.4-design.md` (17KB — потрібно read для §9 question 1)
+  - `tasktorrent/lint_chunk_spec.py` (canonical contract enforcement, v0.4)
+  - `chunks/openonco/*.md` (12 specs, потребуть Severity+Min-Tier backfill)
+- **CHARTER:**
+  - §6.1 — two-reviewer governance
+  - §8.3 — LLMs not clinical decision-makers (architectural foundation)
+  - §2 — non-commercial / banned commercial sources
+
+---
+
+## Decision log
+
+| # | Питання | Відповідь | Reasoning |
+|---|---|---|---|
+| 1 | Окремий plan-doc чи інтегрувати? | Окремий | Cross-repo coordination — окремий concern, не subсекція жодного з 3 OpenOnco workstreams |
+| 2 | Дублюємо чи extend-имо їх improvement plan? | Extend (3 NEW Proposals: #22/#23/#24) | Уникаємо drift; living doc — їхній механізм |
+| 3 | Versioning approach | "Always latest, fail loud" — НЕ adopt-имо Proposal #21 | Per Q3 user choice. Solo-maintainer / one-consumer не платить ціну ceremony. Trade-off задокументовано у §5.3 |
+| 4 | Sync mechanism для contract doc | Both repos + automated drift-detection (CI hash-compare) | Per user Q4 = "sync" |
+| 5 | Coordination без write access | git format-patch у contributions/task_torrent_patches/ | Per user Q1 = "1b" (patches not direct PRs) |
+| 6 | Sequencing | task_torrent schema sync ДО citation-verifier + onboarding scripts | Без нових fields у task_torrent main scripts ламатимуться (fail loud per Q3) |
+| 7 | Чи зачіпає phases-refactor task_torrent суттєво? | Ні (<1 год) | Phases — internal OpenOnco schema, не task_torrent-level concern |

--- a/scripts/kb_coverage_matrix.py
+++ b/scripts/kb_coverage_matrix.py
@@ -1,0 +1,443 @@
+"""KB coverage matrix generator.
+
+Walks knowledge_base/hosted/content/ and emits docs/kb-coverage-matrix.md:
+
+  - Per-disease rows (65) × axes (BMA / IND / RF / regimen / source-coverage)
+  - Quality columns (clinical signoff %, ESCAT-tier %, citation density,
+    recency, NSZU reimbursement %)
+  - Top-level KPIs (entity counts, quality scores, gap counts)
+  - Specific gap lists (diseases with 0 BMA, diseases without 5-type RF
+    matrix, BMAs without ESCAT tier, etc.)
+
+Run:
+    py -V:3.12 -m scripts.kb_coverage_matrix
+or:
+    C:/Python312/python.exe -m scripts.kb_coverage_matrix
+
+Read-only against the KB. Writes only docs/kb-coverage-matrix.md.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+KB_ROOT = REPO_ROOT / "knowledge_base" / "hosted" / "content"
+OUT = REPO_ROOT / "docs" / "kb-coverage-matrix.md"
+
+ESCAT_TIERS = ("IA", "IB", "IIA", "IIB", "IIIA", "IIIB", "IV", "V", "X")
+
+
+def load_yaml(path: Path) -> dict | None:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_all(subdir: str) -> list[dict]:
+    out: list[dict] = []
+    d = KB_ROOT / subdir
+    if not d.is_dir():
+        return out
+    for p in sorted(d.glob("*.yaml")):
+        data = load_yaml(p)
+        if data:
+            data["__path"] = str(p.relative_to(REPO_ROOT)).replace("\\", "/")
+            out.append(data)
+    return out
+
+
+@dataclass
+class DiseaseRow:
+    id: str
+    name: str
+    name_ua: str
+    archetype: str
+    bma_count: int = 0
+    bma_with_escat: int = 0
+    bma_with_civic: int = 0
+    bma_signed_off_ua: int = 0
+    ind_count: int = 0
+    ind_with_outcomes: int = 0
+    ind_with_nccn_cat: int = 0
+    rf_count: int = 0
+    rf_with_sources: int = 0
+    rf_categories: set[str] = field(default_factory=set)
+    regimens_referenced: set[str] = field(default_factory=set)
+    sources_cited: set[str] = field(default_factory=set)
+    has_questionnaire: bool = False
+    molecular_subtypes_count: int = 0
+
+
+def safe_pct(num: int, den: int) -> str:
+    if den == 0:
+        return "—"
+    return f"{int(round(100 * num / den))}%"
+
+
+def main() -> int:
+    diseases = load_all("diseases")
+    bmas = load_all("biomarker_actionability")
+    inds = load_all("indications")
+    rfs = load_all("redflags")
+    drugs = load_all("drugs")
+    sources = load_all("sources")
+    regimens = load_all("regimens")
+    questionnaires = load_all("questionnaires")
+    biomarkers = load_all("biomarkers")
+    algorithms = load_all("algorithms")
+
+    rows: dict[str, DiseaseRow] = {}
+    for d in diseases:
+        did = d.get("id", "")
+        names = d.get("names", {}) or {}
+        rows[did] = DiseaseRow(
+            id=did,
+            name=names.get("preferred") or names.get("english") or did,
+            name_ua=names.get("ukrainian") or "",
+            archetype=d.get("archetype") or "",
+            molecular_subtypes_count=len(d.get("molecular_subtypes") or []),
+        )
+
+    # BMA pass
+    for b in bmas:
+        did = b.get("disease_id")
+        if did not in rows:
+            continue
+        row = rows[did]
+        row.bma_count += 1
+        if b.get("escat_tier") in ESCAT_TIERS:
+            row.bma_with_escat += 1
+        es = b.get("evidence_sources") or []
+        if any(isinstance(e, dict) and e.get("source") == "SRC-CIVIC" for e in es):
+            row.bma_with_civic += 1
+        if b.get("ukrainian_review_status") == "signed_off":
+            row.bma_signed_off_ua += 1
+
+    # IND pass
+    for i in inds:
+        applicable = i.get("applicable_to", {}) or {}
+        did = applicable.get("disease_id")
+        if did not in rows:
+            continue
+        row = rows[did]
+        row.ind_count += 1
+        if i.get("expected_outcomes"):
+            row.ind_with_outcomes += 1
+        if i.get("nccn_category"):
+            row.ind_with_nccn_cat += 1
+        reg = i.get("recommended_regimen")
+        if reg:
+            row.regimens_referenced.add(reg)
+        for s in i.get("primary_sources", []) or []:
+            row.sources_cited.add(s)
+
+    # RF pass
+    for rf in rfs:
+        rel = rf.get("relevant_diseases") or []
+        cat = rf.get("category") or ""
+        for did in rel:
+            if did not in rows:
+                continue
+            row = rows[did]
+            row.rf_count += 1
+            if rf.get("sources"):
+                row.rf_with_sources += 1
+            if cat:
+                row.rf_categories.add(cat)
+            for s in rf.get("sources", []) or []:
+                row.sources_cited.add(s)
+
+    # Questionnaires (simple file-name heuristic)
+    q_diseases = set()
+    for q in questionnaires:
+        # questionnaire id format heuristic: QUES-<DISEASE>
+        qid = q.get("id") or ""
+        m = re.match(r"^QUES[-_](.+?)(?:[-_]|$)", qid)
+        if m:
+            q_diseases.add(f"DIS-{m.group(1).upper().replace('_', '-')}")
+    for did, row in rows.items():
+        row.has_questionnaire = did in q_diseases or any(
+            (q.get("disease_id") == did) for q in questionnaires
+        )
+
+    # ----- Top-level metrics -----
+
+    total_entities = (
+        len(diseases) + len(bmas) + len(inds) + len(rfs) + len(drugs)
+        + len(sources) + len(regimens) + len(biomarkers) + len(algorithms)
+    )
+
+    bmas_with_escat = sum(1 for b in bmas if b.get("escat_tier") in ESCAT_TIERS)
+    bmas_with_civic = sum(
+        1 for b in bmas
+        if any(isinstance(e, dict) and e.get("source") == "SRC-CIVIC"
+               for e in (b.get("evidence_sources") or []))
+    )
+    bmas_signed_off_ua = sum(1 for b in bmas if b.get("ukrainian_review_status") == "signed_off")
+    bmas_pending_ua = sum(1 for b in bmas if b.get("ukrainian_review_status") == "pending_clinical_signoff")
+
+    inds_with_outcomes = sum(1 for i in inds if i.get("expected_outcomes"))
+    inds_with_nccn = sum(1 for i in inds if i.get("nccn_category"))
+
+    rfs_with_sources = sum(1 for r in rfs if r.get("sources"))
+    rfs_with_review_date = sum(1 for r in rfs if r.get("last_reviewed"))
+
+    # Source recency
+    today = dt.date.today()
+    src_recent = 0
+    src_with_license = 0
+    for s in sources:
+        lic = s.get("license") or {}
+        if lic.get("name") or lic.get("spdx_id"):
+            src_with_license += 1
+        cao = s.get("current_as_of")
+        if isinstance(cao, str):
+            try:
+                d = dt.date.fromisoformat(cao[:10])
+                if (today - d).days < 365:
+                    src_recent += 1
+            except ValueError:
+                pass
+
+    # Drug NSZU coverage
+    drugs_nszu = sum(
+        1 for d in drugs
+        if (d.get("regulatory_status", {}) or {})
+            .get("ukraine_registration", {}).get("reimbursed_nszu") is True
+    )
+    drugs_ua_registered = sum(
+        1 for d in drugs
+        if (d.get("regulatory_status", {}) or {})
+            .get("ukraine_registration", {}).get("registered") is True
+    )
+
+    # ESCAT tier distribution
+    escat_dist: Counter[str] = Counter()
+    for b in bmas:
+        t = b.get("escat_tier")
+        escat_dist[t if t in ESCAT_TIERS else "(unset)"] += 1
+
+    # ----- Gap lists -----
+
+    diseases_no_bma = [r for r in rows.values() if r.bma_count == 0]
+    diseases_thin_bma = [r for r in rows.values() if 0 < r.bma_count < 3]
+    diseases_no_rf = [r for r in rows.values() if r.rf_count == 0]
+    diseases_no_questionnaire = [r for r in rows.values() if not r.has_questionnaire]
+    diseases_no_indication = [r for r in rows.values() if r.ind_count == 0]
+
+    bmas_without_escat = [b for b in bmas if b.get("escat_tier") not in ESCAT_TIERS]
+    bmas_without_civic = [
+        b for b in bmas
+        if not any(isinstance(e, dict) and e.get("source") == "SRC-CIVIC"
+                   for e in (b.get("evidence_sources") or []))
+    ]
+    inds_without_outcomes = [i for i in inds if not i.get("expected_outcomes")]
+    rfs_without_sources = [r for r in rfs if not r.get("sources")]
+
+    # ----- Render -----
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    lines.append("# KB Coverage Matrix")
+    lines.append("")
+    lines.append(f"_Generated_: {dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    lines.append("")
+    lines.append(
+        "Auto-generated from `knowledge_base/hosted/content/` by "
+        "`scripts/kb_coverage_matrix.py`. **Do not edit by hand** — re-run the "
+        "script. The strategy doc that explains how to read this is "
+        "[`kb-coverage-strategy.md`](kb-coverage-strategy.md)."
+    )
+    lines.append("")
+
+    # ===== Top-level KPIs =====
+
+    lines.append("## Top-level KPIs")
+    lines.append("")
+    lines.append("| Entity | Count |")
+    lines.append("|---|---:|")
+    lines.append(f"| Diseases | {len(diseases)} |")
+    lines.append(f"| Biomarker_actionability (BMA) | {len(bmas)} |")
+    lines.append(f"| Indications | {len(inds)} |")
+    lines.append(f"| Red flags | {len(rfs)} |")
+    lines.append(f"| Drugs | {len(drugs)} |")
+    lines.append(f"| Regimens | {len(regimens)} |")
+    lines.append(f"| Sources | {len(sources)} |")
+    lines.append(f"| Biomarkers | {len(biomarkers)} |")
+    lines.append(f"| Algorithms | {len(algorithms)} |")
+    lines.append(f"| Questionnaires | {len(questionnaires)} |")
+    lines.append(f"| **Total entities** | **{total_entities}** |")
+    lines.append("")
+
+    # ===== Quality scores =====
+
+    lines.append("## Quality scores")
+    lines.append("")
+    lines.append("| Axis | Numerator | Denominator | Score |")
+    lines.append("|---|---:|---:|---:|")
+    lines.append(f"| BMA with ESCAT tier | {bmas_with_escat} | {len(bmas)} | {safe_pct(bmas_with_escat, len(bmas))} |")
+    lines.append(f"| BMA with CIViC evidence_sources | {bmas_with_civic} | {len(bmas)} | {safe_pct(bmas_with_civic, len(bmas))} |")
+    lines.append(f"| BMA UA-signed-off | {bmas_signed_off_ua} | {len(bmas)} | {safe_pct(bmas_signed_off_ua, len(bmas))} |")
+    lines.append(f"| BMA UA pending review | {bmas_pending_ua} | {len(bmas)} | {safe_pct(bmas_pending_ua, len(bmas))} |")
+    lines.append(f"| Indications with expected_outcomes | {inds_with_outcomes} | {len(inds)} | {safe_pct(inds_with_outcomes, len(inds))} |")
+    lines.append(f"| Indications with NCCN category | {inds_with_nccn} | {len(inds)} | {safe_pct(inds_with_nccn, len(inds))} |")
+    lines.append(f"| RF with sources | {rfs_with_sources} | {len(rfs)} | {safe_pct(rfs_with_sources, len(rfs))} |")
+    lines.append(f"| RF with last_reviewed | {rfs_with_review_date} | {len(rfs)} | {safe_pct(rfs_with_review_date, len(rfs))} |")
+    lines.append(f"| Sources with license declared | {src_with_license} | {len(sources)} | {safe_pct(src_with_license, len(sources))} |")
+    lines.append(f"| Sources current_as_of <365d | {src_recent} | {len(sources)} | {safe_pct(src_recent, len(sources))} |")
+    lines.append(f"| Drugs UA-registered | {drugs_ua_registered} | {len(drugs)} | {safe_pct(drugs_ua_registered, len(drugs))} |")
+    lines.append(f"| Drugs NSZU-reimbursed | {drugs_nszu} | {len(drugs)} | {safe_pct(drugs_nszu, len(drugs))} |")
+    lines.append("")
+
+    # ===== ESCAT distribution =====
+
+    lines.append("## ESCAT tier distribution (across 399 BMAs)")
+    lines.append("")
+    lines.append("| Tier | Count | % |")
+    lines.append("|---|---:|---:|")
+    for t in ESCAT_TIERS + ("(unset)",):
+        c = escat_dist.get(t, 0)
+        lines.append(f"| {t} | {c} | {safe_pct(c, len(bmas))} |")
+    lines.append("")
+
+    # ===== Per-disease matrix =====
+
+    lines.append("## Per-disease coverage matrix")
+    lines.append("")
+    lines.append(
+        "Sorted by (BMA + IND + RF) descending. Diseases with 0 across "
+        "all axes are listed under \"Coverage gaps\" below."
+    )
+    lines.append("")
+    lines.append(
+        "| Disease | Archetype | Subtypes | BMA | ESCAT% | CIViC% | UA✓ | IND | "
+        "Outcomes% | NCCN% | RF | RF cats | Regimens | Sources | Quest |"
+    )
+    lines.append(
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|"
+    )
+
+    sorted_rows = sorted(
+        rows.values(),
+        key=lambda r: (r.bma_count + r.ind_count + r.rf_count),
+        reverse=True,
+    )
+    for r in sorted_rows:
+        if r.bma_count + r.ind_count + r.rf_count == 0:
+            continue  # in gap section
+        lines.append(
+            "| {name} | {arch} | {sub} | {bma} | {escat} | {civic} | {ua} | "
+            "{ind} | {out} | {nccn} | {rf} | {rfcat} | {reg} | {src} | {q} |".format(
+                name=f"{r.name} ({r.id.replace('DIS-', '')})",
+                arch=r.archetype or "—",
+                sub=r.molecular_subtypes_count or "—",
+                bma=r.bma_count,
+                escat=safe_pct(r.bma_with_escat, r.bma_count),
+                civic=safe_pct(r.bma_with_civic, r.bma_count),
+                ua=safe_pct(r.bma_signed_off_ua, r.bma_count),
+                ind=r.ind_count,
+                out=safe_pct(r.ind_with_outcomes, r.ind_count),
+                nccn=safe_pct(r.ind_with_nccn_cat, r.ind_count),
+                rf=r.rf_count,
+                rfcat=len(r.rf_categories),
+                reg=len(r.regimens_referenced),
+                src=len(r.sources_cited),
+                q="✓" if r.has_questionnaire else "—",
+            )
+        )
+    lines.append("")
+
+    # ===== Coverage gaps =====
+
+    lines.append("## Coverage gaps")
+    lines.append("")
+
+    lines.append(f"### Diseases with **zero BMA** ({len(diseases_no_bma)})")
+    lines.append("")
+    if diseases_no_bma:
+        lines.append("| Disease | Archetype | IND | RF |")
+        lines.append("|---|---|---:|---:|")
+        for r in sorted(diseases_no_bma, key=lambda x: x.id):
+            lines.append(f"| {r.name} ({r.id}) | {r.archetype or '—'} | {r.ind_count} | {r.rf_count} |")
+    lines.append("")
+
+    lines.append(f"### Diseases with **thin BMA coverage (1-2 entries)** ({len(diseases_thin_bma)})")
+    lines.append("")
+    if diseases_thin_bma:
+        lines.append("| Disease | BMA |")
+        lines.append("|---|---:|")
+        for r in sorted(diseases_thin_bma, key=lambda x: x.bma_count):
+            lines.append(f"| {r.name} ({r.id}) | {r.bma_count} |")
+    lines.append("")
+
+    lines.append(f"### Diseases with **zero red-flags** ({len(diseases_no_rf)})")
+    lines.append("")
+    if diseases_no_rf:
+        for r in sorted(diseases_no_rf, key=lambda x: x.id):
+            lines.append(f"- {r.name} ({r.id})")
+    lines.append("")
+
+    lines.append(f"### Diseases with **zero indications** ({len(diseases_no_indication)})")
+    lines.append("")
+    if diseases_no_indication:
+        for r in sorted(diseases_no_indication, key=lambda x: x.id):
+            lines.append(f"- {r.name} ({r.id})")
+    lines.append("")
+
+    lines.append(f"### Diseases with **no questionnaire** ({len(diseases_no_questionnaire)})")
+    lines.append("")
+    if diseases_no_questionnaire:
+        for r in sorted(diseases_no_questionnaire, key=lambda x: x.id)[:30]:
+            lines.append(f"- {r.name} ({r.id})")
+        if len(diseases_no_questionnaire) > 30:
+            lines.append(f"- … and {len(diseases_no_questionnaire) - 30} more")
+    lines.append("")
+
+    # ===== Quality gaps =====
+
+    lines.append("## Quality gaps")
+    lines.append("")
+    lines.append(f"- **{len(bmas_without_escat)}** BMAs without ESCAT tier")
+    lines.append(f"- **{len(bmas_without_civic)}** BMAs without CIViC evidence_sources")
+    lines.append(f"- **{len(inds_without_outcomes)}** indications without `expected_outcomes` block")
+    lines.append(f"- **{len(rfs_without_sources)}** redflags without `sources` block")
+    lines.append("")
+
+    # ===== Footer =====
+
+    lines.append("---")
+    lines.append("")
+    lines.append("## How to act on this matrix")
+    lines.append("")
+    lines.append(
+        "Each new TaskTorrent chunk should reference a specific cell or gap "
+        "and state how it advances coverage. Example chunk-spec preamble: "
+        "_\"This chunk advances `Per-disease matrix > breast_cancer > IND-Outcomes%` "
+        "from 60% to 95% by adding expected_outcomes to 12 missing indications.\"_"
+    )
+    lines.append("")
+    lines.append(
+        "Re-run this script after each KB-mutating PR is applied. Schedule "
+        "weekly via cron once the strategy doc lands."
+    )
+
+    OUT.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote {OUT.relative_to(REPO_ROOT)}")
+    print(f"  diseases={len(diseases)}  BMA={len(bmas)}  IND={len(inds)}  RF={len(rfs)}  drugs={len(drugs)}  sources={len(sources)}")
+    print(f"  diseases-with-zero-BMA={len(diseases_no_bma)}  no-RF={len(diseases_no_rf)}  no-IND={len(diseases_no_indication)}")
+    print(f"  BMAs-without-ESCAT={len(bmas_without_escat)}  BMAs-without-CIViC={len(bmas_without_civic)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Direct-execution maintainer task (not via TaskTorrent chunk, per user direction during ongoing DB migration + shared-manifest sync with task_torrent).

Adds three artifacts that turn opportunistic chunk selection into matrix-driven chunk selection.

### scripts/kb_coverage_matrix.py
Read-only script that walks `knowledge_base/hosted/content/` and emits a per-disease × axis matrix plus top-level KPIs and gap lists. Does not mutate KB data.

### docs/kb-coverage-matrix.md
Machine-generated current snapshot (re-run the script to refresh; do not hand-edit).

### docs/kb-coverage-strategy.md
Human-edited strategy doc: how to read the matrix, three orthogonal work queues (coverage-fill / audit-remediate / schema-evolution), v1.0 target state with falsifiable per-axis targets, six measurements we don't yet have.

## Real signal at this snapshot

| KPI | Value |
|---|---|
| Total entities | 2,142 (65 diseases / 399 BMA / 302 IND / 426 RF / 269 sources / 216 drugs / 244 regimens / 110 algorithms / 65 questionnaires) |
| Diseases with **zero BMA** | 14 (mostly rare lymphomas + HNSCC + low-grade glioma) |
| Diseases with thin BMA (1-2) | 25 |
| BMA without CIViC evidence | 104 (26% — legacy holdouts) |
| BMA UA-signed-off | 0% (bottleneck is Co-Lead queue) |
| Sources `current_as_of <365d` | 10% (243 of 269 are stale-by-date) |
| Drugs UA-registered | 70% (151/216) |
| Drugs NSZU-reimbursed | 61% (132/216) |

## How chunks reference the matrix going forward

Every new chunk-spec's Mission section should reference a specific matrix cell:

> _This chunk advances `kb-coverage-matrix.md > Per-disease matrix > glioma-low-grade > BMA` from 0 to ≥3 by adding actionability records for IDH1/IDH2/MGMT/1p19q/BRAF V600E._

Without this discipline, chunks drift toward "what's quick" over "what closes a known gap." The chunk-spec linter doesn't enforce this yet — it's a writing convention.

## Cadence proposal

- After every PR that touches `knowledge_base/hosted/content/` (post-merge maintainer step; could become CI job)
- Weekly cron, posting the diff to a `kb-state` GitHub Discussion

## Out of scope for this PR

- Six metrics I want but didn't add yet: citation-density per claim, citation-recency distribution, regimen × outcomes coverage, regimen × CTCAE toxicity coverage, UA-epidemiology weighting (requires МОЗ/НСЗУ data pull), per-disease patient-scenario coverage. Captured as v0.2 strategy.
- CI automation that auto-regenerates the matrix on KB-touching PRs (deferred; cheap follow-up).
- Cross-reference in CLAUDE.md (separate small PR if you want it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)