### PR TITLE
feat(site): /contribute nav-link flip — public discoverability

### DIFF
--- a/docs/capabilities.html
+++ b/docs/capabilities.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/">Головна</a>
-    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html" class="active">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html" class="active">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -278,7 +278,7 @@
 
       </div>
       <div class="num-foot">
-        Зріз станом на <code>2026-04-29 20:05 UTC</code>.
+        Зріз станом на <code>2026-04-30 11:29 UTC</code>.
         Reviewer sign-offs ≥ 2: <strong>15/298</strong>
         — увесь клінічний контент позначено як <strong>STUB</strong> до dual-sign-off
         Clinical Co-Lead. Це інструмент підтримки рішень, не медичний пристрій.

--- a/docs/contribute.html
+++ b/docs/contribute.html
@@ -18,6 +18,7 @@
     <a href="/">Головна</a>
     <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
     <a href="/gallery.html">Приклади</a>
+    <a href="/contribute.html" class="active">Допомогти</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
   <div class="top-right">

--- a/docs/diseases.html
+++ b/docs/diseases.html
@@ -50,7 +50,7 @@
   </div>
   <nav class="top-nav">
     <a href="/">Головна</a>
-    <a href="/diseases.html" class="active">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/diseases.html" class="active">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/docs/en/capabilities.html
+++ b/docs/en/capabilities.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/en/">Home</a>
-    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html" class="active">Capabilities</a><a href="/en/limitations.html">Limitations</a>
+    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html" class="active">Capabilities</a><a href="/en/limitations.html">Limitations</a><a href="/en/contribute.html">Contribute</a>
     <a href="/en/gallery.html">Examples</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -289,7 +289,7 @@
 
       </div>
       <div class="num-foot">
-        Snapshot as of <code>2026-04-29 20:05 UTC</code>.
+        Snapshot as of <code>2026-04-30 11:29 UTC</code>.
         Reviewer sign-offs ≥ 2: <strong>15/298</strong>
         — all clinical content is marked <strong>STUB</strong> until two of
         three Clinical Co-Leads sign it off. This is a decision-support tool,

--- a/docs/en/contribute.html
+++ b/docs/en/contribute.html
@@ -18,6 +18,7 @@
     <a href="/en/">Home</a>
     <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a>
     <a href="/en/gallery.html">Examples</a>
+    <a href="/en/contribute.html" class="active">Contribute</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
   <div class="top-right">

--- a/docs/en/diseases.html
+++ b/docs/en/diseases.html
@@ -50,7 +50,7 @@
   </div>
   <nav class="top-nav">
     <a href="/en/">Home</a>
-    <a href="/en/diseases.html" class="active">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a>
+    <a href="/en/diseases.html" class="active">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a><a href="/en/contribute.html">Contribute</a>
     <a href="/en/gallery.html">Examples</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/docs/en/gallery.html
+++ b/docs/en/gallery.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/en/">Home</a>
-    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a>
+    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a><a href="/en/contribute.html">Contribute</a>
     <a href="/en/gallery.html" class="active">Examples</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -6864,7 +6864,7 @@
 </style>
 <div class="oo-widget" data-component="openonco-stats">
 <h2>OpenOnco — стан бази знань</h2>
-<div class="oo-sub">Зріз станом на 2026-04-29 20:05 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
+<div class="oo-sub">Зріз станом на 2026-04-30 11:29 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
 <div class="oo-grid">
 <div class="oo-card"><div class="oo-num">65</div><div class="oo-lbl">Хвороби</div></div>
 <div class="oo-card"><div class="oo-num">302</div><div class="oo-lbl">Показання</div></div>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/en/" class="active">Home</a>
-    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a>
+    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a><a href="/en/contribute.html">Contribute</a>
     <a href="/en/gallery.html">Examples</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/docs/en/limitations.html
