### PR TITLE
feat(render): phases-aware HTML output + axi-cel reference migration (PR2)

### DIFF
--- a/knowledge_base/engine/render.py
+++ b/knowledge_base/engine/render.py
@@ -60,6 +60,45 @@ def _h(s) -> str:
     return html.escape(str(s))
 
 
+# ── Regimen phase iteration (PR2 of regimen-phases-refactor) ─────────────
+#
+# `regimen_data` flows through render as a raw dict from the YAML loader
+# (knowledge_base/validation/loader.py stores `"data": raw`). Pydantic's
+# `Regimen._auto_wrap_legacy_components` validator never runs on this
+# path, so we cannot rely on `phases` being populated post-load — the
+# dict has whatever the YAML literally has:
+#
+#   * legacy YAML — `phases` absent, `components: [...]` → use components
+#   * migrated YAML (axi-cel post-PR2) — `phases: [...]`, `components: []`
+#     → iterate phases[*].components; ignore the empty top-level list
+#   * (theoretical authored) — both populated → phases is canonical
+#
+# The helper below is the single source of truth. Three render call
+# sites consume it — `_render_treatment_phases`, `_render_drugs_plain`
+# (patient bundle), `_render_ask_doctor_section` (predicate decoration).
+# Without it, migrated regimens would silently drop drugs from the
+# patient HTML and the ask-doctor questions.
+def _iter_regimen_components(regimen_dict: Optional[dict]):
+    """Yield component dicts from `phases[*].components` if populated,
+    else fall back to top-level `components`. Skips non-dict entries
+    defensively (loader returns plain Python types, but YAML errors can
+    leave None inside lists)."""
+    if not regimen_dict:
+        return
+    phases = regimen_dict.get("phases") or []
+    if phases:
+        for phase in phases:
+            if not isinstance(phase, dict):
+                continue
+            for comp in phase.get("components") or []:
+                if isinstance(comp, dict):
+                    yield comp
+        return
+    for comp in regimen_dict.get("components") or []:
+        if isinstance(comp, dict):
+            yield comp
+
+
 # ── Sign-off badge (CHARTER §6.1) ─────────────────────────────────────────
 #
 # Indications carry `reviewer_signoffs_v2: list[ReviewerSignoff]` after the
@@ -1276,6 +1315,49 @@ _NSZU_DRUGS_LABEL = {
 }
 
 
