### PR TITLE
feat(loader): SRC-* citation referential integrity (PR4 — citation Layer 2)

### DIFF
--- a/knowledge_base/validation/loader.py
+++ b/knowledge_base/validation/loader.py
@@ -7,6 +7,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,6 +84,107 @@ REVIEWER_SIGNOFF_TYPES: tuple[str, ...] = (
 )
 
 
+# PR4 — citation-verifier slice 1: SRC-* referential integrity
+#
+# `_SRC_TOKEN_RE` is greedy (`+`) so multi-segment IDs like
+# `SRC-NCCN-BCELL-2025` capture in one token, not in pieces. The trailing
+# `(?=$|[^A-Z0-9_-])` is a manual word-end so we don't truncate at digits.
+_SRC_TOKEN_RE = re.compile(r"\bSRC-[A-Z0-9_-]+(?=$|[^A-Z0-9_-])")
+
+# Banned-source IDs per CHARTER §2 (non-commercial-only KB) — referencing
+# any of these as an unresolved citation gets a "banned" hint instead of
+# "did you mean…" or "file a stub". Note: `SRC-ONCOKB` IS currently defined
+# as a Source entity (legacy migration metadata), so structural references
+# resolve normally; banned-detection only fires on UNRESOLVED IDs that
+# happen to match one of these names.
+BANNED_SOURCE_IDS: frozenset[str] = frozenset({
+    "SRC-ONCOKB",
+    "SRC-SNOMED",
+    "SRC-MEDDRA",
+})
+
+# Narrative free-text fields where authors mention SRC-XXX inline. The
+# loader scans these for unresolved tokens (warn-only by default — see
+# `strict_source_refs` on `load_content`).
+_NARRATIVE_FIELDS: tuple[str, ...] = (
+    "notes",
+    "evidence_summary",
+    "rationale",
+)
+
+
+def _levenshtein(a: str, b: str, cap: int = 3) -> int:
+    """Bounded Levenshtein. Returns `cap` if distance ≥ cap (so we don't
+    waste cycles on long mismatches). Used only for typo suggestions on
+    unresolved SRC-* IDs — call sites compare ≤ 2.
+    """
+    if a == b:
+        return 0
+    la, lb = len(a), len(b)
+    if abs(la - lb) >= cap:
+        return cap
+    # Standard DP, single-row optimization
+    prev = list(range(lb + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i] + [0] * lb
+        row_min = curr[0]
+        for j, cb in enumerate(b, 1):
+            cost = 0 if ca == cb else 1
+            curr[j] = min(
+                prev[j] + 1,        # deletion
+                curr[j - 1] + 1,    # insertion
+                prev[j - 1] + cost, # substitution
+            )
+            if curr[j] < row_min:
+                row_min = curr[j]
+        if row_min >= cap:
+            return cap
+        prev = curr
+    return min(prev[lb], cap)
+
+
+def _categorize_unresolved_src(
+    ref: str, known_src_ids: set[str]
+) -> tuple[str, str]:
+    """Bucket an unresolved SRC-* token + format the actionable hint.
+
+    Returns ``(category, hint)`` where category is one of:
+      - ``"banned"``   — matches CHARTER §2 banned list
+      - ``"typo"``     — Levenshtein ≤ 2 to a known SRC-* ID
+      - ``"gap"``      — neither; authentic missing Source entity
+    """
+    if ref in BANNED_SOURCE_IDS:
+        return "banned", "banned per CHARTER §2 — non-commercial KB only"
+
+    best: tuple[int, str] | None = None
+    for known in known_src_ids:
+        d = _levenshtein(ref, known, cap=3)
+        if d <= 2 and (best is None or d < best[0]):
+            best = (d, known)
+            if d == 1:
+                break
+    if best is not None:
+        return "typo", f"did you mean {best[1]!r}?"
+
+    return "gap", f"file a source_stub_{ref.lower()}.yaml under sources/"
+
+
+def _format_unresolved_src_msg(
+    ref: str,
+    field_label: str,
+    known_src_ids: set[str],
+) -> str:
+    """Standard error/warning text for an unresolved SRC-* citation.
+
+    Format anchors test #1's substring assertion ('Unresolved citation ref').
+    """
+    _category, hint = _categorize_unresolved_src(ref, known_src_ids)
+    return (
+        f"Unresolved citation ref {ref!r} at field {field_label!r} — "
+        f"no entity defined under sources/. Hint: {hint}"
+    )
+
+
 @dataclass
 class LoadResult:
     entities_by_id: dict[str, dict] = field(default_factory=dict)
@@ -115,11 +217,11 @@ def _extract(obj: dict, dotted: str):
 # fresh on every invocation. A batch build of 99 × 2 cases issues ~400 such
 # calls — over an hour of redundant CPU work in aggregate.
 #
-# Caching is keyed on the *resolved* path so that "knowledge_base/hosted/content"
-# (relative) and the same dir given absolutely hit the same entry. Tests that
+# Caching is keyed on the *resolved* path PLUS the strict-flag, so toggling
+# `strict_source_refs` between calls returns fresh results. Tests that
 # need a fresh load (e.g., after writing a temporary KB to a tmp_path) call
 # `clear_load_cache()` explicitly.
-_LOAD_CACHE: dict[Path, "LoadResult"] = {}
+_LOAD_CACHE: dict[tuple[Path, bool], "LoadResult"] = {}
 
 
 def clear_load_cache() -> None:
@@ -128,21 +230,39 @@ def clear_load_cache() -> None:
     _LOAD_CACHE.clear()
 
 
-def load_content(root: Path) -> LoadResult:
+def load_content(
+    root: Path,
+    *,
+    strict_source_refs: bool = False,
+) -> LoadResult:
     """Walk hosted/content/, validate each YAML against its schema, then do
-    a referential-integrity pass. Result is cached per resolved root path —
-    re-calls with the same KB return the same instance.
+    a referential-integrity pass. Result is cached per (resolved-root,
+    strict_source_refs) tuple — re-calls with the same KB return the same
+    instance.
+
+    Parameters
+    ----------
+    strict_source_refs:
+        When False (default), unresolved SRC-* citations land in
+        `result.contract_warnings` — the load still reports `ok=True`, so
+        legacy callers and existing tests continue to pass. When True,
+        unresolved SRC-* citations land in `result.ref_errors` and break
+        `ok` (suitable for production CI gates).
     """
-    key = Path(root).resolve()
+    key = (Path(root).resolve(), bool(strict_source_refs))
     cached = _LOAD_CACHE.get(key)
     if cached is not None:
         return cached
-    result = _load_content_impl(key)
+    result = _load_content_impl(key[0], strict_source_refs=key[1])
     _LOAD_CACHE[key] = result
     return result
 
 
-def _load_content_impl(root: Path) -> LoadResult:
+def _load_content_impl(
+    root: Path,
+    *,
+    strict_source_refs: bool = False,
+) -> LoadResult:
     """The real loader (uncached). Public callers go through `load_content`."""
     result = LoadResult()
 
@@ -192,10 +312,26 @@ def _load_content_impl(root: Path) -> LoadResult:
     for eid, info in result.entities_by_id.items():
         by_type.setdefault(info["type"], set()).add(eid)
 
+    # PR4 — SRC-* index, used for typo-suggestion + structural resolution
+    known_src_ids: set[str] = by_type.get("sources", set())
+
     def check_ref(path: Path, ref_id, target_type: str, field_label: str) -> None:
         if ref_id is None or ref_id == "":
             return
         if ref_id not in result.entities_by_id:
+            # SRC-* citations get enriched diagnostics (typo / banned / gap)
+            # and respect the `strict_source_refs` toggle.
+            if (
+                target_type == "sources"
+                and isinstance(ref_id, str)
+                and ref_id.startswith("SRC-")
+            ):
+                msg = _format_unresolved_src_msg(ref_id, field_label, known_src_ids)
+                if strict_source_refs:
+                    result.ref_errors.append((path, msg))
+                else:
+                    result.contract_warnings.append((path, msg))
+                return
             result.ref_errors.append(
                 (path, f"{field_label}: '{ref_id}' not found in any loaded entity")
             )
@@ -224,6 +360,20 @@ def _load_content_impl(root: Path) -> LoadResult:
                 check_ref(path, comp.get("drug_id"), "drugs", f"components[{i}].drug_id")
             for sid in data.get("mandatory_supportive_care") or []:
                 check_ref(path, sid, "supportive_care", "mandatory_supportive_care[]")
+            # PR4 — dose_adjustments[].source_refs[] are SRC-* citations.
+            # Drafts skip resolution because authors leave SRC-TODO placeholders.
+            if not data.get("draft"):
+                for da_i, adj in enumerate(data.get("dose_adjustments") or []):
+                    if not isinstance(adj, dict):
+                        continue
+                    for j, sid in enumerate(adj.get("source_refs") or []):
+                        if isinstance(sid, str):
+                            check_ref(
+                                path,
+                                sid,
+                                "sources",
+                                f"dose_adjustments[{da_i}].source_refs[{j}]",
+                            )
         elif etype == "algorithms":
             for sid in data.get("output_indications") or []:
                 check_ref(path, sid, "indications", "output_indications[]")
@@ -266,6 +416,21 @@ def _load_content_impl(root: Path) -> LoadResult:
                 )
             for i, sid in enumerate(primary):
                 check_ref(path, sid, "sources", f"primary_sources[{i}]")