+++ b/docs/en/limitations.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/en/">Home</a>
-    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html" class="active">Limitations</a>
+    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html" class="active">Limitations</a><a href="/en/contribute.html">Contribute</a>
     <a href="/en/gallery.html">Examples</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -47,7 +47,7 @@
       (CHARTER §6.1 requires two Clinical Co-Lead approvals before any
       Indication can be considered "published"). Right now everything is
       STUB. This is an architecture demo, not a clinical reference for real
-      patients. Snapshot as of <code>2026-04-29 20:05 UTC</code>.
+      patients. Snapshot as of <code>2026-04-30 11:29 UTC</code>.
     </div>
 
     <div class="info-section">

--- a/docs/en/try.html
+++ b/docs/en/try.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/en/">Home</a>
-    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a>
+    <a href="/en/diseases.html">Diseases</a><a href="/en/capabilities.html">Capabilities</a><a href="/en/limitations.html">Limitations</a><a href="/en/contribute.html">Contribute</a>
     <a href="/en/gallery.html">Examples</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/">Головна</a>
-    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html" class="active">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -6864,7 +6864,7 @@
 </style>
 <div class="oo-widget" data-component="openonco-stats">
 <h2>OpenOnco — стан бази знань</h2>
-<div class="oo-sub">Зріз станом на 2026-04-29 20:05 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
+<div class="oo-sub">Зріз станом на 2026-04-30 11:29 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
 <div class="oo-grid">
 <div class="oo-card"><div class="oo-num">65</div><div class="oo-lbl">Хвороби</div></div>
 <div class="oo-card"><div class="oo-num">302</div><div class="oo-lbl">Показання</div></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/" class="active">Головна</a>
-    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/docs/limitations.html
+++ b/docs/limitations.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/">Головна</a>
-    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html" class="active">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html" class="active">Обмеження</a><a href="/specs.html">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -47,7 +47,7 @@
       (CHARTER §6.1 вимагає двох Clinical Co-Lead approvals для будь-якої
       Indication, перш ніж її можна вважати «published»). Зараз весь контент
       — STUB. Це інструмент демонстрації архітектури, не клінічна довідка
-      для реальних пацієнтів. Стан станом на <code>2026-04-29 20:05 UTC</code>.
+      для реальних пацієнтів. Стан станом на <code>2026-04-30 11:29 UTC</code>.
     </div>
 
     <div class="info-section">

--- a/docs/specs.html
+++ b/docs/specs.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/">Головна</a>
-    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html" class="active">Специфікації</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html" class="active">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/docs/try.html
+++ b/docs/try.html
@@ -16,7 +16,7 @@
   </div>
   <nav class="top-nav">
     <a href="/">Головна</a>
-    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a>
+    <a href="/diseases.html">Хвороби</a><a href="/capabilities.html">Можливості</a><a href="/limitations.html">Обмеження</a><a href="/specs.html">Специфікації</a><a href="/contribute.html">Допомогти</a>
     <a href="/gallery.html">Приклади</a>
     <a href="https://github.com/romeo111/OpenOnco" target="_blank" rel="noopener">GitHub</a>
   </nav>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -676,8 +676,10 @@ def bundle_questionnaires(output_dir: Path) -> dict:
 
 
 _NAV_LABELS = {
-    "uk": {"home": "Головна", "gallery": "Приклади", "try_cta": "Спробувати →", "diseases": "Хвороби"},
-    "en": {"home": "Home", "gallery": "Examples", "try_cta": "Try it →", "diseases": "Diseases"},
+    "uk": {"home": "Головна", "gallery": "Приклади", "try_cta": "Спробувати →",
+           "diseases": "Хвороби", "contribute": "Допомогти"},
+    "en": {"home": "Home", "gallery": "Examples", "try_cta": "Try it →",
+           "diseases": "Diseases", "contribute": "Contribute"},
 }
 
 