+# ── Phase-aware render labels (PR2 of regimen-phases-refactor) ──────────
+#
+# Maps the curator-facing `phase.name` vocabulary
+# (KNOWLEDGE_SCHEMA_SPECIFICATION §6.4) to a UA/EN heading prefix. The
+# block heading combines the prefix with the phase's `purpose_ua` so a
+# clinician sees both the role ("Перед основною терапією") and the
+# specific intent ("виснаження лімфоцитів перед CAR-T"). Auto-wrapped
+# legacy phases use name="main", which renders without a heading-prefix
+# noise — the visible behavior stays close to pre-PR2.
+_PHASE_HEADING_PREFIX_UK = {
+    "lymphodepletion": "Перед основною терапією: лімфодеплеція",
+    "bridging": "Бриджинг до основної терапії",
+    "induction": "Індукція",
+    "consolidation": "Консолідація",
+    "maintenance": "Підтримуюча терапія",
+    "main": None,  # auto-wrapped legacy — no heading prefix
+    "premedication": "Премедикація",
+    "conditioning": "Кондиціонування",
+    "salvage_induction": "Salvage-індукція",
+    "alternating_block_a": "Чергуючий блок A",
+    "alternating_block_b": "Чергуючий блок B",
+    "il2_support": "IL-2 підтримка",
+}
+_PHASE_HEADING_PREFIX_EN = {
+    "lymphodepletion": "Before main therapy: lymphodepletion",
+    "bridging": "Bridging to main therapy",
+    "induction": "Induction",
+    "consolidation": "Consolidation",
+    "maintenance": "Maintenance",
+    "main": None,
+    "premedication": "Premedication",
+    "conditioning": "Conditioning",
+    "salvage_induction": "Salvage induction",
+    "alternating_block_a": "Alternating block A",
+    "alternating_block_b": "Alternating block B",
+    "il2_support": "IL-2 support",
+}
+_BRIDGING_OPTIONS_LABEL = {
+    "uk": "Якщо очікування на основну терапію >2 тиж — допустимий бриджинг",
+    "en": "If wait for main therapy >2 weeks — acceptable bridging regimens",
+}
+
+
 def _render_nszu_badge(drug_entity, patient_disease_id, disease_names, target_lang="uk") -> str:
     """One drug → one `<span class="nszu-badge nszu-{status}">…</span>`.
 
@@ -1295,55 +1377,180 @@ def _render_nszu_badge(drug_entity, patient_disease_id, disease_names, target_la
     return f'<span class="{cls}"{title_attr}>{_h(label)}</span>'
 
 
-def _render_track_drug_list(
+def _render_drug_row(
+    comp: dict,
+    drugs_lookup: dict,
+    patient_disease_id: str,
+    disease_names: dict,
+    target_lang: str,
+) -> str:
+    """Render a single component dict as one `<li class="drug-row">` with
+    drug name + dose/schedule/route + NSZU availability badge.
+
+    Extracted from the legacy `_render_track_drug_list` so multi-phase
+    regimens can reuse the same per-drug formatting inside each phase
+    block. Returns "" when the component has no `drug_id` (defensive)."""
+    drug_id = comp.get("drug_id")
+    if not drug_id:
+        return ""
+    drug = drugs_lookup.get(drug_id)
+    # Drug display name — prefer ukrainian when rendering UA, else preferred
+    names = (drug or {}).get("names") or {}
+    if (target_lang or "uk").lower().startswith("en"):
+        name = names.get("english") or names.get("preferred") or drug_id
+    else:
+        name = names.get("ukrainian") or names.get("preferred") or drug_id
+    dose_bits: list[str] = []
+    for k in ("dose", "schedule", "route"):
+        v = comp.get(k)
+        if v:
+            dose_bits.append(str(v))
+    dose_str = " · ".join(dose_bits)
+    nszu = _render_nszu_badge(drug, patient_disease_id, disease_names, target_lang)
+    meta = (
+        f'<span class="drug-name">{_h(name)}</span>'
+        f' <span class="drug-id">({_h(drug_id)})</span>'
+    )
+    if dose_str:
+        meta += f' <span class="drug-dose">{_h(dose_str)}</span>'
+    return f'<li class="drug-row">{meta} {nszu}</li>'
+
+
+def _render_treatment_phases(
     track,
     drugs_lookup: dict,
     patient_disease_id: str,
     disease_names: dict,
     target_lang: str = "uk",
 ) -> str:
-    """Render the regimen's drug components as a `<dt>/<dd>` block with
-    an NSZU availability badge per drug. Returns empty string when the
-    track has no regimen / no components — keeps the dl tidy."""
+    """Render the regimen as one or more phase blocks (PR2 of
+    regimen-phases-refactor; replaces the flat single-block drug list).
+
+    Each phase becomes a `<section class="phase-block">` with:
+      - heading combining the phase-name prefix
+        (`_PHASE_HEADING_PREFIX_UK[phase.name]`) and the curator-authored
+        `purpose_ua`. Auto-wrapped legacy phases (`name="main"`) skip
+        the prefix to keep the visual close to pre-PR2.
+      - the phase's drug rows formatted by `_render_drug_row`.
+
+    Falls back to the regimen's flat `components` when the loaded
+    `regimen_data` dict has no `phases` key — covers legacy YAMLs that
+    have not been migrated to multi-phase shape (the Pydantic auto-wrap
+    only runs at `model_validate`, not at render time when YAML is loaded
+    into a raw dict). See `_iter_regimen_components` docstring.
+
+    Returns empty string when no drug components are renderable — keeps
+    the `<dl>` tidy and matches the legacy contract.
+
+    `bridging_options` (CAR-T / TIL manufacturing-window slot) renders as
+    a separate `<div class="bridging-options">` block listed AFTER the
+    phase blocks, naming the acceptable bridging regimen IDs.
+    """
     reg = track.regimen_data or {}
-    components = reg.get("components") or []
-    if not components:
+    if not reg:
         return ""
-    rows: list[str] = []
-    for comp in components:
-        if not isinstance(comp, dict):
-            continue
-        drug_id = comp.get("drug_id")
-        if not drug_id:
-            continue
-        drug = drugs_lookup.get(drug_id)
-        # Drug display name — prefer ukrainian when rendering UA, else preferred
-        names = (drug or {}).get("names") or {}
-        if (target_lang or "uk").lower().startswith("en"):
-            name = names.get("english") or names.get("preferred") or drug_id
-        else:
-            name = names.get("ukrainian") or names.get("preferred") or drug_id
-        dose_bits: list[str] = []
-        for k in ("dose", "schedule", "route"):
-            v = comp.get(k)
-            if v:
-                dose_bits.append(str(v))
-        dose_str = " · ".join(dose_bits)
-        nszu = _render_nszu_badge(drug, patient_disease_id, disease_names, target_lang)
-        meta = (
-            f'<span class="drug-name">{_h(name)}</span>'
-            f' <span class="drug-id">({_h(drug_id)})</span>'
-        )
-        if dose_str:
-            meta += f' <span class="drug-dose">{_h(dose_str)}</span>'
-        rows.append(f'<li class="drug-row">{meta} {nszu}</li>')
-    if not rows:
-        return ""
+
     label = _NSZU_DRUGS_LABEL.get(
         "en" if (target_lang or "uk").lower().startswith("en") else "uk",
         _NSZU_DRUGS_LABEL["uk"],
     )
-    return f'<dt>{_h(label)}</dt><dd><ul class="drug-list">{"".join(rows)}</ul></dd>'
+
+    # Build the phase list — explicit phases when populated, else a synthetic
+    # single phase wrapping the flat components list (mirrors the schema's
+    # auto-wrap; needed at render time because regimen_data is the raw dict,
+    # not a validated Regimen).
+    phases: list[dict] = []
+    raw_phases = reg.get("phases") or []
+    if raw_phases:
+        for ph in raw_phases:
+            if isinstance(ph, dict):
+                phases.append(ph)
+    elif reg.get("components"):
+        phases.append({
+            "name": "main",
+            "purpose_ua": "основна терапія",
+            "components": reg.get("components") or [],
+        })
+
+    prefix_map = (
+        _PHASE_HEADING_PREFIX_EN
+        if (target_lang or "uk").lower().startswith("en")
+        else _PHASE_HEADING_PREFIX_UK
+    )
+
+    blocks: list[str] = []
+    for ph in phases:
+        ph_name = ph.get("name") or ""
+        ph_components = ph.get("components") or []
+        ph_rows = [
+            _render_drug_row(
+                c, drugs_lookup, patient_disease_id, disease_names, target_lang
+            )
+            for c in ph_components
+            if isinstance(c, dict)
+        ]
+        ph_rows = [r for r in ph_rows if r]
+        if not ph_rows:
+            continue
+
+        # Heading: prefix (when defined for this phase name) + purpose_ua.
+        # Legacy auto-wrap (name="main") gets prefix=None → no heading;
+        # the block wrapper alone is a discreet structural marker so it
+        # does not look broken next to a real two-phase render.
+        prefix = prefix_map.get(ph_name)
+        if (target_lang or "uk").lower().startswith("en"):
+            purpose = ph.get("purpose_en") or ph.get("purpose_ua") or ""
+        else:
+            purpose = ph.get("purpose_ua") or ph.get("purpose_en") or ""
+
+        heading_html = ""
+        if prefix:
+            heading = prefix
+            if purpose and purpose.strip():
+                heading = f"{prefix} — {purpose.strip()}"
+            heading_html = f'<h4 class="phase-heading">{_h(heading)}</h4>'
+
+        # data-phase carries the canonical phase name for tests + tooling
+        # (legacy auto-wrap → "main"; explicit phases → curator-authored).
+        blocks.append(
+            f'<section class="phase-block" data-phase="{_h(ph_name)}">'
+            f'{heading_html}'
+            f'<ul class="drug-list">{"".join(ph_rows)}</ul>'
+            f'</section>'
+        )
+
+    bridging_html = ""
+    bridging_ids = reg.get("bridging_options") or []
+    if bridging_ids:
+        items = "".join(
+            f'<li class="bridging-option">{_h(bid)}</li>'
+            for bid in bridging_ids
+            if isinstance(bid, str) and bid
+        )
+        if items:
+            br_label = _BRIDGING_OPTIONS_LABEL.get(
+                "en" if (target_lang or "uk").lower().startswith("en") else "uk",
+                _BRIDGING_OPTIONS_LABEL["uk"],
+            )
+            bridging_html = (
+                f'<div class="bridging-options">'
+                f'<div class="bridging-options-label">{_h(br_label)}</div>'
+                f'<ul class="bridging-options-list">{items}</ul>'
+                f'</div>'
+            )
+
+    if not blocks and not bridging_html:
+        return ""
+
+    inner = "".join(blocks) + bridging_html
+    return f'<dt>{_h(label)}</dt><dd>{inner}</dd>'
+
+
+# Back-compat alias — `_render_track_drug_list` was the pre-PR2 entry point.
+# Kept as a thin wrapper so any out-of-tree code that imported the legacy
+# name keeps working. The internal call site below now calls the new
+# function directly.
+_render_track_drug_list = _render_treatment_phases
 
 
 # ── Variant actionability (ESCAT) ───────────────────────────────────────
@@ -1690,9 +1897,13 @@ def render_plan_html(
             f'<dt>Hard contraindications</dt><dd>{_h(", ".join(c.get("id", "?") for c in t.contraindications_data))}</dd>'
             if t.contraindications_data else ""
         )
-        # Drug components with NSZU availability badges (render-time only;
-        # engine never reads these — same contract as ESCAT tiers).
-        drugs_dd = _render_track_drug_list(
+        # Treatment phases — phase-aware drug list (PR2 of phases-refactor).
+        # Each phase renders as its own <section class="phase-block">.
+        # Legacy single-phase regimens (auto-wrapped from `components`) emit
+        # a single block without a heading prefix, visually close to pre-PR2.
+        # Engine never reads any of this — render-time metadata only,
+        # same contract as ESCAT tiers / NSZU badges.
+        drugs_dd = _render_treatment_phases(
             t, drugs_lookup, plan_result.disease_id or "", disease_names, target_lang
         )
         # TODO(phase-4): inline resistance-conflict banner once the
@@ -1906,11 +2117,10 @@ def _render_drugs_plain(plan_result: PlanResult) -> str:
     blocks: list[str] = []
 
     for t in plan.tracks:
-        regimen = t.regimen_data or {}
-        components = regimen.get("components") or []
-        for comp in components:
-            if not isinstance(comp, dict):
-                continue
+        # Iterate via _iter_regimen_components — covers both legacy
+        # (`components: [...]`) and post-PR2 phase-aware (`phases:` populated,
+        # `components: []`) regimen shapes. See helper docstring.
+        for comp in _iter_regimen_components(t.regimen_data):
             drug_id = comp.get("drug_id") or ""
             if not drug_id or drug_id in seen_drug_ids:
                 continue
@@ -2025,10 +2235,11 @@ def _render_ask_doctor_section(plan_result: PlanResult) -> str:
     seen: set[str] = set()
     if plan is not None:
         for t in plan.tracks:
-            regimen = t.regimen_data or {}
-            for comp in regimen.get("components") or []:
-                if not isinstance(comp, dict):
-                    continue
+            # Iterate via _iter_regimen_components — phase-aware fallback;
+            # see helper docstring. The decorated `recommended_drugs` feeds
+            # _ask_doctor predicates, which must surface every drug across
+            # phases (lymphodepletion + main for axi-cel, etc.).
+            for comp in _iter_regimen_components(t.regimen_data):
                 did = comp.get("drug_id") or ""
                 if not did or did in seen:
                     continue

--- a/knowledge_base/engine/render_styles.py
+++ b/knowledge_base/engine/render_styles.py
@@ -580,6 +580,45 @@ h3 {
 .drug-list .drug-name { font-weight: 600; }
 .drug-list .drug-id { font-family: var(--font-mono); font-size: 11px; color: var(--gray-500); }
 .drug-list .drug-dose { color: var(--gray-700); font-size: 12px; margin-left: 4px; }
+
+/* Treatment phases — multi-phase regimen rendering (PR2 of phases-refactor).
+   Each phase is a discrete block with its own heading + drug list. Legacy
+   auto-wrapped single-phase regimens (name="main") render the wrapper but
+   suppress the heading, keeping the visual close to pre-PR2 for unmigrated
+   YAMLs. Multi-phase regimens (lymphodepletion → main_infusion for axi-cel,
+   etc.) render as visually separated blocks per
+   docs/reviews/regimen-phases-refactor-plan-2026-04-28.md §4.4. */
+.phase-block {
+    border: 1px solid var(--gray-200); border-radius: 6px;
+    padding: 10px 14px; margin-bottom: 8px; background: var(--gray-50);
+}
+.phase-block:last-child { margin-bottom: 4px; }
+.phase-block[data-phase="main"]:only-of-type {
+    /* Auto-wrapped legacy regimen — single block, no border noise. */
+    border: none; padding: 0; background: transparent;
+}
+.phase-block .phase-heading {
+    font-family: var(--font-mono); font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.5px;
+    color: var(--green-700); margin: 0 0 6px 0; font-weight: 700;
+}
+.phase-block .drug-list { margin: 0; }
+
+/* Bridging options block — CAR-T / TIL manufacturing-window slot. Lists
+   acceptable bridging regimen IDs; rendered after all phase blocks. */
+.bridging-options {
+    margin-top: 10px; padding: 10px 14px; background: var(--blue-bg);
+    border-left: 3px solid var(--blue-700); border-radius: 4px;
+}
+.bridging-options .bridging-options-label {
+    font-size: 12px; color: var(--blue-700);
+    font-weight: 600; margin-bottom: 4px;
+}
+.bridging-options-list {
+    list-style: none; padding-left: 0; margin: 0;
+    font-family: var(--font-mono); font-size: 11px; color: var(--gray-700);
+}
+.bridging-options-list li.bridging-option { padding: 2px 0; }
 """
 
 

