### PR TITLE
feat(kb): migrate 17 high-stakes regimens to multi-phase shape (PR3)

### DIFF
--- a/knowledge_base/hosted/content/regimens/codox_m_ivac.yaml
+++ b/knowledge_base/hosted/content/regimens/codox_m_ivac.yaml
@@ -4,16 +4,44 @@ name_ua: "CODOX-M / IVAC по черзі × 4 циклів (протокол М�
 alternate_names: ["Magrath", "LMB-style"]
 
 # Components listed are the core agents — actual schedule is alternating
-# CODOX-M and IVAC blocks; details encoded in notes for brevity.
-components:
-  - {drug_id: DRUG-CYCLOPHOSPHAMIDE, dose: "800 mg/m² day 1 + 200 mg/m² days 2-5 (CODOX-M)", schedule: "IV per CODOX-M block", route: IV}
-  - {drug_id: DRUG-VINCRISTINE, dose: "1.5 mg/m² day 1 (cap 2 mg)", schedule: "IV per CODOX-M block", route: IV}
-  - {drug_id: DRUG-DOXORUBICIN, dose: "40 mg/m² day 1 (CODOX-M)", schedule: "IV per CODOX-M block", route: IV}
-  - {drug_id: DRUG-METHOTREXATE, dose: "3 g/m² day 10 (HD-MTX) + 12 mg IT day 1 + day 3", schedule: "CODOX-M HD + IT", route: IV/IT}
-  - {drug_id: DRUG-CYTARABINE, dose: "2 g/m² q12h × 4 doses (IVAC)", schedule: "IV per IVAC block", route: IV}
-  - {drug_id: DRUG-ETOPOSIDE, dose: "60 mg/m² days 1-5 (IVAC)", schedule: "IV per IVAC block", route: IV}
-  - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m² day 1 each block (when CD20+, R-CODOX-M/R-IVAC)", schedule: "IV", route: IV}
-  - {drug_id: DRUG-FILGRASTIM, dose: "5 µg/kg/day", schedule: "SC from day 13 each block until ANC recovery", route: SC}
+# CODOX-M and IVAC blocks; details encoded in phase components per block.
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  # Block A — CODOX-M
+  - name: alternating_block_a
+    purpose_ua: "блок A (CODOX-M): cyclophosphamide-vincristine-doxorubicin + HD-методreксат з IT-CNS-профілактикою; з ритуксимабом для CD20+; чергує з блоком B (IVAC) × 4 разом"
+    purpose_en: "block A (CODOX-M): cyclophosphamide-vincristine-doxorubicin + HD-MTX with IT-CNS prophylaxis; with rituximab for CD20+; alternates with block B (IVAC) × 4 total"
+    duration: "21 days per CODOX-M block × 2 (cycles 1, 3 of 4 alternating)"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - {drug_id: DRUG-CYCLOPHOSPHAMIDE, dose: "800 mg/m² day 1 + 200 mg/m² days 2-5 (CODOX-M)", schedule: "IV per CODOX-M block", route: IV}
+      - {drug_id: DRUG-VINCRISTINE, dose: "1.5 mg/m² day 1 (cap 2 mg)", schedule: "IV per CODOX-M block", route: IV}
+      - {drug_id: DRUG-DOXORUBICIN, dose: "40 mg/m² day 1 (CODOX-M)", schedule: "IV per CODOX-M block", route: IV}
+      - {drug_id: DRUG-METHOTREXATE, dose: "3 g/m² day 10 (HD-MTX) + 12 mg IT day 1 + day 3", schedule: "CODOX-M HD + IT", route: IV/IT}
+      # Shared — applies to all blocks
+      - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m² day 1 each block (when CD20+, R-CODOX-M/R-IVAC)", schedule: "IV", route: IV}
+      - {drug_id: DRUG-FILGRASTIM, dose: "5 µg/kg/day", schedule: "SC from day 13 each block until ANC recovery", route: SC}
+    sources:
+      - SRC-NCCN-BCELL-2025
+  # Block B — IVAC
+  - name: alternating_block_b
+    purpose_ua: "блок B (IVAC): ifosfamide + HD-cytarabine + etoposide; з ритуксимабом для CD20+; чергує з блоком A (CODOX-M) × 4 разом"
+    purpose_en: "block B (IVAC): ifosfamide + HD-cytarabine + etoposide; with rituximab for CD20+; alternates with block A (CODOX-M) × 4 total"
+    duration: "21 days per IVAC block × 2 (cycles 2, 4 of 4 alternating)"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components:
+      - {drug_id: DRUG-CYTARABINE, dose: "2 g/m² q12h × 4 doses (IVAC)", schedule: "IV per IVAC block", route: IV}
+      - {drug_id: DRUG-ETOPOSIDE, dose: "60 mg/m² days 1-5 (IVAC)", schedule: "IV per IVAC block", route: IV}
+      # Shared — applies to all blocks
+      - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m² day 1 each block (when CD20+, R-CODOX-M/R-IVAC)", schedule: "IV", route: IV}
+      - {drug_id: DRUG-FILGRASTIM, dose: "5 µg/kg/day", schedule: "SC from day 13 each block until ANC recovery", route: SC}
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days: 21
 total_cycles: "4 alternating blocks (CODOX-M, IVAC, CODOX-M, IVAC)"

--- a/knowledge_base/hosted/content/regimens/hyper_cvad_r.yaml
+++ b/knowledge_base/hosted/content/regimens/hyper_cvad_r.yaml
@@ -3,20 +3,47 @@ name: "Hyper-CVAD + Rituximab (CD20+) — alternating courses A/B, 8 cycles tota
 name_ua: "Hyper-CVAD + ритуксимаб (для CD20+) — чергуючі цикли A/B, 8 циклів"
 alternate_names: ["Hyper-CVAD-R", "MD Anderson protocol", "MDACC ALL"]
 
