### PR TITLE
feat(tasktorrent): next_chunk CLI — claimable-chunk discovery

### DIFF
--- a/docs/contribute.html
+++ b/docs/contribute.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenOnco · Допомогти</title>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Source+Sans+3:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link href="/style.css" rel="stylesheet">
+</head>
+<body>
+<header class="top-bar">
+  <div class="brand-line">
+    <a href="/" class="brand-mini">OpenOnco</a>
+    <span class="brand-version" title="Released 2026-04-27">v0.1.1 · 2026-04-27</span>
+  </div>
+  <nav class="top-nav">
+    <a href="/">Головна</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/gallery.html">Приклади</a>
+    <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
+  </nav>
+  <div class="top-right">
+    <div class="lang-switch" role="group" aria-label="Language">
+      <span class="lang-current"><span class="lang-flag flag-ua" aria-hidden="true"></span>UA</span>
+      <a class="lang-other" href="/en/contribute.html"><span class="lang-flag flag-en" aria-hidden="true"></span>EN</a>
+    </div>
+    <a href="/try.html" class="btn-cta-try" >Спробувати →</a>
+  </div>
+</header>
+
+<main>
+  <section class="info-page">
+    <h1>Допомогти OpenOnco</h1>
+    <p class="lead">
+      У вас є непрацюючий потенціал у Claude Code, Codex, Cursor чи ChatGPT? Ваш AI-агент може взяти один структурований шматок роботи з нашої черги, виконати його за 1-3 години, і відкрити Pull Request. Так ми колективно наповнюємо публічну онкологічну базу знань для України.
+    </p>
+
+    <h2>Що це таке</h2>
+    <p>
+      OpenOnco — безкоштовний публічний ресурс для підтримки клінічних рішень в онкології. База знань складається з тисяч структурованих записів: біомаркери, схеми лікування, червоні прапорці, цитати на NCCN/ESMO/RCT. Кожен запис верифікується. Кожне твердження має джерело.
+    </p>
+    <p>
+      <strong>TaskTorrent</strong> — наш протокол для розподіленої роботи. Maintainer публікує "чанк" (одну задачу: ~100k-300k токенів роботи). Контрибутор зі своїм AI-tool бере чанк, виконує, відкриває PR. Maintainer перевіряє і мерджить.
+    </p>
+
+    <h2>Як долучитись — 8 рядків</h2>
+    <p>
+      Скопіюй цей промпт у свій AI-агент (Claude Code, Codex, Cursor, ChatGPT). Все інше зробить агент.
+    </p>
+
+    <pre style="background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:1em;overflow-x:auto;font-family:'JetBrains Mono',monospace;font-size:0.9em;line-height:1.45;"><code>You are an OpenOnco TaskTorrent contributor agent. Your goal is to do one chunk of structured KB work and submit it as a PR.
+
+1. Read https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/CONTRIBUTOR_QUICKSTART.md (full workflow).
+2. Run scripts/tasktorrent/bootstrap_contributor.sh — it tells you the next available chunk.
+3. Read the chunk spec at the printed URL. Confirm you can complete it within the Drop estimate. If not, exit.
+4. Run scripts/tasktorrent/auto_claim.sh &lt;chunk-id&gt; --issue &lt;#&gt; --method &lt;method&gt;.
+5. Do the work on branch tasktorrent/&lt;chunk-id&gt;, only under contributions/&lt;chunk-id&gt;/. Every sidecar's _contribution_meta.yaml must declare ai_tool + ai_model.
+6. Run python -m scripts.tasktorrent.validate_contributions &lt;chunk-id&gt; until it passes.
+7. Run scripts/tasktorrent/auto_pr.sh &lt;chunk-id&gt; --issue &lt;#&gt; to open the PR.
+8. STOP after PR is opened. Do not push to master, do not create chunks, do not delete branches.</code></pre>
+
+    <p>
+      Канонічна копія: <a href="https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/PROMPT_PASTE_AND_GO.md">PROMPT_PASTE_AND_GO.md</a>.
+    </p>
+
+    <h2>Вимоги до контрибутора</h2>
+    <ul>
+      <li><strong>AI-tool</strong>: Claude Code (Pro+), Codex, Cursor, ChatGPT (з web access). Token budget на чанк — 100k-300k.</li>
+      <li><strong>GitHub account</strong> + встановлений <code>gh</code> CLI (<a href="https://cli.github.com/" target="_blank" rel="noopener">cli.github.com</a>).</li>
+      <li><strong>Python 3.10+</strong> для валідатора.</li>
+      <li><strong>Web access</strong> у вашого агента — багато чанків потребують PubMed / NCCN / ESMO read.</li>
+    </ul>
+
+    <h2>Що буде з вашим внеском</h2>
+    <ul>
+      <li>Кожен PR проходить <strong>2 reviewer-signoff</strong> для clinical content (CHARTER §6.1).</li>
+      <li>Maintainer запускає re-verify скрипти на mechanical-частину.</li>
+      <li>Вибірковий sample-review від Clinical Co-Lead на semantic-частину.</li>
+      <li>Після merge — внесок landing у master, потім в hosted KB, потім у render для пацієнтів.</li>
+    </ul>
+
+    <h2>Що ми НЕ приймаємо</h2>
+    <ul>
+      <li>Медичні поради чи treatment recommendations у виводі (CHARTER §8.3 — LLM не приймає клінічні рішення).</li>
+      <li>Patient-specific output (без явної згоди + de-identification + ethics approval).</li>
+      <li>Цитати з заборонених джерел: <code>SRC-ONCOKB</code>, <code>SRC-SNOMED</code>, <code>SRC-MEDDRA</code> (CHARTER §2 — non-commercial only).</li>
+      <li>Обхід валідатора (<code>--no-verify</code>, <code>git add -A</code>, etc.).</li>
+      <li>Файли поза <code>contributions/&lt;chunk-id&gt;/</code> (allowlist enforcement).</li>
+    </ul>
+
+    <h2>Підтримка</h2>
+    <p>
+      Питання — <a href="https://github.com/romeo111/OpenOnco/issues/new?labels=question" target="_blank" rel="noopener">відкрийте issue з тегом <code>question</code></a>. Не пишіть приватно maintainer-у — публічний audit trail важливіший.
+    </p>
+    <p>
+      <a href="https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/CONTRIBUTOR_QUICKSTART.md" target="_blank" rel="noopener">Повна інструкція →</a>
+    </p>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <p>OpenOnco · CHARTER §11 — research/support tool, not a medical device. Усі рекомендації мають бути верифіковані кваліфікованим онкологом.</p>
+</footer>
+</body>
+</html>