--- a/knowledge_base/hosted/content/regimens/reg_car_t_axicel.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_car_t_axicel.yaml
@@ -7,22 +7,48 @@ alternate_names:
   - "ZUMA-1 regimen"
   - "ZUMA-7 regimen (2L primary-refractory)"
 
-components:
-  - drug_id: DRUG-CYCLOPHOSPHAMIDE
-    dose: "500 mg/m²/day"
-    schedule: "IV days -5, -4, -3 (lymphodepletion, with fludarabine 30 mg/m²/day same days)"
-    route: IV
-  - drug_id: DRUG-AXICABTAGENE-CILOLEUCEL
-    dose: "Target 2 × 10^6 anti-CD19 CAR+ T-cells/kg (max 2 × 10^8 total)"
-    schedule: "Single IV infusion day 0, after lymphodepletion completed"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR2 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: lymphodepletion
+    purpose_ua: "виснаження лімфоцитів перед CAR-T для приживлення клітин"
+    purpose_en: "lymphocyte depletion before CAR-T to enable cell engraftment"
+    duration: "3 days, days -5 to -3"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -5
+    optional: false
+    components:
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "500 mg/m²/day"
+        schedule: "IV days -5, -4, -3"
+        route: IV
+      - drug_id: DRUG-FLUDARABINE
+        dose: "30 mg/m²/day"
+        schedule: "IV days -5, -4, -3"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - name: main
+    purpose_ua: "основна CAR-T інфузія"
+    purpose_en: "main CAR-T infusion"
+    duration: "single infusion"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-AXICABTAGENE-CILOLEUCEL
+        dose: "Target 2 × 10^6 anti-CD19 CAR+ T-cells/kg (max 2 × 10^8 total)"
+        schedule: "Single IV infusion day 0, after lymphodepletion completed"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days:
 total_cycles: "Single infusion (one-time therapy)"
 toxicity_profile: severe
 
 premedication:
