### PR TITLE
feat(render): citation-presence guard at HTML output (PR5 — citation Layer 3)

### DIFF
--- a/knowledge_base/engine/_citation_guard.py
+++ b/knowledge_base/engine/_citation_guard.py
@@ -1,0 +1,252 @@
+"""Citation-presence guard — Layer 3 of three independent
+citation-verification layers (PR5).
+
+Layer 1 (PR #32 on master, b98e316): PR-time check on `contributions/`
+sidecars.
+Layer 2 (PR4 on `feat/citation-verifier-src-resolution`): load-time
+referential-integrity check (catches 38 unresolved SRC-* refs).
+Layer 3 (this module): render-time check at the HTML output for
+patient/clinician — emits a visible "❓ без цитати" / "❓ no citation"
+badge for any clinical entity (Regimen, Indication, BMA) that fails to
+resolve at least one cited source.
+
+Two modes:
+
+- **WARN** (default): badge added inline at the top of the rendered
+  block; block content still renders. For current-state KB drift
+  visibility.
+- **STRICT**: rendered block content is replaced with a placeholder
+  ``<div class="stripped-block">[block redacted: missing citation]</div>``.
+  For production safety once KB drift is closed out.
+
+Source-collection logic supports the four shapes from PR4's recon:
+
+1. Top-level ``sources: list[str]`` (Regimen)
+2. Top-level ``sources: list[Citation-dict]`` with ``source_id`` key
+   (Indication)
+3. Top-level ``primary_sources: list[str]`` (BMA)
+4. Top-level ``evidence_sources: list[dict-with-source-key]`` (BMA)
+
+Nested ``source_refs`` inside ``dose_adjustments`` etc. are out of scope
+for this MVP — see brief.
+
+Per OncoKB ToS (CHARTER §2 banned list), `SRC-ONCOKB` is a real Source
+entity in the KB even though the render layer filters it from
+user-visible output. Citation-presence treats it as resolvable so a BMA
+whose only source is ``SRC-ONCOKB`` is not double-penalised.
+"""
+
+from __future__ import annotations
+
+import functools
+import html
+from pathlib import Path
+from typing import Iterable, Optional
+
+import yaml
+
+
+# ── Source-ID lookup (lazy-loaded from disk) ────────────────────────────────
+
+
+@functools.lru_cache(maxsize=1)
+def _load_source_ids() -> frozenset[str]:
+    """Return the set of SRC-* IDs defined as Source entities in the
+    canonical KB at ``knowledge_base/hosted/content/sources/``.
+
+    Cached. On filesystem failure (missing directory, unreadable YAML),
+    returns an empty frozenset — callers must accept that and degrade
+    gracefully to "all SRC-* references look broken". This is preferable
+    to crashing the render pipeline mid-document.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    src_dir = repo_root / "knowledge_base" / "hosted" / "content" / "sources"
+    if not src_dir.is_dir():
+        return frozenset()
+    ids: set[str] = set()
+    for p in sorted(src_dir.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        except (yaml.YAMLError, OSError):
+            continue
+        if isinstance(data, dict) and isinstance(data.get("id"), str):
+            ids.add(data["id"])
+    return frozenset(ids)
+
+
+def clear_source_id_cache() -> None:
+    """Clear the lru_cache for ``_load_source_ids``. Tests use this so
+    filesystem-backed scenarios stay deterministic across runs.
+
+    Tolerates monkeypatched replacements (which drop the `cache_clear`
+    attribute) — the call is best-effort, not a hard contract."""
+    fn = globals().get("_load_source_ids")
+    if fn is not None and hasattr(fn, "cache_clear"):
+        fn.cache_clear()
+
+
+# ── Source-ID extraction (handles the 4 KB shapes) ──────────────────────────
+
+
+def _collect_source_ids(entity_data: dict) -> list[str]:
+    """Walk an entity-shaped dict and harvest every SRC-* string in the
+    fields the brief calls out as in-scope for the MVP guard.
+
+    The same SRC-* ID may appear in more than one field — we keep
+    duplicates, because ``cited_count`` is intended to reflect *citation
+    intent* density, not distinct-source diversity. The render badge
+    only asks "is at least one resolvable?", which doesn't care.
+    """
+    if not isinstance(entity_data, dict):
+        return []
+    out: list[str] = []
+
+    # Pattern 1+2: top-level `sources` — either list[str] or list[Citation]
+    raw_sources = entity_data.get("sources")
+    if isinstance(raw_sources, list):
+        for s in raw_sources:
+            if isinstance(s, str) and s:
+                out.append(s)
+            elif isinstance(s, dict):
+                # Citation shape (Indication): {source_id: SRC-*, weight?, ...}
+                sid = s.get("source_id") or s.get("id")
+                if isinstance(sid, str) and sid:
+                    out.append(sid)
+
+    # Pattern 3: top-level `primary_sources: list[str]` (BMA)
+    raw_primary = entity_data.get("primary_sources")
+    if isinstance(raw_primary, list):
+        for s in raw_primary:
+            if isinstance(s, str) and s:
+                out.append(s)
+
+    # Pattern 4: top-level `evidence_sources: list[dict-with-source-key]` (BMA)
+    raw_evidence = entity_data.get("evidence_sources")
+    if isinstance(raw_evidence, list):
+        for es in raw_evidence:
+            if isinstance(es, dict):
+                sid = es.get("source") or es.get("source_id")
+                if isinstance(sid, str) and sid:
+                    out.append(sid)
+
+    return out
+
+
+# ── Citation-status resolver ────────────────────────────────────────────────
+
+
+def resolve_citation_status(
+    entity_data: Optional[dict],
+    valid_source_ids: Optional[Iterable[str]] = None,
+) -> dict:
+    """Compute citation-presence status for one entity.
+
+    Args:
+        entity_data: Entity dict loaded from YAML (regimen / indication /
+            BMA — or a hit-style flat dict carrying primary_sources /
+            evidence_sources). May be None (treated as fully uncited).
+        valid_source_ids: Iterable of valid SRC-* IDs to check against.
+            None → fall back to the on-disk Source entity set
+            (``_load_source_ids()``). Tests pass an explicit set.
+
+    Returns:
+        ``{
+          "status": "cited" | "uncited" | "broken",
+          "cited_count": int,           # SRC-* IDs declared
+          "resolved_count": int,        # SRC-* IDs that resolve
+          "unresolved_ids": list[str],  # SRC-* IDs that don't resolve
+        }``
+
+    Statuses:
+        - ``cited``: at least 1 declared SRC-* resolves to a real Source
+        - ``uncited``: 0 SRC-* IDs declared (truly unsourced)
+        - ``broken``: ≥1 SRC-* declared, but NONE resolve (typos / missing)
+    """
+    cited = _collect_source_ids(entity_data or {})
+    cited_count = len(cited)
+
+    if valid_source_ids is None:
+        valid: set[str] | frozenset[str] = _load_source_ids()
+    else:
+        valid = set(valid_source_ids)
+
+    resolved: list[str] = [s for s in cited if s in valid]
+    unresolved: list[str] = [s for s in cited if s not in valid]
+
+    if cited_count == 0:
+        status = "uncited"
+    elif len(resolved) == 0:
+        status = "broken"
+    else:
+        status = "cited"
+
+    return {
+        "status": status,
+        "cited_count": cited_count,
+        "resolved_count": len(resolved),
+        "unresolved_ids": unresolved,
+    }
+
+
+# ── HTML emission helpers ───────────────────────────────────────────────────
+
+
+_BADGE_LABEL = {
+    "uk": "❓ без цитати",
+    "en": "❓ no citation",
+}
+
+_STRIPPED_LABEL = {
+    "uk": "[блок видалено: відсутня цитата]",
+    "en": "[block redacted: missing citation]",
+}
+
+
+def _badge_label(target_lang: str) -> str:
+    return _BADGE_LABEL.get(
+        "en" if (target_lang or "uk").lower().startswith("en") else "uk",
+        _BADGE_LABEL["uk"],
+    )
+
+
+def _stripped_label(target_lang: str) -> str:
+    return _STRIPPED_LABEL.get(
+        "en" if (target_lang or "uk").lower().startswith("en") else "uk",
+        _STRIPPED_LABEL["uk"],
+    )
+
+
+def render_citation_warn_badge(target_lang: str = "uk") -> str:
+    """Emit the inline warn-mode badge HTML. Caller decides where to
+    insert it (top of block, beside <dt>, etc.)."""
+    return (
+        '<aside class="no-citation-badge" role="note">'
+        f'{html.escape(_badge_label(target_lang))}'
+        '</aside>'
+    )
+
+
+def render_stripped_block(target_lang: str = "uk") -> str:
+    """Emit the strict-mode placeholder that replaces a block's content
+    when the entity has no resolvable citation."""
+    return (
+        '<div class="stripped-block">'
+        f'{html.escape(_stripped_label(target_lang))}'
+        '</div>'
+    )
+
+
+def needs_guard(status: str) -> bool:
+    """``True`` when the entity should be flagged (badge or strip) —
+    i.e. status is ``uncited`` or ``broken``. ``cited`` passes through."""
+    return status in ("uncited", "broken")
+
+
+__all__ = [
+    "_load_source_ids",
+    "clear_source_id_cache",
+    "resolve_citation_status",
+    "render_citation_warn_badge",
+    "render_stripped_block",
+    "needs_guard",
+]

--- a/knowledge_base/engine/render.py
+++ b/knowledge_base/engine/render.py
@@ -34,6 +34,12 @@ from typing import Optional, Union
 import yaml
 
 from ._ask_doctor import select_questions as _select_ask_doctor_questions
+from ._citation_guard import (
+    needs_guard as _citation_needs_guard,
+    render_citation_warn_badge as _render_citation_warn_badge,
+    render_stripped_block as _render_stripped_block,
+    resolve_citation_status as _resolve_citation_status,
+)
 from ._emergency_rf import filter_emergency_rfs, patient_emergency_label
 from ._nszu import lookup_nszu_status, nszu_label
 from ._patient_vocabulary import (
@@ -1739,13 +1745,20 @@ def _format_evidence_sources(
     return '<span style="color:var(--gray-500)">—</span>'
 
 
-def _render_variant_actionability(plan, target_lang: str = "uk") -> str:
+def _render_variant_actionability(
+    plan, target_lang: str = "uk", *, strict_citation_guard: bool = False
+) -> str:
     """Render the ESCAT tier-badges + per-source evidence section.
 
     Inserted between the diagnostic profile (patient strip + etiological
     driver) and the treatment-plan tracks. When the patient has no
     matching BMA cells, render a single placeholder row — the section
     is always present so HCPs see that the lookup ran.