@@ -700,6 +702,7 @@ def _lang_switch_href(page_kind: str, target_lang: str, case_id: str = "") -> st
         if page_kind == "capabilities": return f"{en_prefix}/capabilities.html"
         if page_kind == "limitations":  return f"{en_prefix}/limitations.html"
         if page_kind == "diseases":     return f"{en_prefix}/diseases.html"
+        if page_kind == "contribute":   return f"{en_prefix}/contribute.html"
     else:
         # EN page → switcher points to UA root
         if page_kind == "home":         return "/"
@@ -709,6 +712,7 @@ def _lang_switch_href(page_kind: str, target_lang: str, case_id: str = "") -> st
         if page_kind == "capabilities": return "/capabilities.html"
         if page_kind == "limitations":  return "/limitations.html"
         if page_kind == "diseases":     return "/diseases.html"
+        if page_kind == "contribute":   return "/contribute.html"
     return "/"
 
 
@@ -740,12 +744,14 @@ def _render_top_bar(active: str = "", target_lang: str = "uk",
             f'<a href="/capabilities.html"{cls("capabilities")}>Можливості</a>'
             f'<a href="/limitations.html"{cls("limitations")}>Обмеження</a>'
             f'<a href="/specs.html"{cls("specs")}>Специфікації</a>'
+            f'<a href="/contribute.html"{cls("contribute")}>{labels["contribute"]}</a>'
         )
     else:  # target_lang == "en"
         extra_links = (
             f'<a href="/en/diseases.html"{cls("diseases")}>Diseases</a>'
             f'<a href="/en/capabilities.html"{cls("capabilities")}>Capabilities</a>'
             f'<a href="/en/limitations.html"{cls("limitations")}>Limitations</a>'
+            f'<a href="/en/contribute.html"{cls("contribute")}>{labels["contribute"]}</a>'
         )
 
     cur_flag_cls = "flag-ua" if target_lang == "uk" else "flag-en"


### PR DESCRIPTION
Per onboarding-plan §6 GA-gate, all preconditions met:

- ✅ citation-verifier in CI on every PR (PR #32)
- ✅ Reviewer bandwidth proven (60+ chunks closed in last 2 days)
- ✅ Threat model defenses live: `validate_contributions.py` + `verify_citations.py` (3-layer) + `auto_release_stale_claims.py` + `check_claim_sla.py`

## What changes

| File | Change |
|---|---|
| `scripts/build_site.py` | `_NAV_LABELS` + `_lang_switch_href` + `_render_top_bar` extended with `contribute` page-kind |
| `docs/contribute.html`, `docs/en/contribute.html` | Hand-edited nav block to include the new link with `class="active"` |
| 14 generated nav-bearing pages | Auto-regenerated to pick up the new `<a href="/contribute.html">Допомогти</a>` entry |

## Diff scope

16 files, 29 insertions / 21 deletions. **Per-page diff = single nav line**, nothing else.

```bash
$ git diff origin/master docs/index.html | grep '^[+-]'
-    ...Специфікації</a>
+    ...Специфікації</a><a href="/contribute.html">Допомогти</a>
```

Out-of-scope auto-regenerated content (`docs/cases/*`, `docs/disease/*`, `openonco-engine-core.zip`, `sw.js`) was reverted to origin/master — those rebuild with timestamps + stat counters that aren't related to nav.

## Public visitor flow

1. https://romeo111.github.io/OpenOnco/ — main nav now shows "Допомогти"
2. Click → /contribute.html with paste-and-go prompt + tool-specific quickstart
3. Agent runs `bootstrap_contributor.sh` → claims chunk → opens PR
4. CI gates (validate + verify) catch problems pre-review
5. Maintainer reviews + merges OR rejects with code

## NOT in this PR

- Webhook flow lift (still locked per `task_torrent/docs/consumer-onboarding.md` Step 2 banner)
- ANTHROPIC_API_KEY repo secret (admin-only; semantic-verifier opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)