-  - "Lymphodepletion: fludarabine 30 mg/m² + cyclophosphamide 500 mg/m² IV days -5 to -3 (NOT a separate component above — fludarabine added as adjunct)"
   - "Acetaminophen 650 mg PO + diphenhydramine 12.5 mg IV pre-infusion"
   - "AVOID prophylactic systemic corticosteroids — reduces CAR-T expansion + efficacy"
   - "Tocilizumab MUST be on-site (≥2 doses available) BEFORE infusion — for emergency CRS rescue"

--- a/tests/test_regimen_phases.py
+++ b/tests/test_regimen_phases.py
@@ -188,10 +188,22 @@ def test_no_regression_r_chop():
 
 
 def test_no_regression_axicel():
+    """axi-cel has been migrated to multi-phase shape (PR2). The YAML
+    carries `components: []` and authors `phases:` explicitly with
+    lymphodepletion + main. The auto-wrap MUST NOT fire (phases is
+    non-empty on input). Total drug count across phases (3) exceeds the
+    flat `components` length (0) — the new shape is canonical."""
     raw, r = _load_regimen("reg_car_t_axicel.yaml")
-    assert len(r.phases) >= 1
-    assert len(r.components) == _raw_component_count(raw)
-    assert sum(len(p.components) for p in r.phases) == len(r.components)
+    assert len(r.phases) == 2, "post-migration axi-cel must carry exactly two phases"
+    assert [p.name for p in r.phases] == ["lymphodepletion", "main"]
+    # Components is the no-op shape (loader-side opt-out from auto-wrap)
+    assert len(r.components) == _raw_component_count(raw) == 0
+    # Drugs flow via phases now
+    drug_ids_in_phases = [c.drug_id for p in r.phases for c in p.components]
+    assert "DRUG-CYCLOPHOSPHAMIDE" in drug_ids_in_phases
+    assert "DRUG-FLUDARABINE" in drug_ids_in_phases
+    assert "DRUG-AXICABTAGENE-CILOLEUCEL" in drug_ids_in_phases
+    assert len(drug_ids_in_phases) == 3
 
 
 def test_no_regression_lifileucel():
