### PR TITLE
fix(engine): close 4 KB-drift defects surfaced by curated examples (PR #150)

### DIFF
--- a/examples/patient_breast_her2_pos_met_2l_tdxd.json
+++ b/examples/patient_breast_her2_pos_met_2l_tdxd.json
@@ -2,6 +2,7 @@
   "patient_id": "BREAST-HER2-MET-2L-001",
   "comment": "Synthetic metastatic HER2-positive breast cancer, female 54, prior progression on 1L THP (docetaxel + trastuzumab + pertuzumab CLEOPATRA backbone). Engine should fire RF-BREAST-HER2-AMP-ACTIONABLE → ALGO-BREAST-HER2-POS-2L step 1 PASS → step 2 brain-mets-negative → IND-BREAST-HER2-POS-MET-2L-TDXD (DESTINY-Breast03, mPFS 28.8 mo).",
   "disease": {"id": "DIS-BREAST"},
+  "disease_state": "HER2-positive",
   "line_of_therapy": 2,
   "biomarkers": {
     "BIO-HER2-SOLID": "positive",

--- a/examples/patient_breast_hr_pos_post_cdk46i_pik3ca_alpelisib.json
+++ b/examples/patient_breast_hr_pos_post_cdk46i_pik3ca_alpelisib.json
@@ -2,6 +2,7 @@
   "patient_id": "BREAST-HR-2L-PIK3CA-001",
   "comment": "Synthetic HR+/HER2- metastatic breast cancer, female 62 postmenopausal, prior progression on AI + palbociclib (PALOMA-2). Tumor NGS: PIK3CA H1047R hotspot mutation. Anchor target: alpelisib + fulvestrant (SOLAR-1). Engine: ALGO-BREAST-HR-POS-2L step 0 BRCA-neg → step 1 RF-BREAST-PIK3CA-MUT-ACTIONABLE fires → IND-BREAST-HR-POS-2L-AKT-CAPIVASERTIB (CAPItello-291) — observed routing recorded after smoke test.",
   "disease": {"id": "DIS-BREAST"},
+  "disease_state": "HR-positive_HER2-negative",
   "line_of_therapy": 2,
   "biomarkers": {
     "BIO-ER": "positive",

--- a/examples/patient_breast_tnbc_met_sacituzumab_2l.json
+++ b/examples/patient_breast_tnbc_met_sacituzumab_2l.json
@@ -2,6 +2,7 @@
   "patient_id": "BREAST-TNBC-2L-SACI-001",
   "comment": "Synthetic metastatic TNBC, female 47, prior progression on 1L pembrolizumab + carboplatin + paclitaxel (KEYNOTE-355). Tumor: ER<1%, PR<1%, HER2 IHC 0; germline BRCA1/2 wild-type. Anchor: ASCENT → sacituzumab govitecan. Engine: line=2 dispatches to ALGO-BREAST-HER2-POS-2L per current KB load order — drift from anchor recorded; the curated profile still represents an authentic clinical path even if the KB router lands elsewhere.",
   "disease": {"id": "DIS-BREAST"},
+  "disease_state": "TNBC",
   "line_of_therapy": 2,
   "biomarkers": {
     "BIO-ER": "negative",

--- a/knowledge_base/engine/_track_filter.py
+++ b/knowledge_base/engine/_track_filter.py
@@ -176,10 +176,12 @@ def _matches_excluded_value(patient_value: Any, exclusion_spec: Any) -> bool:
 
     pv = (variant or "").strip().lower()
     if not pv:
-        # Patient is gene-level positive ("positive"/True) and the
-        # exclusion is qualified — be conservative and treat any positive
-        # presence as a match (lenient toward exclusion when explicit).
-        return True
+        # Patient is gene-level positive (no specific variant string), but
+        # the exclusion is qualified by a value_constraint. The patient has
+        # not reported the qualifying condition, so don't drop the track —
+        # consistent with the file's "missing biomarkers do not drop a
+        # track" stance. The clinician decides on the more nuanced data.
+        return False
 
     for expected in expected_values:
         ev = expected.strip().lower()

--- a/knowledge_base/engine/plan.py
+++ b/knowledge_base/engine/plan.py
@@ -155,13 +155,50 @@ def _find_disease_id(patient: dict, entities_by_id: dict) -> Optional[str]:
     return None
 
 
-def _find_algorithm(disease_id: str, line: int, entities_by_id: dict) -> Optional[dict]:
-    for eid, info in entities_by_id.items():
+def _find_algorithm(
+    disease_id: str,
+    line: int,
+    entities_by_id: dict,
+    disease_state: Optional[str] = None,
+) -> Optional[dict]:
+    """Find the algorithm matching disease + line, with optional disease_state
+    disambiguation.
+
+    When multiple algorithms exist for the same disease + line (e.g. prostate
+    mHSPC vs mCRPC), the patient's `disease_state` selects the right one.
+    Match priority: state-matched > state-agnostic. State-mismatched
+    algorithms are never returned.
+    """
+    state_matched: list[dict] = []
+    state_agnostic: list[dict] = []
+    state_specific_any: list[dict] = []  # legacy fallback only
+    patient_state = (disease_state or "").strip().lower() or None
+    for info in entities_by_id.values():
         if info["type"] != "algorithms":
             continue
         d = info["data"]
-        if d.get("applicable_to_disease") == disease_id and d.get("applicable_to_line_of_therapy") == line:
-            return d
+        if d.get("applicable_to_disease") != disease_id:
+            continue
+        if d.get("applicable_to_line_of_therapy") != line:
+            continue
+        algo_state_raw = d.get("applicable_to_disease_state")
+        if algo_state_raw is None:
+            state_agnostic.append(d)
+            continue
+        state_specific_any.append(d)
+        algo_state = str(algo_state_raw).strip().lower()
+        if patient_state and algo_state == patient_state:
+            state_matched.append(d)
+        # else: state set on algorithm but does not match patient → skip
+    if state_matched:
+        return state_matched[0]
+    if state_agnostic:
+        return state_agnostic[0]
+    # Legacy patient profile (no disease_state) and only state-specific
+    # algorithms exist → load-order fallback to avoid breaking older cases.
+    # The caller emits a warning so the gap is visible.
+    if patient_state is None and state_specific_any:
+        return state_specific_any[0]
     return None
 
 
@@ -346,12 +383,26 @@ def generate_plan(
     result.disease_id = disease_id
 
     line = int(patient.get("line_of_therapy", 1))
-    algo = _find_algorithm(disease_id, line, entities)
+    patient_disease_state = patient.get("disease_state") or (
+        (patient.get("disease") or {}).get("state")
+        if isinstance(patient.get("disease"), dict)
+        else None
+    )
+    algo = _find_algorithm(disease_id, line, entities, disease_state=patient_disease_state)
     if algo is None:
+        state_suffix = f", disease_state={patient_disease_state}" if patient_disease_state else ""
         result.warnings.append(
-            f"No Algorithm found for disease={disease_id}, line_of_therapy={line}"
+            f"No Algorithm found for disease={disease_id}, line_of_therapy={line}{state_suffix}"
         )
         return result
+    if (
+        patient_disease_state is None
+        and algo.get("applicable_to_disease_state") is not None
+    ):
+        result.warnings.append(
+            f"patient.disease_state is missing — fell back to {algo['id']} by load-order; "
+            f"set disease_state explicitly to disambiguate (e.g. 'mHSPC' vs 'mCRPC')"
+        )
     result.algorithm_id = algo["id"]
 
     # Flatten findings + biomarkers + demographics for clause evaluation

--- a/knowledge_base/hosted/content/algorithms/algo_breast_her2_pos_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_breast_her2_pos_2l.yaml
@@ -1,5 +1,6 @@
 id: ALGO-BREAST-HER2-POS-2L
 applicable_to_disease: DIS-BREAST
+applicable_to_disease_state: HER2-positive
 applicable_to_line_of_therapy: 2
 purpose: >
   Select 2L+ HER2+ metastatic breast Indication after progression

--- a/knowledge_base/hosted/content/algorithms/algo_breast_hr_pos_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_breast_hr_pos_2l.yaml
@@ -1,5 +1,6 @@
 id: ALGO-BREAST-HR-POS-2L
 applicable_to_disease: DIS-BREAST
+applicable_to_disease_state: HR-positive_HER2-negative
 applicable_to_line_of_therapy: 2
 purpose: >
   Select 2L+ HR+/HER2- metastatic breast Indication after progression

--- a/knowledge_base/hosted/content/algorithms/algo_breast_tnbc_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_breast_tnbc_2l.yaml
@@ -1,5 +1,6 @@
 id: ALGO-BREAST-TNBC-2L
 applicable_to_disease: DIS-BREAST
+applicable_to_disease_state: TNBC
 applicable_to_line_of_therapy: 2
 purpose: >
   Select 2L+ TNBC metastatic Indication after progression on 1L

--- a/knowledge_base/hosted/content/algorithms/algo_endometrial_advanced_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_endometrial_advanced_1l.yaml
@@ -9,10 +9,12 @@ decision_tree:
   - step: 1
     evaluate:
       any_of:
-        - {condition: "dMMR / MSI-high tumor"}
+        - {finding: mmr_status, value: deficient}
+        - {finding: msi_status, value: MSI-H}
+        - {finding: msi_status, value: MSI-high}
     if_true: {result: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO}
     if_false: {result: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO}
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: "Gate replaced free-text condition with structured finding lookups for dMMR (mmr_status=deficient) and MSI-H (msi_status=MSI-H/MSI-high) — both label as eligible for dostarlimab arm."
 sources: [SRC-NCCN-UTERINE-2025, SRC-ESMO-ENDOMETRIAL-2022]
 last_reviewed: null
 notes: "Both pembro and dostarlimab approved; chemoimmuno superior to chemo alone regardless of MMR."

--- a/knowledge_base/hosted/content/algorithms/algo_gastric_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gastric_metastatic_1l.yaml
@@ -36,12 +36,12 @@ decision_tree:
     evaluate:
       all_of:
         - red_flag: RF-GASTRIC-PDL1-CPS-1-PLUS
-        - condition: "HER2-negative"
+        - {finding: her2_status, value: negative}
     if_true:
       result: IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI
     if_false:
       result: IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI
-    notes: "Partially wired - RF-GASTRIC-PDL1-CPS-1-PLUS gates ICI add-on (CheckMate-649 FOLFOX+nivo); HER2-negative criterion kept as MDT-text (HER2+ pre-routed at step 1)."
+    notes: "RF-GASTRIC-PDL1-CPS-1-PLUS gates ICI add-on (CheckMate-649 FOLFOX+nivo); HER2-negative criterion now structured as finding lookup (HER2+ already pre-routed at step 1)."
 
 sources:
   - SRC-NCCN-GASTRIC-2025

--- a/knowledge_base/hosted/content/algorithms/algo_urothelial_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_urothelial_metastatic_1l.yaml
@@ -9,10 +9,10 @@ decision_tree:
   - step: 1
     evaluate:
       any_of:
-        - {condition: "Patient eligible for EV+pembro (no severe diabetes, neuropathy, ocular)"}
+        - {finding: ev_pembro_eligible, value: true}
     if_true: {result: IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO}
     if_false: {result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB}
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: "Gate replaced free-text condition with structured finding lookup (EV+pembro eligibility composite — see patient_urothelial_muc_ev_pembro fixture). RF authoring still owed for the composite criteria (no severe diabetes / neuropathy / ocular disease)."
 sources: [SRC-NCCN-BLADDER-2025, SRC-EAU-BLADDER-2024]
 last_reviewed: null
 notes: "EV-302 paradigm shift."

--- a/tests/test_engine_find_algorithm.py
+++ b/tests/test_engine_find_algorithm.py
@@ -113,3 +113,36 @@ def test_disease_id_mismatch_returns_none():
 def test_line_mismatch_returns_none():
     entities = _build_entities()
     assert _find_algorithm("DIS-PROSTATE", 2, entities, disease_state="mCRPC") is None
+
+
+# ── End-to-end via generate_plan: breast 2L subtype routing ─────────────
+
+
+def test_breast_2l_subtype_routing_via_disease_state():
+    """Three breast 2L algorithms (HER2-POS, HR-POS, TNBC) collide on
+    disease + line. With disease_state populated on both algorithms and
+    patients, each subtype routes to its correct algorithm.
+
+    Regression for PR #150 KB-drift signal #3 (S2 BREAST chunk):
+    load-order silently picked HER2-POS-2L for TNBC and HR-POS patients.
+    """
+    import json
+    from pathlib import Path
+    from knowledge_base.engine import generate_plan
+
+    repo_root = Path(__file__).parent.parent
+    kb_root = repo_root / "knowledge_base" / "hosted" / "content"
+    cases = {
+        "patient_breast_her2_pos_met_2l_tdxd.json": "ALGO-BREAST-HER2-POS-2L",
+        "patient_breast_tnbc_met_sacituzumab_2l.json": "ALGO-BREAST-TNBC-2L",
+        "patient_breast_hr_pos_post_cdk46i_pik3ca_alpelisib.json": "ALGO-BREAST-HR-POS-2L",
+    }
+    for fname, expected_algo in cases.items():
+        path = repo_root / "examples" / fname
+        with path.open(encoding="utf-8") as fh:
+            patient = json.load(fh)
+        result = generate_plan(patient, kb_root=kb_root)
+        assert result.algorithm_id == expected_algo, (
+            f"{fname}: expected {expected_algo}, got {result.algorithm_id}; "
+            f"disease_state={patient.get('disease_state')}"
+        )

--- a/tests/test_engine_find_algorithm.py
+++ b/tests/test_engine_find_algorithm.py
@@ -1,0 +1,115 @@
+"""Tests for `_find_algorithm` disease-state disambiguation.
+
+Regression for PR #150 KB-drift signal #2: when multiple algorithms exist
+for the same disease + line_of_therapy but differ on
+`applicable_to_disease_state`, the engine must pick the one matching the
+patient's `disease_state`. Previously it returned whichever loaded first
+(load-order coin flip), which caused 4 prostate cases (S5 chunk) to drop.
+"""
+
+from __future__ import annotations
+
+from knowledge_base.engine.plan import _find_algorithm
+
+
+def _algo_entity(algo_id: str, disease_id: str, line: int, state: str | None) -> dict:
+    data: dict = {
+        "id": algo_id,
+        "applicable_to_disease": disease_id,
+        "applicable_to_line_of_therapy": line,
+    }
+    if state is not None:
+        data["applicable_to_disease_state"] = state
+    return {"type": "algorithms", "data": data}
+
+
+def _build_entities() -> dict:
+    return {
+        "ALGO-PROSTATE-MHSPC-1L": _algo_entity(
+            "ALGO-PROSTATE-MHSPC-1L", "DIS-PROSTATE", 1, "mHSPC"
+        ),
+        "ALGO-PROSTATE-MCRPC-1L": _algo_entity(
+            "ALGO-PROSTATE-MCRPC-1L", "DIS-PROSTATE", 1, "mCRPC"
+        ),
+    }
+
+
+def test_state_matched_algorithm_wins_mcrpc():
+    entities = _build_entities()
+    algo = _find_algorithm("DIS-PROSTATE", 1, entities, disease_state="mCRPC")
+    assert algo is not None
+    assert algo["id"] == "ALGO-PROSTATE-MCRPC-1L"
+
+
+def test_state_matched_algorithm_wins_mhspc():
+    entities = _build_entities()
+    algo = _find_algorithm("DIS-PROSTATE", 1, entities, disease_state="mHSPC")
+    assert algo is not None
+    assert algo["id"] == "ALGO-PROSTATE-MHSPC-1L"
+
+
+def test_disease_state_match_is_case_insensitive():
+    entities = _build_entities()
+    algo = _find_algorithm("DIS-PROSTATE", 1, entities, disease_state="mcrpc")
+    assert algo is not None
+    assert algo["id"] == "ALGO-PROSTATE-MCRPC-1L"
+
+
+def test_no_disease_state_falls_back_to_state_agnostic():
+    """Patient with no disease_state and a state-agnostic algorithm available
+    should match the state-agnostic algorithm."""
+    entities = {
+        "ALGO-PROSTATE-MCRPC-1L": _algo_entity(
+            "ALGO-PROSTATE-MCRPC-1L", "DIS-PROSTATE", 1, "mCRPC"
+        ),
+        "ALGO-PROSTATE-GENERIC-1L": _algo_entity(
+            "ALGO-PROSTATE-GENERIC-1L", "DIS-PROSTATE", 1, None
+        ),
+    }
+    algo = _find_algorithm("DIS-PROSTATE", 1, entities, disease_state=None)
+    assert algo is not None
+    assert algo["id"] == "ALGO-PROSTATE-GENERIC-1L"
+
+
+def test_state_agnostic_when_no_state_match_available():
+    """Patient has disease_state but only a state-agnostic algorithm exists
+    → use the state-agnostic one (don't return None)."""
+    entities = {
+        "ALGO-NSCLC-1L": _algo_entity("ALGO-NSCLC-1L", "DIS-NSCLC", 1, None),
+    }
+    algo = _find_algorithm("DIS-NSCLC", 1, entities, disease_state="any-state")
+    assert algo is not None
+    assert algo["id"] == "ALGO-NSCLC-1L"
+
+
+def test_state_mismatch_returns_none_when_only_mismatched_available():
+    """Patient is mCRPC, only mHSPC algorithm exists → no match (don't
+    silently return mHSPC just because it's the only candidate)."""
+    entities = {
+        "ALGO-PROSTATE-MHSPC-1L": _algo_entity(
+            "ALGO-PROSTATE-MHSPC-1L", "DIS-PROSTATE", 1, "mHSPC"
+        ),
+    }
+    algo = _find_algorithm("DIS-PROSTATE", 1, entities, disease_state="mCRPC")
+    assert algo is None
+
+
+def test_no_state_falls_back_to_load_order_for_legacy_patients():
+    """Legacy patient profile (no disease_state) + only state-specific
+    algorithms → fall back to load-order pick rather than returning None.
+    This preserves backward compat for example files predating disease_state.
+    The caller emits a warning so the gap is visible."""
+    entities = _build_entities()
+    algo = _find_algorithm("DIS-PROSTATE", 1, entities)
+    assert algo is not None
+    assert algo["id"] in {"ALGO-PROSTATE-MHSPC-1L", "ALGO-PROSTATE-MCRPC-1L"}
+
+
+def test_disease_id_mismatch_returns_none():
+    entities = _build_entities()
+    assert _find_algorithm("DIS-NSCLC", 1, entities, disease_state="mCRPC") is None
+
+
+def test_line_mismatch_returns_none():
+    entities = _build_entities()
+    assert _find_algorithm("DIS-PROSTATE", 2, entities, disease_state="mCRPC") is None

--- a/tests/test_engine_track_filter_smoke.py
+++ b/tests/test_engine_track_filter_smoke.py
@@ -71,6 +71,46 @@ def test_helper_negative_value_does_not_drop():
     assert is_track_excluded(ind, {"MSI-STATUS": "MSS"}) is False
 
 
+def test_helper_gene_level_positive_does_not_satisfy_qualifier():
+    """Patient reports gene-level positive (e.g. 'positive', True) but the
+    exclusion is qualified by a specific value_constraint. The patient has
+    NOT reported the qualifying condition, so the track must not be dropped.
+
+    Regression for the S1 NSCLC T790M case (PR #150 KB-drift signal #1):
+    IND-NSCLC-2L-EGFR-POST-OSI-AMI-LAZ excludes 'histologic transformation'
+    on BIO-EGFR-MUTATION. Patient with BIO-EGFR-MUTATION='positive' has not
+    reported transformation status — track must remain available.
+    """
+    ind = {
+        "applicable_to": {
+            "biomarker_requirements_excluded": [
+                {
+                    "biomarker_id": "BIO-EGFR-MUTATION",
+                    "value_constraint": "histologic transformation",
+                },
+            ]
+        }
+    }
+    assert is_track_excluded(ind, {"BIO-EGFR-MUTATION": "positive"}) is False
+    assert is_track_excluded(ind, {"EGFR": "positive"}) is False
+    assert is_track_excluded(ind, {"BIO-EGFR-MUTATION": True}) is False
+
+
+def test_helper_gene_level_positive_still_drops_unqualified_exclusion():
+    """Counter-case: when the exclusion has NO value_constraint (gene-level
+    only), gene-level positive in the patient should still drop the track.
+    Confirms the fix only affects qualified exclusions."""
+    ind = {
+        "applicable_to": {
+            "biomarker_requirements_excluded": [
+                {"biomarker_id": "BIO-MSI-STATUS"},
+            ]
+        }
+    }
+    assert is_track_excluded(ind, {"MSI-STATUS": "positive"}) is True
+    assert is_track_excluded(ind, {"MSI": True}) is True
+
+
 def test_helper_handles_none_and_non_dict():
     assert is_track_excluded(None, {"X": "Y"}) is False
     assert is_track_excluded({}, {"X": "Y"}) is False


### PR DESCRIPTION
## Summary

Closes 4 of the 10 KB-drift defects surfaced by the curated-examples expansion ([PR #150](https://github.com/romeo111/OpenOnco/pull/150)). Each defect had at least one failing case proving the bug; each fix has a regression test.

The remaining 6 are missing-content gaps (KEYNOTE-006/-054, EXTREME HNSCC, CPX-351, GO AML, loncastuximab DLBCL, CLL zanu 1L, esophageal CheckMate-577) and are queued as a separate shelf task.

## Fixes

### 1. Track filter honors qualified `value_constraint` exclusions
- **File**: `knowledge_base/engine/_track_filter.py`
- **Bug**: when `biomarker_requirements_excluded` had a `value_constraint`, gene-level positive patient values (`"positive"`, `True`) matched as exclusions regardless of the qualifier.
- **Failing case**: `patient_nsclc_egfr_t790m_2l_post_1g_tki` — IND-NSCLC-2L-EGFR-POST-OSI-AMI-LAZ excludes "histologic transformation" on BIO-EGFR-MUTATION; patient with `"BIO-EGFR-MUTATION": "positive"` was being dropped despite not reporting transformation.
- **Test**: `tests/test_engine_track_filter_smoke.py` — 2 new cases covering qualified vs unqualified exclusions.

### 2. `_find_algorithm` consults patient `disease_state`
- **File**: `knowledge_base/engine/plan.py`
- **Bug**: when multiple algorithms shared disease + line (prostate mHSPC vs mCRPC), the engine returned whichever loaded first.
- **Failing cases**: 4 of 5 prostate cases in S5 chunk (`fdd334ef`).
- **Match priority**: state-matched > state-agnostic > load-order fallback (legacy patients without `disease_state` keep working with a warning).
- **Test**: `tests/test_engine_find_algorithm.py` — 9 unit tests.

### 3. Breast 2L algorithm disambiguation
- **Files**: `algo_breast_{her2_pos,tnbc,hr_pos}_2l.yaml` + 3 PR #150 patient fixtures
- **Bug**: 3 breast 2L algorithms collided with no discriminator → load-order picked HER2-POS for every case (TNBC patient → wrong plan).
- **Fix**: added `applicable_to_disease_state` to all 3 algos (semantic broadened to cover subtype, not just stage); set `disease_state` on the 3 patient fixtures.
- **Failing cases verified**: HER2+ → HER2-POS-2L, TNBC → TNBC-2L, HR+ → HR-POS-2L (was all routing to HER2-POS-2L pre-fix).
- **Test**: end-to-end test in `test_engine_find_algorithm.py`.

### 4. Free-text condition gates → structured finding clauses
- **Files**: `algo_{urothelial,endometrial,gastric}_*_1l.yaml`
- **Bug**: clauses like `condition: "Patient eligible for EV+pembro..."` look up the entire free-text string as a key in patient findings — never resolves, gate silently fell through.
- **Fix**: replaced 3 free-text gates with structured `finding:` clauses using existing patient finding keys (`ev_pembro_eligible`, `mmr_status`, `msi_status`, `her2_status`).
- **Engine code untouched** — `_eval_clause` already prefers `finding:` over `condition:`.
- **Verified end-to-end**: urothelial → EV-PEMBRO, endometrial dMMR → DOSTARLIMAB, gastric HER2+ → TOGA, gastric PD-L1-high HER2- → PDL1-CHEMO-ICI.

## Out of scope (follow-ups)

- The other ~200 free-text conditions across other algorithms — each needs per-disease structured re-authoring against curated case fixtures.
- 6 missing indications/regimens — shelf task tracks KEYNOTE-006/-054, EXTREME HNSCC, CPX-351, GO AML, loncastuximab DLBCL, CLL zanu 1L, esophageal CheckMate-577.
- The 4 prostate cases dropped in PR #150 from S5 chunk also need KB additions (mHSPC algorithm refinements + indications).

## Test plan

- [x] `tests/test_engine_track_filter_smoke.py` — 9 passed (was 7)
- [x] `tests/test_engine_find_algorithm.py` — 10 passed (new file)
- [x] Focused engine + plan + MDT suite — 44 passed
- [x] Smoke tests on each curated patient fixture confirm correct routing
- [ ] CI: `Validate Knowledge Base` (will run on PR; only KB-touching workflow that fires for `knowledge_base/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)