-components:
-  # Course A (cycles 1, 3, 5, 7) — Hyper-CVAD
-  - {drug_id: DRUG-CYCLOPHOSPHAMIDE, dose: "300 mg/m² q12h × 6 doses", schedule: "IV days 1-3 (Course A only)", route: IV}
-  - {drug_id: DRUG-VINCRISTINE, dose: "2 mg flat dose", schedule: "IV days 4 + 11 (Course A only)", route: IV}
-  - {drug_id: DRUG-DOXORUBICIN, dose: "50 mg/m²", schedule: "IV day 4 (Course A only)", route: IV}
-  - {drug_id: DRUG-DEXAMETHASONE, dose: "40 mg", schedule: "PO/IV days 1-4 + 11-14 (Course A only)", route: PO}
-  # Course B (cycles 2, 4, 6, 8) — HD-MTX + HD-cytarabine
-  - {drug_id: DRUG-METHOTREXATE, dose: "1 g/m²", schedule: "IV 24h infusion day 1 (Course B only); leucovorin rescue", route: IV}
-  - {drug_id: DRUG-CYTARABINE, dose: "3 g/m² q12h × 4 doses", schedule: "IV days 2-3 (Course B only)", route: IV}
-  # Rituximab (cycles 1-4 для CD20+)
-  - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m²", schedule: "IV days 1 + 11 (cycles 1-4 для CD20+ only)", route: IV}
-  # CNS prophylaxis (all cycles)
-  - {drug_id: DRUG-METHOTREXATE, dose: "12 mg IT", schedule: "IT day 2 each cycle", route: IT}
-  - {drug_id: DRUG-CYTARABINE, dose: "100 mg IT", schedule: "IT day 8 each cycle", route: IT}
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  # Course A (cycles 1, 3, 5, 7) — Hyper-CVAD: cyclophosphamide + vincristine + doxorubicin + dexamethasone
+  - name: alternating_block_a
+    purpose_ua: "блок A (Hyper-CVAD): cyclophosphamide + vincristine + doxorubicin + dexamethasone — цикли 1, 3, 5, 7; з ритуксимабом для CD20+ (цикли 1-4) та IT-CNS-профілактикою"
+    purpose_en: "block A (Hyper-CVAD): cyclophosphamide + vincristine + doxorubicin + dexamethasone — cycles 1, 3, 5, 7; with rituximab for CD20+ (cycles 1-4) and IT-CNS prophylaxis"
+    duration: "21 days per cycle × 4 A-cycles (cycles 1, 3, 5, 7)"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - {drug_id: DRUG-CYCLOPHOSPHAMIDE, dose: "300 mg/m² q12h × 6 doses", schedule: "IV days 1-3 (Course A only)", route: IV}
+      - {drug_id: DRUG-VINCRISTINE, dose: "2 mg flat dose", schedule: "IV days 4 + 11 (Course A only)", route: IV}
+      - {drug_id: DRUG-DOXORUBICIN, dose: "50 mg/m²", schedule: "IV day 4 (Course A only)", route: IV}
+      - {drug_id: DRUG-DEXAMETHASONE, dose: "40 mg", schedule: "PO/IV days 1-4 + 11-14 (Course A only)", route: PO}
+      # Rituximab — applies to A-cycles 1, 3 (within cycles 1-4 для CD20+)
+      - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m²", schedule: "IV days 1 + 11 (cycles 1-4 для CD20+ only)", route: IV}
+      # CNS prophylaxis (all cycles, including A)
+      - {drug_id: DRUG-METHOTREXATE, dose: "12 mg IT", schedule: "IT day 2 each cycle", route: IT}
+      - {drug_id: DRUG-CYTARABINE, dose: "100 mg IT", schedule: "IT day 8 each cycle", route: IT}
+    sources:
+      - SRC-NCCN-BCELL-2025
+  # Course B (cycles 2, 4, 6, 8) — MA: HD-MTX + HD-cytarabine
+  - name: alternating_block_b
+    purpose_ua: "блок B (MA): high-dose methotrexate + HD-cytarabine — цикли 2, 4, 6, 8; з ритуксимабом для CD20+ (цикли 1-4) та IT-CNS-профілактикою"
+    purpose_en: "block B (MA): high-dose methotrexate + HD-cytarabine — cycles 2, 4, 6, 8; with rituximab for CD20+ (cycles 1-4) and IT-CNS prophylaxis"
+    duration: "21 days per cycle × 4 B-cycles (cycles 2, 4, 6, 8)"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components:
+      - {drug_id: DRUG-METHOTREXATE, dose: "1 g/m²", schedule: "IV 24h infusion day 1 (Course B only); leucovorin rescue", route: IV}
+      - {drug_id: DRUG-CYTARABINE, dose: "3 g/m² q12h × 4 doses", schedule: "IV days 2-3 (Course B only)", route: IV}
+      # Rituximab — applies to B-cycles 2, 4 (within cycles 1-4 для CD20+)
+      - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m²", schedule: "IV days 1 + 11 (cycles 1-4 для CD20+ only)", route: IV}
+      # CNS prophylaxis (all cycles, including B)
+      - {drug_id: DRUG-METHOTREXATE, dose: "12 mg IT", schedule: "IT day 2 each cycle", route: IT}
+      - {drug_id: DRUG-CYTARABINE, dose: "100 mg IT", schedule: "IT day 8 each cycle", route: IT}
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days: 21
 total_cycles: "8 alternating cycles (A/B/A/B/A/B/A/B); maintenance POMP × 30 months Ph-, або continuous TKI Ph+"

--- a/knowledge_base/hosted/content/regimens/matrix.yaml
+++ b/knowledge_base/hosted/content/regimens/matrix.yaml
@@ -3,11 +3,24 @@ name: "MATRix (HD-Methotrexate + HD-Cytarabine + Thiotepa + Rituximab), 4 cycles
 name_ua: "MATRix — HD-MTX + HD-Cytarabine + тіотепа + ритуксимаб, 4 цикли"
 alternate_names: ["MATRix", "IELSG32 induction"]
 
-components:
-  - {drug_id: DRUG-METHOTREXATE, dose: "3.5 g/m²", schedule: "IV 24h infusion day 1; leucovorin rescue from h+24", route: IV}
-  - {drug_id: DRUG-CYTARABINE, dose: "2 g/m² BID", schedule: "IV days 2-3 (4 doses total)", route: IV}
-  - {drug_id: DRUG-THIOTEPA, dose: "30 mg/m²", schedule: "IV day 4", route: IV}
-  - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m²", schedule: "IV days -5, 0", route: IV}
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: induction
+    purpose_ua: "індукція MATRix × 4 цикли — HD-MTX + HD-Cytarabine + тіотепа + ритуксимаб для PCNSL; провадить до окремого регімену autoSCT-консолідації (BCNU + thiotepa)"
+    purpose_en: "MATRix induction × 4 cycles — HD-MTX + HD-Cytarabine + thiotepa + rituximab for PCNSL; followed by separate autoSCT consolidation regimen (BCNU + thiotepa)"
+    duration: "4 cycles × 21 days each"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - {drug_id: DRUG-METHOTREXATE, dose: "3.5 g/m²", schedule: "IV 24h infusion day 1; leucovorin rescue from h+24", route: IV}
+      - {drug_id: DRUG-CYTARABINE, dose: "2 g/m² BID", schedule: "IV days 2-3 (4 doses total)", route: IV}
+      - {drug_id: DRUG-THIOTEPA, dose: "30 mg/m²", schedule: "IV day 4", route: IV}
+      - {drug_id: DRUG-RITUXIMAB, dose: "375 mg/m²", schedule: "IV days -5, 0", route: IV}
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days: 21
 total_cycles: "4 cycles induction; followed by autoSCT consolidation (BCNU + thiotepa)"

--- a/knowledge_base/hosted/content/regimens/r_dhap_autosct.yaml
+++ b/knowledge_base/hosted/content/regimens/r_dhap_autosct.yaml
@@ -3,35 +3,59 @@ name: "Intensive 1L MCL: alternating R-CHOP / R-DHAP × 6 cycles + autoSCT conso
 name_ua: "Інтенсивна 1L MCL: альтернація R-CHOP / R-DHAP × 6 циклів + autoSCT + R-підтримка"
 alternate_names: ["Nordic regimen", "MCL Younger", "R-DHAP/R-CHOP alternating"]
 
-components:
-  - drug_id: DRUG-RITUXIMAB
-    dose: "375 mg/m²"
-    schedule: "IV day 1 each cycle (R-CHOP + R-DHAP)"
-    route: IV
-  - drug_id: DRUG-CYCLOPHOSPHAMIDE
-    dose: "750 mg/m²"
-    schedule: "IV day 1 of R-CHOP cycles only"
-    route: IV
-  - drug_id: DRUG-DOXORUBICIN
-    dose: "50 mg/m²"
-    schedule: "IV day 1 of R-CHOP cycles only"
-    route: IV
-  - drug_id: DRUG-VINCRISTINE
-    dose: "1.4 mg/m² (cap 2 mg)"
-    schedule: "IV day 1 of R-CHOP cycles only"
-    route: IV
-  - drug_id: DRUG-PREDNISONE
-    dose: "100 mg"
-    schedule: "PO days 1-5 of R-CHOP cycles"
-    route: PO
-  - drug_id: DRUG-DEXAMETHASONE
-    dose: "40 mg"
-    schedule: "IV days 1-4 of R-DHAP cycles only"
-    route: IV
-  - drug_id: DRUG-CYTARABINE
-    dose: "2 g/m² q12h"
-    schedule: "IV day 2 of R-DHAP cycles (HiDAC component)"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: induction
+    purpose_ua: "індукція: 6 чергуючих циклів R-CHOP та R-DHAP (3 + 3); анти-CD20 з anthracycline-вмісним та HiDAC-вмісним блоками для максимальної ремісії перед autoSCT"
+    purpose_en: "induction: 6 alternating cycles R-CHOP and R-DHAP (3 + 3); anti-CD20 with anthracycline-containing and HiDAC-containing blocks for maximum remission before autoSCT"
+    duration: "~18 weeks (6 × 21-day cycles)"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-RITUXIMAB
+        dose: "375 mg/m²"
+        schedule: "IV day 1 each cycle (R-CHOP + R-DHAP)"
+        route: IV
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "750 mg/m²"
+        schedule: "IV day 1 of R-CHOP cycles only"
+        route: IV
+      - drug_id: DRUG-DOXORUBICIN
+        dose: "50 mg/m²"
+        schedule: "IV day 1 of R-CHOP cycles only"
+        route: IV
+      - drug_id: DRUG-VINCRISTINE
+        dose: "1.4 mg/m² (cap 2 mg)"
+        schedule: "IV day 1 of R-CHOP cycles only"
+        route: IV
+      - drug_id: DRUG-PREDNISONE
+        dose: "100 mg"
+        schedule: "PO days 1-5 of R-CHOP cycles"
+        route: PO
+      - drug_id: DRUG-DEXAMETHASONE
+        dose: "40 mg"
+        schedule: "IV days 1-4 of R-DHAP cycles only"
+        route: IV
+      - drug_id: DRUG-CYTARABINE
+        dose: "2 g/m² q12h"
+        schedule: "IV day 2 of R-DHAP cycles (HiDAC component)"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - name: consolidation_autosct
+    purpose_ua: "консолідація аутологічною ТГСК після відповіді на індукцію (BEAM/CBV кондиціонування)"
+    purpose_en: "consolidation with autologous HCT after response to induction (BEAM/CBV conditioning)"
+    duration: "single transplant procedure"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # BEAM/CBV conditioning + autoSCT — institution-specific;
+                   # not enumerated as drug components in this regimen entity
+                   # (consolidation pathway placeholder per plan-doc §5 Group C)
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days: 21
 total_cycles: "6 alternating (3 R-CHOP + 3 R-DHAP), then BEAM/CBV-conditioned autoSCT, then R maintenance every 2 mo × 3 years"