@@ -203,11 +215,18 @@ def test_no_regression_lifileucel():
 
 def test_no_regression_all_244_legacy_yamls_load():
     """Catch-all: every existing regimen YAML loads under the new schema.
-    Auto-wrap invariant: phases is non-empty iff components is non-empty
-    (a single legitimate surveillance "regimen" carries 0 components and
-    therefore stays at 0 phases).
 
-    Drives the load-bearing claim of PR1: zero existing YAML breaks.
+    Three valid shapes after PR2 (one regimen migrated to multi-phase):
+
+    * **legacy auto-wrapped** — `phases:` absent, `components: [drugs…]`
+      → after validate, `phases = [{name: 'main', components: drugs…}]`.
+    * **explicitly authored multi-phase** — `phases: [...]` populated,
+      `components: []` (axi-cel post-PR2; the curator-canonical form).
+      Auto-wrap MUST NOT fire — phases is preserved as authored.
+    * **surveillance-only** — both fields empty (e.g. observation-only
+      "regimen" with no drugs). The render layer routes this differently.
+
+    Drives the load-bearing claim of PR1+PR2: zero existing YAML breaks.
     """
     yaml_paths = sorted(KB_REGIMENS.glob("*.yaml"))
     assert len(yaml_paths) >= 240, (
@@ -215,44 +234,272 @@ def test_no_regression_all_244_legacy_yamls_load():
         "fixture changed?"
     )
 