+            # PR4 — evidence_sources[].source are SRC-* citations (CIViC,
+            # NCCN, OncoKB legacy, …). Drafts skip; authors may leave
+            # placeholders during reconstruction.
+            if not data.get("draft"):
+                for j, es in enumerate(data.get("evidence_sources") or []):
+                    if not isinstance(es, dict):
+                        continue
+                    sid = es.get("source")
+                    if isinstance(sid, str):
+                        check_ref(
+                            path,
+                            sid,
+                            "sources",
+                            f"evidence_sources[{j}].source",
+                        )
         elif etype == "workups":
             for sid in data.get("required_tests") or []:
                 check_ref(path, sid, "tests", "required_tests[]")
@@ -298,6 +463,36 @@ def _load_content_impl(root: Path) -> LoadResult:
                         "reviewers",
                         f"reviewer_signoffs[{i}].reviewer_id",
                     )
+
+    # Pass 2.5 — narrative SRC-* token scan. Authors mention citation IDs
+    # inline in `notes:`, `evidence_summary:`, `rationale:` fields. Those
+    # mentions aren't structural FKs (they're prose), but if they reference
+    # a SRC-* ID that doesn't exist, downstream rendering surfaces a
+    # dangling reference. Track them so the citation-verifier workstream
+    # has a complete unresolved-ID inventory to work from.
+    #
+    # Drafts skip — author work-in-progress may include placeholders.
+    seen_unresolved: set[tuple[str, str]] = set()  # (path, src_id) — dedupe
+    for eid, info in result.entities_by_id.items():
+        data = info["data"]
+        if data.get("draft"):
+            continue
+        path = info["path"]
+        for fld in _NARRATIVE_FIELDS:
+            text = data.get(fld)
+            if not isinstance(text, str):
+                continue
+            for token in _SRC_TOKEN_RE.findall(text):
+                if token in result.entities_by_id:
+                    continue
+                if (str(path), token) in seen_unresolved:
+                    continue
+                seen_unresolved.add((str(path), token))
+                msg = _format_unresolved_src_msg(token, fld, known_src_ids)
+                if strict_source_refs:
+                    result.ref_errors.append((path, msg))
+                else:
+                    result.contract_warnings.append((path, msg))
 
     # Pass 3: entity-contract checks (semantics beyond schema)
     _check_redflag_contracts(result)