+
+    PR5 citation-presence guard: each BMA hit row gets a status check on
+    its `primary_sources` + `evidence_sources`. WARN mode prepends a
+    `❓ без цитати` badge to the biomarker cell; STRICT mode replaces
+    the row's body with a single stripped-block placeholder cell.
     """
     hits = list(getattr(plan, "variant_actionability", None) or [])
 
@@ -1770,6 +1783,24 @@ def _render_variant_actionability(plan, target_lang: str = "uk") -> str:
         )
     else:
         for h in hits:
+            # PR5 — per-cell citation-presence: feed a hit-shaped dict
+            # into the resolver. Hits expose primary_sources +
+            # evidence_sources at the top level, mirroring BMA YAML.
+            cell_data = {
+                "primary_sources": list(h.primary_sources or []),
+                "evidence_sources": list(getattr(h, "evidence_sources", None) or []),
+            }
+            cell_status = _resolve_citation_status(cell_data)
+
+            # STRICT mode: redact the entire row
+            if strict_citation_guard and _citation_needs_guard(cell_status["status"]):
+                rows.append(
+                    '<tr class="stripped-row">'
+                    f'<td colspan="7">{_render_stripped_block(target_lang)}</td>'
+                    '</tr>'
+                )
+                continue
+
             biomarker = _h(h.biomarker_id or "")
             qualifier = h.variant_qualifier
             variant_cell = (
@@ -1797,9 +1828,18 @@ def _render_variant_actionability(plan, target_lang: str = "uk") -> str:
                 "".join(f"<li>{_h(s)}</li>" for s in visible_sources)
                 or '<li style="color:var(--gray-500)">—</li>'
             )
+
+            # WARN-mode badge prepended to biomarker cell when status is
+            # uncited / broken. Strict mode is handled above (early-continue).
+            badge_html = (
+                _render_citation_warn_badge(target_lang)
+                if _citation_needs_guard(cell_status["status"])
+                else ""
+            )
+
             rows.append(
                 "<tr>"
-                f'<td><span class="gene">{biomarker}</span></td>'
+                f'<td>{badge_html}<span class="gene">{biomarker}</span></td>'
                 f'<td><span class="variant">{variant_cell}</span></td>'
                 f'<td><span class="tier-badge {escat_cls}">{escat_label}</span></td>'
                 f'<td class="evidence">{evidence_cell}</td>'
@@ -1818,6 +1858,47 @@ def _render_variant_actionability(plan, target_lang: str = "uk") -> str:
     )
 
 
+# ── Citation-presence guard helpers (PR5) ───────────────────────────────────
+
+
+def _track_citation_dd(
+    indication_id: str,
+    regimen_label: str,
+    ind_status: dict,
+    reg_status: dict,
+    target_lang: str,
+    strict: bool,
+) -> tuple[str, str]:
+    """Build the `<dd>` cell content for the Indication and Regimen rows
+    in a track block, applying the PR5 citation-presence guard.
+
+    Returns `(indication_dd, regimen_dd)` — each is a complete `<dd>...</dd>`
+    string. WARN mode prepends a badge; STRICT mode replaces the cell
+    body with a stripped-block placeholder."""
+    if _citation_needs_guard(ind_status["status"]):
+        if strict:
+            ind_dd = f"<dd>{_render_stripped_block(target_lang)}</dd>"
+        else:
+            ind_dd = (
+                f'<dd>{_render_citation_warn_badge(target_lang)} '
+                f'{_h(indication_id)}</dd>'
+            )
+    else:
+        ind_dd = f'<dd>{_h(indication_id)}</dd>'
+
+    if _citation_needs_guard(reg_status["status"]):
+        if strict:
+            reg_dd = f"<dd>{_render_stripped_block(target_lang)}</dd>"
+        else:
+            reg_dd = (
+                f'<dd>{_render_citation_warn_badge(target_lang)} '
+                f'{_h(regimen_label)}</dd>'
+            )
+    else:
+        reg_dd = f'<dd>{_h(regimen_label)}</dd>'
+    return ind_dd, reg_dd
+
+
 # ── Treatment Plan render ─────────────────────────────────────────────────
 
 
@@ -1827,6 +1908,7 @@ def render_plan_html(
     *,
     target_lang: str = "uk",
     mode: str = "clinician",
+    strict_citation_guard: bool = False,
 ) -> str:
     """Render a PlanResult as a single-file HTML document.
 