-    nonempty_count = 0
+    legacy_autowrap_count = 0
+    explicit_multiphase_count = 0
     empty_count = 0
     for path in yaml_paths:
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
         r = Regimen.model_validate(raw)
         raw_count = _raw_component_count(raw)
-        # Component preservation (idempotent on the legacy schema)
+        raw_has_phases = bool(raw.get("phases"))
+
+        # Component preservation (the validator never adds/drops top-level)
         assert len(r.components) == raw_count, (
             f"{path.name}: components count drifted "
             f"({raw_count} raw vs {len(r.components)} model)"
         )
-        # Auto-wrap invariant
-        if raw_count > 0:
+
+        if raw_has_phases:
+            # Explicit author — auto-wrap suppressed, phases as written
             assert len(r.phases) >= 1, (
-                f"{path.name}: components={raw_count} but phases empty "
-                "— auto-wrap failed"
+                f"{path.name}: phases authored explicitly but model has 0"
+            )
+            # Drugs live in phases now; top-level components is the no-op
+            phase_drugs = sum(len(p.components) for p in r.phases)
+            assert phase_drugs > 0, (
+                f"{path.name}: explicit phases must have ≥1 component"
+            )
+            explicit_multiphase_count += 1
+        elif raw_count > 0:
+            # Legacy auto-wrap — single phase named "main"
+            assert len(r.phases) == 1, (
+                f"{path.name}: components={raw_count} but auto-wrap produced "
+                f"{len(r.phases)} phases"
             )
             assert r.phases[0].name == "main", (
                 f"{path.name}: auto-wrapped phase has unexpected name "
                 f"{r.phases[0].name!r} (expected 'main')"
             )
-            nonempty_count += 1
+            legacy_autowrap_count += 1
         else:
-            # Surveillance-only "regimen" with components: [] — phases
-            # also stays empty. Render layer is responsible for routing
-            # this kind of entity differently.
+            # Surveillance — zero components AND no authored phases.
+            # Render is responsible for routing this kind of entity
+            # differently (e.g. follow-up schedule rather than drug list).
             assert len(r.phases) == 0, (
-                f"{path.name}: zero components but phases populated "
-                "— auto-wrap fired spuriously"
+                f"{path.name}: zero components AND no authored phases, "
+                "but model has phases populated — auto-wrap fired spuriously"
             )
             empty_count += 1
 