--- a/knowledge_base/hosted/content/regimens/reg_allohct_cml_advanced.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_allohct_cml_advanced.yaml
@@ -5,11 +5,36 @@ alternate_names:
   - "AlloHCT CML"
   - "Allogeneic SCT advanced CML"
 
-components:
-  - drug_id: DRUG-CYTARABINE
-    dose: "Conditioning regimen (variable per institution): typically myeloablative (Bu/Cy or Cy/TBI) for fit younger; reduced-intensity (Flu/Mel) for older"
-    schedule: "Pre-transplant conditioning days -7 to -1"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: conditioning
+    purpose_ua: "кондиціонування перед ало-ТГСК — мієлоаблятивне (Bu/Cy або Cy/TBI) для фіт-молодих; редукованої інтенсивності (Flu/Mel) для старших; включає цитарабін за інституційним протоколом дні -7 до -1"
+    purpose_en: "conditioning before allo-HCT — myeloablative (Bu/Cy or Cy/TBI) for fit younger; reduced-intensity (Flu/Mel) for older; cytarabine per institutional protocol days -7 to -1"
+    duration: "7 days, days -7 to -1 before HCT"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -7
+    optional: false
+    components:
+      - drug_id: DRUG-CYTARABINE
+        dose: "Conditioning regimen (variable per institution): typically myeloablative (Bu/Cy or Cy/TBI) for fit younger; reduced-intensity (Flu/Mel) for older"
+        schedule: "Pre-transplant conditioning days -7 to -1"
+        route: IV
+    sources:
+      - SRC-NCCN-MPN-2025
+      - SRC-ELN-CML-2020
+  - name: allohct
+    purpose_ua: "алогенна трансплантація гемопоетичних клітин (ало-ТГСК) — єдина куративна опція в бластному кризі CML або після провалу кількох ТКІ; пост-ТГСК підтримка ТКІ ≥2 років"
+    purpose_en: "allogeneic hematopoietic cell transplant (allo-HCT) — only curative option for CML blast crisis or multi-TKI failure; post-HCT TKI maintenance ≥2 years"
+    duration: "single transplant procedure"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # AlloHCT — pathway placeholder, no drug components
+    sources:
+      - SRC-NCCN-MPN-2025
+      - SRC-ELN-CML-2020
 
 cycle_length_days:
 total_cycles: "Single transplant procedure; post-HCT TKI maintenance (typically dasatinib or imatinib) for ≥2 years per institution"

--- a/knowledge_base/hosted/content/regimens/reg_allohct_mds_hr.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_allohct_mds_hr.yaml
@@ -5,11 +5,45 @@ alternate_names:
   - "AlloHCT MDS-HR"
   - "Allogeneic SCT MDS"
 
-components:
-  - drug_id: DRUG-AZACITIDINE
-    dose: "Pre-HCT cytoreduction: azacitidine 75 mg/m² SC days 1-7 q28d × 4-6 cycles to reduce blast burden + bridge to HCT"
-    schedule: "Bridging until donor identified + transplant slot available; conditioning regimen institution-specific (myeloablative Bu/Cy or Bu/Flu for fit younger; reduced-intensity Flu/Mel or Flu/Bu for older / comorbid)"
-    route: SC
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: bridging
+    purpose_ua: "HMA-бриджинг 4-6 циклів азацитидину перед ало-ТГСК — зменшити навантаження бластами + bridge до пошуку донора"
+    purpose_en: "HMA bridging 4-6 cycles of azacitidine pre-HCT — reduce blast burden + bridge to donor search"
+    duration: "4-6 cycles × 28 days each (until donor identified + transplant slot available)"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -120
+    optional: false
+    components:
+      - drug_id: DRUG-AZACITIDINE
+        dose: "Pre-HCT cytoreduction: azacitidine 75 mg/m² SC days 1-7 q28d × 4-6 cycles to reduce blast burden + bridge to HCT"
+        schedule: "Bridging until donor identified + transplant slot available; conditioning regimen institution-specific (myeloablative Bu/Cy or Bu/Flu for fit younger; reduced-intensity Flu/Mel or Flu/Bu for older / comorbid)"
+        route: SC
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-ESMO-MDS-2021
+  - name: conditioning_allohct
+    purpose_ua: "кондиціонування перед ало-ТГСК — мієлоаблятивне (Bu/Cy або Bu/Flu) для фіт-молодших; редукованої інтенсивності (Flu/Mel або Flu/Bu) для старших/коморбідних; інституційно специфічне"
+    purpose_en: "conditioning before allo-HCT — myeloablative (Bu/Cy or Bu/Flu) for fit younger; reduced-intensity (Flu/Mel or Flu/Bu) for older/comorbid; institution-specific"
+    duration: "single conditioning regimen (institution-specific) before HCT"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # Conditioning regimen institution-specific; not enumerated
+                   # as drug components here (placeholder per plan-doc §5 Group D)
+    sources:
+      - SRC-NCCN-AML-2025
+  - name: allohct
+    purpose_ua: "алогенна трансплантація гемопоетичних клітин (ало-ТГСК) — єдина куративна опція для MDS-HR; пост-ТГСК підтримка азацитидином опціонально × 12 місяців"
+    purpose_en: "allogeneic hematopoietic cell transplant (allo-HCT) — only curative option for MDS-HR; post-HCT azacitidine maintenance optional × 12 months"
+    duration: "single transplant procedure"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # AlloHCT — pathway placeholder, no drug components
+    sources:
+      - SRC-NCCN-AML-2025
 
 cycle_length_days:
 total_cycles: "Single transplant procedure; HMA bridging 4-6 cycles pre-HCT; post-HCT azacitidine maintenance optional ×12 months for high-risk subset"

--- a/knowledge_base/hosted/content/regimens/reg_allohct_pmf.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_allohct_pmf.yaml
@@ -5,11 +5,45 @@ alternate_names:
   - "AlloHCT PMF"
   - "Allogeneic SCT myelofibrosis"
 