--- a/docs/contributing/CONTRIBUTOR_QUICKSTART.md
+++ b/docs/contributing/CONTRIBUTOR_QUICKSTART.md
@@ -4,6 +4,16 @@ You want to help OpenOnco. You have an AI tool (Codex / Claude Code / Cursor / C
 
 > Prerequisite reading: [`HELP_WANTED.md`](HELP_WANTED.md) — pilot framing and safety boundaries. **You will not write medical advice or treatment recommendations.** You drive your AI tool through structured evidence drafting; maintainers review.
 
+## Fastest path — paste-and-go (recommended)
+
+If your AI tool has filesystem + shell access (Claude Code, Codex CLI, Cursor):
+
+1. Read [`PROMPT_PASTE_AND_GO.md`](PROMPT_PASTE_AND_GO.md) — the canonical 8-line prompt
+2. Paste it into your AI agent
+3. The agent runs `scripts/tasktorrent/bootstrap_contributor.sh` → finds next chunk → orchestrates `auto_claim.sh` → does work → runs `auto_pr.sh`
+
+Manual phase-by-phase steps below if you want to understand each step or your tool is web-only (ChatGPT).
+
 ## 1. Setup (5 min)
 
 ```bash

--- a/docs/contributing/PROMPT_PASTE_AND_GO.md
+++ b/docs/contributing/PROMPT_PASTE_AND_GO.md
@@ -1,0 +1,89 @@
+# OpenOnco contributor — paste-and-go prompt
+
+Copy-paste this into Claude Code, Codex, Cursor, or ChatGPT. The agent will discover the next claimable chunk, do the work, and open a PR.
+
+> **Read this before pasting.** OpenOnco is a free public oncology decision-support project. By contributing you agree:
+> - No medical advice or treatment recommendations in your output
+> - No patient-specific data
+> - Banned sources: SRC-ONCOKB, SRC-SNOMED, SRC-MEDDRA (CHARTER §2)
+> - Two-reviewer signoff for clinical content
+> - You verify your output against cited sources
+
+---
+
+## The 8-line prompt
+
+```
+You are an OpenOnco TaskTorrent contributor agent. Your goal is to do one chunk of structured KB work and submit it as a PR.
+
+1. Read https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/CONTRIBUTOR_QUICKSTART.md (full workflow).
+2. Run scripts/tasktorrent/bootstrap_contributor.sh — it tells you the next available chunk.
+3. Read the chunk spec at the printed URL. Confirm you can complete it within the Drop estimate. If not, exit.
+4. Run scripts/tasktorrent/auto_claim.sh <chunk-id> --issue <#> --method <method>.
+5. Do the work on branch tasktorrent/<chunk-id>, only under contributions/<chunk-id>/. Every sidecar's _contribution_meta.yaml must declare ai_tool + ai_model.
+6. Run python -m scripts.tasktorrent.validate_contributions <chunk-id> until it passes.
+7. Run scripts/tasktorrent/auto_pr.sh <chunk-id> --issue <#> to open the PR.
+8. STOP after PR is opened. Do not push to master, do not create chunks, do not delete branches.
+```
+
+## How it works under the hood
+
+| Step | What runs | Side effects |
+|---|---|---|
+| 2 | `next_chunk.py` queries GitHub for `chunk-task,status-active,assignee=none` and returns oldest | read-only |
+| 4 | `auto_claim.sh` either comments on the issue or pushes a WIP branch to origin (depends on `claim_method`) | one comment OR one branch push |
+| 5 | Your agent's actual work | files in `contributions/<chunk-id>/` only |
+| 6 | `validate_contributions.py` — schema, manifest, banned-sources, ID-collision checks | read-only |
+| 7 | `auto_pr.sh` — pre-flight (branch, scope, validator) then `gh pr create` | one PR |
+
+## Hard invariants the agent must respect
+
+- **Allowlist:** every file you touch must be under `contributions/<chunk-id>/`. Anything outside is a `scope` rejection.
+- **Banned sources** (CHARTER §2): SRC-ONCOKB, SRC-SNOMED, SRC-MEDDRA. Hard rejection on any reference.
+- **No `git add -A`:** stage explicit pathspecs only. Other in-flight work might be on the same branch.
+- **No `--no-verify`** on commits. Pre-commit hooks are gates, not noise.
+- **No medical advice, no patient-specific output.** The KB describes evidence; it does not prescribe. CHARTER §8.3.
+- **Two-reviewer signoff** for clinical content (CHARTER §6.1). The maintainer routes; you don't self-approve.
+
+## What if you get stuck
+
+Add `_contribution.notes_for_reviewer` to your sidecar explaining the blocker. Maintainer will reroute or close.
+
+If the validator rejects in a way you don't understand, **don't bypass it**. Read the error, fix the cause, re-run. The validator is the contract.
+
+## Quick reference
+
+```bash
+# Discovery
+$ python -m scripts.tasktorrent.next_chunk --json-only
+{
+  "chunk_id": "trial-source-ingest-pubmed",
+  "issue_number": 26,
+  "claim_method": "formal-issue",
+  ...
+}
+
+# Claim
+$ scripts/tasktorrent/auto_claim.sh trial-source-ingest-pubmed --issue 26 --method formal-issue
+
+# Validate (run this often during work)
+$ python -m scripts.tasktorrent.validate_contributions trial-source-ingest-pubmed
+
+# Open PR
+$ scripts/tasktorrent/auto_pr.sh trial-source-ingest-pubmed --issue 26
+```
+
+## Cadence + expectations
+
+- Drop estimate ≈ 100k tokens of structured AI work. Most chunks are 1-3 Drops.
+- 24-hour SLA on `formal-issue` claims (claim-sla-bot enforces).
+- 14-day stale-claim release: if your branch goes silent for 14 days, the bot releases the assignee back to the shelf.
+- One contributor per chunk; one chunk per PR.
+
+## License + attribution
+
+OpenOnco is non-commercial public-good. Your contributions land under the project's license (see CHARTER §2). Cited sources keep their own licenses; you classify them in source stubs.
+
+## Questions
+
+Open an issue with the `question` label on https://github.com/romeo111/OpenOnco. Don't DM the maintainer privately — keep the audit trail public.

--- a/docs/contributing/cross-repo-contract.md
+++ b/docs/contributing/cross-repo-contract.md
@@ -1,0 +1,48 @@
+---
+synced_from: task_torrent@main#docs/cross-repo-contract.md
+last_synced: 2026-04-29
+note: |
+  This is a mirror of the canonical cross-repo contract maintained
+  in romeo111/task_torrent. Do not edit here directly — propose
+  changes upstream via PR to task_torrent. The mirror is for
+  contributor convenience (linkable from OpenOnco docs without a
+  cross-repo redirect).
+
+  Sync-check CI deferred to protocol v0.5 per cross-repo plan §5.5.
+  Until then, mirror staleness is detected by hand or via the
+  changelog in protocol-v0.4-design.md.
+---
+
+# Cross-Repo Contract — task_torrent ↔ OpenOnco
+
+**Canonical:** [`task_torrent/docs/cross-repo-contract.md`](https://github.com/romeo111/task_torrent/blob/main/docs/cross-repo-contract.md)
+
+This file is a mirror. Read the canonical doc for the authoritative version. The mirror exists so that OpenOnco contributors don't need to context-switch repos to read the contract.
+
+If the two diverge, **the canonical wins.** Open an issue if you spot drift.
+
+## Quick reference for OpenOnco contributors
+
+The full contract covers:
+
+- **Discovery** — how `next_chunk.py` finds open chunks
+- **Issue body** — what `## ` headings the parser expects
+- **Chunk spec** — what fields the linter requires
+- **Claim** — `formal-issue` vs `trusted-agent-wip-branch-first` flows
+- **Sidecar** — required files in `contributions/<chunk-id>/`
+- **Rejection codes** — 9-item vocabulary for maintainer rejections
+- **Banned sources** — `SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA` (CHARTER §2)
+- **Versioning** — v0.4 observability-only (optional commit-hash; no semver tags)
+- **Trust tiers** — T0/T1/T2, per-consumer (not portable across consumers by default)
+- **Reference implementations** — where each piece lives in this repo
+
+## OpenOnco-specific addenda
+
+The contract is generic. OpenOnco-specific bits:
+
+- Banned sources list: `SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`. CHARTER §2 enforces non-commercial.
+- Two-reviewer signoff required for clinical content (CHARTER §6.1) — currently in dev-mode exemption per project-memory.
+- Patient-specific output banned (CHARTER §9.3) — even with consent, requires de-identification + ethics approval before public release.
+- Ukrainian-first KB; English mirrored where applicable.
+
+For the full contract, read the [canonical](https://github.com/romeo111/task_torrent/blob/main/docs/cross-repo-contract.md).

--- a/docs/en/contribute.html
+++ b/docs/en/contribute.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenOnco · Contribute</title>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Source+Sans+3:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link href="/style.css" rel="stylesheet">
+</head>
+<body>
+<header class="top-bar">
+  <div class="brand-line">
+    <a href="/en/" class="brand-mini">OpenOnco</a>
+    <span class="brand-version" title="Released 2026-04-27">v0.1.1 · 2026-04-27</span>
+  </div>
+  <nav class="top-nav">
+    <a href="/en/">Home</a>
+    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a>
+    <a href="/en/gallery.html">Examples</a>
+    <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
+  </nav>
+  <div class="top-right">
+    <div class="lang-switch" role="group" aria-label="Language">
+      <a class="lang-other" href="/contribute.html"><span class="lang-flag flag-ua" aria-hidden="true"></span>UA</a>
+      <span class="lang-current"><span class="lang-flag flag-en" aria-hidden="true"></span>EN</span>
+    </div>
+    <a href="/en/try.html" class="btn-cta-try" >Try →</a>
+  </div>
+</header>
+
+<main>
+  <section class="info-page">
+    <h1>Contribute to OpenOnco</h1>
+    <p class="lead">
+      Got idle capacity in Claude Code, Codex, Cursor, or ChatGPT? Your AI agent can take one structured chunk of work from our queue, finish it in 1-3 hours, and open a Pull Request. That's how we collectively build a public oncology knowledge base.
+    </p>
+
+    <h2>What this is</h2>
+    <p>
+      OpenOnco is a free public clinical decision-support resource for oncology. The KB consists of thousands of structured records: biomarkers, treatment regimens, red flags, citations to NCCN/ESMO/RCTs. Every record is verified. Every claim has a source.
+    </p>
+    <p>
+      <strong>TaskTorrent</strong> is our protocol for distributed work. The maintainer publishes a "chunk" (one task: ~100k-300k tokens of work). A contributor with their own AI tool takes the chunk, executes, opens a PR. The maintainer reviews and merges.
+    </p>
+
+    <h2>How to contribute — 8 lines</h2>
+    <p>
+      Paste this prompt into your AI agent (Claude Code, Codex, Cursor, ChatGPT). The agent does the rest.
+    </p>
+
+    <pre style="background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:1em;overflow-x:auto;font-family:'JetBrains Mono',monospace;font-size:0.9em;line-height:1.45;"><code>You are an OpenOnco TaskTorrent contributor agent. Your goal is to do one chunk of structured KB work and submit it as a PR.
+
+1. Read https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/CONTRIBUTOR_QUICKSTART.md (full workflow).
+2. Run scripts/tasktorrent/bootstrap_contributor.sh — it tells you the next available chunk.
+3. Read the chunk spec at the printed URL. Confirm you can complete it within the Drop estimate. If not, exit.
+4. Run scripts/tasktorrent/auto_claim.sh &lt;chunk-id&gt; --issue &lt;#&gt; --method &lt;method&gt;.
+5. Do the work on branch tasktorrent/&lt;chunk-id&gt;, only under contributions/&lt;chunk-id&gt;/. Every sidecar's _contribution_meta.yaml must declare ai_tool + ai_model.
+6. Run python -m scripts.tasktorrent.validate_contributions &lt;chunk-id&gt; until it passes.
+7. Run scripts/tasktorrent/auto_pr.sh &lt;chunk-id&gt; --issue &lt;#&gt; to open the PR.
+8. STOP after PR is opened. Do not push to master, do not create chunks, do not delete branches.</code></pre>
+
+    <p>
+      Canonical copy: <a href="https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/PROMPT_PASTE_AND_GO.md">PROMPT_PASTE_AND_GO.md</a>.
+    </p>
+
+    <h2>Contributor requirements</h2>
+    <ul>
+      <li><strong>AI tool</strong>: Claude Code (Pro+), Codex, Cursor, ChatGPT (with web access). Per-chunk token budget: 100k-300k.</li>
+      <li><strong>GitHub account</strong> + the <code>gh</code> CLI installed (<a href="https://cli.github.com/" target="_blank" rel="noopener">cli.github.com</a>).</li>
+      <li><strong>Python 3.10+</strong> for the validator.</li>
+      <li><strong>Web access</strong> for your agent — many chunks require PubMed / NCCN / ESMO reads.</li>
+    </ul>
+
+    <h2>What happens to your contribution</h2>
+    <ul>
+      <li>Every PR gets <strong>two-reviewer signoff</strong> for clinical content (CHARTER §6.1).</li>
+      <li>Maintainer runs re-verify scripts on the mechanical part.</li>
+      <li>Sample-review by a Clinical Co-Lead on the semantic part.</li>
+      <li>After merge — your contribution lands on master, then in the hosted KB, then in renders for patients.</li>
+    </ul>
+
+    <h2>What we do NOT accept</h2>
+    <ul>
+      <li>Medical advice or treatment recommendations in your output (CHARTER §8.3 — LLM does not make clinical decisions).</li>
+      <li>Patient-specific output (without explicit consent + de-identification + ethics approval).</li>
+      <li>Citations from banned sources: <code>SRC-ONCOKB</code>, <code>SRC-SNOMED</code>, <code>SRC-MEDDRA</code> (CHARTER §2 — non-commercial only).</li>
+      <li>Validator bypass (<code>--no-verify</code>, <code>git add -A</code>, etc.).</li>
+      <li>Files outside <code>contributions/&lt;chunk-id&gt;/</code> (allowlist enforcement).</li>
+    </ul>
+
+    <h2>Support</h2>
+    <p>
+      Questions — <a href="https://github.com/romeo111/OpenOnco/issues/new?labels=question" target="_blank" rel="noopener">open an issue with the <code>question</code> label</a>. Don't DM the maintainer — public audit trail matters.
+    </p>
+    <p>
+      <a href="https://github.com/romeo111/OpenOnco/blob/master/docs/contributing/CONTRIBUTOR_QUICKSTART.md" target="_blank" rel="noopener">Full guide →</a>
+    </p>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <p>OpenOnco · CHARTER §11 — research/support tool, not a medical device. All recommendations must be verified by a qualified oncologist.</p>
+</footer>
+</body>
+</html>

--- a/scripts/tasktorrent/README.md
+++ b/scripts/tasktorrent/README.md
@@ -1,0 +1,73 @@
+# TaskTorrent contributor + maintainer scripts
+
+## Contributor flow (one-prompt onboarding)
+
+| Script | What it does |
+|---|---|
+| `bootstrap_contributor.sh` | One-shot setup: deps check, gh auth, clone, find next chunk, print marching orders |
+| `next_chunk.py` | Discover the next claimable chunk; emit JSON for agent context |
+| `auto_claim.sh <chunk-id>` | Claim per declared method (`formal-issue` comment OR push WIP branch) |
+| `auto_pr.sh <chunk-id>` | Pre-flight then `gh pr create` for the finished sidecar |
+| `validate_contributions.py` | Schema + manifest + banned-source + ID-collision checks (run often during work) |
+
+Paste-and-go prompt for AI tools: [`docs/contributing/PROMPT_PASTE_AND_GO.md`](../../docs/contributing/PROMPT_PASTE_AND_GO.md).
+
+Full workflow: [`docs/contributing/CONTRIBUTOR_QUICKSTART.md`](../../docs/contributing/CONTRIBUTOR_QUICKSTART.md).
+
+## Maintainer flow
+
+| Script | What it does |
+|---|---|
+| `validate_contributions.py` | Same as above; also gates CI on PR |
+| `upsert_contributions.py` | Apply merged sidecars to hosted KB (`--confirm` required) |
+| `check_manifest_overlap.py` | Pre-flight when opening a new chunk against active chunks |
+| `check_claim_sla.py` | Hourly bot — auto-release issues unassigned >24h |
+| `auto_release_stale_claims.py` | Daily bot — release assignees inactive >14d |
+| `reverify_*.py` | Per-chunk-type computational re-verification (BMA via CIViC, citation title-substring, etc.) |
+| `triage_*.py` | Generate maintainer-walkable markdown queues from audit chunks |
+| `extract_trials_needing_source.py` | Helper for trial-source-ingest chunks |
+
+## Quick reference for contributors
+
+```bash
+# Find next chunk + print orders
+scripts/tasktorrent/bootstrap_contributor.sh
+
+# Or just discover (JSON)
+python -m scripts.tasktorrent.next_chunk --json-only
+
+# Claim it (formal-issue OR trusted-agent — script auto-detects from issue body)
+scripts/tasktorrent/auto_claim.sh <chunk-id> --issue <#>
+
+# Validate as you work
+python -m scripts.tasktorrent.validate_contributions <chunk-id>
+
+# Open the PR
+scripts/tasktorrent/auto_pr.sh <chunk-id> --issue <#>
+```
+
+## Hard invariants the scripts enforce
+
+- **Allowlist**: `auto_pr.sh` rejects PRs whose diff includes files outside `contributions/<chunk-id>/`.
+- **Sidecar minimum**: `_contribution_meta.yaml` + `task_manifest.txt` required.
+- **Validator gate**: `auto_pr.sh` blocks PR open if `validate_contributions.py` fails.
+- **Claim methods**: only `formal-issue` and `trusted-agent-wip-branch-first` accepted.
+
+## Script flags
+
+All four contributor scripts accept `--dry-run` to print what they would do without side effects.
+
+`bootstrap_contributor.sh` accepts `--no-clone` if you've already cloned the repo.
+
+## Why bash scripts (not Python)
+
+The contributor scripts wrap `gh` and `git` — both shell-native. Python wrappers would add an interpreter dependency between contributor and the work. Discovery + parsing (which has real complexity) is in `next_chunk.py`. Everything else is glue.
+
+## Tests
+
+```bash
+C:/Python312/python.exe -m pytest tests/test_tasktorrent_next_chunk.py
+C:/Python312/python.exe -m pytest tests/test_tasktorrent_scripts_smoke.py
+```
+
+22 tests for the parser + 12 smoke tests for the bash scripts.

--- a/scripts/tasktorrent/auto_claim.sh
+++ b/scripts/tasktorrent/auto_claim.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# auto_claim — claim a TaskTorrent chunk per its declared claim_method.
+#
+# Usage:
+#   auto_claim.sh <chunk-id> [--repo OWNER/REPO]
+#                              [--issue NUMBER]      # required for formal-issue
+#                              [--branch BRANCH]     # default: tasktorrent/<chunk-id>
+#                              [--method METHOD]     # formal-issue | trusted-agent-wip-branch-first
+#                              [--dry-run]
+#
+# Behavior per claim_method:
+#   formal-issue:
+#     - gh issue comment <#> -b "I'd like to take this chunk."
+#     - Maintainer assigns within 24h SLA (claim-sla-bot enforces).
+#
+#   trusted-agent-wip-branch-first:
+#     - git checkout -b tasktorrent/<chunk-id>
+#     - empty commit "WIP <chunk-id>"
+#     - git push -u origin tasktorrent/<chunk-id>
+#     - Branch on origin = visible lock (other agents won't duplicate).
+#
+# If --method is omitted, the script reads the issue body via gh and
+# extracts claim_method from the `## Claim Method` section. Falls back
+# to formal-issue if nothing parseable is found.
+#
+# Exit codes:
+#   0 — claimed successfully
+#   1 — usage / argument error
+#   2 — gh CLI missing
+#   3 — issue lookup or comment failed
+#   4 — git operation failed
+
+set -euo pipefail
+
+REPO="romeo111/OpenOnco"
+CHUNK_ID=""
+ISSUE_NUMBER=""
+BRANCH=""
+METHOD=""
+DRY_RUN=0
+
+usage() {
+  sed -n '3,/^$/p' "$0" | sed -n '/^# /s/^# //p'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)    REPO="$2"; shift 2 ;;
+    --issue)   ISSUE_NUMBER="$2"; shift 2 ;;
+    --branch)  BRANCH="$2"; shift 2 ;;
+    --method)  METHOD="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage 0 ;;
+    --*)       echo "ERROR: unknown flag $1" >&2; usage 1 >&2 ;;
+    *)
+      if [[ -z "$CHUNK_ID" ]]; then CHUNK_ID="$1"; shift
+      else echo "ERROR: unexpected positional $1" >&2; usage 1 >&2
+      fi ;;
+  esac
+done
+
+if [[ -z "$CHUNK_ID" ]]; then
+  echo "ERROR: chunk-id is required" >&2; usage 1 >&2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not on PATH (install: https://cli.github.com/)" >&2
+  exit 2
+fi
+
+BRANCH="${BRANCH:-tasktorrent/$CHUNK_ID}"
+
+# If method not given, try parsing it from the issue body.
+if [[ -z "$METHOD" ]]; then
+  if [[ -z "$ISSUE_NUMBER" ]]; then
+    # Find issue by chunk-id in title heuristic: search "[Chunk] <chunk-id>"
+    ISSUE_NUMBER=$(gh issue list --repo "$REPO" --label chunk-task --state open \
+      --search "in:title \"$CHUNK_ID\"" --json number --jq '.[0].number' 2>/dev/null || true)
+  fi
+  if [[ -n "$ISSUE_NUMBER" ]]; then
+    BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || true)
+    METHOD=$(printf '%s\n' "$BODY" | awk '
+      /^## Claim Method/ { in_section=1; next }
+      in_section && /^## / { in_section=0 }
+      in_section && /`(formal-issue|trusted-agent-wip-branch-first)`/ {
+        match($0, /`(formal-issue|trusted-agent-wip-branch-first)`/, m)
+        gsub("`","",m[0]); print m[0]; exit
+      }
+    ')
+  fi
+  METHOD="${METHOD:-formal-issue}"
+fi
+
+case "$METHOD" in
+  formal-issue|trusted-agent-wip-branch-first) ;;
+  *)
+    echo "ERROR: invalid --method $METHOD (expected formal-issue or trusted-agent-wip-branch-first)" >&2
+    exit 1
+    ;;
+esac
+
+echo "→ chunk_id:     $CHUNK_ID"
+echo "→ repo:         $REPO"
+echo "→ method:       $METHOD"
+[[ -n "$ISSUE_NUMBER" ]] && echo "→ issue:        #$ISSUE_NUMBER"
+echo "→ branch:       $BRANCH"
+[[ "$DRY_RUN" -eq 1 ]] && echo "→ DRY-RUN (no side effects)"
+echo
+
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ $*"
+  else
+    "$@"
+  fi
+}
+
+case "$METHOD" in
+  formal-issue)
+    if [[ -z "$ISSUE_NUMBER" ]]; then
+      echo "ERROR: formal-issue claim requires --issue NUMBER (or chunk-id resolvable from open issues)" >&2
+      exit 1
+    fi
+    echo "Claiming via comment on issue #$ISSUE_NUMBER..."
+    if ! run gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+         --body "I'd like to take this chunk."; then
+      echo "ERROR: gh issue comment failed" >&2
+      exit 3
+    fi
+    echo
+    echo "Claim posted. Maintainer assigns within 24h (claim-sla-bot enforces)."
+    echo "If not assigned within 24h, bot auto-releases and chunk reopens for others."
+    ;;
+
+  trusted-agent-wip-branch-first)
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      echo "ERROR: not inside a git working tree" >&2
+      exit 4
+    fi
+    # Create branch (or switch if it already exists locally)
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+      run git checkout "$BRANCH" || { echo "ERROR: cannot checkout $BRANCH" >&2; exit 4; }
+    else
+      run git checkout -b "$BRANCH" || { echo "ERROR: cannot create $BRANCH" >&2; exit 4; }
+    fi
+    # Empty WIP commit
+    run git commit --allow-empty -m "WIP: $CHUNK_ID — visible-lock per L-19 trusted-agent flow" \
+      || { echo "ERROR: empty commit failed" >&2; exit 4; }
+    run git push -u origin "$BRANCH" \
+      || { echo "ERROR: git push failed" >&2; exit 4; }
+    echo
+    echo "WIP branch on origin = your visible claim. Other agents won't duplicate."
+    echo "Stale-claim auto-release: 14 days of no branch activity → bot reopens."
+    ;;
+esac
+
+echo
+echo "Next: do the work, then run scripts/tasktorrent/auto_pr.sh $CHUNK_ID"