-    # Sanity: vast majority of regimens have ≥1 component
-    assert nonempty_count >= 240, (
-        f"expected ~243 non-empty regimens, got {nonempty_count}"
+    # Sanity: vast majority of regimens are still legacy auto-wrap shape
+    # (PR2 migrates only axi-cel; PR3 migrates the remaining 17).
+    assert legacy_autowrap_count >= 240, (
+        f"expected ~242 legacy auto-wrap regimens, got {legacy_autowrap_count}"
     )
-    # Documented exception
+    # PR2 migrated exactly one regimen so far
+    assert explicit_multiphase_count == 1, (
+        f"expected exactly one explicit multi-phase regimen (axi-cel), "
+        f"got {explicit_multiphase_count}"
+    )
+    # Documented exception (surveillance / observation-only "regimen")
     assert empty_count == 1, (
         f"expected exactly one zero-component surveillance regimen, "
         f"got {empty_count}"
     )
+
+
+# ── 5. Render layer (PR2 of regimen-phases-refactor) ─────────────────────────
+#
+# These tests exercise `_render_treatment_phases` (the visible render
+# entry point per the regimen track block). Two integration tests drive
+# a real end-to-end Plan → HTML render against the migrated axi-cel YAML
+# and against a legacy R-CHOP regimen, asserting the phase-block visual
+# contract (axi-cel: two blocks; R-CHOP: still one). A third unit test
+# constructs a minimal `PlanTrack` to drive `bridging_options` rendering
+# in isolation (no production regimen has bridging_options yet).
+
+import json  # noqa: E402 — imports grouped above schema imports above on purpose
+
+from knowledge_base.engine.render import _render_treatment_phases  # noqa: E402
+from knowledge_base.schemas import Plan, PlanTrack  # noqa: E402
+
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+KB_CONTENT = REPO_ROOT / "knowledge_base" / "hosted" / "content"
+
+
+def _patient(name: str) -> dict:
+    return json.loads((EXAMPLES / name).read_text(encoding="utf-8"))
+
+
+def test_render_axicel_emits_two_phase_blocks():
+    """Post-migration axi-cel renders as TWO `<section class="phase-block">`
+    elements — one per phase (lymphodepletion + main). Each phase block
+    carries a `data-phase` attribute with the canonical phase name and a
+    UA heading that includes the curator-authored `purpose_ua`. Drug
+    components flow into the right phase: cyclophosphamide + fludarabine
+    under lymphodepletion, axi-cel under main.
+
+    Drives the migrated YAML through the render path directly — the
+    engine routing rules for an HGBL-double-hit patient → axi-cel are
+    out of scope for THIS test (and would couple the test to indication
+    selection). Loading the YAML via Pydantic gives us the canonical
+    post-migration shape; calling `_render_treatment_phases` with that
+    `regimen_data` exercises the render contract end-to-end.
+    """
+    raw_axicel = yaml.safe_load(
+        (KB_REGIMENS / "reg_car_t_axicel.yaml").read_text(encoding="utf-8")
+    )
+    track = PlanTrack(
+        track_id="aggressive",
+        label="axi-cel test track",
+        indication_id="IND-TEST-AXICEL",
+        is_default=True,
+        regimen_data=raw_axicel,
+    )
+
+    html_out = _render_treatment_phases(
+        track,
+        drugs_lookup={},  # render uses drug_id when names lookup is empty
+        patient_disease_id="",
+        disease_names={},
+        target_lang="uk",
+    )
+
+    # Exactly two phase-block sections — lymphodepletion + main
+    assert html_out.count('class="phase-block"') == 2, (
+        f"expected 2 phase-block sections, got {html_out.count('class=phase-block')}"
+    )
+    assert 'data-phase="lymphodepletion"' in html_out
+    assert 'data-phase="main"' in html_out
+
+    # Heading text — UA prefix + purpose_ua come through escaped
+    assert "Перед основною терапією: лімфодеплеція" in html_out, (
+        "phase heading prefix for lymphodepletion missing"
+    )
+    assert "виснаження лімфоцитів перед CAR-T" in html_out, (
+        "lymphodepletion purpose_ua not surfaced in heading"
+    )
+
+    # Drug routing per phase — slice the lymphodepletion section out and
+    # assert cyclo + fludarabine inside it; assert axi-cel is OUTSIDE it
+    # (in the main block).
+    lymph_start = html_out.find('data-phase="lymphodepletion"')
+    assert lymph_start > 0
+    lymph_end = html_out.find("</section>", lymph_start)
+    lymph_block = html_out[lymph_start:lymph_end]
+    assert "DRUG-CYCLOPHOSPHAMIDE" in lymph_block
+    assert "DRUG-FLUDARABINE" in lymph_block
+    assert "DRUG-AXICABTAGENE-CILOLEUCEL" not in lymph_block, (
+        "axi-cel infusion belongs in the main phase, not lymphodepletion"
+    )
+
+    # And axi-cel IS in the main block
+    main_start = html_out.find('data-phase="main"')
+    assert main_start > 0
+    main_end = html_out.find("</section>", main_start)
+    main_block = html_out[main_start:main_end]
+    assert "DRUG-AXICABTAGENE-CILOLEUCEL" in main_block
+
+
+def test_render_legacy_regimen_visually_unchanged():
+    """Legacy R-CHOP YAML (no `phases:` field) still renders all 5 drugs
+    in a single auto-wrapped phase block named "main". The render-time
+    fallback in `_render_treatment_phases` synthesises a single phase
+    when the loaded dict has no `phases` key — symmetric with the
+    Pydantic auto-wrap (which never runs on the loader-dict path).
+
+    Visual-similarity contract: the legacy auto-wrap MUST suppress the
+    phase-heading (`<h4>`) so an unmigrated regimen doesn't grow
+    spurious "основна терапія" labels above its drug list. The CSS rule
+    `.phase-block[data-phase="main"]:only-of-type` further strips the
+    wrapper border."""
+    raw_rchop = yaml.safe_load(
+        (KB_REGIMENS / "r_chop.yaml").read_text(encoding="utf-8")
+    )
+    # Sanity: R-CHOP is still in the legacy shape (no phases authored)
+    assert "phases" not in raw_rchop or not raw_rchop.get("phases"), (
+        "fixture invariant: r_chop.yaml is legacy; if it gains phases, "
+        "this test should swap to another single-phase legacy regimen"
+    )
+
+    track = PlanTrack(
+        track_id="standard",
+        label="R-CHOP test track",
+        indication_id="IND-TEST-RCHOP",
+        is_default=True,
+        regimen_data=raw_rchop,
+    )
+
+    html_out = _render_treatment_phases(
+        track,
+        drugs_lookup={},
+        patient_disease_id="",
+        disease_names={},
+        target_lang="uk",
+    )
+
+    # All 5 R-CHOP drugs visible
+    for drug_id in (
+        "DRUG-RITUXIMAB",
+        "DRUG-CYCLOPHOSPHAMIDE",
+        "DRUG-DOXORUBICIN",
+        "DRUG-VINCRISTINE",
+        "DRUG-PREDNISONE",
+    ):
+        assert drug_id in html_out, f"{drug_id} missing from R-CHOP render"
+
+    # Single auto-wrapped phase
+    assert html_out.count('class="phase-block"') == 1
+    assert 'data-phase="main"' in html_out
+
+    # No heading emitted for the legacy single phase (visual-similarity
+    # contract). The mapping `_PHASE_HEADING_PREFIX_UK["main"]` is None,
+    # which suppresses the <h4>.
+    assert 'class="phase-heading"' not in html_out, (
+        "legacy auto-wrap must NOT emit a phase-heading <h4> — it would "
+        "introduce spurious 'основна терапія' chrome above unmigrated "
+        "regimens"
+    )
+
+    # And no lymphodepletion prefix (this is R-CHOP, not CAR-T)
+    assert "Перед основною терапією" not in html_out
+
+
+def test_render_bridging_options():
+    """`bridging_options` renders as a separate visible block listing the
+    accepted bridging-regimen IDs. Constructed in-test because no
+    production regimen YAML has `bridging_options:` populated yet (PR3
+    will add them to ~8 indications referencing CAR-T / TIL)."""
+    track = PlanTrack(
+        track_id="aggressive",
+        label="Test track",
+        indication_id="IND-TEST",
+        is_default=False,
+        regimen_data={
+            "id": "REG-FAKE-CART",
+            "name": "fake CART",
+            "phases": [
+                {
+                    "name": "lymphodepletion",
+                    "purpose_ua": "test lymphodepletion",
+                    "components": [{"drug_id": "DRUG-CYCLOPHOSPHAMIDE"}],
+                },
+                {
+                    "name": "main",
+                    "purpose_ua": "test main",
+                    "components": [{"drug_id": "DRUG-AXICABTAGENE-CILOLEUCEL"}],
+                },
+            ],
+            "components": [],
+            "bridging_options": ["REG-RICE", "REG-DHAP"],
+        },
+    )
+
+    html_out = _render_treatment_phases(
+        track,
+        drugs_lookup={},  # empty lookup — drug name falls back to drug_id
+        patient_disease_id="",
+        disease_names={},
+        target_lang="uk",
+    )
+
+    # Bridging block rendered with both regimen IDs visible
+    assert "bridging-options" in html_out
+    assert "REG-RICE" in html_out
+    assert "REG-DHAP" in html_out
+    # UA label present
+    assert "Якщо очікування на основну терапію" in html_out
+    # And the phase blocks rendered too
+    assert 'data-phase="lymphodepletion"' in html_out
+    assert 'data-phase="main"' in html_out


### PR DESCRIPTION
## TL;DR

Builds on PR #154 (schema). Makes phases user-visible: each phase renders as distinct HTML block with own \`purpose_ua\` heading. Migrates axi-cel as reference YAML.

## What

- \`_render_treatment_phases(regimen)\` + \`_iter_regimen_components\` helper (handles both legacy + migrated shapes at dict level — render reads raw dicts from loader, not Pydantic instances)
- CSS for phase-block visual separation (+39 lines)
- Reference migration \`reg_car_t_axicel.yaml\`: lymphodepletion (Cy+Flu, days -5/-4/-3) → main_infusion. Fludarabine promoted from premedication-string to proper RegimenComponent. Clinical content preserved verbatim.

## Tests

13 pass (10 from PR1 + 3 new render tests). Full regression unchanged.

## Plan reference

\`docs/reviews/regimen-phases-refactor-plan-2026-04-28.md\` §4.4