-components:
-  - drug_id: DRUG-RUXOLITINIB
-    dose: "JAKi optimization 3-6 months pre-HCT (5-20 mg PO BID by baseline plt) to reduce spleen volume + symptom burden; taper 5-7 days before conditioning"
-    schedule: "Pre-HCT bridging; conditioning regimen institution-specific (myeloablative Bu/Flu or Bu/Cy for fit younger; reduced-intensity Flu/Mel or Flu/Bu for older / comorbid)"
-    route: PO
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: bridging
+    purpose_ua: "JAKi-бриджинг 3-6 місяців перед ало-ТГСК — оптимізація рoxolitinib для зменшення селезінки + симптоматичного навантаження; taper за 5-7 днів до кондиціонування"
+    purpose_en: "JAKi bridging 3-6 months pre-HCT — ruxolitinib optimization to reduce spleen volume + symptom burden; taper 5-7 days before conditioning"
+    duration: "3-6 months pre-HCT"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -180
+    optional: false
+    components:
+      - drug_id: DRUG-RUXOLITINIB
+        dose: "JAKi optimization 3-6 months pre-HCT (5-20 mg PO BID by baseline plt) to reduce spleen volume + symptom burden; taper 5-7 days before conditioning"
+        schedule: "Pre-HCT bridging; conditioning regimen institution-specific (myeloablative Bu/Flu or Bu/Cy for fit younger; reduced-intensity Flu/Mel or Flu/Bu for older / comorbid)"
+        route: PO
+    sources:
+      - SRC-NCCN-MPN-2025
+      - SRC-DIPSS-PLUS-GANGAT-2011
+  - name: conditioning_allohct
+    purpose_ua: "кондиціонування перед ало-ТГСК — мієлоаблятивне (Bu/Flu або Bu/Cy) для фіт-молодших; редукованої інтенсивності (Flu/Mel або Flu/Bu) для старших/коморбідних; інституційно специфічне"
+    purpose_en: "conditioning before allo-HCT — myeloablative (Bu/Flu or Bu/Cy) for fit younger; reduced-intensity (Flu/Mel or Flu/Bu) for older/comorbid; institution-specific"
+    duration: "single conditioning regimen (institution-specific) before HCT"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # Conditioning regimen institution-specific; not enumerated
+                   # as drug components here (placeholder per plan-doc §5 Group D)
+    sources:
+      - SRC-NCCN-MPN-2025
+  - name: allohct
+    purpose_ua: "алогенна трансплантація гемопоетичних клітин (ало-ТГСК) — єдина куративна опція для PMF; donor: sibling > matched unrelated > haplo > cord"
+    purpose_en: "allogeneic hematopoietic cell transplant (allo-HCT) — only curative option for PMF; donor priority: sibling > matched unrelated > haplo > cord"
+    duration: "single transplant procedure"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # AlloHCT — pathway placeholder, no drug components
+    sources:
+      - SRC-NCCN-MPN-2025
 
 cycle_length_days:
 total_cycles: "Single transplant procedure; consider post-HCT JAKi resumption (off-label) if early molecular relapse signal; donor lymphocyte infusion (DLI) for relapse"

--- a/knowledge_base/hosted/content/regimens/reg_car_t_axicel_fl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_car_t_axicel_fl.yaml
@@ -3,22 +3,48 @@ name: "Axicabtagene ciloleucel (axi-cel) CAR-T for r/r FL — single infusion af
 name_ua: "Аксікабтаген цилолейцел (axi-cel) CAR-T для рефрактерної ФЛ — одна інфузія після лімфодеплеції (ZUMA-5)"
 alternate_names: ["Axi-cel FL", "Yescarta FL", "ZUMA-5 regimen"]
 
-components:
-  - drug_id: DRUG-CYCLOPHOSPHAMIDE
-    dose: "500 mg/m²/day"
-    schedule: "IV days -5, -4, -3 (lymphodepletion, with fludarabine 30 mg/m²/day same days)"
-    route: IV
-  - drug_id: DRUG-AXICABTAGENE-CILOLEUCEL
-    dose: "Target 2 × 10^6 anti-CD19 CAR+ T-cells/kg (max 2 × 10^8 total)"
-    schedule: "Single IV infusion day 0, after lymphodepletion completed"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: lymphodepletion
+    purpose_ua: "виснаження лімфоцитів перед CAR-T для приживлення клітин"
+    purpose_en: "lymphocyte depletion before CAR-T to enable cell engraftment"
+    duration: "3 days, days -5 to -3"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -5
+    optional: false
+    components:
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "500 mg/m²/day"
+        schedule: "IV days -5, -4, -3"
+        route: IV
+      - drug_id: DRUG-FLUDARABINE
+        dose: "30 mg/m²/day"
+        schedule: "IV days -5, -4, -3"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - name: main
+    purpose_ua: "основна CAR-T інфузія"
+    purpose_en: "main CAR-T infusion"
+    duration: "single infusion"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-AXICABTAGENE-CILOLEUCEL
+        dose: "Target 2 × 10^6 anti-CD19 CAR+ T-cells/kg (max 2 × 10^8 total)"
+        schedule: "Single IV infusion day 0, after lymphodepletion completed"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days:
 total_cycles: "Single infusion (one-time therapy)"
 toxicity_profile: severe
 
 premedication:
-  - "Lymphodepletion: fludarabine 30 mg/m² + cyclophosphamide 500 mg/m² IV days -5 to -3"
   - "Acetaminophen 650 mg PO + diphenhydramine 12.5 mg IV pre-infusion"
   - "AVOID prophylactic systemic corticosteroids — reduces CAR-T expansion + efficacy"
   - "Tocilizumab MUST be on-site (≥2 doses available) BEFORE infusion — for emergency CRS rescue"

--- a/knowledge_base/hosted/content/regimens/reg_car_t_axicel_hgbl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_car_t_axicel_hgbl.yaml
@@ -4,11 +4,43 @@ name_ua: Аксікабтагене сілолейцел (CAR-T) при реци
 alternate_names:
   - Axi-cel HGBL
   - ZUMA-7-style CAR-T
-components:
-  - drug_id: DRUG-AXICABTAGENE-CILOLEUCEL
-    dose: 2 × 10⁶ CAR+ T cells/kg (max 2 × 10⁸)
-    schedule: Single IV infusion after lymphodepletion (Flu/Cy days -5 to -3)
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: lymphodepletion
+    purpose_ua: "виснаження лімфоцитів перед CAR-T для приживлення клітин (Flu/Cy days -5 to -3 per ZUMA pattern)"
+    purpose_en: "lymphocyte depletion before CAR-T to enable cell engraftment (Flu/Cy days -5 to -3 per ZUMA pattern)"
+    duration: "3 days, days -5 to -3"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -5
+    optional: false
+    components:
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "500 mg/m²/day"
+        schedule: "IV days -5, -4, -3 (lymphodepletion)"
+        route: IV
+      - drug_id: DRUG-FLUDARABINE
+        dose: "30 mg/m²/day"
+        schedule: "IV days -5, -4, -3 (lymphodepletion)"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - name: main
+    purpose_ua: "основна CAR-T інфузія"
+    purpose_en: "main CAR-T infusion"
+    duration: "single infusion"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-AXICABTAGENE-CILOLEUCEL
+        dose: 2 × 10⁶ CAR+ T cells/kg (max 2 × 10⁸)
+        schedule: Single IV infusion after lymphodepletion (Flu/Cy days -5 to -3)
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 cycle_length_days: 1
 total_cycles: Single infusion
 toxicity_profile: high (CRS + ICANS)

--- a/knowledge_base/hosted/content/regimens/reg_car_t_brexucel_mcl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_car_t_brexucel_mcl.yaml
@@ -3,22 +3,48 @@ name: "Brexucabtagene autoleucel (brexu-cel) CAR-T for r/r MCL — single infusi
 name_ua: "Брексукабтаген аутолейцел (brexu-cel) CAR-T для рефрактерної MCL — одна інфузія після лімфодеплеції (ZUMA-2)"
 alternate_names: ["Brexu-cel MCL", "Tecartus MCL", "ZUMA-2 regimen"]
 