@@ -541,13 +736,21 @@ def main() -> int:
     parser.add_argument(
         "--strict", action="store_true", help="Exit non-zero on ref errors (on by default)."
     )
+    parser.add_argument(
+        "--strict-source-refs",
+        action="store_true",
+        help=(
+            "Promote unresolved SRC-* citations from contract_warnings to "
+            "ref_errors. Off by default for back-compat — production CI flips on."
+        ),
+    )
     args = parser.parse_args()
 
     if not args.root.is_dir():
         print(f"ERROR: not a directory: {args.root}", file=sys.stderr)
         return 2
 
-    result = load_content(args.root)
+    result = load_content(args.root, strict_source_refs=args.strict_source_refs)
     print(f"Loaded {len(result.entities_by_id)} entities.")
 
     by_type: dict[str, int] = {}

--- a/scripts/audit_unresolved_sources.py
+++ b/scripts/audit_unresolved_sources.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Standalone audit: lists every unresolved SRC-* citation in the live KB,
+grouped by category (typo / banned / authentic gap).
+
+Loads the KB in strict-source-refs mode, pulls the resulting ref_errors
+that match the canonical "Unresolved citation ref" format, and prints a
+markdown table grouped by category. Suitable for posting in a GitHub
+Discussion or planning thread.
+
+Usage:
+    py -V:3.12 -m scripts.audit_unresolved_sources
+    py -V:3.12 -m scripts.audit_unresolved_sources --root knowledge_base/hosted/content
+    py -V:3.12 -m scripts.audit_unresolved_sources --json
+
+Exit codes:
+  0 — zero unresolved SRC-* citations
+  1 — at least one unresolved citation
+  2 — KB root missing / not a directory
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from knowledge_base.validation.loader import (
+    _categorize_unresolved_src,
+    clear_load_cache,
+    load_content,
+)
+
+_UNRESOLVED_RE = re.compile(
+    r"Unresolved citation ref '(?P<sid>SRC-[A-Z0-9_-]+)' at field '(?P<field>[^']*)'"
+)
+
+
+def _audit(root: Path) -> dict:
+    """Walk the KB and return a categorized inventory of unresolved SRC-* IDs.
+
+    Returns a dict shaped::
+
+        {
+          "kb_root": str,
+          "total_entries": int,         # one per (path, sid) in ref_errors
+          "unique_sids": int,
+          "by_category": {
+            "banned": [{"sid", "hint", "occurrences": [{"path", "field"}]}],
+            "typo":   [...],
+            "gap":    [...]
+          }
+        }
+    """
+    clear_load_cache()
+    result = load_content(root, strict_source_refs=True)
+    known_src_ids = {
+        eid for eid, info in result.entities_by_id.items() if info["type"] == "sources"
+    }
+
+    by_sid: dict[str, list[dict]] = defaultdict(list)
+    for path, msg in result.ref_errors:
+        m = _UNRESOLVED_RE.search(msg)
+        if not m:
+            continue
+        sid = m.group("sid")
+        field_label = m.group("field")
+        by_sid[sid].append({"path": str(path), "field": field_label})
+
+    by_cat: dict[str, list[dict]] = defaultdict(list)
+    for sid, occs in by_sid.items():
+        cat, hint = _categorize_unresolved_src(sid, known_src_ids)
+        by_cat[cat].append({"sid": sid, "hint": hint, "occurrences": occs})
+
+    for cat in by_cat:
+        by_cat[cat].sort(key=lambda e: e["sid"])
+
+    return {
+        "kb_root": str(root),
+        "total_entries": sum(len(occs) for occs in by_sid.values()),
+        "unique_sids": len(by_sid),
+        "by_category": dict(by_cat),
+    }
+
+
+def _format_markdown(report: dict) -> str:
+    out: list[str] = []
+    out.append("# Unresolved SRC-* citation audit")
+    out.append("")
+    out.append(f"- KB root: `{report['kb_root']}`")
+    out.append(f"- Total unresolved entries: **{report['total_entries']}**")
+    out.append(f"- Unique SRC-* IDs: **{report['unique_sids']}**")
+    out.append("")
+    cats = report["by_category"]
+    counts = ", ".join(
+        f"{cat}={len(cats.get(cat, []))}" for cat in ("banned", "typo", "gap")
+    )
+    out.append(f"- By category: {counts}")
+    out.append("")
+
+    for cat_name, header in (
+        ("banned", "Banned per CHARTER §2"),
+        ("typo", "Likely typos (Levenshtein ≤ 2)"),
+        ("gap", "Authentic gaps (no close match)"),
+    ):
+        entries = cats.get(cat_name, [])
+        out.append(f"## {header} — {len(entries)}")
+        out.append("")
+        if not entries:
+            out.append("_None._")
+            out.append("")
+            continue
+        out.append("| SRC-* ID | Hint | Occurrences |")
+        out.append("|---|---|---|")
+        for e in entries:
+            n = len(e["occurrences"])
+            out.append(f"| `{e['sid']}` | {e['hint']} | {n} |")
+        out.append("")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="List unresolved SRC-* citations grouped by category.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("knowledge_base/hosted/content"),
+        help="Path to hosted/content/ (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of markdown.",
+    )
+    args = parser.parse_args()
+
+    if not args.root.is_dir():
+        print(f"ERROR: not a directory: {args.root}", file=sys.stderr)
+        return 2
+
+    report = _audit(args.root)
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print(_format_markdown(report))
+
+    return 0 if report["total_entries"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_source_ref_integrity.py
+++ b/tests/test_source_ref_integrity.py
@@ -1,0 +1,435 @@
+"""PR4 — citation-verifier slice 1: SRC-* referential integrity tests.
+
+These tests cover the loader's new pass that walks SRC-* citations
+(structural FKs and inline narrative mentions) and reports unresolved
+IDs with categorized hints.
+
+The loader gates this behaviour on ``strict_source_refs``:
+  - default (False) → contract_warnings (does not break ``result.ok``)
+  - strict (True)   → ref_errors (breaks ``result.ok``)
+
+The tests cover both paths plus three categories of unresolved IDs:
+  - ``typo``  — Levenshtein ≤ 2 to a known SRC-* ID; "did you mean…?"
+  - ``banned`` — matches CHARTER §2 ban list; "banned per CHARTER §2"
+  - ``gap``    — neither; "file a source_stub_<id>.yaml"
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from knowledge_base.validation.loader import (
+    BANNED_SOURCE_IDS,
+    _categorize_unresolved_src,
+    _levenshtein,
+    clear_load_cache,
+    load_content,
+)
+
+LIVE_KB = Path(__file__).parent.parent / "knowledge_base" / "hosted" / "content"
+_UNRESOLVED_RE = re.compile(r"Unresolved citation ref '(SRC-[A-Z0-9_-]+)'")
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders for synthetic mini-KBs.
+# ---------------------------------------------------------------------------
+
+
+def _write_source(root: Path, src_id: str, *, name: str | None = None) -> Path:
+    """Write a minimal Source YAML stub that satisfies the Pydantic
+    schema (only ``id`` / ``source_type`` / ``title`` are required).
+    """
+    sources_dir = root / "sources"
+    sources_dir.mkdir(parents=True, exist_ok=True)
+    p = sources_dir / f"{src_id.lower()}.yaml"
+    p.write_text(
+        textwrap.dedent(
+            f"""\
+            id: {src_id}
+            source_type: guideline
+            title: {name or src_id}
+            """
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _write_regimen(
+    root: Path,
+    reg_id: str,
+    *,
+    sources: list[str],
+    drug_ids: list[str] | None = None,
+) -> Path:
+    """Write a regimen citing the given SRC-* IDs in its top-level
+    ``sources`` list."""
+    reg_dir = root / "regimens"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    p = reg_dir / f"{reg_id.lower()}.yaml"
+    components = drug_ids or ["DRUG-RITUXIMAB"]
+    yaml_src = ["id: " + reg_id, "name: Test regimen", "components:"]
+    for d in components:
+        yaml_src.append(f"  - drug_id: {d}")
+    yaml_src.append("sources:")
+    for s in sources:
+        yaml_src.append(f"  - {s}")
+    p.write_text("\n".join(yaml_src) + "\n", encoding="utf-8")
+    return p
+
+
+def _write_drug(root: Path, drug_id: str) -> Path:
+    drug_dir = root / "drugs"
+    drug_dir.mkdir(parents=True, exist_ok=True)
+    p = drug_dir / f"{drug_id.lower()}.yaml"
+    p.write_text(
+        textwrap.dedent(
+            f"""\
+            id: {drug_id}
+            names:
+              preferred: {drug_id}
+            sources: []
+            """
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _unresolved_entries(entries: list[tuple[Path, str]]) -> list[tuple[Path, str]]:
+    """Filter (path, msg) entries down to SRC-resolution-only ones."""
+    return [(p, m) for (p, m) in entries if "Unresolved citation ref" in m]
+
+
+# ---------------------------------------------------------------------------
+# Helper-function unit tests (pure, no I/O — fast smoke).
+# ---------------------------------------------------------------------------
+
+
+def test_levenshtein_basic_distances():
+    assert _levenshtein("abc", "abc") == 0
+    assert _levenshtein("abc", "abd") == 1
+    assert _levenshtein("kitten", "sitting") == 3
+    # Bounded by cap
+    assert _levenshtein("abc", "xyzwxyz", cap=3) == 3
+
+
+def test_categorize_banned_id_returns_banned():
+    cat, hint = _categorize_unresolved_src("SRC-ONCOKB", set())
+    assert cat == "banned"
+    assert "CHARTER" in hint
+
+
+def test_categorize_typo_id_returns_typo_with_suggestion():
+    known = {"SRC-NCCN-BCELL-2025"}
+    cat, hint = _categorize_unresolved_src("SRC-NCCN-BCELL-2024", known)
+    assert cat == "typo"
+    assert "SRC-NCCN-BCELL-2025" in hint
+
+
+def test_categorize_authentic_gap_returns_gap_with_stub_hint():
+    known = {"SRC-NCCN-BCELL-2025", "SRC-ESMO-DLBCL-2024"}
+    cat, hint = _categorize_unresolved_src("SRC-COMPLETELY-NOVEL-2026", known)
+    assert cat == "gap"
+    assert "source_stub" in hint
+
+
+def test_banned_set_includes_oncokb_snomed_meddra():
+    assert "SRC-ONCOKB" in BANNED_SOURCE_IDS
+    assert "SRC-SNOMED" in BANNED_SOURCE_IDS
+    assert "SRC-MEDDRA" in BANNED_SOURCE_IDS
+
+
+# ---------------------------------------------------------------------------
+# Live KB drift count — proves the check is active.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not LIVE_KB.exists(),
+    reason="live knowledge_base/hosted/content not present",
+)
+def test_live_kb_strict_surfaces_unresolved_src_refs():
+    """Run strict mode against the real KB. Assert at least 1 unresolved
+    SRC-* citation surfaces — proves the check is wired up.
+
+    Don't pin exact count (changes as Source stubs are filed); just that
+    the check is active and produces the canonical message.
+    """
+    clear_load_cache()
+    result = load_content(LIVE_KB, strict_source_refs=True)
+    src_errs = _unresolved_entries(result.ref_errors)
+    # At time of writing PR4: 38 unresolved entries (35 unique IDs:
+    # 2 typo / 0 banned / 33 authentic gaps). Lower bound: > 0.
+    assert len(src_errs) > 0, (
+        "strict-mode load against live KB found 0 unresolved SRC-* refs — "
+        "check is unwired or KB has been fully filled"
+    )
+    # Drift inventory for posterity / future regression: capture unique IDs.
+    unique = {
+        m.group(1) for (_, msg) in src_errs if (m := _UNRESOLVED_RE.search(msg))
+    }
+    print(
+        f"\n[drift] live KB strict-mode unresolved SRC-* unique IDs: "
+        f"{len(unique)} (entries={len(src_errs)})"
+    )
+
+
+@pytest.mark.skipif(
+    not LIVE_KB.exists(),
+    reason="live knowledge_base/hosted/content not present",
+)
+def test_live_kb_default_mode_is_warn_only():
+    """Default load (warn-only) must keep result.ok=True even when the
+    live KB has unresolved SRC-* citations. Existing test_loader tests
+    rely on this back-compat.
+    """
+    clear_load_cache()
+    result = load_content(LIVE_KB)  # default strict_source_refs=False
+    src_warns = _unresolved_entries(result.contract_warnings)
+    src_errs = _unresolved_entries(result.ref_errors)
+    assert src_errs == [], (
+        "default mode leaked SRC-resolution into ref_errors — "
+        "back-compat broken"
+    )
+    assert len(src_warns) > 0, "default mode should warn on unresolved SRC-* refs"
+    # Result.ok should still be True (modulo other unrelated contract
+    # errors that may exist on master). Specifically: SRC-resolution must
+    # NOT have populated ref_errors or contract_errors.
+
+
+# ---------------------------------------------------------------------------
+# Synthetic clean KB — passes both strict and default modes.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_clean_kb_passes_strict(tmp_path: Path):
+    clear_load_cache()
+    _write_source(tmp_path, "SRC-X")
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_regimen(tmp_path, "REG-X", sources=["SRC-X"])
+
+    result = load_content(tmp_path, strict_source_refs=True)
+    src_errs = _unresolved_entries(result.ref_errors)
+    src_warns = _unresolved_entries(result.contract_warnings)
+    assert src_errs == [], f"unexpected ref_errors: {src_errs}"
+    assert src_warns == [], f"unexpected warnings: {src_warns}"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic broken KB — fails cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_broken_kb_strict_fails_with_one_error(tmp_path: Path):
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    # No SRC-MISSING source defined.
+    _write_regimen(tmp_path, "REG-Y", sources=["SRC-MISSING"])
+
+    result = load_content(tmp_path, strict_source_refs=True)
+    src_errs = _unresolved_entries(result.ref_errors)
+    assert len(src_errs) == 1, f"expected 1 ref_error, got: {src_errs}"
+    path, msg = src_errs[0]
+    assert "SRC-MISSING" in msg
+    assert "Unresolved citation ref" in msg
+    assert "sources[" in msg  # field label
+    # Authentic gap, no typo candidates
+    assert "source_stub" in msg
+
+
+def test_synthetic_broken_kb_default_warns_only(tmp_path: Path):
+    """Default mode keeps result.ok=True; unresolved SRC-* lands in
+    contract_warnings instead."""
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_regimen(tmp_path, "REG-Z", sources=["SRC-MISSING"])
+
+    result = load_content(tmp_path)  # default warn-only
+    src_errs = _unresolved_entries(result.ref_errors)
+    src_warns = _unresolved_entries(result.contract_warnings)
+    assert src_errs == [], "default mode must not populate ref_errors"
+    assert len(src_warns) == 1
+    assert "SRC-MISSING" in src_warns[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Banned-source detection.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_kb_banned_source_id_gets_banned_hint(tmp_path: Path):
+    """Unresolved banned-legacy ID (SRC-SNOMED) gets a 'banned' hint per
+    CHARTER §2 instead of a typo suggestion or stub-file hint.
+
+    SRC-SNOMED is used here because it never appears as a Source entity
+    (license-incompatible). SRC-ONCOKB and SRC-MEDDRA are also in the
+    banned set; the categorization helper covers all three (see
+    test_categorize_banned_id_returns_banned).
+    """
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_regimen(tmp_path, "REG-BANNED", sources=["SRC-SNOMED"])
+
+    result = load_content(tmp_path, strict_source_refs=True)
+    src_errs = _unresolved_entries(result.ref_errors)
+    assert len(src_errs) == 1
+    msg = src_errs[0][1]
+    assert "SRC-SNOMED" in msg
+    assert "banned" in msg.lower()
+    assert "CHARTER" in msg
+
+
+# ---------------------------------------------------------------------------
+# Typo suggestion.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_kb_typo_gets_did_you_mean(tmp_path: Path):
+    """Brief test #5: two sources, regimen cites a typo'd version of one
+    of them. Loader suggests the closest match.
+    """
+    clear_load_cache()
+    _write_source(tmp_path, "SRC-NCCN-BCELL-2025")
+    _write_source(tmp_path, "SRC-NCCN-DLBCL-2024")
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    # Typo: 2024 vs 2025 — Levenshtein distance 1 from SRC-NCCN-BCELL-2025
+    _write_regimen(tmp_path, "REG-TYPO", sources=["SRC-NCCN-BCELL-2024"])
+
+    result = load_content(tmp_path, strict_source_refs=True)
+    src_errs = _unresolved_entries(result.ref_errors)
+    assert len(src_errs) == 1
+    msg = src_errs[0][1]
+    assert "SRC-NCCN-BCELL-2024" in msg
+    assert "did you mean" in msg.lower()
+    assert "SRC-NCCN-BCELL-2025" in msg
+
+
+# ---------------------------------------------------------------------------
+# Narrative-field scan — notes / evidence_summary mentions.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_kb_notes_field_unresolved_src_is_caught(tmp_path: Path):
+    """SRC-XYZ mentioned inside ``notes:`` markdown is caught even though
+    it isn't a structural FK. This is what the citation-verifier
+    workstream needs — narrative drift is a render hazard."""
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_source(tmp_path, "SRC-X")
+    reg_dir = tmp_path / "regimens"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    (reg_dir / "reg_narrative.yaml").write_text(
+        textwrap.dedent(
+            """\
+            id: REG-NARRATIVE
+            name: Test regimen
+            components:
+              - drug_id: DRUG-RITUXIMAB
+            sources:
+              - SRC-X
+            notes: |
+              Per SRC-INVENTED-2099, response rate was 80% in pivotal trial.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = load_content(tmp_path, strict_source_refs=True)
+    src_errs = _unresolved_entries(result.ref_errors)
+    # One unresolved: SRC-INVENTED-2099 in notes.
+    assert any("SRC-INVENTED-2099" in m for (_, m) in src_errs), (
+        f"narrative SRC-* mention not caught: {src_errs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache key invalidates on strict-flag toggle.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_includes_strict_flag(tmp_path: Path):
+    """Toggling strict_source_refs between calls must produce distinct
+    LoadResult instances (different ref_errors/contract_warnings)."""
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_regimen(tmp_path, "REG-CACHE", sources=["SRC-MISSING"])
+
+    warn = load_content(tmp_path, strict_source_refs=False)
+    strict = load_content(tmp_path, strict_source_refs=True)
+
+    assert warn is not strict, "cache mistakenly merges strict + warn entries"
+    assert _unresolved_entries(warn.ref_errors) == []
+    assert _unresolved_entries(strict.ref_errors) != []
+
+
+# ---------------------------------------------------------------------------
+# Audit script smoke test.
+# ---------------------------------------------------------------------------
+
+
+def test_audit_script_runs_end_to_end_on_synthetic(tmp_path: Path):
+    """``scripts.audit_unresolved_sources`` runs against a tmp_path mini-KB,
+    emits structured markdown, and exits 1 when unresolved refs exist."""
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_regimen(tmp_path, "REG-AUDIT", sources=["SRC-MISSING"])
+
+    import subprocess
+    import sys as _sys
+
+    proc = subprocess.run(
+        [
+            _sys.executable,
+            "-X",
+            "utf8",
+            "-m",
+            "scripts.audit_unresolved_sources",
+            "--root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    # Exit code should be 1 (unresolved refs present)
+    assert proc.returncode == 1, (
+        f"unexpected exit code {proc.returncode}; stderr={proc.stderr!r}"
+    )
+    # Output should be markdown with the table sections
+    assert "# Unresolved SRC-* citation audit" in proc.stdout
+    assert "Authentic gaps" in proc.stdout
+    assert "SRC-MISSING" in proc.stdout
+
+
+def test_audit_script_clean_kb_exits_zero(tmp_path: Path):
+    clear_load_cache()
+    _write_drug(tmp_path, "DRUG-RITUXIMAB")
+    _write_source(tmp_path, "SRC-CLEAN")
+    _write_regimen(tmp_path, "REG-OK", sources=["SRC-CLEAN"])
+
+    import subprocess
+    import sys as _sys
+
+    proc = subprocess.run(
+        [
+            _sys.executable,
+            "-X",
+            "utf8",
+            "-m",
+            "scripts.audit_unresolved_sources",
+            "--root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert proc.returncode == 0, (
+        f"clean KB should exit 0; got {proc.returncode}; "
+        f"stdout={proc.stdout!r}; stderr={proc.stderr!r}"
+    )


### PR DESCRIPTION
## TL;DR

KB has 2,330 SRC-citation references; 38 of them are unresolved (broken refs). Loader now catches these as referential-integrity findings + categorizes (typo / banned / gap) with actionable hints.

Independent of phases-refactor. Per data-quality plan Q5 task #1 (CI warnings for unsourced claim text).

## What

- \`load_content(strict_source_refs: bool = False)\` flag (default warn-only via \`contract_warnings\`; opt-in strict via \`ref_errors\`)
- New helpers: \`_levenshtein\`, \`_categorize_unresolved_src\`, \`_format_unresolved_src_msg\`
- Structural FK checks for \`regimens.dose_adjustments[].source_refs[]\` and \`biomarker_actionability.evidence_sources[].source\`
- Pass 2.5 narrative-field SRC token scan (notes / evidence_summary / rationale)
- Cache key extended with \`strict_flag\` for toggle correctness
- \`scripts/audit_unresolved_sources.py\` — standalone reporter (markdown + \`--json\`)

## Live KB drift

| Category | Count | Examples |
|---|---|---|
| typo | 2 | \`SRC-EANO-LGG-2021\` → \`2024\`; \`SRC-MOUNTAINEER-...-2023\` → \`2022\` |
| banned | 0 | (\`SRC-ONCOKB\` defined as legacy entity) |
| gap | 33 | trial-nicknames in narrative: \`SRC-PROFOUND\`, \`SRC-OLYMPIA\`, \`SRC-KEYNOTE-811\` etc. |
| **Total** | **38 entries / 35 unique IDs** | |

All in narrative \`notes:\` / \`evidence_summary:\` text fields. Structural FK sweep returns 0 unresolved.

## Tests

23/23 (16 new + 7 existing loader). 1868 total pass.

## Plan reference

\`docs/reviews/cross-repo-task_torrent-sync-plan-2026-04-28.md\` §6 + KB Data Quality Plan Q5