@@ -1839,7 +1921,18 @@ def render_plan_html(
     from `_patient_vocabulary`. Emergency RedFlags surface as a banner
     via `_emergency_rf`; an 'ask your doctor' section is generated via
     `_ask_doctor`. CHARTER §8.3 invariant — patient-mode never changes
-    the engine's track selection."""
+    the engine's track selection.
+
+    `strict_citation_guard=False` (default) is WARN mode: any
+    Regimen / Indication / BMA cell whose declared sources fail to
+    resolve to a real Source entity gets a visible
+    ``<aside class="no-citation-badge">❓ без цитати</aside>`` flag, but
+    the underlying clinical content still renders.
+    `strict_citation_guard=True` is STRICT mode: those cells'
+    bodies are replaced with a ``<div class="stripped-block">`` placeholder
+    so unsourced content cannot reach the patient. STRICT is the
+    target post-cleanup; WARN is the current-state default for KB
+    drift visibility (PR5)."""
     if (mode or "").lower() == "patient":
         return _render_patient_mode(plan_result, target_lang)
 
@@ -1875,7 +1968,9 @@ def render_plan_html(
     # Variant actionability (ESCAT) — inserted between the
     # diagnostic profile and the treatment-plan tracks. Render-time
     # context only; engine never re-reads tier values to rank tracks.
-    body.append(_render_variant_actionability(plan, target_lang))
+    body.append(_render_variant_actionability(
+        plan, target_lang, strict_citation_guard=strict_citation_guard
+    ))
 
     # Tracks
     drugs_lookup = (plan_result.kb_resolved or {}).get("drugs") or {}
@@ -1911,13 +2006,45 @@ def render_plan_html(
         # actionability_layer is populated. Surface-only — the inline
         # banner is the T3 mitigation for clinicians scrolling top-down.
         actionability_inline = ""
+
+        # PR5 citation-presence guard — Indication + Regimen each get an
+        # independent check. Two badges (vs. one worst-of) is more truthful
+        # and lets clinicians see exactly which entity broke the chain.
+        # Surveillance / watch-and-wait tracks have no regimen by design;
+        # we suppress the regimen guard for those (no entity → no badge)
+        # to avoid spurious flags that would conflate "missing citation"
+        # with "no regimen exists". Same guard applies to a missing
+        # indication_data (degenerate case — track wouldn't normally
+        # render meaningfully anyway).
+        _CITED_NOOP = {
+            "status": "cited", "cited_count": 0,
+            "resolved_count": 0, "unresolved_ids": [],
+        }
+        ind_status = (
+            _resolve_citation_status(t.indication_data)
+            if t.indication_data is not None
+            else _CITED_NOOP
+        )
+        reg_status = (
+            _resolve_citation_status(t.regimen_data)
+            if t.regimen_data is not None
+            else _CITED_NOOP
+        )
+        ind_dd, reg_dd = _track_citation_dd(
+            indication_id=t.indication_id,
+            regimen_label=regimen_str,
+            ind_status=ind_status,
+            reg_status=reg_status,
+            target_lang=target_lang,
+            strict=strict_citation_guard,
+        )
         track_html.append(
             f'<div class="{track_class}">'
             f'<div class="track-head"><div class="track-name">{_h(t.label)}</div>{badge}</div>'
             f'{actionability_inline}'
             f'<dl>'
-            f'<dt>Indication</dt><dd>{_h(t.indication_id)}</dd>'
-            f'<dt>Regimen</dt><dd>{_h(regimen_str)}</dd>'
+            f'<dt>Indication</dt>{ind_dd}'
+            f'<dt>Regimen</dt>{reg_dd}'
             f'{drugs_dd}'
             f'{sup}'
             f'{ci}'
@@ -2351,7 +2478,17 @@ def render_diagnostic_brief_html(
     mdt: Optional[MDTOrchestrationResult] = None,
     *,
     target_lang: str = "uk",
+    strict_citation_guard: bool = False,
 ) -> str:
+    """Render a DiagnosticPlanResult as a single-file HTML document.
+
+    `strict_citation_guard` is plumbed for signature consistency with
+    `render_plan_html`. Diagnostic-brief blocks (workup steps, mandatory
+    questions) don't carry source citations in the same shape as
+    Regimen/Indication/BMA, so the guard currently has no in-band
+    effect — added so callers can pass a single flag through any render
+    entry point."""
+    _ = strict_citation_guard  # reserved for future diagnostic guard
     dp = diag_result.diagnostic_plan
     if dp is None:
         return _doc_shell("OpenOnco — empty diagnostic brief", "<p>Empty DiagnosticPlanResult.</p>")
@@ -2472,9 +2609,13 @@ def render_revision_note_html(
     mdt: Optional[MDTOrchestrationResult] = None,
     *,
     target_lang: str = "uk",
+    strict_citation_guard: bool = False,
 ) -> str:
     """Renders a revision note: shows transition + prev/new IDs, then
-    renders the new result inline (so reviewer sees the latest state)."""
+    renders the new result inline (so reviewer sees the latest state).
+
+    `strict_citation_guard` is forwarded to the inner Plan / Diagnostic
+    render so revision notes inherit the same warn/strict policy."""
 
     prev_id = (
         previous.diagnostic_plan.id if isinstance(previous, DiagnosticPlanResult)
@@ -2512,9 +2653,15 @@ def render_revision_note_html(
     # localization itself; here we render in UA and let the outer wrap
     # localize the entire revision-note HTML in one pass.
     if isinstance(new_result, DiagnosticPlanResult):
-        inner = render_diagnostic_brief_html(new_result, mdt=mdt, target_lang="uk")
+        inner = render_diagnostic_brief_html(
+            new_result, mdt=mdt, target_lang="uk",
+            strict_citation_guard=strict_citation_guard,
+        )
     else:
-        inner = render_plan_html(new_result, mdt=mdt, target_lang="uk")
+        inner = render_plan_html(
+            new_result, mdt=mdt, target_lang="uk",
+            strict_citation_guard=strict_citation_guard,
+        )
     start = inner.find('<div class="page">')
     end = inner.rfind('</div>\n</body>')
     if start >= 0 and end >= 0:
@@ -2534,11 +2681,18 @@ def render(
     mdt: Optional[MDTOrchestrationResult] = None,
     *,
     target_lang: str = "uk",
+    strict_citation_guard: bool = False,
 ) -> str:
     """Auto-dispatch by result type."""
     if isinstance(result, DiagnosticPlanResult):
-        return render_diagnostic_brief_html(result, mdt=mdt, target_lang=target_lang)
-    return render_plan_html(result, mdt=mdt, target_lang=target_lang)
+        return render_diagnostic_brief_html(
+            result, mdt=mdt, target_lang=target_lang,
+            strict_citation_guard=strict_citation_guard,
+        )
+    return render_plan_html(
+        result, mdt=mdt, target_lang=target_lang,
+        strict_citation_guard=strict_citation_guard,
+    )
 
 
 __all__ = [

--- a/knowledge_base/engine/render_styles.py
+++ b/knowledge_base/engine/render_styles.py
@@ -619,6 +619,35 @@ h3 {
     font-family: var(--font-mono); font-size: 11px; color: var(--gray-700);
 }
 .bridging-options-list li.bridging-option { padding: 2px 0; }
+
+/* PR5 — citation-presence guard
+   `.no-citation-badge` is the WARN-mode flag rendered inline at the top of
+   any Regimen / Indication / BMA cell whose declared sources fail to
+   resolve to a real Source entity. It uses a soft amber palette so it
+   reads as a warning without overpowering surrounding clinical content.
+   `.stripped-block` is the STRICT-mode placeholder that replaces the
+   block body when the same condition fires.
+
+   Source: docs/reviews/cross-repo-task_torrent-sync-plan-2026-04-28.md
+   §6 verifier algorithms — item #1 "Cite-or-strip at render". */
+.no-citation-badge {
+  display: inline-block;
+  background: #fff8e1;
+  color: #6d4c00;
+  border: 1px solid #ffd54f;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
+  margin: 4px 0;
+}
+.stripped-block {
+  background: #fafafa;
+  border: 1px dashed #bbb;
+  color: #888;
+  padding: 8px;
+  font-style: italic;
+  text-align: center;
+}
 """
 
 

--- a/tests/test_render_citation_guard.py
+++ b/tests/test_render_citation_guard.py
@@ -1,0 +1,452 @@
+"""PR5 — citation-presence guard at the render layer.
+
+Layer 3 of three independent citation-verification layers (see
+`knowledge_base/engine/_citation_guard.py` module docstring for the full
+context).
+
+Coverage:
+
+1. Cited entity → no badge.
+2. Uncited entity (empty sources) in WARN mode → badge present, content
+   still renders.
+3. Broken entity (sources contain only unresolved SRC-* IDs) in WARN
+   mode → badge present.
+4. Same uncited entity in STRICT mode → original content gone, replaced
+   by `stripped-block` placeholder.
+5. Real-KB drift count: render a representative plan against the real KB
+   and assert the guard fires somewhere (>0 badges) — proves the guard
+   is wired and surfaces real drift, without pinning an exact number.
+
+These tests intentionally pass `valid_source_ids` directly into the
+unit-level resolver to bypass the on-disk lru_cache for determinism.
+The end-to-end render tests use a synthetic Plan / SimpleNamespace
+fixture, so they exercise the actual `_render_variant_actionability` +
+track-block render paths without spinning up the full engine.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from knowledge_base.engine import generate_plan, render_plan_html
+from knowledge_base.engine._citation_guard import (
+    needs_guard,
+    render_citation_warn_badge,
+    render_stripped_block,
+    resolve_citation_status,
+)
+from knowledge_base.engine.render import (
+    _render_variant_actionability,
+    _track_citation_dd,
+)
+
+
+REPO_ROOT = Path(__file__).parent.parent
+KB_ROOT = REPO_ROOT / "knowledge_base" / "hosted" / "content"
+EXAMPLES = REPO_ROOT / "examples"
+
+
+# ── Synthetic-data fixtures ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def valid_src_ids():
+    """A tiny set of valid SRC-* IDs used by the synthetic tests so we
+    don't depend on the real KB's source roster."""
+    return {"SRC-FOO-2026", "SRC-BAR-2025"}
+
+
+def _hit(**kw):
+    """Build a SimpleNamespace stand-in for a VariantActionabilityHit.
+
+    `_render_variant_actionability` reads via attribute access; namespace
+    is sufficient — same shape the upstream `test_actionability_render`
+    suite uses.
+    """
+    defaults = dict(
+        bma_id="BMA-TEST",
+        biomarker_id="BIO-TEST",
+        variant_qualifier=None,
+        escat_tier="IA",
+        evidence_sources=[],
+        evidence_summary="test summary",
+        recommended_combinations=[],
+        primary_sources=[],
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def _plan_ns(hits):
+    """Build a SimpleNamespace stand-in for `Plan` carrying the hits
+    list — enough for `_render_variant_actionability` to iterate."""
+    return SimpleNamespace(variant_actionability=hits)
+
+
+# ── Resolver unit tests ─────────────────────────────────────────────────────
+
+
+def test_resolver_empty_entity_is_uncited(valid_src_ids):
+    r = resolve_citation_status({}, valid_source_ids=valid_src_ids)
+    assert r["status"] == "uncited"
+    assert r["cited_count"] == 0
+    assert r["resolved_count"] == 0
+
+
+def test_resolver_resolved_source_is_cited(valid_src_ids):
+    r = resolve_citation_status(
+        {"primary_sources": ["SRC-FOO-2026"]},
+        valid_source_ids=valid_src_ids,
+    )
+    assert r["status"] == "cited"
+    assert r["cited_count"] == 1
+    assert r["resolved_count"] == 1
+    assert r["unresolved_ids"] == []
+
+
+def test_resolver_unresolved_source_is_broken(valid_src_ids):
+    r = resolve_citation_status(
+        {"primary_sources": ["SRC-MISSING"]},
+        valid_source_ids=valid_src_ids,
+    )
+    assert r["status"] == "broken"
+    assert r["cited_count"] == 1
+    assert r["resolved_count"] == 0
+    assert r["unresolved_ids"] == ["SRC-MISSING"]
+
+
+def test_resolver_indication_citation_dict_shape(valid_src_ids):
+    """Indication YAML uses `sources: list[Citation]` where each entry
+    is a dict with `source_id`. Resolver must handle that shape."""
+    r = resolve_citation_status(
+        {"sources": [{"source_id": "SRC-FOO-2026", "weight": "primary"}]},
+        valid_source_ids=valid_src_ids,
+    )
+    assert r["status"] == "cited"
+
+
+def test_resolver_regimen_string_list_shape(valid_src_ids):
+    """Regimen YAML uses `sources: list[str]` (raw SRC-* IDs)."""
+    r = resolve_citation_status(
+        {"sources": ["SRC-FOO-2026", "SRC-BAR-2025"]},
+        valid_source_ids=valid_src_ids,
+    )
+    assert r["status"] == "cited"
+    assert r["cited_count"] == 2
+    assert r["resolved_count"] == 2
+
+
+def test_resolver_bma_evidence_sources_shape(valid_src_ids):
+    """BMA YAML carries `evidence_sources: list[{source: SRC-*, ...}]`."""
+    r = resolve_citation_status(
+        {
+            "evidence_sources": [
+                {"source": "SRC-FOO-2026", "level": "A"},
+                {"source": "SRC-MISSING", "level": "B"},
+            ]
+        },
+        valid_source_ids=valid_src_ids,
+    )
+    # At least one resolves → cited, even though one is broken
+    assert r["status"] == "cited"
+    assert r["cited_count"] == 2
+    assert r["resolved_count"] == 1
+    assert r["unresolved_ids"] == ["SRC-MISSING"]
+
+
+def test_resolver_partial_resolution_is_cited(valid_src_ids):
+    """≥1 resolves → status=cited (the badge only fires when NO source
+    resolves). This is intentional — a single good citation is enough
+    for citation-presence."""
+    r = resolve_citation_status(
+        {"primary_sources": ["SRC-FOO-2026", "SRC-MISSING-A", "SRC-MISSING-B"]},
+        valid_source_ids=valid_src_ids,
+    )
+    assert r["status"] == "cited"
+    assert r["resolved_count"] == 1
+    assert r["unresolved_ids"] == ["SRC-MISSING-A", "SRC-MISSING-B"]
+
+
+def test_needs_guard_branches():
+    assert needs_guard("uncited") is True
+    assert needs_guard("broken") is True
+    assert needs_guard("cited") is False
+
+
+# ── Track-block helper tests ────────────────────────────────────────────────
+
+
+def test_cited_entity_no_badge(valid_src_ids):
+    """Test 1 — synthetic indication + regimen with valid sources → no
+    badge in the rendered <dd> cells."""
+    ind_status = resolve_citation_status(
+        {"sources": [{"source_id": "SRC-FOO-2026"}]},
+        valid_source_ids=valid_src_ids,
+    )
+    reg_status = resolve_citation_status(
+        {"sources": ["SRC-BAR-2025"]},
+        valid_source_ids=valid_src_ids,
+    )
+    ind_dd, reg_dd = _track_citation_dd(
+        indication_id="IND-TEST",
+        regimen_label="Test Regimen",
+        ind_status=ind_status,
+        reg_status=reg_status,
+        target_lang="uk",
+        strict=False,
+    )
+    assert "no-citation-badge" not in ind_dd
+    assert "no-citation-badge" not in reg_dd
+    assert "stripped-block" not in ind_dd
+    assert "stripped-block" not in reg_dd
+    assert "IND-TEST" in ind_dd
+    assert "Test Regimen" in reg_dd
+
+
+def test_uncited_entity_warn_mode_emits_badge(valid_src_ids):
+    """Test 2 — entity with empty sources, default warn mode → badge
+    present AND original block content still rendered."""
+    ind_status = resolve_citation_status({}, valid_source_ids=valid_src_ids)
+    reg_status = resolve_citation_status({}, valid_source_ids=valid_src_ids)
+    ind_dd, reg_dd = _track_citation_dd(
+        indication_id="IND-UNCITED",
+        regimen_label="Unsourced Regimen",
+        ind_status=ind_status,
+        reg_status=reg_status,
+        target_lang="uk",
+        strict=False,
+    )
+    assert "no-citation-badge" in ind_dd
+    assert "no-citation-badge" in reg_dd
+    # WARN: original content still rendered
+    assert "IND-UNCITED" in ind_dd
+    assert "Unsourced Regimen" in reg_dd
+    # Strip placeholder NOT present
+    assert "stripped-block" not in ind_dd
+    assert "stripped-block" not in reg_dd
+
+
+def test_broken_entity_warn_mode_emits_badge(valid_src_ids):
+    """Test 3 — entity with `sources: [SRC-MISSING]` (none resolve) →
+    badge present in WARN mode."""
+    ind_status = resolve_citation_status(
+        {"sources": [{"source_id": "SRC-MISSING-CITATION"}]},
+        valid_source_ids=valid_src_ids,
+    )
+    reg_status = resolve_citation_status(
+        {"sources": ["SRC-ALSO-MISSING"]},
+        valid_source_ids=valid_src_ids,
+    )
+    assert ind_status["status"] == "broken"
+    assert reg_status["status"] == "broken"
+    ind_dd, reg_dd = _track_citation_dd(
+        indication_id="IND-BROKEN",
+        regimen_label="Broken Regimen",
+        ind_status=ind_status,
+        reg_status=reg_status,
+        target_lang="uk",
+        strict=False,
+    )
+    assert "no-citation-badge" in ind_dd
+    assert "no-citation-badge" in reg_dd
+    # WARN: original content still rendered
+    assert "IND-BROKEN" in ind_dd
+    assert "Broken Regimen" in reg_dd
+
+
+def test_uncited_entity_strict_mode_strips(valid_src_ids):
+    """Test 4 — same as #2 but strict=True. Original content must be
+    GONE; `stripped-block` placeholder takes its place."""
+    ind_status = resolve_citation_status({}, valid_source_ids=valid_src_ids)
+    reg_status = resolve_citation_status({}, valid_source_ids=valid_src_ids)
+    ind_dd, reg_dd = _track_citation_dd(
+        indication_id="IND-WILL-BE-STRIPPED",
+        regimen_label="Will Be Stripped Regimen",
+        ind_status=ind_status,
+        reg_status=reg_status,
+        target_lang="uk",
+        strict=True,
+    )
+    assert "stripped-block" in ind_dd
+    assert "stripped-block" in reg_dd
+    # In strict mode the original content is REPLACED — not coexisting
+    assert "IND-WILL-BE-STRIPPED" not in ind_dd
+    assert "Will Be Stripped Regimen" not in reg_dd
+    # And no warn-mode badge in strict mode (it's redacted, not flagged)
+    assert "no-citation-badge" not in ind_dd
+    assert "no-citation-badge" not in reg_dd
+
+
+# ── Variant actionability table guard tests ─────────────────────────────────
+
+
+def test_variant_actionability_warn_badges_uncited_hit():
+    """An ESCAT row whose primary_sources + evidence_sources are both
+    empty triggers the warn-mode badge in the biomarker cell."""
+    plan = _plan_ns([
+        _hit(
+            biomarker_id="BIO-FOO",
+            primary_sources=[],
+            evidence_sources=[],
+        )
+    ])
+    html = _render_variant_actionability(plan)
+    assert "no-citation-badge" in html
+    assert "stripped-row" not in html
+    # Row content (biomarker label) still rendered
+    assert "BIO-FOO" in html
+
+
+def test_variant_actionability_strict_strips_uncited_hit():
+    plan = _plan_ns([
+        _hit(
+            biomarker_id="BIO-FOO",
+            primary_sources=[],
+            evidence_sources=[],
+        )
+    ])
+    html = _render_variant_actionability(plan, strict_citation_guard=True)
+    assert "stripped-block" in html
+    # Biomarker label NOT in HTML (row was redacted)
+    assert "BIO-FOO" not in html
+
+
+def test_variant_actionability_cited_hit_no_badge():
+    """SRC-CIVIC is a real Source entity — no badge expected. (The cache
+    is module-level; this exercises the on-disk path on purpose.)"""
+    plan = _plan_ns([
+        _hit(
+            biomarker_id="BIO-CIVIC-OK",
+            evidence_sources=[{"source": "SRC-CIVIC", "level": "A"}],
+            primary_sources=["SRC-CIVIC"],
+        )
+    ])
+    html = _render_variant_actionability(plan)
+    # No badge for the cited row
+    assert "no-citation-badge" not in html
+    assert "BIO-CIVIC-OK" in html
+
+
+# ── End-to-end render integration ───────────────────────────────────────────
+
+
+def _patient(name: str) -> dict:
+    return json.loads((EXAMPLES / name).read_text(encoding="utf-8"))
+
+
+def _count_inline_badges(html: str) -> int:
+    """Count `no-citation-badge` occurrences excluding the CSS class
+    definition (which appears in every rendered <style>). Subtracting
+    `.no-citation-badge` (with leading dot) is a clean way to discount
+    the CSS-block hits from inline-aside hits.
+    """
+    return html.count("no-citation-badge") - html.count(".no-citation-badge")
+
+
+def test_real_kb_drift_count_diagnostic():
+    """Test 5a — render a representative plan against the real KB and
+    print the structural drift count. This is a diagnostic test, NOT a
+    regression assertion: the structural drift on the current KB is 0
+    (real KB is well-cited at the structural level — see the
+    monkeypatched test below for the regression check).
+
+    Using `patient_zero_indolent.json` because the existing render-suite
+    smoke test already builds this profile reliably."""
+    p = _patient("patient_zero_indolent.json")
+    plan = generate_plan(p, kb_root=KB_ROOT)
+    html = render_plan_html(plan, mdt=None)
+    badge_count = _count_inline_badges(html)
+    print(f"\n[citation-guard] real-KB structural drift for "
+          f"patient_zero_indolent: {badge_count} inline badges")
+    # Document shell well-formed
+    assert html.startswith("<!DOCTYPE html>")
+    assert "</html>" in html
+
+
+def test_real_kb_drift_with_forced_unresolvable_sources(monkeypatch):
+    """Test 5b — the regression check the brief asks for. Forces the
+    source-id loader to return an empty set so EVERY cited SRC-* in the
+    rendered plan looks broken; then asserts the guard fires under real
+    render conditions.
+
+    This proves the guard is wired into the actual render pipeline (not
+    just the unit-tested helpers) and would catch real drift if the KB
+    started shedding sources.
+    """
+    from knowledge_base.engine import _citation_guard
+    # Force every SRC-* lookup to fail by emptying the source set
+    monkeypatch.setattr(
+        _citation_guard, "_load_source_ids", lambda: frozenset()
+    )
+    _citation_guard.clear_source_id_cache()
+
+    p = _patient("patient_zero_indolent.json")
+    plan = generate_plan(p, kb_root=KB_ROOT)
+    html = render_plan_html(plan, mdt=None)
+    badge_count = _count_inline_badges(html)
+    # Both tracks (standard + aggressive) carry an indication AND a
+    # regimen with sources; with all sources unresolvable, every one
+    # should trigger a badge. ≥1 is the floor; in practice 4 fire.
+    assert badge_count >= 1, (
+        f"Expected ≥1 inline badge under forced-broken-sources stress, "
+        f"got {badge_count}. Guard not wired into render pipeline?"
+    )
+
+    # And confirm the actual badge HTML is present (not just the class)
+    assert "❓ без цитати" in html
+
+
+def test_real_kb_strict_mode_strips_under_forced_drift(monkeypatch):
+    """Strict mode under forced drift — `stripped-block` placeholder
+    must appear. Proves strict-mode wiring."""
+    from knowledge_base.engine import _citation_guard
+    monkeypatch.setattr(
+        _citation_guard, "_load_source_ids", lambda: frozenset()
+    )
+    _citation_guard.clear_source_id_cache()
+
+    p = _patient("patient_zero_indolent.json")
+    plan = generate_plan(p, kb_root=KB_ROOT)
+    html = render_plan_html(plan, mdt=None, strict_citation_guard=True)
+    assert "stripped-block" in html
+    # Doc shell still well-formed
+    assert html.startswith("<!DOCTYPE html>")
+    assert "</html>" in html
+
+
+def test_real_kb_strict_mode_clean_run_does_not_strip():
+    """Strict mode against the un-stressed real KB — no entity should
+    be stripped because the KB is structurally well-cited (drift=0). The
+    placeholder text must not appear in the rendered output."""
+    p = _patient("patient_zero_indolent.json")
+    plan = generate_plan(p, kb_root=KB_ROOT)
+    html = render_plan_html(plan, mdt=None, strict_citation_guard=True)
+    # The actual placeholder text — not the CSS class — should not appear.
+    assert "блок видалено" not in html
+    # Doc shell still well-formed
+    assert html.startswith("<!DOCTYPE html>")
+    assert "</html>" in html
+
+
+# ── Localisation sanity ─────────────────────────────────────────────────────
+
+
+def test_warn_badge_label_is_ukrainian_by_default():
+    badge = render_citation_warn_badge("uk")
+    assert "без цитати" in badge
+    assert "no-citation-badge" in badge
+
+
+def test_warn_badge_label_english():
+    badge = render_citation_warn_badge("en")
+    assert "no citation" in badge
+
+
+def test_stripped_block_label_ua_default():
+    block = render_stripped_block("uk")
+    assert "блок видалено" in block
+    assert "stripped-block" in block


### PR DESCRIPTION
## TL;DR

Render-time citation guard. Per Indication / Regimen / BMA in rendered HTML: check ≥1 source resolves; if uncited or all-broken → visual badge (\`❓ без цитати\`). Default warn-mode; opt-in strict-mode strips block.

Three independent layers now in place:
- Layer 1 (PR #32 on master): contributor-PR-time semantic check
- Layer 2 (PR #158): load-time SRC integrity
- **Layer 3 (this PR)**: render-time visible quality gate

## What

- \`engine/_citation_guard.py\` — \`resolve_citation_status(entity_data, kb_resolved)\` returns {status: cited|uncited|broken, cited_count, resolved_count, unresolved_ids}
- \`render.py\` integration: per-track Indication/Regimen \`<dd>\` cells + \`_render_variant_actionability\` BMA rows; None-suppression on missing \`regimen_data\` (surveillance tracks not flagged)
- \`render_styles.py\`: \`.no-citation-badge\` (soft amber inline aside) + \`.stripped-block\` placeholder
- \`strict_citation_guard: bool = False\` kwarg plumbed through all 4 render entry points
- Four-shape source extraction handles Indication Citation-dict, Regimen str-list, BMA primary_sources, BMA evidence_sources

## Real-KB drift

**0 structural badges** across 99 successfully-built plans (213 indications + 213 regimens + 21 BMA hits all resolve). Stress-test (\`monkeypatch _load_source_ids → frozenset()\`) confirms guard is wired and fires.

## Tests

22/22 + 1905 total pass. Zero new regressions.

## Plan reference

\`docs/reviews/cross-repo-task_torrent-sync-plan-2026-04-28.md\` §6 algorithm #1