-components:
-  - drug_id: DRUG-CYCLOPHOSPHAMIDE
-    dose: "500 mg/m²/day"
-    schedule: "IV days -5, -4, -3 (lymphodepletion, with fludarabine 30 mg/m²/day same days)"
-    route: IV
-  - drug_id: DRUG-BREXUCABTAGENE-AUTOLEUCEL
-    dose: "Target 2 × 10^6 anti-CD19 CAR+ T-cells/kg (max 2 × 10^8 total)"
-    schedule: "Single IV infusion day 0, after lymphodepletion completed"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: lymphodepletion
+    purpose_ua: "виснаження лімфоцитів перед CAR-T для приживлення клітин"
+    purpose_en: "lymphocyte depletion before CAR-T to enable cell engraftment"
+    duration: "3 days, days -5 to -3"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -5
+    optional: false
+    components:
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "500 mg/m²/day"
+        schedule: "IV days -5, -4, -3"
+        route: IV
+      - drug_id: DRUG-FLUDARABINE
+        dose: "30 mg/m²/day"
+        schedule: "IV days -5, -4, -3"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - name: main
+    purpose_ua: "основна CAR-T інфузія"
+    purpose_en: "main CAR-T infusion"
+    duration: "single infusion"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-BREXUCABTAGENE-AUTOLEUCEL
+        dose: "Target 2 × 10^6 anti-CD19 CAR+ T-cells/kg (max 2 × 10^8 total)"
+        schedule: "Single IV infusion day 0, after lymphodepletion completed"
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days:
 total_cycles: "Single infusion (one-time therapy)"
 toxicity_profile: severe
 
 premedication:
-  - "Lymphodepletion: fludarabine 30 mg/m² + cyclophosphamide 500 mg/m² IV days -5 to -3"
   - "Acetaminophen 650 mg PO + diphenhydramine 12.5 mg IV pre-infusion"
   - "AVOID prophylactic systemic corticosteroids — reduces CAR-T expansion + efficacy"
   - "Tocilizumab MUST be on-site (≥2 doses available) BEFORE infusion — for emergency CRS rescue"

--- a/knowledge_base/hosted/content/regimens/reg_choep_allosct_consolidation.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_choep_allosct_consolidation.yaml
@@ -3,27 +3,63 @@ name: "CHOEP × 6 + allogeneic SCT consolidation in CR1 (fit transplant-eligible
 name_ua: "CHOEP × 6 + алогенна ТКМ в CR1 (придатні до трансплантації PTCL NOS)"
 alternate_names: ["CHOEP-alloSCT", "Aggressive 1L PTCL NOS"]
 
-components:
-  - drug_id: DRUG-CYCLOPHOSPHAMIDE
-    dose: "750 mg/m²"
-    schedule: "IV day 1 of each 21-day cycle × 6 (induction)"
-    route: IV
-  - drug_id: DRUG-DOXORUBICIN
-    dose: "50 mg/m²"
-    schedule: "IV day 1 each cycle × 6"
-    route: IV
-  - drug_id: DRUG-VINCRISTINE
-    dose: "1.4 mg/m² (cap 2 mg)"
-    schedule: "IV day 1 each cycle × 6"
-    route: IV
-  - drug_id: DRUG-ETOPOSIDE
-    dose: "100 mg/m²"
-    schedule: "IV days 1-3 each cycle × 6"
-    route: IV
-  - drug_id: DRUG-PREDNISONE
-    dose: "100 mg"
-    schedule: "PO days 1-5 each cycle × 6"
-    route: PO
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: induction
+    purpose_ua: "індукція CHOEP × 6 циклів — анти-CD20-незалежний CHOP+етопозид режим для досягнення CR1 в фіт-молодих PTCL NOS"
+    purpose_en: "induction CHOEP × 6 cycles — CHOP + etoposide regimen to achieve CR1 in fit younger PTCL NOS"
+    duration: "~18 weeks (6 × 21-day cycles)"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "750 mg/m²"
+        schedule: "IV day 1 of each 21-day cycle × 6 (induction)"
+        route: IV
+      - drug_id: DRUG-DOXORUBICIN
+        dose: "50 mg/m²"
+        schedule: "IV day 1 each cycle × 6"
+        route: IV
+      - drug_id: DRUG-VINCRISTINE
+        dose: "1.4 mg/m² (cap 2 mg)"
+        schedule: "IV day 1 each cycle × 6"
+        route: IV
+      - drug_id: DRUG-ETOPOSIDE
+        dose: "100 mg/m²"
+        schedule: "IV days 1-3 each cycle × 6"
+        route: IV
+      - drug_id: DRUG-PREDNISONE
+        dose: "100 mg"
+        schedule: "PO days 1-5 each cycle × 6"
+        route: PO
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-PTCL-2024
+  - name: conditioning_allohct
+    purpose_ua: "кондиціонування перед ало-ТГСК — RIC (Flu/Mel або Flu/Bu2) для старших/коморбідних, мієлоаблятивне для молодших фіт-пацієнтів; інституційно специфічне"
+    purpose_en: "conditioning before allo-HCT — RIC (Flu/Mel or Flu/Bu2) for older/comorbid; myeloablative for fit younger; institution-specific"
+    duration: "single conditioning regimen (institution-specific) before HCT"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # Conditioning regimen is institution-specific (RIC vs MA);
+                   # not enumerated as drug components here (placeholder per
+                   # plan-doc §5 Group D)
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-PTCL-2024
+  - name: allohct
+    purpose_ua: "алогенна трансплантація гемопоетичних клітин (ало-ТГСК) — консолідація CR1 з донором (sibling > matched unrelated > haploidentical)"
+    purpose_en: "allogeneic hematopoietic cell transplant — consolidation in CR1 (sibling > matched unrelated > haploidentical donor)"
+    duration: "single transplant procedure"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # AlloHCT — pathway placeholder, no drug components
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-PTCL-2024
 
 cycle_length_days: 21
 total_cycles: "6 induction → restage by PET-CT → if CR1 in fit transplant-eligible: alloSCT consolidation (RIC or myeloablative based on age + comorbidity)"

--- a/knowledge_base/hosted/content/regimens/reg_lifileucel_til_melanoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_lifileucel_til_melanoma.yaml
@@ -3,12 +3,56 @@ name: "Lifileucel TIL therapy (Amtagvi, melanoma 3L+)"
 name_ua: "Ліфілеуцел TIL-терапія (Amtagvi, меланома 3L+)"
 alternate_names: ["Amtagvi", "C-144-01 regimen", "TIL"]
 
-components:
-  - drug_id: DRUG-LIFILEUCEL
-    dose: "Single IV infusion of 7.5 × 10⁹ to 72 × 10⁹ viable autologous TIL cells"
-    schedule: "Once, after lymphodepletion; followed by IL-2 supportive bolus regimen"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: lymphodepletion
+    purpose_ua: "виснаження лімфоцитів перед TIL для приживлення клітин (NMA-Cy/Flu)"
+    purpose_en: "lymphocyte depletion before TIL infusion to enable engraftment (NMA-Cy/Flu)"
+    duration: "7 days: cyclophosphamide 60 mg/kg × 2 days, then fludarabine 25 mg/m² × 5 days"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -7
+    optional: false
+    components:
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "60 mg/kg/day"
+        schedule: "IV × 2 days (lymphodepletion)"
+        route: IV
+      - drug_id: DRUG-FLUDARABINE
+        dose: "25 mg/m²/day"
+        schedule: "IV × 5 days (lymphodepletion, after cyclophosphamide)"
+        route: IV
+    sources:
+      - SRC-C14401-CHESNEY-2024
+      - SRC-NCCN-MELANOMA-2025
+  - name: main
+    purpose_ua: "основна TIL інфузія (Amtagvi)"
+    purpose_en: "main TIL infusion (Amtagvi)"
     duration: "single infusion"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-LIFILEUCEL
+        dose: "Single IV infusion of 7.5 × 10⁹ to 72 × 10⁹ viable autologous TIL cells"
+        schedule: "Once, after lymphodepletion; followed by IL-2 supportive bolus regimen"
+        route: IV
+        duration: "single infusion"
+    sources:
+      - SRC-C14401-CHESNEY-2024
+      - SRC-NCCN-MELANOMA-2025
+  - name: il2_support
+    purpose_ua: "IL-2 (aldesleukin) болюсна підтримка для розширення TIL клітин: 600 000 МО/кг IV q8-12h, до 6 доз, розпочато протягом 24 год після інфузії TIL"
+    purpose_en: "IL-2 (aldesleukin) bolus support for TIL expansion: 600,000 IU/kg IV q8-12h, max 6 doses, started within 24 h of TIL infusion"
+    duration: "up to 6 doses q8-12h, started within 24 h of TIL infusion"
+    timing_relative_to: "previous_phase_completion"
+    timing_offset_days: 0
+    optional: false
+    components: []  # aldesleukin (IL-2) details captured in purpose_ua/duration —
+                   # no DRUG-ALDESLEUKIN entity exists in the KB yet (PR4 scope).
+    sources:
+      - SRC-C14401-CHESNEY-2024
 
 cycle_length_days: null
 total_cycles: "Single TIL infusion (one-time treatment intent); ~6-week inpatient pathway including lymphodepletion + TIL + IL-2 + recovery"