--- a/scripts/tasktorrent/auto_pr.sh
+++ b/scripts/tasktorrent/auto_pr.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# auto_pr — open a PR for a finished TaskTorrent chunk.
+#
+# Usage:
+#   auto_pr.sh <chunk-id> [--repo OWNER/REPO]
+#                          [--base BRANCH]       # default: master
+#                          [--branch BRANCH]     # default: tasktorrent/<chunk-id>
+#                          [--issue NUMBER]      # links into PR body
+#                          [--draft]
+#                          [--dry-run]
+#
+# Pre-flight checks (abort if any fails):
+#   1. We're on the expected branch (--branch / tasktorrent/<chunk-id>).
+#   2. Working tree is clean.
+#   3. contributions/<chunk-id>/ exists and contains _contribution_meta.yaml.
+#   4. task_manifest.txt exists in contributions/<chunk-id>/.
+#   5. validate_contributions.py passes for this chunk.
+#   6. git diff --name-only base..HEAD lists only files under
+#      contributions/<chunk-id>/ (allowlist enforcement).
+#
+# PR body is generated from the chunk-spec acceptance criteria + the
+# sidecar's _contribution_meta.yaml. Links the chunk-task issue if
+# given via --issue.
+#
+# Exit codes:
+#   0 — PR opened
+#   1 — usage / argument error
+#   2 — gh CLI missing
+#   3 — pre-flight check failed
+#   4 — gh pr create failed
+
+set -euo pipefail
+
+REPO="romeo111/OpenOnco"
+CHUNK_ID=""
+BASE="master"
+BRANCH=""
+ISSUE_NUMBER=""
+DRAFT=0
+DRY_RUN=0
+
+usage() {
+  sed -n '3,/^$/p' "$0" | sed -n '/^# /s/^# //p'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)    REPO="$2"; shift 2 ;;
+    --base)    BASE="$2"; shift 2 ;;
+    --branch)  BRANCH="$2"; shift 2 ;;
+    --issue)   ISSUE_NUMBER="$2"; shift 2 ;;
+    --draft)   DRAFT=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage 0 ;;
+    --*)       echo "ERROR: unknown flag $1" >&2; usage 1 >&2 ;;
+    *)
+      if [[ -z "$CHUNK_ID" ]]; then CHUNK_ID="$1"; shift
+      else echo "ERROR: unexpected positional $1" >&2; usage 1 >&2
+      fi ;;
+  esac
+done
+
+if [[ -z "$CHUNK_ID" ]]; then
+  echo "ERROR: chunk-id is required" >&2; usage 1 >&2
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not on PATH" >&2; exit 2
+fi
+
+BRANCH="${BRANCH:-tasktorrent/$CHUNK_ID}"
+SIDECAR_DIR="contributions/$CHUNK_ID"
+
+echo "→ chunk_id: $CHUNK_ID"
+echo "→ branch:   $BRANCH (base $BASE)"
+echo "→ sidecar:  $SIDECAR_DIR/"
+[[ -n "$ISSUE_NUMBER" ]] && echo "→ issue:    #$ISSUE_NUMBER"
+[[ "$DRY_RUN" -eq 1 ]] && echo "→ DRY-RUN"
+echo
+
+# --- Pre-flight ---
+
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ "$current_branch" != "$BRANCH" ]]; then
+  echo "ERROR: pre-flight failed — on branch '$current_branch', expected '$BRANCH'" >&2
+  exit 3
+fi
+
+if ! git diff --quiet --exit-code; then
+  echo "ERROR: pre-flight failed — working tree has unstaged changes" >&2
+  exit 3
+fi
+if ! git diff --quiet --cached --exit-code; then
+  echo "ERROR: pre-flight failed — working tree has staged-but-uncommitted changes" >&2
+  exit 3
+fi
+
+if [[ ! -d "$SIDECAR_DIR" ]]; then
+  echo "ERROR: pre-flight failed — $SIDECAR_DIR/ does not exist" >&2
+  exit 3
+fi
+if [[ ! -f "$SIDECAR_DIR/_contribution_meta.yaml" ]]; then
+  echo "ERROR: pre-flight failed — $SIDECAR_DIR/_contribution_meta.yaml missing" >&2
+  exit 3
+fi
+if [[ ! -f "$SIDECAR_DIR/task_manifest.txt" ]]; then
+  echo "ERROR: pre-flight failed — $SIDECAR_DIR/task_manifest.txt missing" >&2
+  exit 3
+fi
+
+# Allowlist enforcement: every changed file relative to base must live under sidecar dir.
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+out_of_scope=$(git diff --name-only "origin/$BASE...HEAD" -- ":(exclude)$SIDECAR_DIR" || true)
+if [[ -n "$out_of_scope" ]]; then
+  echo "ERROR: pre-flight failed — files outside $SIDECAR_DIR/ in this branch:" >&2
+  echo "$out_of_scope" >&2
+  exit 3
+fi
+
+# Optional but recommended: run the validator if it's available.
+if [[ -f "scripts/tasktorrent/validate_contributions.py" ]]; then
+  echo "→ Running validate_contributions.py..."
+  if ! python -m scripts.tasktorrent.validate_contributions "$CHUNK_ID" >/dev/null 2>&1; then
+    echo "ERROR: pre-flight failed — validate_contributions.py reported errors" >&2
+    echo "       Run manually to see details:" >&2
+    echo "       python -m scripts.tasktorrent.validate_contributions $CHUNK_ID" >&2
+    exit 3
+  fi
+fi
+
+echo "✓ Pre-flight passed"
+echo
+
+# --- Generate PR body ---
+
+PR_TITLE="[TaskTorrent] $CHUNK_ID — chunk deliverable"
+PR_BODY_FILE=$(mktemp)
+trap 'rm -f "$PR_BODY_FILE"' EXIT
+
+cat > "$PR_BODY_FILE" <<EOF
+## Chunk: \`$CHUNK_ID\`
+
+EOF
+
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  echo "Closes #$ISSUE_NUMBER" >> "$PR_BODY_FILE"
+  echo "" >> "$PR_BODY_FILE"
+fi
+
+cat >> "$PR_BODY_FILE" <<EOF
+## Sidecar files
+
+\`\`\`
+$(git diff --name-only "origin/$BASE...HEAD" | head -50)
+\`\`\`
+
+## Validation
+
+- [x] Pre-flight: branch + working tree + sidecar dir
+- [x] Allowlist: only files under \`$SIDECAR_DIR/\`
+- [x] \`task_manifest.txt\` committed
+- [x] \`_contribution_meta.yaml\` includes \`ai_tool\` + \`ai_model\`
+EOF
+
+if [[ -f "scripts/tasktorrent/validate_contributions.py" ]]; then
+  echo "- [x] \`validate_contributions.py\` passes locally" >> "$PR_BODY_FILE"
+fi
+
+cat >> "$PR_BODY_FILE" <<EOF
+
+## Maintainer review
+
+- [ ] Computational re-verify (per chunk-spec)
+- [ ] Sample re-verify (if applicable)
+- [ ] Acceptance criteria semantic check
+
+🤖 Generated by \`scripts/tasktorrent/auto_pr.sh\`
+EOF
+
+# --- Open PR ---
+
+CMD=(gh pr create --repo "$REPO" --base "$BASE" --head "$BRANCH"
+     --title "$PR_TITLE" --body-file "$PR_BODY_FILE")
+[[ "$DRAFT" -eq 1 ]] && CMD+=(--draft)
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "DRY-RUN — would run:"
+  printf '  %q ' "${CMD[@]}"; echo
+  echo
+  echo "PR body would be:"
+  echo "================"
+  cat "$PR_BODY_FILE"
+  exit 0
+fi
+
+if ! "${CMD[@]}"; then
+  echo "ERROR: gh pr create failed" >&2
+  exit 4
+fi

--- a/scripts/tasktorrent/bootstrap_contributor.sh
+++ b/scripts/tasktorrent/bootstrap_contributor.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# bootstrap_contributor — one-prompt onboarding entry point.
+#
+# Usage:
+#   bootstrap_contributor.sh [--repo OWNER/REPO]
+#                             [--clone-dir PATH]   # default: ./openonco
+#                             [--no-clone]         # skip clone (already cloned)
+#                             [--dry-run]
+#
+# Pipeline:
+#   1. Sanity-check deps (git, gh, python ≥3.10)
+#   2. Verify gh authentication
+#   3. Clone OpenOnco (unless --no-clone)
+#   4. Run next_chunk.py to find the next claimable chunk
+#   5. Print the contributor's marching orders + next-step commands
+#
+# Does NOT itself claim a chunk — that's `auto_claim.sh`. This is just
+# the discovery + handoff stage so the contributor's agent can decide
+# whether the chunk fits its skills + token budget.
+#
+# Exit codes:
+#   0 — discovered next chunk and printed orders
+#   1 — dependency check failed
+#   2 — auth failed
+#   3 — clone failed
+#   4 — no chunks available (shelf empty)
+#   5 — next_chunk parse error
+
+set -euo pipefail
+
+REPO="romeo111/OpenOnco"
+CLONE_DIR="./openonco"
+NO_CLONE=0
+DRY_RUN=0
+
+usage() {
+  sed -n '3,/^$/p' "$0" | sed -n '/^# /s/^# //p'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)      REPO="$2"; shift 2 ;;
+    --clone-dir) CLONE_DIR="$2"; shift 2 ;;
+    --no-clone)  NO_CLONE=1; shift ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    -h|--help)   usage 0 ;;
+    *)           echo "ERROR: unknown arg $1" >&2; usage 1 >&2 ;;
+  esac
+done
+
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then echo "+ $*"
+  else "$@"
+  fi
+}
+
+echo "TaskTorrent contributor bootstrap"
+echo "================================="
+echo "→ repo:      $REPO"
+echo "→ clone dir: $CLONE_DIR"
+[[ "$NO_CLONE" -eq 1 ]] && echo "→ skipping clone (--no-clone)"
+[[ "$DRY_RUN" -eq 1 ]] && echo "→ DRY-RUN"
+echo
+
+# --- 1. Dependency check ---
+
+echo "Step 1/5: Checking dependencies..."
+for cmd in git gh; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "  ERROR: $cmd not on PATH" >&2
+    echo "    git: https://git-scm.com/" >&2
+    echo "    gh:  https://cli.github.com/" >&2
+    exit 1
+  fi
+done
+
+# Find a Python 3.10+ interpreter from common candidates.
+# PY_CMD is an array so multi-token launchers like `py -3` work.
+PY_CMD=()
+PYTHON_VERSION_RE='Python 3\.(1[0-9]|[2-9][0-9])'
+declare -a CANDIDATES=(
+  "python3"
+  "python"
+  "py -3.12"
+  "py -3.11"
+  "py -3.10"
+  "py -3"
+)
+for candidate in "${CANDIDATES[@]}"; do
+  # shellcheck disable=SC2086
+  ver=$($candidate --version 2>&1 || true)
+  if printf '%s' "$ver" | grep -qE "$PYTHON_VERSION_RE"; then
+    # shellcheck disable=SC2206
+    PY_CMD=($candidate); break
+  fi
+done
+if [[ ${#PY_CMD[@]} -eq 0 ]]; then
+  echo "  ERROR: Python 3.10+ not found." >&2
+  echo "    Tried: ${CANDIDATES[*]}" >&2
+  echo "    Install: https://python.org/ (3.10+)" >&2
+  exit 1
+fi
+echo "  ✓ git, gh, ${PY_CMD[*]} ($("${PY_CMD[@]}" --version 2>&1))"
+
+# --- 2. gh auth ---
+
+echo
+echo "Step 2/5: Checking gh authentication..."
+if ! gh auth status >/dev/null 2>&1; then
+  echo "  Not authenticated. Run: gh auth login" >&2
+  exit 2
+fi
+echo "  ✓ gh authenticated"
+
+# --- 3. Clone (unless --no-clone) ---
+
+REPO_ROOT="$CLONE_DIR"
+if [[ "$NO_CLONE" -eq 0 ]]; then
+  echo
+  echo "Step 3/5: Cloning $REPO..."
+  if [[ -d "$CLONE_DIR/.git" ]]; then
+    echo "  $CLONE_DIR already exists; skipping clone (use git pull manually if you want updates)"
+  else
+    if ! run gh repo clone "$REPO" "$CLONE_DIR"; then
+      echo "  ERROR: clone failed" >&2
+      exit 3
+    fi
+  fi
+else
+  echo
+  echo "Step 3/5: Skipped clone (--no-clone)"
+  REPO_ROOT="."
+fi
+
+# --- 4. Find next chunk ---
+
+echo
+echo "Step 4/5: Finding next claimable chunk..."
+NEXT_JSON_FILE=$(mktemp)
+trap 'rm -f "$NEXT_JSON_FILE"' EXIT
+
+# Run from inside the clone so module path resolves
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "+ (${PY_CMD[*]} -m scripts.tasktorrent.next_chunk --repo $REPO --json-only) > $NEXT_JSON_FILE"
+  echo '  (dry-run: skipping actual fetch)'
+  exit 0
+fi
+
+if [[ -d "$REPO_ROOT/scripts/tasktorrent" ]]; then
+  ( cd "$REPO_ROOT" && "${PY_CMD[@]}" -m scripts.tasktorrent.next_chunk \
+      --repo "$REPO" --json-only ) > "$NEXT_JSON_FILE" || true
+else
+  # Fallback: invoke from current directory
+  "${PY_CMD[@]}" -m scripts.tasktorrent.next_chunk --repo "$REPO" --json-only \
+    > "$NEXT_JSON_FILE" || true
+fi
+
+STATUS=$("${PY_CMD[@]}" -c "import json,sys; print(json.load(open(sys.argv[1])).get('status','error'))" "$NEXT_JSON_FILE" 2>/dev/null || echo "error")
+
+if [[ "$STATUS" == "no_chunks_available" ]]; then
+  echo
+  echo "Shelf is empty — no chunks open for new claims right now."
+  echo "Watch https://github.com/$REPO/issues?q=is%3Aopen+label%3Achunk-task+label%3Astatus-active for new ones."
+  exit 4
+fi
+if [[ "$STATUS" != "ok" ]]; then
+  echo "  ERROR: next_chunk.py returned unexpected status: $STATUS" >&2
+  cat "$NEXT_JSON_FILE" >&2
+  exit 5
+fi
+
+# Extract a few key fields for the orders
+read -r CHUNK_ID ISSUE_NUMBER BRANCH METHOD SPEC_URL DROPS < <(
+  "${PY_CMD[@]}" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+def s(k): return str(d.get(k) or '')
+print(s('chunk_id'), s('issue_number'), s('branch'), s('claim_method'), s('spec_url'), s('drop_estimate'))
+" "$NEXT_JSON_FILE"
+)
+
+# --- 5. Print marching orders ---
+
+echo
+echo "Step 5/5: Marching orders"
+echo "========================="
+echo
+echo "Chunk:         $CHUNK_ID"
+echo "Issue:         #$ISSUE_NUMBER  (https://github.com/$REPO/issues/$ISSUE_NUMBER)"
+echo "Branch:        $BRANCH"
+echo "Claim method:  $METHOD"
+echo "Spec:          $SPEC_URL"
+echo "Drop estimate: $DROPS"
+echo
+echo "To claim and start work:"
+echo
+echo "  cd $REPO_ROOT"
+echo "  scripts/tasktorrent/auto_claim.sh $CHUNK_ID --issue $ISSUE_NUMBER --method $METHOD"
+echo
+echo "Then do the work in $BRANCH on contributions/$CHUNK_ID/."
+echo "Read the chunk spec carefully:  $SPEC_URL"
+echo
+echo "When done:"
+echo "  scripts/tasktorrent/auto_pr.sh $CHUNK_ID --issue $ISSUE_NUMBER"
+echo
+echo "Full JSON for your agent (paste into context):"
+cat "$NEXT_JSON_FILE"

--- a/scripts/tasktorrent/next_chunk.py
+++ b/scripts/tasktorrent/next_chunk.py
@@ -1,0 +1,319 @@
+"""next_chunk — find the next claimable TaskTorrent chunk and emit JSON.
+
+Discovery contract (per docs/reviews/one-prompt-onboarding-plan-2026-04-28.md §4):
+
+    GET /repos/<owner>/<repo>/issues
+        ?labels=chunk-task,status-active
+        &assignee=none
+        &state=open
+
+The oldest unassigned issue wins (FIFO; oldest-first encourages stale-claim
+release before new claims pile on).
+
+Issue body parsing handles the structured headings emitted by
+.github/ISSUE_TEMPLATE/tasktorrent-chunk-task.md:
+
+    ## Chunk Spec               → first https://… URL
+    ## Chunk ID                 → first inline `code` token
+    ## Branch Naming Convention → first inline `code` token
+    ## Sidecar Output Path      → first fenced codeblock body (one line)
+    ## Claim Method             → first inline `code` token; must be one of
+                                  formal-issue / trusted-agent-wip-branch-first
+    ## Drop Estimate            → text + numeric extraction (Drops/tokens)
+    ## Required Skill           → first inline `code` token
+    ## Task Manifest            → first fenced codeblock or bullet list
+    ## Topic Labels             → list of inline `code` tokens
+    ## Acceptance Criteria (machine-checkable) → checklist count
+
+Output (JSON to stdout):
+
+    {
+      "issue_number": 26,
+      "issue_url": "https://github.com/owner/repo/issues/26",
+      "chunk_id": "trial-source-ingest-pubmed",
+      "spec_url": "https://github.com/.../chunks/openonco/<id>.md",
+      "branch": "tasktorrent/trial-source-ingest-pubmed",
+      "sidecar_dir": "contributions/trial-source-ingest-pubmed/",
+      "claim_method": "formal-issue",
+      "drop_estimate": "~3 Drops (~300k tokens)",
+      "drop_estimate_tokens": 300000,
+      "required_skill": "citation-verification",
+      "topic_labels": ["source-ingest", "metadata-classification"],
+      "manifest_preview": ["CROSS", "PARADIGM", ...],
+      "acceptance_criteria_machine_count": 12,
+      "agent_prompt_url_guess": "https://github.com/owner/repo/blob/master/docs/contributing/AGENT_PROMPT_<id>.md"
+    }
+
+Exit codes:
+    0 — success, JSON emitted
+    1 — parse error or issue lookup failed
+    2 — no claimable chunks (`{"status": "no_chunks_available"}` to stdout)
+    3 — gh CLI unavailable
+
+Usage:
+    python -m scripts.tasktorrent.next_chunk
+    python -m scripts.tasktorrent.next_chunk --repo owner/repo
+    python -m scripts.tasktorrent.next_chunk --json-only      # silent on stderr
+    python -m scripts.tasktorrent.next_chunk --offline FILE   # parse a saved JSON dump (testing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO = "romeo111/OpenOnco"
+VALID_CLAIM_METHODS = {"formal-issue", "trusted-agent-wip-branch-first"}
+
+SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+URL_RE = re.compile(r"https?://\S+")
+FENCE_RE = re.compile(r"```[a-zA-Z]*\s*\n(.*?)\n```", re.DOTALL)
+DROPS_NUM_RE = re.compile(r"~?(\d+)\s*Drops?", re.IGNORECASE)
+TOKENS_NUM_RE = re.compile(r"~?(\d+)\s*[kK]\s*tokens", re.IGNORECASE)
+
+
+@dataclass
+class ChunkInfo:
+    issue_number: int
+    issue_url: str
+    chunk_id: str | None = None
+    spec_url: str | None = None
+    branch: str | None = None
+    sidecar_dir: str | None = None
+    claim_method: str | None = None
+    drop_estimate: str | None = None
+    drop_estimate_tokens: int | None = None
+    required_skill: str | None = None
+    topic_labels: list[str] = field(default_factory=list)
+    manifest_preview: list[str] = field(default_factory=list)
+    acceptance_criteria_machine_count: int = 0
+    agent_prompt_url_guess: str | None = None
+    parse_warnings: list[str] = field(default_factory=list)
+
+
+# ---------- Section parsing ----------
+
+def parse_sections(body: str) -> dict[str, str]:
+    """Split issue body into {heading: body} keyed by `## ` headings."""
+    sections: dict[str, str] = {}
+    matches = list(SECTION_RE.finditer(body))
+    for i, m in enumerate(matches):
+        heading = m.group(1).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections[heading] = body[start:end].strip()
+    return sections
+
+
+def first_inline_code(text: str) -> str | None:
+    m = INLINE_CODE_RE.search(text)
+    return m.group(1).strip() if m else None
+
+
+def first_url(text: str) -> str | None:
+    m = URL_RE.search(text)
+    if not m:
+        return None
+    url = m.group(0)
+    # strip trailing punctuation that's not part of a real URL
+    return url.rstrip(".,;)]")
+
+
+def first_fenced_block(text: str) -> str | None:
+    m = FENCE_RE.search(text)
+    return m.group(1).strip() if m else None
+
+
+def all_inline_codes(text: str) -> list[str]:
+    return [c.strip() for c in INLINE_CODE_RE.findall(text)]
+
+
+def parse_drop_estimate(text: str) -> tuple[str, int | None]:
+    """Return (raw_text_first_line, numeric_token_estimate_or_None).
+
+    Token estimate priority: explicit tokens > drops × 100k.
+    """
+    first_line = text.split("\n", 1)[0].strip() if text else ""
+    tokens: int | None = None
+    tm = TOKENS_NUM_RE.search(text)
+    if tm:
+        tokens = int(tm.group(1)) * 1000
+    else:
+        dm = DROPS_NUM_RE.search(text)
+        if dm:
+            tokens = int(dm.group(1)) * 100000
+    return first_line, tokens
+
+
+def parse_manifest(text: str) -> list[str]:
+    """Extract manifest entries; prefer fenced block, fall back to bullet list."""
+    block = first_fenced_block(text)
+    if block:
+        items = re.split(r"[,\n]", block)
+        return [i.strip() for i in items if i.strip() and not i.strip().startswith("#")]
+    bullets = re.findall(r"^\s*[-*]\s+(.+?)\s*$", text, re.MULTILINE)
+    return [b.strip("`") for b in bullets if b]
+
+
+def count_machine_acceptance(text: str) -> int:
+    return len(re.findall(r"^\s*-\s*\[\s?\]\s+", text, re.MULTILINE))
+
+
+# ---------- Issue body → ChunkInfo ----------
+
+def parse_issue(issue: dict) -> ChunkInfo:
+    info = ChunkInfo(
+        issue_number=issue["number"],
+        issue_url=issue.get("url", issue.get("html_url", "")),
+    )
+    body = issue.get("body") or ""
+    sections = parse_sections(body)
+
+    if "Chunk Spec" in sections:
+        info.spec_url = first_url(sections["Chunk Spec"])
+    if "Chunk ID" in sections:
+        info.chunk_id = first_inline_code(sections["Chunk ID"])
+    if "Branch Naming Convention" in sections:
+        info.branch = first_inline_code(sections["Branch Naming Convention"])
+    elif "Branch Naming" in sections:
+        info.branch = first_inline_code(sections["Branch Naming"])
+    if "Sidecar Output Path" in sections:
+        block = first_fenced_block(sections["Sidecar Output Path"])
+        info.sidecar_dir = block.strip() if block else None
+
+    if "Claim Method" in sections:
+        cm = first_inline_code(sections["Claim Method"])
+        if cm and cm in VALID_CLAIM_METHODS:
+            info.claim_method = cm
+        else:
+            info.parse_warnings.append(
+                f"Claim Method `{cm}` not in {sorted(VALID_CLAIM_METHODS)}"
+            )
+
+    if "Drop Estimate" in sections:
+        info.drop_estimate, info.drop_estimate_tokens = parse_drop_estimate(
+            sections["Drop Estimate"]
+        )
+
+    if "Required Skill" in sections:
+        info.required_skill = first_inline_code(sections["Required Skill"])
+    if "Topic Labels" in sections:
+        info.topic_labels = all_inline_codes(sections["Topic Labels"])
+    if "Task Manifest" in sections:
+        info.manifest_preview = parse_manifest(sections["Task Manifest"])[:20]
+
+    machine_section = sections.get("Acceptance Criteria (machine-checkable)") or ""
+    info.acceptance_criteria_machine_count = count_machine_acceptance(machine_section)
+
+    # Required-section sanity
+    for req in ("Chunk Spec", "Chunk ID", "Claim Method"):
+        if req not in sections:
+            info.parse_warnings.append(f"missing required section: {req}")
+
+    if info.chunk_id and info.issue_url:
+        m = re.match(r"https?://[^/]+/([^/]+)/([^/]+)/", info.issue_url)
+        if m:
+            owner, repo = m.group(1), m.group(2)
+            info.agent_prompt_url_guess = (
+                f"https://github.com/{owner}/{repo}/blob/master/"
+                f"docs/contributing/AGENT_PROMPT_{info.chunk_id}.md"
+            )
+    return info
+
+
+# ---------- gh CLI integration ----------
+
+def gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def fetch_open_chunks(repo: str) -> list[dict]:
+    """Query GitHub for open status-active chunk-task issues with no assignee."""
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--label", "chunk-task,status-active",
+        "--state", "open",
+        "--limit", "50",
+        "--json", "number,title,body,assignees,labels,createdAt,url",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if res.returncode != 0:
+        raise RuntimeError(f"gh issue list failed: {res.stderr.strip()}")
+    issues = json.loads(res.stdout or "[]")
+    # Filter to unassigned only — gh doesn't have a `--no-assignee` flag
+    unassigned = [i for i in issues if not i.get("assignees")]
+    # Oldest first (FIFO); avoid `-r` to keep the script simple
+    unassigned.sort(key=lambda i: i.get("createdAt", ""))
+    return unassigned
+
+
+# ---------- CLI ----------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="scripts.tasktorrent.next_chunk",
+        description="Find the next claimable TaskTorrent chunk and emit JSON.",
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help=f"GitHub repo (default: {DEFAULT_REPO})")
+    parser.add_argument("--json-only", action="store_true", help="suppress stderr human-readable output")
+    parser.add_argument(
+        "--offline",
+        type=Path,
+        default=None,
+        help="path to a JSON file containing a list of issue dicts (for testing)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.offline:
+        try:
+            issues = json.loads(args.offline.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"ERROR: cannot read offline file: {e}", file=sys.stderr)
+            return 1
+        if not isinstance(issues, list):
+            print("ERROR: offline file must contain a list of issue dicts", file=sys.stderr)
+            return 1
+        unassigned = [i for i in issues if not i.get("assignees")]
+        unassigned.sort(key=lambda i: i.get("createdAt", ""))
+    else:
+        if not gh_available():
+            print("ERROR: gh CLI not on PATH; install from https://cli.github.com/", file=sys.stderr)
+            return 3
+        try:
+            unassigned = fetch_open_chunks(args.repo)
+        except (RuntimeError, subprocess.TimeoutExpired) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+
+    if not unassigned:
+        print(json.dumps({"status": "no_chunks_available"}))
+        return 2
+
+    pick = unassigned[0]
+    info = parse_issue(pick)
+
+    out = asdict(info)
+    out["status"] = "ok"
+    print(json.dumps(out, indent=2))
+
+    if not args.json_only:
+        rest = len(unassigned) - 1
+        if rest > 0:
+            print(f"\n{rest} more claimable chunk(s) in queue.", file=sys.stderr)
+        if info.parse_warnings:
+            print(f"WARNINGS: {info.parse_warnings}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_tasktorrent_next_chunk.py
+++ b/tests/test_tasktorrent_next_chunk.py
@@ -1,0 +1,272 @@
+"""Tests for scripts.tasktorrent.next_chunk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.tasktorrent.next_chunk import (
+    ChunkInfo,
+    all_inline_codes,
+    count_machine_acceptance,
+    first_fenced_block,
+    first_inline_code,
+    first_url,
+    main,
+    parse_drop_estimate,
+    parse_issue,
+    parse_manifest,
+    parse_sections,
+)
+
+
+# ---------- Real-issue fixture (shape from issue #26 trial-source-ingest-pubmed) ----------
+
+REAL_ISSUE_BODY = """## Chunk Spec
+
+Full spec: https://github.com/romeo111/task_torrent/blob/main/chunks/openonco/trial-source-ingest-pubmed.md
+
+## Chunk ID
+
+`trial-source-ingest-pubmed`
+
+## Topic Labels
+
+`source-ingest`, `metadata-classification`, `pubmed-fetch`
+
+## Drop Estimate
+
+~3 Drops (~300k tokens). 47 candidate trials × ~6k tokens each.
+
+## Required Skill
+
+`citation-verification` (license classification + metadata extraction).
+
+## Branch Naming Convention
+
+`tasktorrent/trial-source-ingest-pubmed`
+
+## Sidecar Output Path
+
+```
+contributions/trial-source-ingest-pubmed/
+```
+
+## Claim Method
+
+`formal-issue` — comment to claim, maintainer assigns within 24h SLA.
+
+## Task Manifest
+
+48 candidate trial names from the v2 audit.
+
+```
+CROSS, PARADIGM, RUBY, NRG-GY018, PAOLA-1, AIDA, CODEBREAK
+```
+
+## Allowed Sources
+
+PubMed E-utilities.
+
+## Acceptance Criteria (machine-checkable)
+
+- [ ] Every sidecar has `_contribution.ai_tool` and `_contribution.ai_model` set.
+- [ ] PR branch name matches `tasktorrent/trial-source-ingest-pubmed`.
+- [ ] `task_manifest.txt` contains the 48 trial names.
+
+## Acceptance Criteria (semantic, maintainer-checked)
+
+- [ ] False-positive filter ≥ 90% accurate.
+"""
+
+
+def make_issue(**overrides) -> dict:
+    base = {
+        "number": 26,
+        "title": "[Chunk] trial-source-ingest-pubmed",
+        "body": REAL_ISSUE_BODY,
+        "assignees": [],
+        "labels": [{"name": "chunk-task"}, {"name": "status-active"}],
+        "createdAt": "2026-04-28T18:00:00Z",
+        "url": "https://github.com/romeo111/OpenOnco/issues/26",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------- Section + helper unit tests ----------
+
+def test_parse_sections_simple() -> None:
+    md = "Pre.\n\n## A\n\nA-body\n\n## B\n\nB-body line\n"
+    secs = parse_sections(md)
+    assert secs == {"A": "A-body", "B": "B-body line"}
+
+
+def test_first_inline_code_strips_backticks() -> None:
+    assert first_inline_code("`formal-issue`") == "formal-issue"
+    assert first_inline_code("Some prose then `value` then more.") == "value"
+
+
+def test_first_inline_code_returns_none_when_absent() -> None:
+    assert first_inline_code("plain prose, no code") is None
+
+
+def test_first_url_strips_trailing_punct() -> None:
+    assert first_url("see https://example.com/x.md.") == "https://example.com/x.md"
+    assert first_url("link: (https://example.com/y)") == "https://example.com/y"
+
+
+def test_first_fenced_block_yaml_or_plain() -> None:
+    text = "prose\n```\nline1\nline2\n```\nmore"
+    assert first_fenced_block(text) == "line1\nline2"
+    text2 = "prose\n```yaml\nfoo: 1\n```\nmore"
+    assert first_fenced_block(text2) == "foo: 1"
+
+
+def test_all_inline_codes_collects_all() -> None:
+    assert all_inline_codes("`a`, `b`, `c`") == ["a", "b", "c"]
+
+
+def test_parse_drop_estimate_tokens_priority() -> None:
+    text, tok = parse_drop_estimate("~3 Drops (~300k tokens). lots of detail.")
+    assert "300k" in text or "Drops" in text
+    assert tok == 300_000
+
+
+def test_parse_drop_estimate_drops_fallback() -> None:
+    _, tok = parse_drop_estimate("~5 Drops, no token figure")
+    assert tok == 500_000
+
+
+def test_parse_drop_estimate_neither() -> None:
+    raw, tok = parse_drop_estimate("vaguely large work")
+    assert raw == "vaguely large work"
+    assert tok is None
+
+
+def test_parse_manifest_fenced_block() -> None:
+    text = "prose\n```\nA, B, C\n```"
+    assert parse_manifest(text) == ["A", "B", "C"]
+
+
+def test_parse_manifest_bullet_list_fallback() -> None:
+    text = "Items:\n- BMA-X\n- BMA-Y\n"
+    assert parse_manifest(text) == ["BMA-X", "BMA-Y"]
+
+
+def test_count_machine_acceptance() -> None:
+    text = "- [ ] one\n- [ ] two\n- [x] done\n- [ ] three"
+    # Counts unchecked boxes ([ ]); does not count [x]
+    assert count_machine_acceptance(text) == 3
+
+
+# ---------- parse_issue end-to-end ----------
+
+def test_parse_issue_real_shape() -> None:
+    info = parse_issue(make_issue())
+    assert info.issue_number == 26
+    assert info.chunk_id == "trial-source-ingest-pubmed"
+    assert info.spec_url == "https://github.com/romeo111/task_torrent/blob/main/chunks/openonco/trial-source-ingest-pubmed.md"
+    assert info.branch == "tasktorrent/trial-source-ingest-pubmed"
+    assert info.sidecar_dir == "contributions/trial-source-ingest-pubmed/"
+    assert info.claim_method == "formal-issue"
+    assert info.drop_estimate_tokens == 300_000
+    assert info.required_skill == "citation-verification"
+    assert "source-ingest" in info.topic_labels
+    assert info.acceptance_criteria_machine_count == 3
+    assert info.manifest_preview[:3] == ["CROSS", "PARADIGM", "RUBY"]
+    assert info.parse_warnings == []
+    assert info.agent_prompt_url_guess == (
+        "https://github.com/romeo111/OpenOnco/blob/master/"
+        "docs/contributing/AGENT_PROMPT_trial-source-ingest-pubmed.md"
+    )
+
+
+def test_parse_issue_invalid_claim_method_warns() -> None:
+    body = REAL_ISSUE_BODY.replace("`formal-issue`", "`open-bidding`")
+    info = parse_issue(make_issue(body=body))
+    assert info.claim_method is None
+    assert any("open-bidding" in w for w in info.parse_warnings)
+
+
+def test_parse_issue_missing_section_warns() -> None:
+    # Drop the entire Chunk ID section
+    body = REAL_ISSUE_BODY.replace(
+        "## Chunk ID\n\n`trial-source-ingest-pubmed`\n\n", ""
+    )
+    info = parse_issue(make_issue(body=body))
+    assert any("Chunk ID" in w for w in info.parse_warnings)
+
+
+def test_parse_issue_branch_naming_alt_heading() -> None:
+    body = REAL_ISSUE_BODY.replace("## Branch Naming Convention", "## Branch Naming")
+    info = parse_issue(make_issue(body=body))
+    assert info.branch == "tasktorrent/trial-source-ingest-pubmed"
+
+
+# ---------- CLI offline-mode integration ----------
+
+def write_issues(tmp_path: Path, issues: list[dict]) -> Path:
+    p = tmp_path / "issues.json"
+    p.write_text(json.dumps(issues), encoding="utf-8")
+    return p
+
+
+def test_cli_offline_picks_oldest(tmp_path: Path, capsys) -> None:
+    older = make_issue(number=26, createdAt="2026-04-28T18:00:00Z")
+    newer = make_issue(
+        number=27,
+        createdAt="2026-04-28T19:00:00Z",
+        body=REAL_ISSUE_BODY.replace("trial-source-ingest-pubmed", "other-chunk"),
+    )
+    p = write_issues(tmp_path, [newer, older])  # intentionally out of order
+    rc = main(["--offline", str(p), "--json-only"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["issue_number"] == 26
+    assert out["chunk_id"] == "trial-source-ingest-pubmed"
+    assert out["status"] == "ok"
+
+
+def test_cli_offline_skips_assigned(tmp_path: Path, capsys) -> None:
+    assigned = make_issue(number=26, assignees=[{"login": "someone"}])
+    available = make_issue(
+        number=27,
+        body=REAL_ISSUE_BODY.replace("trial-source-ingest-pubmed", "open-chunk"),
+        createdAt="2026-04-28T20:00:00Z",
+    )
+    p = write_issues(tmp_path, [assigned, available])
+    rc = main(["--offline", str(p), "--json-only"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["issue_number"] == 27
+
+
+def test_cli_offline_no_chunks(tmp_path: Path, capsys) -> None:
+    p = write_issues(tmp_path, [])
+    rc = main(["--offline", str(p), "--json-only"])
+    assert rc == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"status": "no_chunks_available"}
+
+
+def test_cli_offline_all_assigned(tmp_path: Path, capsys) -> None:
+    assigned = make_issue(assignees=[{"login": "x"}])
+    p = write_issues(tmp_path, [assigned])
+    rc = main(["--offline", str(p), "--json-only"])
+    assert rc == 2
+
+
+def test_cli_offline_bad_file(tmp_path: Path, capsys) -> None:
+    p = tmp_path / "missing.json"
+    rc = main(["--offline", str(p), "--json-only"])
+    assert rc == 1
+
+
+def test_cli_offline_bad_shape(tmp_path: Path) -> None:
+    p = tmp_path / "wrong.json"
+    p.write_text(json.dumps({"not": "a list"}), encoding="utf-8")
+    rc = main(["--offline", str(p), "--json-only"])
+    assert rc == 1

--- a/tests/test_tasktorrent_scripts_smoke.py
+++ b/tests/test_tasktorrent_scripts_smoke.py
@@ -1,0 +1,141 @@
+"""Smoke tests for the bash-based onboarding scripts.
+
+These don't replace shell-level tests (bats/shellcheck) but verify:
+  - Syntax via `bash -n`
+  - Exit codes + dry-run output for known-good inputs
+  - Pre-flight error paths (auto_pr rejects wrong-branch / missing sidecar)
+
+Skipped when bash is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts" / "tasktorrent"
+SCRIPTS = ["auto_claim.sh", "auto_pr.sh", "bootstrap_contributor.sh"]
+
+if not shutil.which("bash"):
+    pytest.skip("bash not on PATH", allow_module_level=True)
+
+
+def run_bash(args: list[str], cwd: Path | None = None, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Invoke bash <script> <args> with default cwd at repo root."""
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        ["bash", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd or SCRIPTS_DIR.parent.parent,
+        env=full_env,
+        timeout=30,
+    )
+
+
+# ---------- Syntax check ----------
+
+@pytest.mark.parametrize("script", SCRIPTS)
+def test_script_syntax_valid(script: str) -> None:
+    res = subprocess.run(
+        ["bash", "-n", str(SCRIPTS_DIR / script)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert res.returncode == 0, f"bash -n failed for {script}: {res.stderr}"
+
+
+# ---------- auto_claim.sh ----------
+
+def test_auto_claim_no_chunk_id_fails() -> None:
+    res = run_bash([str(SCRIPTS_DIR / "auto_claim.sh")])
+    assert res.returncode == 1
+    assert "chunk-id is required" in res.stderr
+
+
+def test_auto_claim_invalid_method_fails() -> None:
+    res = run_bash(
+        [str(SCRIPTS_DIR / "auto_claim.sh"), "test-chunk",
+         "--method", "open-bidding", "--issue", "1", "--dry-run"]
+    )
+    assert res.returncode == 1
+    assert "invalid --method" in res.stderr
+
+
+def test_auto_claim_formal_issue_dry_run() -> None:
+    res = run_bash(
+        [str(SCRIPTS_DIR / "auto_claim.sh"), "test-chunk",
+         "--method", "formal-issue", "--issue", "999", "--dry-run"]
+    )
+    assert res.returncode == 0
+    assert "DRY-RUN" in res.stdout
+    assert "+ gh issue comment 999" in res.stdout
+    assert "I'd like to take this chunk" in res.stdout
+
+
+def test_auto_claim_trusted_agent_dry_run() -> None:
+    res = run_bash(
+        [str(SCRIPTS_DIR / "auto_claim.sh"), "test-chunk",
+         "--method", "trusted-agent-wip-branch-first", "--dry-run"]
+    )
+    assert res.returncode == 0
+    assert "+ git checkout -b tasktorrent/test-chunk" in res.stdout
+    assert "+ git commit --allow-empty" in res.stdout
+    assert "+ git push -u origin tasktorrent/test-chunk" in res.stdout
+
+
+def test_auto_claim_formal_issue_requires_issue_number() -> None:
+    """Without --issue and without resolvable repo issues, formal-issue must fail."""
+    # Use a repo unlikely to have a chunk-task issue matching "definitely-fake-chunk"
+    res = run_bash(
+        [str(SCRIPTS_DIR / "auto_claim.sh"), "definitely-fake-chunk",
+         "--method", "formal-issue",
+         "--repo", "romeo111/OpenOnco",
+         "--dry-run"]
+    )
+    assert res.returncode == 1
+    assert "formal-issue claim requires --issue" in res.stderr
+
+
+# ---------- auto_pr.sh ----------
+
+def test_auto_pr_no_chunk_id_fails() -> None:
+    res = run_bash([str(SCRIPTS_DIR / "auto_pr.sh")])
+    assert res.returncode == 1
+
+
+def test_auto_pr_pre_flight_wrong_branch_fails() -> None:
+    """We're on feat/tasktorrent-next-chunk-cli, not on tasktorrent/test-chunk."""
+    res = run_bash(
+        [str(SCRIPTS_DIR / "auto_pr.sh"), "test-chunk", "--dry-run"]
+    )
+    assert res.returncode == 3
+    assert "pre-flight failed" in res.stderr
+
+
+# ---------- bootstrap_contributor.sh ----------
+
+def test_bootstrap_dry_run_with_no_clone() -> None:
+    res = run_bash(
+        [str(SCRIPTS_DIR / "bootstrap_contributor.sh"), "--no-clone", "--dry-run"]
+    )
+    # Possible outcomes:
+    #   0 — dry-run completed
+    #   1 — local Python missing
+    #   2 — gh not authenticated (CI without gh login may hit this)
+    assert res.returncode in (0, 1, 2)
+    assert "TaskTorrent contributor bootstrap" in res.stdout
+
+
+def test_bootstrap_unknown_arg_fails() -> None:
+    res = run_bash(
+        [str(SCRIPTS_DIR / "bootstrap_contributor.sh"), "--bogus-flag"]
+    )
+    assert res.returncode == 1


### PR DESCRIPTION
## Summary

Complete one-prompt contributor onboarding kit for OpenOnco TaskTorrent. Per [`docs/reviews/one-prompt-onboarding-plan-2026-04-28.md`](https://github.com/romeo111/OpenOnco/blob/docs/one-prompt-onboarding-plan-2026-04-28/docs/reviews/one-prompt-onboarding-plan-2026-04-28.md) §5.1 + §5.3.

Pairs with [task_torrent PR #20](https://github.com/romeo111/task_torrent/pull/20) (cross-repo canonical contract).

## OpenOnco-side scripts (§5.1)

| File | Lines | Purpose |
|---|---:|---|
| `scripts/tasktorrent/next_chunk.py` | 230 | Discover next claimable chunk; emit JSON for agent context |
| `scripts/tasktorrent/auto_claim.sh` | 130 | Claim per declared method (formal-issue OR trusted-agent-wip-branch-first); auto-detects from issue body |
| `scripts/tasktorrent/auto_pr.sh` | 165 | Pre-flight (branch+tree+sidecar+allowlist+validator) → `gh pr create` |
| `scripts/tasktorrent/bootstrap_contributor.sh` | 165 | Pipeline: deps + auth + clone + next_chunk + marching-orders printout |
| `scripts/tasktorrent/README.md` | — | Script index for contributors + maintainers |
| `docs/contributing/PROMPT_PASTE_AND_GO.md` | — | Canonical 8-line paste-and-go prompt |
| `docs/contributing/CONTRIBUTOR_QUICKSTART.md` | +12 | "Fastest path" callout pointing to bootstrap |

## Public landing (§5.3)

| File | Purpose |
|---|---|
| `docs/contribute.html` | UA landing — inline 8-line prompt, requirements, rejection criteria |
| `docs/en/contribute.html` | English mirror |

NOT yet linked from main nav (per onboarding plan §6 GA gate — flip discoverability after citation-verifier in CI lands). URL is reachable for early-access contributors.

## Cross-repo contract (§5.2 partial)

| File | Purpose |
|---|---|
| `docs/contributing/cross-repo-contract.md` | Mirror of canonical contract in `task_torrent/docs/cross-repo-contract.md` (frontmatter `synced_from`) |

The canonical lives in [task_torrent PR #20](https://github.com/romeo111/task_torrent/pull/20).

## Tests

| Suite | Tests | Status |
|---|---:|---|
| `tests/test_tasktorrent_next_chunk.py` | 22 | ✅ all passing |
| `tests/test_tasktorrent_scripts_smoke.py` | 12 | ✅ all passing |

```
34 passed in 1.84s
```

## Live smoke

```bash
$ python -m scripts.tasktorrent.next_chunk --json-only
{"status": "no_chunks_available"}
```

```bash
$ bash scripts/tasktorrent/bootstrap_contributor.sh --no-clone
TaskTorrent contributor bootstrap
=================================
Step 1/5: Checking dependencies...  ✓ git, gh, py -3.12 (Python 3.12.5)
Step 2/5: Checking gh authentication...  ✓ gh authenticated
Step 4/5: Finding next claimable chunk...
Shelf is empty — no chunks open for new claims right now.
```

```bash
$ bash scripts/tasktorrent/auto_pr.sh test-chunk --dry-run
ERROR: pre-flight failed — on branch 'feat/tasktorrent-next-chunk-cli', expected 'tasktorrent/test-chunk'
```

Pre-flight error paths verified.

## Hard invariants enforced by the kit

- Allowlist: `auto_pr.sh` rejects PRs with files outside `contributions/<chunk-id>/`
- Sidecar minimum: `_contribution_meta.yaml` + `task_manifest.txt` required
- Validator gate: blocks PR open if `validate_contributions.py` fails
- Claim methods: only `formal-issue` and `trusted-agent-wip-branch-first` accepted
- Banned sources (CHARTER §2): `SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`
- No medical advice / patient data (CHARTER §8.3 / §9.3)
- No `git add -A`, no `--no-verify`

## What's NOT in this PR

- **Public-landing nav-link flip** — gated on `feat/citation-verifier` landing in CI (per onboarding plan §6)
- **Static `chunks/index.json`** in task_torrent — optional per plan §5.2; defer
- **Sync-check CI** for cross-repo-contract.md drift detection — defer to v0.5
- **Severity / Min Contributor Tier / Verifier Threshold** chunk-spec fields — separate workstream (cross-repo plan §3.1 Proposals #22/#23/#24)
- **SHA-256 trust** for bootstrap script — per plan one-line note for v0.2

## Branched off origin/master

Local master locked by parallel worktree (`feat/regimen-phases-refactor` agent). Branch base is `origin/master` to avoid touching shared state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)