@@ -17,8 +61,6 @@ toxicity_profile: severe
 premedication:
   - "Tumor procurement (~1.5 cm³ resection) → central manufacturing ~22 days"
   - "Bridging therapy permitted during manufacturing window if disease threatening"
-  - "Lymphodepletion: cyclophosphamide 60 mg/kg/day IV × 2 days, then fludarabine 25 mg/m²/day IV × 5 days"
-  - "Aldesleukin (IL-2) 600,000 IU/kg IV q8-12h, max 6 doses, started within 24 h of TIL infusion"
   - "G-CSF support starting D+1 post-TIL"
   - "Antimicrobial prophylaxis: PCP, HSV, fungal during prolonged neutropenia"
 

--- a/knowledge_base/hosted/content/regimens/reg_r_ice_pmbcl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_r_ice_pmbcl.yaml
@@ -4,23 +4,50 @@ name_ua: R-ICE salvage з консолідацією autoSCT (рецидивна
 alternate_names:
   - R-ICE → autoSCT
   - Salvage R-ICE
-components:
-  - drug_id: DRUG-RITUXIMAB
-    dose: 375 mg/m²
-    schedule: IV day 1
-    route: IV
-  - drug_id: DRUG-IFOSFAMIDE
-    dose: 5000 mg/m² (with mesna)
-    schedule: CI day 2
-    route: IV
-  - drug_id: DRUG-CARBOPLATIN
-    dose: AUC 5 (max 800 mg)
-    schedule: IV day 2
-    route: IV
-  - drug_id: DRUG-ETOPOSIDE
-    dose: 100 mg/m²
-    schedule: IV days 1-3
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: salvage_induction
+    purpose_ua: "сальвадж-індукція R-ICE × 2-3 цикли — для рецидивної/рефрактерної PMBCL перед BEAM-кондиціонованою ASCT"
+    purpose_en: "salvage induction R-ICE × 2-3 cycles — for r/r PMBCL before BEAM-conditioned autoSCT"
+    duration: "2-3 cycles × 14 days each"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-RITUXIMAB
+        dose: 375 mg/m²
+        schedule: IV day 1
+        route: IV
+      - drug_id: DRUG-IFOSFAMIDE
+        dose: 5000 mg/m² (with mesna)
+        schedule: CI day 2
+        route: IV
+      - drug_id: DRUG-CARBOPLATIN
+        dose: AUC 5 (max 800 mg)
+        schedule: IV day 2
+        route: IV
+      - drug_id: DRUG-ETOPOSIDE
+        dose: 100 mg/m²
+        schedule: IV days 1-3
+        route: IV
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-DLBCL-2024
+  - name: consolidation_autosct
+    purpose_ua: "консолідація BEAM-кондиціонованою аутологічною ТГСК після PR/CR на сальвадж-індукцію"
+    purpose_en: "consolidation with BEAM-conditioned autologous HCT after PR/CR to salvage induction"
+    duration: "single transplant procedure (post PET-CT response assessment)"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # BEAM-conditioned autoSCT — institution-specific
+                   # conditioning; not enumerated as drug components here
+                   # (placeholder per plan-doc §5 Group C)
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-DLBCL-2024
+
 cycle_length_days: 14
 total_cycles: 2-3 cycles → restage → autoSCT if chemosensitive
 toxicity_profile: high

--- a/knowledge_base/hosted/content/regimens/reg_rdhap_burkitt.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_rdhap_burkitt.yaml
@@ -3,27 +3,53 @@ name: "R-DHAP (Rituximab + Dexamethasone + HD-Cytarabine + Cisplatin) × 2-3 cyc
 name_ua: "R-DHAP × 2-3 циклів → ASCT/алоТКМ (рятувальна терапія Беркітта; не перехресно-резистентна до R-ICE)"
 alternate_names: ["R-DHAP Burkitt salvage"]
 
-components:
-  - drug_id: DRUG-RITUXIMAB
-    dose: "375 mg/m²"
-    schedule: "IV day 1 of each cycle"
-    route: IV
-  - drug_id: DRUG-DEXAMETHASONE
-    dose: "40 mg"
-    schedule: "IV/PO days 1-4 each cycle"
-    route: IV
-  - drug_id: DRUG-CYTARABINE
-    dose: "2 g/m² q12h × 2 doses"
-    schedule: "IV day 2 each cycle (HiDAC component)"
-    route: IV
-  - drug_id: DRUG-CISPLATIN
-    dose: "100 mg/m²"
-    schedule: "IV continuous 24h day 1 each cycle"
-    route: IV
-  - drug_id: DRUG-METHOTREXATE
-    dose: "12 mg IT"
-    schedule: "IT each cycle (CNS prophylaxis / treatment)"
-    route: IT
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: salvage_induction
+    purpose_ua: "сальвадж-індукція R-DHAP × 2-3 цикли — цисплатин + HiDAC + стероїд для рефрактерної/рецидивної Беркітт-лімфоми перед консолідацією трансплантацією"
+    purpose_en: "salvage induction R-DHAP × 2-3 cycles — cisplatin + HiDAC + steroid for r/r Burkitt before transplant consolidation"
+    duration: "2-3 cycles × 21 days each"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-RITUXIMAB
+        dose: "375 mg/m²"
+        schedule: "IV day 1 of each cycle"
+        route: IV
+      - drug_id: DRUG-DEXAMETHASONE
+        dose: "40 mg"
+        schedule: "IV/PO days 1-4 each cycle"
+        route: IV
+      - drug_id: DRUG-CYTARABINE
+        dose: "2 g/m² q12h × 2 doses"
+        schedule: "IV day 2 each cycle (HiDAC component)"
+        route: IV
+      - drug_id: DRUG-CISPLATIN
+        dose: "100 mg/m²"
+        schedule: "IV continuous 24h day 1 each cycle"
+        route: IV
+      - drug_id: DRUG-METHOTREXATE
+        dose: "12 mg IT"
+        schedule: "IT each cycle (CNS prophylaxis / treatment)"
+        route: IT
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-BURKITT-2024
+  - name: consolidation_autosct
+    purpose_ua: "консолідація аутологічною (або алогенною за рефрактерним перебігом) ТГСК після PET-CR2 на сальвадж-індукцію"
+    purpose_en: "consolidation with autologous (or allogeneic for refractory) HCT after PET-CR2 to salvage induction"
+    duration: "single transplant procedure (post PET-CT restaging)"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # ASCT (BEAM-conditioned) or alloSCT pathway —
+                   # institution-specific conditioning; not enumerated as
+                   # drug components here (placeholder per plan-doc §5 Group C)
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-BURKITT-2024
 
 cycle_length_days: 21
 total_cycles: "2-3 cycles induction → restage by PET-CT → ASCT in CR2 (fit transplant-eligible) OR alloSCT (refractory)"

--- a/knowledge_base/hosted/content/regimens/reg_rice_burkitt.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_rice_burkitt.yaml
@@ -3,27 +3,53 @@ name: "R-ICE (Rituximab + Ifosfamide + Carboplatin + Etoposide) × 2-3 cycles �
 name_ua: "R-ICE × 2-3 циклів → ASCT в CR2 (рятувальна терапія рефрактерної Беркітта)"
 alternate_names: ["R-ICE Burkitt salvage", "R-ICE-ASCT"]
 
-components:
-  - drug_id: DRUG-RITUXIMAB
-    dose: "375 mg/m²"
-    schedule: "IV day 1 of each 14-day cycle × 2-3"
-    route: IV
-  - drug_id: DRUG-IFOSFAMIDE
-    dose: "5 g/m²"
-    schedule: "IV continuous 24h day 2; mesna co-administration"
-    route: IV
-  - drug_id: DRUG-CARBOPLATIN
-    dose: "AUC 5 (max 800 mg)"
-    schedule: "IV day 2"
-    route: IV
-  - drug_id: DRUG-ETOPOSIDE
-    dose: "100 mg/m²"
-    schedule: "IV days 1-3"
-    route: IV
-  - drug_id: DRUG-METHOTREXATE
-    dose: "12 mg IT"
-    schedule: "IT each cycle (CNS prophylaxis / treatment)"
-    route: IT
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: salvage_induction
+    purpose_ua: "сальвадж-індукція R-ICE × 2-3 цикли — іфосфамід + карбоплатин + етопозид з ритуксимабом для рефрактерної/рецидивної Беркітт-лімфоми перед ASCT"
+    purpose_en: "salvage induction R-ICE × 2-3 cycles — ifosfamide + carboplatin + etoposide with rituximab for r/r Burkitt before ASCT"
+    duration: "2-3 cycles × 14 days each"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-RITUXIMAB
+        dose: "375 mg/m²"
+        schedule: "IV day 1 of each 14-day cycle × 2-3"
+        route: IV
+      - drug_id: DRUG-IFOSFAMIDE
+        dose: "5 g/m²"
+        schedule: "IV continuous 24h day 2; mesna co-administration"
+        route: IV
+      - drug_id: DRUG-CARBOPLATIN
+        dose: "AUC 5 (max 800 mg)"
+        schedule: "IV day 2"
+        route: IV
+      - drug_id: DRUG-ETOPOSIDE
+        dose: "100 mg/m²"
+        schedule: "IV days 1-3"
+        route: IV
+      - drug_id: DRUG-METHOTREXATE
+        dose: "12 mg IT"
+        schedule: "IT each cycle (CNS prophylaxis / treatment)"
+        route: IT
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-BURKITT-2024
+  - name: consolidation_autosct
+    purpose_ua: "консолідація BEAM-кондиціонованою ASCT після PET-CR2 на сальвадж-індукцію (або алоТКМ при рефрактерності)"
+    purpose_en: "consolidation with BEAM-conditioned ASCT after PET-CR2 to salvage induction (or alloSCT for refractory cases)"
+    duration: "single transplant procedure (post PET-CT restaging)"
+    timing_relative_to: "previous_phase_completion"
+    optional: false
+    components: []  # BEAM-conditioned ASCT or alloSCT — institution-specific
+                   # conditioning; not enumerated as drug components here
+                   # (placeholder per plan-doc §5 Group C)
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-BURKITT-2024
 
 cycle_length_days: 14
 total_cycles: "2-3 cycles induction → restage by PET-CT → BEAM-conditioned ASCT in CR2 (fit transplant-eligible) OR alloSCT (refractory after R-ICE)"

--- a/knowledge_base/hosted/content/regimens/reg_tisagenlecleucel_b_all.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_tisagenlecleucel_b_all.yaml
@@ -6,19 +6,44 @@ alternate_names:
   - "Kymriah B-ALL"
   - "ELIANA regimen"
 
-components:
-  - drug_id: DRUG-FLUDARABINE
-    dose: "30 mg/m² IV daily × 4 days (lymphodepleting conditioning)"
-    schedule: "Days -4 to -1 before CAR-T infusion"
-    route: IV
-  - drug_id: DRUG-CYCLOPHOSPHAMIDE
-    dose: "500 mg/m² IV daily × 2 days (lymphodepleting conditioning)"
-    schedule: "Days -4 to -3 before CAR-T infusion"
-    route: IV
-  - drug_id: DRUG-TISAGENLECLEUCEL
-    dose: "Single IV infusion: 0.2 to 5.0 × 10⁶ CAR-positive viable T cells per kg for patients ≤50 kg; 0.1 to 2.5 × 10⁸ CAR-positive viable T cells (not weight-based) for patients >50 kg"
-    schedule: "Single infusion day 0 after lymphodepletion completion; no maintenance"
-    route: IV
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: lymphodepletion
+    purpose_ua: "виснаження лімфоцитів перед CAR-T для приживлення клітин (ELIANA-style: Flu × 4 days + Cy × 2 days)"
+    purpose_en: "lymphocyte depletion before CAR-T to enable cell engraftment (ELIANA-style: Flu × 4 days + Cy × 2 days)"
+    duration: "4 days, days -4 to -1"
+    timing_relative_to: "main_infusion"
+    timing_offset_days: -4
+    optional: false
+    components:
+      - drug_id: DRUG-FLUDARABINE
+        dose: "30 mg/m² IV daily × 4 days (lymphodepleting conditioning)"
+        schedule: "Days -4 to -1 before CAR-T infusion"
+        route: IV
+      - drug_id: DRUG-CYCLOPHOSPHAMIDE
+        dose: "500 mg/m² IV daily × 2 days (lymphodepleting conditioning)"
+        schedule: "Days -4 to -3 before CAR-T infusion"
+        route: IV
+    sources:
+      - SRC-ELIANA-MAUDE-2018
+      - SRC-NCCN-BCELL-2025
+  - name: main
+    purpose_ua: "основна CAR-T інфузія"
+    purpose_en: "main CAR-T infusion"
+    duration: "single infusion"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - drug_id: DRUG-TISAGENLECLEUCEL
+        dose: "Single IV infusion: 0.2 to 5.0 × 10⁶ CAR-positive viable T cells per kg for patients ≤50 kg; 0.1 to 2.5 × 10⁸ CAR-positive viable T cells (not weight-based) for patients >50 kg"
+        schedule: "Single infusion day 0 after lymphodepletion completion; no maintenance"
+        route: IV
+    sources:
+      - SRC-ELIANA-MAUDE-2018
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days:
 total_cycles: "Single infusion procedure; no maintenance; bridge chemo during 3-4 week manufacturing window for active disease"

--- a/knowledge_base/hosted/content/regimens/smile.yaml
+++ b/knowledge_base/hosted/content/regimens/smile.yaml
@@ -3,12 +3,25 @@ name: "SMILE (Steroid + MTX + Ifosfamide + L-asparaginase + Etoposide), 2-4 cycl
 name_ua: "SMILE — стероїд + MTX + іфосфамід + L-аспарагіназа + етопозид, 2-4 цикли"
 alternate_names: ["SMILE", "Yamaguchi protocol"]
 
-components:
-  - {drug_id: DRUG-DEXAMETHASONE, dose: "40 mg", schedule: "PO/IV days 2-4", route: PO}
-  - {drug_id: DRUG-METHOTREXATE, dose: "2 g/m²", schedule: "IV 6h infusion day 1; leucovorin rescue", route: IV}
-  - {drug_id: DRUG-IFOSFAMIDE, dose: "1.5 g/m²", schedule: "IV days 2-4; mesna co-administration", route: IV}
-  - {drug_id: DRUG-L-ASPARAGINASE, dose: "6000 IU/m²", schedule: "IM days 8, 10, 12, 14, 16, 18, 20", route: IM}
-  - {drug_id: DRUG-ETOPOSIDE, dose: "100 mg/m²", schedule: "IV days 2-4", route: IV}
+components: []  # phases supersede; kept empty for back-compat with downstream
+                # consumers that still iterate `components` directly. PR3 of
+                # regimen-phases-refactor — see plan-doc 2026-04-28 §4 + §5.
+
+phases:
+  - name: induction
+    purpose_ua: "SMILE-індукція 2-4 цикли — комбінований режим Steroid + MTX + Ifosfamide + L-asparaginase + Etoposide для extranodal NK/T-cell lymphoma; провадить до RT 50 Gy при локалізованих stage I/II"
+    purpose_en: "SMILE induction 2-4 cycles — combined regimen Steroid + MTX + Ifosfamide + L-asparaginase + Etoposide for extranodal NK/T-cell lymphoma; followed by RT 50 Gy for localized stage I/II"
+    duration: "2-4 cycles × 28 days each"
+    timing_relative_to: "absolute"
+    optional: false
+    components:
+      - {drug_id: DRUG-DEXAMETHASONE, dose: "40 mg", schedule: "PO/IV days 2-4", route: PO}
+      - {drug_id: DRUG-METHOTREXATE, dose: "2 g/m²", schedule: "IV 6h infusion day 1; leucovorin rescue", route: IV}
+      - {drug_id: DRUG-IFOSFAMIDE, dose: "1.5 g/m²", schedule: "IV days 2-4; mesna co-administration", route: IV}
+      - {drug_id: DRUG-L-ASPARAGINASE, dose: "6000 IU/m²", schedule: "IM days 8, 10, 12, 14, 16, 18, 20", route: IM}
+      - {drug_id: DRUG-ETOPOSIDE, dose: "100 mg/m²", schedule: "IV days 2-4", route: IV}
+    sources:
+      - SRC-NCCN-BCELL-2025
 
 cycle_length_days: 28
 total_cycles: "2-4 cycles induction; followed by RT 50 Gy для localized stage I/II"

--- a/tests/test_regimen_phases.py
+++ b/tests/test_regimen_phases.py
@@ -207,10 +207,23 @@ def test_no_regression_axicel():
 
 
 def test_no_regression_lifileucel():
+    """lifileucel has been migrated to multi-phase shape (PR3). The YAML
+    carries `components: []` and authors `phases:` explicitly with
+    lymphodepletion + main + il2_support. The il2_support phase has empty
+    components (no DRUG-ALDESLEUKIN entity in KB yet) but a structured
+    `purpose_ua` capturing the IL-2 dose/schedule. Lymphodepletion holds
+    cyclophosphamide + fludarabine; main holds the TIL product
+    (DRUG-LIFILEUCEL)."""
     raw, r = _load_regimen("reg_lifileucel_til_melanoma.yaml")
-    assert len(r.phases) >= 1
-    assert len(r.components) == _raw_component_count(raw)
-    assert sum(len(p.components) for p in r.phases) == len(r.components)
+    assert len(r.phases) == 3, "post-migration lifileucel must carry exactly three phases"
+    assert [p.name for p in r.phases] == ["lymphodepletion", "main", "il2_support"]
+    # Components is the no-op shape (loader-side opt-out from auto-wrap)
+    assert len(r.components) == _raw_component_count(raw) == 0
+    # Drugs flow via phases now
+    drug_ids_in_phases = [c.drug_id for p in r.phases for c in p.components]
+    assert "DRUG-CYCLOPHOSPHAMIDE" in drug_ids_in_phases
+    assert "DRUG-FLUDARABINE" in drug_ids_in_phases
+    assert "DRUG-LIFILEUCEL" in drug_ids_in_phases
 
 
 def test_no_regression_all_244_legacy_yamls_load():
@@ -282,20 +295,73 @@ def test_no_regression_all_244_legacy_yamls_load():
             empty_count += 1
 
     # Sanity: vast majority of regimens are still legacy auto-wrap shape
-    # (PR2 migrates only axi-cel; PR3 migrates the remaining 17).
-    assert legacy_autowrap_count >= 240, (
-        f"expected ~242 legacy auto-wrap regimens, got {legacy_autowrap_count}"
+    # (PR2 migrated axi-cel; PR3 migrated 17 more high-stakes regimens —
+    # CAR-T A4, TIL B1, induction→autoSCT C4, induction→alloSCT D4,
+    # multi-block / alternating E4. Total 18 explicit multi-phase.)
+    assert legacy_autowrap_count >= 220, (
+        f"expected ~225 legacy auto-wrap regimens after PR3, got {legacy_autowrap_count}"
     )
-    # PR2 migrated exactly one regimen so far
-    assert explicit_multiphase_count == 1, (
-        f"expected exactly one explicit multi-phase regimen (axi-cel), "
-        f"got {explicit_multiphase_count}"
+    # PR2 migrated 1 (axi-cel); PR3 migrated 17 more → 18 total
+    assert explicit_multiphase_count == 18, (
+        f"expected exactly 18 explicit multi-phase regimens (PR2 axi-cel "
+        f"+ PR3 17 high-stakes), got {explicit_multiphase_count}"
     )
     # Documented exception (surveillance / observation-only "regimen")
     assert empty_count == 1, (
         f"expected exactly one zero-component surveillance regimen, "
         f"got {empty_count}"
     )
+
+
+def test_18_migrated_yamls_have_multi_phase():
+    """All 18 high-stakes regimens (PR2 axi-cel + PR3 the remaining 17 per
+    regimen-phases-refactor plan §5) are migrated to multi-phase shape:
+    `phases:` is authored explicitly in the raw YAML, every phase carries
+    a meaningful `purpose_ua`, and no phase relies on the auto-wrap
+    fallback.
+
+    A single semantically-meaningful phase is acceptable for files that
+    do not decompose cleanly (e.g. SMILE, MATRix induction); the contract
+    is "explicit phases in YAML + purpose_ua present", not "≥2 phases".
+    """
+    migrated = [
+        # Group A — CAR-T (Lymphodepletion + main_infusion)
+        "reg_car_t_axicel.yaml",  # PR2 reference
+        "reg_car_t_axicel_fl.yaml",
+        "reg_car_t_axicel_hgbl.yaml",
+        "reg_car_t_brexucel_mcl.yaml",
+        "reg_tisagenlecleucel_b_all.yaml",
+        # Group B — TIL with 3 phases
+        "reg_lifileucel_til_melanoma.yaml",
+        # Group C — Induction → autoSCT
+        "r_dhap_autosct.yaml",
+        "reg_rdhap_burkitt.yaml",
+        "reg_rice_burkitt.yaml",
+        "reg_r_ice_pmbcl.yaml",
+        # Group D — Induction → conditioning → alloSCT
+        "reg_choep_allosct_consolidation.yaml",
+        "reg_allohct_pmf.yaml",
+        "reg_allohct_mds_hr.yaml",
+        "reg_allohct_cml_advanced.yaml",
+        # Group E — Multi-block / alternating
+        "hyper_cvad_r.yaml",
+        "codox_m_ivac.yaml",
+        "matrix.yaml",
+        "smile.yaml",
+    ]
+    assert len(migrated) == 18, "the brief specifies 18 high-stakes regimens"
+    for filename in migrated:
+        raw, r = _load_regimen(filename)
+        assert "phases" in raw, (
+            f"{filename}: phases not authored explicitly in YAML "
+            "(would auto-wrap into a generic 'main' phase)"
+        )
+        assert raw["phases"], f"{filename}: phases authored but empty"
+        assert len(r.phases) >= 1, f"{filename}: model has no phases after load"
+        for phase in r.phases:
+            assert phase.purpose_ua, (
+                f"{filename}: phase '{phase.name}' missing purpose_ua"
+            )
 
 
 # ── 5. Render layer (PR2 of regimen-phases-refactor) ─────────────────────────


### PR DESCRIPTION
## TL;DR

Builds on PR #155. Mechanically migrates remaining 17 of 18 high-stakes regimens to multi-phase shape (axi-cel was reference in PR2).

## Migrated (17)

- **Group A** CAR-T (4): \`reg_car_t_axicel_fl\`, \`_hgbl\`, \`reg_car_t_brexucel_mcl\`, \`reg_tisagenlecleucel_b_all\`
- **Group B** TIL (1): \`reg_lifileucel_til_melanoma\` (lymphodepletion → main → il2_support)
- **Group C** autoSCT (4): \`r_dhap_autosct\`, \`reg_rdhap_burkitt\`, \`reg_rice_burkitt\`, \`reg_r_ice_pmbcl\`
- **Group D** alloSCT (4): \`reg_choep_allosct_consolidation\`, \`reg_allohct_pmf\`, \`_mds_hr\`, \`_cml_advanced\`
- **Group E** alternating (4): \`hyper_cvad_r\`, \`codox_m_ivac\`, \`matrix\`, \`smile\`

Clinical content preserved verbatim (drug IDs, doses, schedules, sources, dose_adjustments, ukraine_availability, notes).

## Tests

14 pass; \`test_18_migrated_yamls_have_multi_phase\` covers the new contract. All 244 regimens load cleanly.

## Caveats

2 net-new engine test failures surfaced (engine code reads \`regimen_data["components"]\` directly which is now empty for migrated regimens) — fixed in PR3.5 (next).

## Plan reference

\`docs/reviews/regimen-phases-refactor-plan-2026-04-28.md\` §5