### PR TITLE
feat(audit): claim-anchor grounding verifier — Q4+Q5 of data-quality plan (PR6)

### DIFF
--- a/.github/workflows/claim-grounding-audit.yml
+++ b/.github/workflows/claim-grounding-audit.yml
@@ -1,0 +1,102 @@
+name: KB claim-grounding audit
+
+# Periodic audit of claim-bearing KB prose: do clinical assertions on
+# Indication/Regimen/BMA entities cite a SRC-* anchor? Implements Q4+Q5 of
+# docs/plans/kb_data_quality_plan_2026-04-29.md.
+#
+# Default mode: detection-only (no API calls, no secret needed). Forks
+# without an ANTHROPIC_API_KEY get a useful coverage report each Monday.
+# Manual workflow_dispatch supports an opt-in semantic grounding pass
+# (calls the Claude API; consumes ~$5-15 per full run).
+#
+# When the report changes, the workflow opens a small PR to refresh
+# `docs/kb-claim-grounding-report.md` + `.json`. We mirror the
+# civic-monthly-refresh.yml pattern (same peter-evans action, same
+# label conventions) for operator familiarity.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      semantic:
+        description: "Run semantic check (requires ANTHROPIC_API_KEY secret; ~$5-15 cost)"
+        type: boolean
+        default: false
+      limit:
+        description: "Cap entities checked (smoke runs); leave blank for full audit"
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml pydantic
+          if [ "${{ github.event.inputs.semantic }}" = "true" ]; then
+            pip install 'anthropic>=0.40,<1.0'
+          fi
+
+      - name: Run audit (detection or semantic)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -e
+          ARGS=""
+          if [ -n "${{ github.event.inputs.limit }}" ]; then
+            ARGS="$ARGS --limit ${{ github.event.inputs.limit }}"
+          fi
+          if [ "${{ github.event.inputs.semantic }}" = "true" ]; then
+            if [ -z "$ANTHROPIC_API_KEY" ]; then
+              echo "::warning::semantic requested but ANTHROPIC_API_KEY missing — falling back to detection-only"
+            else
+              ARGS="$ARGS --semantic"
+            fi
+          fi
+          # shellcheck disable=SC2086
+          python -m scripts.audit_claim_grounding $ARGS
+
+      - name: Detect report changes
+        id: diff
+        run: |
+          if git diff --quiet -- docs/kb-claim-grounding-report.md docs/kb-claim-grounding-report.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open refresh PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: kb-claim-grounding-refresh-${{ github.run_id }}
+          title: "chore(kb): claim-grounding audit refresh"
+          add-paths: |
+            docs/kb-claim-grounding-report.md
+            docs/kb-claim-grounding-report.json
+          commit-message: "chore(kb): refresh claim-grounding audit report"
+          body: |
+            Automated refresh of the KB claim-anchor grounding report.
+
+            See `docs/kb-claim-grounding-report.md` for the human-readable
+            summary and `docs/kb-claim-grounding-report.json` for the
+            structured payload. This is an audit, not a gate — no quality
+            decisions are made here. Tracks Q4 + Q5 of
+            `docs/plans/kb_data_quality_plan_2026-04-29.md`.
+          labels: |
+            kb-quality
+            kb-audit-refresh

--- a/docs/kb-claim-grounding-report.md
+++ b/docs/kb-claim-grounding-report.md
@@ -1,0 +1,23 @@
+# KB Claim-Anchor Grounding Report
+
+_Generated_: 2026-04-30T11:41:05.484875+00:00
+
+Audit of claim-bearing prose fields on Indication, Regimen, and BiomarkerActionability entities. Layer 1 (detection) checks whether the parent entity cites ≥1 SRC-* anchor; Layer 2 (semantic, opt-in) asks the Claude API whether each cited source plausibly supports the claim. Tracks Q4/Q5 of `docs/plans/kb_data_quality_plan_2026-04-29.md`; v1.0 target ≥90% anchor coverage.
+
+## Top-level metrics
+
+| Metric | Numerator | Denominator | Score |
+|---|---:|---:|---:|
+| Claim-bearing fields with ≥1 anchor | 2112 | 2112 | 100.0% |
+
+## Per-entity-type breakdown
+
+| Entity type | Total claims | Anchored | Coverage |
+|---|---:|---:|---:|
+| biomarker_actionability | 798 | 798 | 100.0% |
+| indications | 866 | 866 | 100.0% |
+| regimens | 448 | 448 | 100.0% |
+
+## Detached claims (top 50 of 0)
+
+_None — every claim-bearing field has at least one cited Source._

--- a/knowledge_base/engine/_claim_extraction.py
+++ b/knowledge_base/engine/_claim_extraction.py
@@ -1,0 +1,276 @@
+"""Extract claim-bearing text fields from KB entities.
+
+Used by `scripts/audit_claim_grounding.py` (Q4 + Q5 of
+`docs/plans/kb_data_quality_plan_2026-04-29.md`).
+
+A "claim-bearing field" is a free-text field on a KB entity that asserts
+clinical fact — outcomes, mechanism, comparative efficacy, line-of-therapy
+rationale, etc. Each such field should be backed by ≥1 cited source.
+This module walks an already-loaded KB (LoadResult-style dict) and yields
+one `ExtractedClaim` per (entity, claim-bearing field) pair.
+
+Field map (chosen after reading schemas/indication.py, schemas/regimen.py,
+schemas/biomarker_actionability.py):
+
+  Indication
+    - rationale          (free-text rationale paragraph)
+    - notes              (clinical notes)
+    - expected_outcomes  (structured object — stringified by joining
+                          non-null subfields; the `notes` subfield is
+                          included if present)
+  Regimen
+    - notes              (clinical notes)
+    - notes_ua           (Ukrainian translation — same claim, separate
+                          extraction so contributors can see the UA-side
+                          grounding state independently)
+  BiomarkerActionability
+    - evidence_summary   (1-3 sentence clinical interpretation)
+    - notes              (clinical notes)
+
+The brief (slice 3 spec) lists `evidence_summary` and `recommendation_rationale`
+on Indication. Those names don't exist on the schema — see commit notes —
+so we map them to the actual schema fields `rationale` and `notes`. The
+schema for `expected_outcomes` is structured; we stringify it so the
+grounding check has prose to score.
+
+`cited_sources` is the union of source IDs mentioned anywhere on the
+entity (top-level `sources`/`primary_sources`/`supporting_sources`,
+nested Citation.source_id, dose_adjustments[].source_refs, and
+evidence_sources[].source). A field's claim is "anchored" iff that
+union is non-empty AND ≥1 of the cited IDs resolves to a Source entity
+in the KB. Field-local citation precision (which specific source backs
+which specific sentence) is out of scope for this layer — that's PR4
+work — but a fully detached claim (no SRC-* anywhere on the entity)
+is what we flag here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+
+# Entities we extract claims from, and how their claim-bearing fields
+# are stringified. Order matters only for stable report output.
+CLAIM_BEARING_ENTITIES: tuple[str, ...] = (
+    "indications",
+    "regimens",
+    "biomarker_actionability",
+)
+
+
+@dataclass
+class ExtractedClaim:
+    """One claim-bearing field on one entity, plus its citation context."""
+
+    entity_type: str          # "indications" | "regimens" | "biomarker_actionability"
+    entity_id: str            # IND-FOO-123 / REG-BAR / BMA-BAZ
+    entity_path: str          # repo-relative POSIX path to source YAML
+    field: str                # "expected_outcomes" | "notes" | "evidence_summary" | ...
+    text: str                 # the claim-bearing prose (stringified)
+    cited_sources: list[str] = field(default_factory=list)
+    has_anchor: bool = False  # cited_sources non-empty AND ≥1 resolves
+
+
+# ---------- Source ID collection ----------
+
+def _walk_source_ids(value: Any, out: set[str]) -> None:
+    """Recursively collect SRC-* strings from any nested structure.
+
+    Picks up:
+      - bare strings starting with "SRC-"
+      - Citation dicts with a `source_id` key
+      - dose_adjustments[].source_refs
+      - evidence_sources[].source
+      - any list/dict containing the above
+    """
+    if value is None:
+        return
+    if isinstance(value, str):
+        if value.startswith("SRC-"):
+            out.add(value)
+        return
+    if isinstance(value, list):
+        for v in value:
+            _walk_source_ids(v, out)
+        return
+    if isinstance(value, dict):
+        # Common citation patterns
+        for key in ("source_id", "source"):
+            v = value.get(key)
+            if isinstance(v, str) and v.startswith("SRC-"):
+                out.add(v)
+        for key in ("source_refs", "sources", "primary_sources",
+                   "supporting_sources"):
+            v = value.get(key)
+            if isinstance(v, list):
+                _walk_source_ids(v, out)
+        # Recurse into nested values that aren't already handled, so
+        # we catch SRC-* IDs nested inside e.g. known_controversies →
+        # positions[].sources, or evidence_sources[].source.
+        for v in value.values():
+            if isinstance(v, (list, dict)):
+                _walk_source_ids(v, out)
+
+
+def _collect_cited_sources(entity_data: dict) -> list[str]:
+    """All SRC-* IDs cited anywhere on the entity, sorted+deduped."""
+    out: set[str] = set()
+    _walk_source_ids(entity_data, out)
+    return sorted(out)
+
+
+# ---------- Per-entity-type field extraction ----------
+
+def _stringify_expected_outcomes(eo: Any) -> str:
+    """Turn ExpectedOutcomes (struct) into a single prose blob.
+
+    Joins non-null subfield values with field labels so the resulting
+    text reads like a coherent claim ("ORR ~70%; PFS median 7 mo;
+    notes: OlympiAD"). Empty if no subfields populated.
+    """
+    if not isinstance(eo, dict):
+        return ""
+    parts: list[str] = []
+    # Stable order for cache-key stability.
+    for k in sorted(eo.keys()):
+        v = eo.get(k)
+        if v is None or v == "":
+            continue
+        if isinstance(v, (list, dict)):
+            # Defensive: skip unexpected nested shapes.
+            continue
+        parts.append(f"{k}: {v}")
+    return "; ".join(parts)
+
+
+def _coerce_text(value: Any) -> str:
+    """Best-effort conversion of YAML scalar/list to a prose string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return "\n".join(_coerce_text(v) for v in value if v).strip()
+    if isinstance(value, dict):
+        return _stringify_expected_outcomes(value)
+    return str(value).strip()
+
+
+def _extract_indication_fields(data: dict) -> Iterable[tuple[str, str]]:
+    """Yield (field_name, text) for each claim-bearing field on an Indication."""
+    for fname in ("rationale", "notes"):
+        text = _coerce_text(data.get(fname))
+        if text:
+            yield fname, text
+    eo_text = _stringify_expected_outcomes(data.get("expected_outcomes"))
+    if eo_text:
+        yield "expected_outcomes", eo_text
+
+
+def _extract_regimen_fields(data: dict) -> Iterable[tuple[str, str]]:
+    for fname in ("notes", "notes_ua"):
+        text = _coerce_text(data.get(fname))
+        if text:
+            yield fname, text
+
+
+def _extract_bma_fields(data: dict) -> Iterable[tuple[str, str]]:
+    for fname in ("evidence_summary", "notes"):
+        text = _coerce_text(data.get(fname))
+        if text:
+            yield fname, text
+
+
+_EXTRACTORS = {
+    "indications": _extract_indication_fields,
+    "regimens": _extract_regimen_fields,
+    "biomarker_actionability": _extract_bma_fields,
+}
+
+
+# ---------- Public API ----------
+
+def extract_claims(kb_resolved: dict) -> list[ExtractedClaim]:
+    """Walk a loaded KB and produce one ExtractedClaim per claim-bearing field.
+
+    Parameters
+    ----------
+    kb_resolved
+        Either a `LoadResult` instance (has `entities_by_id` attribute)
+        or its `entities_by_id` dict directly. Each entry is
+        ``{"type": <dir name>, "data": <raw YAML dict>, "path": <Path>}``.
+
+    Returns
+    -------
+    list of ExtractedClaim sorted by (entity_type, entity_id, field).
+    """
+    entities = _normalize_entities(kb_resolved)
+
+    # Index Source entity IDs so we can compute has_anchor per claim.
+    source_ids: set[str] = {
+        eid for eid, info in entities.items()
+        if info.get("type") == "sources"
+    }
+
+    out: list[ExtractedClaim] = []
+    for eid, info in entities.items():
+        etype = info.get("type")
+        if etype not in CLAIM_BEARING_ENTITIES:
+            continue
+        data = info.get("data") or {}
+        path_obj = info.get("path")
+        path_str = _path_to_repo_relative(path_obj)
+
+        cited = _collect_cited_sources(data)
+        has_anchor = bool(cited) and any(s in source_ids for s in cited)
+
+        extractor = _EXTRACTORS[etype]
+        for field_name, text in extractor(data):
+            out.append(ExtractedClaim(
+                entity_type=etype,
+                entity_id=eid,
+                entity_path=path_str,
+                field=field_name,
+                text=text,
+                cited_sources=cited,
+                has_anchor=has_anchor,
+            ))
+
+    out.sort(key=lambda c: (c.entity_type, c.entity_id, c.field))
+    return out
+
+
+def _normalize_entities(kb_resolved: Any) -> dict:
+    """Accept either a LoadResult or its `entities_by_id` dict."""
+    if hasattr(kb_resolved, "entities_by_id"):
+        return kb_resolved.entities_by_id
+    if isinstance(kb_resolved, dict):
+        # Heuristic: a LoadResult-style dict has values with "type"/"data" keys.
+        sample = next(iter(kb_resolved.values()), None)
+        if isinstance(sample, dict) and "data" in sample and "type" in sample:
+            return kb_resolved
+    raise TypeError(
+        "extract_claims expects a LoadResult or its entities_by_id dict"
+    )
+
+
+def _path_to_repo_relative(p: Any) -> str:
+    """Convert a Path to a repo-relative POSIX-style string when possible."""
+    if p is None:
+        return ""
+    try:
+        from pathlib import Path
+        path = Path(p)
+        # Best-effort: strip everything before knowledge_base/ if present
+        parts = path.parts
+        for marker in ("knowledge_base",):
+            if marker in parts:
+                idx = parts.index(marker)
+                return "/".join(parts[idx:])
+        return path.as_posix()
+    except Exception:
+        return str(p)
+
+
+__all__ = ["ExtractedClaim", "extract_claims", "CLAIM_BEARING_ENTITIES"]

--- a/scripts/audit_claim_grounding.py
+++ b/scripts/audit_claim_grounding.py
@@ -1,0 +1,569 @@
+"""KB claim-anchor grounding audit (slice 3 of citation-verifier).
+
+Implements Q4 + Q5 of `docs/plans/kb_data_quality_plan_2026-04-29.md`:
+
+  Q4. Add claim-level source anchors where `expected_outcomes` or
+      line-of-therapy text is currently detached from a specific
+      trial/guideline source.
+  Q5. Regression prevention — track citation density / outcome coverage
+      / signoff readiness over time.
+
+Two-layer audit:
+
+  1. Detection (no API): walks claim-bearing text fields on Indication,
+     Regimen, BiomarkerActionability. For each, records whether the
+     entity carries ≥1 cited SRC-* that resolves to a Source entity.
+
+  2. Verification (--semantic, opt-in, requires ANTHROPIC_API_KEY):
+     for fields WITH at least one anchor, asks Claude whether the
+     cited sources plausibly support the claim. Reuses the
+     `check_semantic` function from
+     `scripts.tasktorrent.verify_citations` — single source of truth
+     for the API integration prevents drift between contributor-side
+     and hosted-side verifiers.
+
+Outputs (overwritten each run):
+
+  docs/kb-claim-grounding-report.md     human-readable summary
+  docs/kb-claim-grounding-report.json   structured
+
+Cache (skip-on-rerun, opt-out via --no-cache):
+
+  .cache/citation-grounding/<entity_id>__<field>__<hash8>.json
+
+  Each file: {"cached_at": ISO8601, "result": CheckResult-as-dict, ...}
+  TTL: 30 days from `cached_at`. Hash is sha256 of (text + sorted
+  cited_sources) so any content change invalidates.
+
+Exit codes:
+  0 — success (this is an audit, not a gate)
+  1 — fatal error (file IO, KB load failure)
+  2 — usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+KB_CONTENT = REPO_ROOT / "knowledge_base" / "hosted" / "content"
+CACHE_DIR = REPO_ROOT / ".cache" / "citation-grounding"
+REPORT_MD = REPO_ROOT / "docs" / "kb-claim-grounding-report.md"
+REPORT_JSON = REPO_ROOT / "docs" / "kb-claim-grounding-report.json"
+
+CACHE_TTL = timedelta(days=30)
+
+
+# ---------- Data ----------
+
+@dataclass
+class GroundingResult:
+    """Outcome of a semantic grounding check on one claim.
+
+    Mirrors `verify_citations.CheckResult` plus claim identity so the
+    record is self-describing in the cache and report.
+    """
+
+    entity_type: str
+    entity_id: str
+    field: str
+    grounded: Optional[bool] = None  # None when not run / skipped
+    confidence: Optional[float] = None
+    reasoning: str = ""
+    raw_detail: str = ""
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+@dataclass
+class AuditMetrics:
+    total_claims: int = 0
+    claims_with_anchor: int = 0
+    by_entity_type: dict = field(default_factory=lambda: defaultdict(
+        lambda: {"total": 0, "anchored": 0}
+    ))
+    semantic_ran: int = 0
+    semantic_grounded: int = 0
+    semantic_ungrounded: int = 0
+    semantic_skipped: int = 0
+
+
+# ---------- Cache ----------
+
+def _claim_hash(text: str, cited_sources: list[str]) -> str:
+    h = hashlib.sha256()
+    h.update(text.encode("utf-8", errors="replace"))
+    h.update(b"\x00")
+    for s in sorted(cited_sources):
+        h.update(s.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def _cache_path(entity_id: str, field_name: str, content_hash: str) -> Path:
+    safe_id = entity_id.replace("/", "_").replace(":", "_")
+    safe_field = field_name.replace("/", "_")
+    return CACHE_DIR / f"{safe_id}__{safe_field}__{content_hash[:16]}.json"
+
+
+def _read_cache(path: Path) -> Optional[dict]:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    cached_at = payload.get("cached_at")
+    if not isinstance(cached_at, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(cached_at)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    if datetime.now(timezone.utc) - ts > CACHE_TTL:
+        return None
+    return payload
+
+
+def _write_cache(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+# ---------- Core audit ----------
+
+def run_audit(
+    kb_root: Path,
+    *,
+    enable_semantic: bool = False,
+    limit: Optional[int] = None,
+    use_cache: bool = True,
+    semantic_fn: Optional[Callable] = None,
+    source_titles: Optional[dict[str, str]] = None,
+) -> tuple[AuditMetrics, list, list]:
+    """Walk the KB, extract claims, optionally run grounding checks.
+
+    Parameters
+    ----------
+    kb_root
+        Path to ``knowledge_base/hosted/content``.
+    enable_semantic
+        When True, call ``semantic_fn`` for each anchored claim.
+    limit
+        Cap on entities (NOT claims) processed. None = no cap.
+    use_cache
+        When True, read/write per-claim cache files in ``CACHE_DIR``.
+    semantic_fn
+        Override for the API-call function (test injection point).
+        Default: ``scripts.tasktorrent.verify_citations.check_semantic``.
+    source_titles
+        Override for the SRC-id -> "title + notes" map (test injection).
+
+    Returns
+    -------
+    (metrics, extracted_claims, grounding_results)
+    """
+    from knowledge_base.validation.loader import clear_load_cache, load_content
+    from knowledge_base.engine._claim_extraction import (
+        extract_claims,
+    )
+
+    clear_load_cache()  # always start with a fresh load
+    load_result = load_content(kb_root)
+    claims = extract_claims(load_result.entities_by_id)
+
+    # Apply --limit at entity granularity (not claim) so a single
+    # entity's multiple claims are kept together.
+    if limit is not None and limit > 0:
+        kept_entities: set[str] = set()
+        capped: list = []
+        for c in claims:
+            if c.entity_id in kept_entities or len(kept_entities) < limit:
+                kept_entities.add(c.entity_id)
+                capped.append(c)
+        claims = capped
+
+    metrics = AuditMetrics()
+    grounding_results: list[GroundingResult] = []
+
+    # Semantic dependencies — load lazily so detection-only mode never
+    # imports anthropic.
+    semantic_call = None
+    Claim = None
+    if enable_semantic:
+        from scripts.tasktorrent.verify_citations import (
+            Claim,
+            check_semantic,
+            load_master_source_titles,
+        )
+        semantic_call = semantic_fn if semantic_fn is not None else check_semantic
+        if source_titles is None:
+            source_titles = load_master_source_titles()
+
+    for c in claims:
+        metrics.total_claims += 1
+        bucket = metrics.by_entity_type[c.entity_type]
+        bucket["total"] += 1
+        if c.has_anchor:
+            metrics.claims_with_anchor += 1
+            bucket["anchored"] += 1
+
+        if not enable_semantic:
+            continue
+        if not c.has_anchor:
+            continue
+
+        content_hash = _claim_hash(c.text, c.cited_sources)
+        cache_path = _cache_path(c.entity_id, c.field, content_hash)
+        cached = _read_cache(cache_path) if use_cache else None
+        if cached is not None:
+            metrics.semantic_ran += 1
+            res = _grounding_from_cache_payload(c, cached)
+        else:
+            assert Claim is not None and semantic_call is not None
+            api_claim = Claim(
+                sidecar=c.entity_path,
+                target_id=c.entity_id,
+                summary=c.text,
+                cited_sources=list(c.cited_sources),
+                civic_eids=[],
+            )
+            check_result = semantic_call(api_claim, source_titles or {})
+            res = _grounding_from_check_result(c, check_result)
+            metrics.semantic_ran += 1
+            if use_cache:
+                _write_cache(cache_path, {
+                    "cached_at": datetime.now(timezone.utc).isoformat(),
+                    "entity_type": c.entity_type,
+                    "entity_id": c.entity_id,
+                    "field": c.field,
+                    "content_hash": content_hash,
+                    "result": asdict(res),
+                })
+
+        if res.skipped:
+            metrics.semantic_skipped += 1
+        elif res.grounded is False:
+            metrics.semantic_ungrounded += 1
+        elif res.grounded is True:
+            metrics.semantic_grounded += 1
+        grounding_results.append(res)
+
+    return metrics, claims, grounding_results
+
+
+def _grounding_from_check_result(claim, check_result) -> GroundingResult:
+    """Translate a verify_citations.CheckResult into a GroundingResult."""
+    detail = getattr(check_result, "detail", "") or ""
+    skipped = (
+        ("skipped" in detail.lower())
+        or ("n/a" in detail.lower())
+        or ("non-blocking" in detail.lower())
+    )
+    grounded: Optional[bool] = None
+    confidence: Optional[float] = None
+    reasoning = ""
+    if not skipped and detail.startswith("grounded="):
+        # Parse "grounded=True conf=0.92 — reasoning text..."
+        try:
+            head, _, tail = detail.partition(" — ")
+            tokens = head.split()
+            for tok in tokens:
+                if tok.startswith("grounded="):
+                    grounded = tok.split("=", 1)[1].lower() == "true"
+                elif tok.startswith("conf="):
+                    confidence = float(tok.split("=", 1)[1])
+            reasoning = tail.strip()
+        except (ValueError, IndexError):
+            pass
+    return GroundingResult(
+        entity_type=claim.entity_type,
+        entity_id=claim.entity_id,
+        field=claim.field,
+        grounded=grounded,
+        confidence=confidence,
+        reasoning=reasoning,
+        raw_detail=detail,
+        skipped=skipped,
+        skip_reason=detail if skipped else "",
+    )
+
+
+def _grounding_from_cache_payload(claim, payload: dict) -> GroundingResult:
+    raw = payload.get("result") or {}
+    return GroundingResult(
+        entity_type=claim.entity_type,
+        entity_id=claim.entity_id,
+        field=claim.field,
+        grounded=raw.get("grounded"),
+        confidence=raw.get("confidence"),
+        reasoning=raw.get("reasoning") or "",
+        raw_detail=raw.get("raw_detail") or "",
+        skipped=bool(raw.get("skipped")),
+        skip_reason=raw.get("skip_reason") or "",
+    )
+
+
+# ---------- Report writers ----------
+
+def _excerpt(text: str, n: int = 140) -> str:
+    """Single-line excerpt for table cells."""
+    one_line = " ".join(text.split())
+    if len(one_line) > n:
+        return one_line[: n - 1] + "…"
+    return one_line
+
+
+def _percent(num: int, denom: int) -> str:
+    return f"{(100.0 * num / denom):.1f}%" if denom > 0 else "n/a"
+
+
+def write_reports(
+    metrics: AuditMetrics,
+    claims: list,
+    grounding_results: list,
+    *,
+    semantic_enabled: bool,
+    md_path: Path = REPORT_MD,
+    json_path: Path = REPORT_JSON,
+) -> None:
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Top-50 detached claims (claims whose entity has no resolving anchor)
+    detached = [c for c in claims if not c.has_anchor]
+    # Stable sort: by entity_type then entity_id
+    detached.sort(key=lambda c: (c.entity_type, c.entity_id, c.field))
+    top_detached = detached[:50]
+
+    ungrounded = [
+        g for g in grounding_results
+        if g.grounded is False and not g.skipped
+    ]
+
+    # ----- Markdown -----
+    lines: list[str] = []
+    lines.append("# KB Claim-Anchor Grounding Report")
+    lines.append("")
+    lines.append(f"_Generated_: {datetime.now(timezone.utc).isoformat()}")
+    lines.append("")
+    lines.append(
+        "Audit of claim-bearing prose fields on Indication, Regimen, and "
+        "BiomarkerActionability entities. Layer 1 (detection) checks whether "
+        "the parent entity cites ≥1 SRC-* anchor; Layer 2 (semantic, opt-in) "
+        "asks the Claude API whether each cited source plausibly supports "
+        "the claim. Tracks Q4/Q5 of "
+        "`docs/plans/kb_data_quality_plan_2026-04-29.md`; v1.0 target ≥90% "
+        "anchor coverage."
+    )
+    lines.append("")
+    lines.append("## Top-level metrics")
+    lines.append("")
+    lines.append("| Metric | Numerator | Denominator | Score |")
+    lines.append("|---|---:|---:|---:|")
+    lines.append(
+        f"| Claim-bearing fields with ≥1 anchor | "
+        f"{metrics.claims_with_anchor} | {metrics.total_claims} | "
+        f"{_percent(metrics.claims_with_anchor, metrics.total_claims)} |"
+    )
+    if semantic_enabled:
+        denom = metrics.semantic_grounded + metrics.semantic_ungrounded
+        lines.append(
+            f"| Anchored claims with semantic grounding | "
+            f"{metrics.semantic_grounded} | {denom} | "
+            f"{_percent(metrics.semantic_grounded, denom)} |"
+        )
+        lines.append(
+            f"| Semantic checks skipped (insufficient text/no key) | "
+            f"{metrics.semantic_skipped} | {metrics.semantic_ran} | "
+            f"{_percent(metrics.semantic_skipped, metrics.semantic_ran)} |"
+        )
+    lines.append("")
+    lines.append("## Per-entity-type breakdown")
+    lines.append("")
+    lines.append("| Entity type | Total claims | Anchored | Coverage |")
+    lines.append("|---|---:|---:|---:|")
+    for etype in sorted(metrics.by_entity_type.keys()):
+        b = metrics.by_entity_type[etype]
+        lines.append(
+            f"| {etype} | {b['total']} | {b['anchored']} | "
+            f"{_percent(b['anchored'], b['total'])} |"
+        )
+    lines.append("")
+    lines.append(f"## Detached claims (top 50 of {len(detached)})")
+    lines.append("")
+    if not detached:
+        lines.append("_None — every claim-bearing field has at least one cited Source._")
+    else:
+        lines.append("These entities make claim-bearing assertions but cite no "
+                     "resolving SRC-* anchor anywhere on the entity. Each is a "
+                     "candidate for a Q4 remediation chunk.")
+        lines.append("")
+        lines.append("| Entity | Field | Excerpt | Suggested action |")
+        lines.append("|---|---|---|---|")
+        for c in top_detached:
+            lines.append(
+                f"| `{c.entity_id}` ({c.entity_type}) | `{c.field}` | "
+                f"{_excerpt(c.text)} | "
+                f"add SRC-* anchor or downgrade to maintainer-review note |"
+            )
+    lines.append("")
+    if semantic_enabled:
+        lines.append(f"## Grounding-fail claims (semantic mode) — {len(ungrounded)}")
+        lines.append("")
+        if not ungrounded:
+            lines.append("_None — all sampled anchors plausibly support their claims._")
+        else:
+            lines.append("| Entity | Field | Confidence | Reasoning |")
+            lines.append("|---|---|---:|---|")
+            for g in ungrounded[:50]:
+                conf = (
+                    f"{g.confidence:.2f}"
+                    if isinstance(g.confidence, float) else "n/a"
+                )
+                lines.append(
+                    f"| `{g.entity_id}` ({g.entity_type}) | `{g.field}` | "
+                    f"{conf} | {_excerpt(g.reasoning, 200)} |"
+                )
+        lines.append("")
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+
+    # ----- JSON -----
+    json_payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "semantic_enabled": semantic_enabled,
+        "metrics": {
+            "total_claims": metrics.total_claims,
+            "claims_with_anchor": metrics.claims_with_anchor,
+            "anchor_coverage": (
+                metrics.claims_with_anchor / metrics.total_claims
+                if metrics.total_claims else None
+            ),
+            "by_entity_type": {
+                k: dict(v) for k, v in metrics.by_entity_type.items()
+            },
+            "semantic": {
+                "ran": metrics.semantic_ran,
+                "grounded": metrics.semantic_grounded,
+                "ungrounded": metrics.semantic_ungrounded,
+                "skipped": metrics.semantic_skipped,
+            },
+        },
+        "detached_top": [
+            {
+                "entity_type": c.entity_type,
+                "entity_id": c.entity_id,
+                "field": c.field,
+                "excerpt": _excerpt(c.text),
+                "entity_path": c.entity_path,
+            }
+            for c in top_detached
+        ],
+        "ungrounded": [
+            asdict(g) for g in ungrounded[:200]
+        ] if semantic_enabled else [],
+    }
+    json_path.write_text(
+        json.dumps(json_payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+# ---------- CLI ----------
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="scripts.audit_claim_grounding",
+        description=(
+            "Audit KB claim-bearing prose for source anchors. Default: "
+            "detection-only (no API). --semantic adds Claude grounding check."
+        ),
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Cap entities checked (smoke runs)",
+    )
+    parser.add_argument(
+        "--semantic", action="store_true",
+        help="Enable Claude API grounding (requires ANTHROPIC_API_KEY)",
+    )
+    parser.add_argument(
+        "--no-cache", action="store_true",
+        help="Skip cache; force re-query for every claim in --semantic mode",
+    )
+    parser.add_argument(
+        "--kb-root", type=Path, default=KB_CONTENT,
+        help="Override KB content root (default: knowledge_base/hosted/content)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.semantic and not os.environ.get("ANTHROPIC_API_KEY"):
+        print(
+            "WARNING: --semantic without ANTHROPIC_API_KEY — grounding "
+            "checks will be skipped (non-blocking).",
+            file=sys.stderr,
+        )
+
+    if not args.kb_root.is_dir():
+        print(f"ERROR: KB root not a directory: {args.kb_root}", file=sys.stderr)
+        return 1
+
+    try:
+        metrics, claims, grounding = run_audit(
+            args.kb_root,
+            enable_semantic=args.semantic,
+            limit=args.limit,
+            use_cache=not args.no_cache,
+        )
+    except Exception as e:  # pragma: no cover (defensive)
+        print(f"ERROR: audit failed: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        write_reports(
+            metrics, claims, grounding,
+            semantic_enabled=args.semantic,
+        )
+    except OSError as e:
+        print(f"ERROR: writing report failed: {e}", file=sys.stderr)
+        return 1
+
+    # Console summary
+    print(f"Total claim-bearing fields: {metrics.total_claims}")
+    print(
+        f"Anchor coverage: {metrics.claims_with_anchor}/{metrics.total_claims} "
+        f"({_percent(metrics.claims_with_anchor, metrics.total_claims)})"
+    )
+    for etype in sorted(metrics.by_entity_type.keys()):
+        b = metrics.by_entity_type[etype]
+        print(
+            f"  {etype}: {b['anchored']}/{b['total']} "
+            f"({_percent(b['anchored'], b['total'])})"
+        )
+    if args.semantic:
+        denom = metrics.semantic_grounded + metrics.semantic_ungrounded
+        print(
+            f"Semantic: {metrics.semantic_grounded}/{denom} grounded, "
+            f"{metrics.semantic_ungrounded} ungrounded, "
+            f"{metrics.semantic_skipped} skipped"
+        )
+    print(f"Reports written: {REPORT_MD} + {REPORT_JSON}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_claim_grounding.py
+++ b/tests/test_claim_grounding.py
@@ -1,0 +1,449 @@
+"""Tests for the claim-grounding audit (slice 3 of citation-verifier).
+
+Covers:
+  - Claim extraction shape: anchor presence/absence; structured outcomes
+  - Real KB sanity (claim count > threshold; all expected entity types)
+  - Semantic call mocked end-to-end through the audit
+  - Cache hit + cache invalidation on content change
+  - CLI smoke run against real KB
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from knowledge_base.engine._claim_extraction import (
+    CLAIM_BEARING_ENTITIES,
+    ExtractedClaim,
+    extract_claims,
+)
+from knowledge_base.validation.loader import clear_load_cache, load_content
+from scripts import audit_claim_grounding as aud
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REAL_KB = REPO_ROOT / "knowledge_base" / "hosted" / "content"
+
+
+# ---------- helpers ----------
+
+def _build_synthetic_kb(root: Path, *, with_anchor: bool) -> None:
+    """Lay out a tiny KB so the loader produces a LoadResult.
+
+    Always provides one Disease, one Drug, one Source, plus a Regimen
+    (bare bones). The extra `with_anchor` flag toggles whether the
+    Indication/BMA/Regimen reference SRC-* IDs.
+    """
+    (root / "diseases").mkdir(parents=True, exist_ok=True)
+    (root / "drugs").mkdir(parents=True, exist_ok=True)
+    (root / "regimens").mkdir(parents=True, exist_ok=True)
+    (root / "indications").mkdir(parents=True, exist_ok=True)
+    (root / "biomarkers").mkdir(parents=True, exist_ok=True)
+    (root / "biomarker_actionability").mkdir(parents=True, exist_ok=True)
+    (root / "sources").mkdir(parents=True, exist_ok=True)
+
+    (root / "diseases" / "dis_test.yaml").write_text(
+        yaml.safe_dump({
+            "id": "DIS-TEST",
+            "names": {"preferred": "Test cancer", "ukrainian": "Тест"},
+            "codes": {"icd_10": "C00"},
+        }),
+        encoding="utf-8",
+    )
+    (root / "drugs" / "drug_test.yaml").write_text(
+        yaml.safe_dump({
+            "id": "DRUG-TEST",
+            "names": {"preferred": "Testdrug"},
+            "drug_class": "test",
+        }),
+        encoding="utf-8",
+    )
+    (root / "biomarkers" / "bio_test.yaml").write_text(
+        yaml.safe_dump({
+            "id": "BIO-TEST",
+            "names": {"preferred": "Test biomarker"},
+        }),
+        encoding="utf-8",
+    )
+    (root / "sources" / "src_test.yaml").write_text(
+        yaml.safe_dump({
+            "id": "SRC-TEST",
+            "source_type": "guideline",
+            "title": "Test guideline",
+            "evidence_tier": 1,
+        }),
+        encoding="utf-8",
+    )
+
+    reg_payload: dict = {
+        "id": "REG-TEST",
+        "name": "Test Regimen",
+        "components": [{"drug_id": "DRUG-TEST"}],
+        "notes": (
+            "Median PFS ~7 months in OlympiAD per the cited NCCN guideline."
+        ),
+    }
+    if with_anchor:
+        reg_payload["sources"] = ["SRC-TEST"]
+    (root / "regimens" / "reg_test.yaml").write_text(
+        yaml.safe_dump(reg_payload), encoding="utf-8",
+    )
+
+    ind_payload: dict = {
+        "id": "IND-TEST",
+        "applicable_to": {
+            "disease_id": "DIS-TEST",
+            "line_of_therapy": 1,
+        },
+        "recommended_regimen": "REG-TEST",
+        "rationale": "Test rationale: KEYNOTE-522 shows benefit.",
+        "expected_outcomes": {
+            "overall_response_rate": "~70%",
+            "progression_free_survival": "median 7 months",
+            "notes": "OlympiAD",
+        },
+    }
+    if with_anchor:
+        ind_payload["sources"] = [{"source_id": "SRC-TEST", "weight": "primary"}]
+    (root / "indications" / "ind_test.yaml").write_text(
+        yaml.safe_dump(ind_payload), encoding="utf-8",
+    )
+
+    bma_payload: dict = {
+        "id": "BMA-TEST",
+        "biomarker_id": "BIO-TEST",
+        "disease_id": "DIS-TEST",
+        "escat_tier": "IB",
+        "evidence_summary": "Test biomarker drives sensitivity to testdrug.",
+        "primary_sources": ["SRC-TEST"] if with_anchor else [],
+        "last_verified": "2026-04-27",
+    }
+    (root / "biomarker_actionability" / "bma_test.yaml").write_text(
+        yaml.safe_dump(bma_payload), encoding="utf-8",
+    )
+
+
+# ---------- 1+2: claim extraction unit tests ----------
+
+def test_extract_claims_indication(tmp_path: Path) -> None:
+    """Synthetic Indication with cited source → ExtractedClaim with has_anchor=True."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=True)
+    clear_load_cache()
+    lr = load_content(kb)
+    claims = extract_claims(lr.entities_by_id)
+
+    ind_claims = [c for c in claims if c.entity_id == "IND-TEST"]
+    assert len(ind_claims) >= 2  # rationale + expected_outcomes at minimum
+    fields = {c.field for c in ind_claims}
+    assert "rationale" in fields
+    assert "expected_outcomes" in fields
+    for c in ind_claims:
+        assert c.has_anchor is True
+        assert "SRC-TEST" in c.cited_sources
+
+
+def test_extract_claims_no_anchor(tmp_path: Path) -> None:
+    """Synthetic entity without cited SRC-* → has_anchor=False."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=False)
+    clear_load_cache()
+    lr = load_content(kb)
+    claims = extract_claims(lr.entities_by_id)
+
+    ind_claims = [c for c in claims if c.entity_id == "IND-TEST"]
+    assert ind_claims, "expected indication claims even without anchor"
+    for c in ind_claims:
+        assert c.has_anchor is False
+        assert c.cited_sources == []
+
+
+def test_expected_outcomes_stringified(tmp_path: Path) -> None:
+    """Structured ExpectedOutcomes → stringified prose blob, not Python repr."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=True)
+    clear_load_cache()
+    lr = load_content(kb)
+    claims = extract_claims(lr.entities_by_id)
+    eo_claims = [c for c in claims
+                 if c.entity_id == "IND-TEST" and c.field == "expected_outcomes"]
+    assert len(eo_claims) == 1
+    text = eo_claims[0].text
+    assert "overall_response_rate" in text
+    assert "~70%" in text
+    assert "OlympiAD" in text
+
+
+# ---------- 3: real-KB sanity ----------
+
+def test_extract_claims_real_kb() -> None:
+    """Real KB walks produce > 100 claims and cover all 3 entity types."""
+    if not REAL_KB.is_dir():
+        pytest.skip("real KB not present in this checkout")
+    clear_load_cache()
+    lr = load_content(REAL_KB)
+    claims = extract_claims(lr.entities_by_id)
+    assert len(claims) > 100
+    types = {c.entity_type for c in claims}
+    for expected in CLAIM_BEARING_ENTITIES:
+        assert expected in types, f"missing {expected} in extracted claims"
+
+
+# ---------- 4: semantic call mocked end-to-end ----------
+
+def test_check_semantic_mocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Audit invokes injected semantic_fn; report mentions the canned outcome."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=True)
+
+    # Canned CheckResult-like object: ungrounded with high confidence
+    canned_detail = "grounded=False conf=0.92 — fabricated source title"
+
+    class _CR:
+        layer = "semantic"
+        passed = False
+        detail = canned_detail
+
+    semantic_fn = MagicMock(return_value=_CR())
+
+    md_path = tmp_path / "report.md"
+    json_path = tmp_path / "report.json"
+
+    metrics, claims, grounding = aud.run_audit(
+        kb,
+        enable_semantic=True,
+        use_cache=False,
+        semantic_fn=semantic_fn,
+        source_titles={"SRC-TEST": "Test guideline title"},
+    )
+    aud.write_reports(
+        metrics, claims, grounding,
+        semantic_enabled=True,
+        md_path=md_path, json_path=json_path,
+    )
+
+    # Audit ran the semantic check at least once (one per anchored claim)
+    assert semantic_fn.call_count >= 1
+    assert metrics.semantic_ungrounded >= 1
+    md_text = md_path.read_text(encoding="utf-8")
+    assert "Grounding-fail claims" in md_text
+    assert "fabricated source title" in md_text
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["semantic_enabled"] is True
+    assert payload["metrics"]["semantic"]["ungrounded"] >= 1
+
+
+# ---------- 5+6: cache behaviour ----------
+
+def test_cache_skip_unchanged_claims(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pre-existing cache entry prevents the API from being re-called."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=True)
+
+    # Redirect cache dir to a tmp location
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(aud, "CACHE_DIR", cache_dir)
+
+    # Pre-populate cache for every claim that will be extracted
+    clear_load_cache()
+    lr = load_content(kb)
+    from knowledge_base.engine._claim_extraction import extract_claims as _extract
+    pre_claims = [c for c in _extract(lr.entities_by_id) if c.has_anchor]
+    assert pre_claims, "synthetic anchored KB produced no claims"
+
+    fixed_now = datetime.now(timezone.utc).isoformat()
+    for c in pre_claims:
+        h = aud._claim_hash(c.text, c.cited_sources)
+        path = aud._cache_path(c.entity_id, c.field, h)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "cached_at": fixed_now,
+            "entity_type": c.entity_type,
+            "entity_id": c.entity_id,
+            "field": c.field,
+            "content_hash": h,
+            "result": {
+                "entity_type": c.entity_type,
+                "entity_id": c.entity_id,
+                "field": c.field,
+                "grounded": True,
+                "confidence": 0.95,
+                "reasoning": "from cache",
+                "raw_detail": "grounded=True conf=0.95 — from cache",
+                "skipped": False,
+                "skip_reason": "",
+            },
+        }), encoding="utf-8")
+
+    semantic_fn = MagicMock()
+    metrics, claims, grounding = aud.run_audit(
+        kb,
+        enable_semantic=True,
+        use_cache=True,
+        semantic_fn=semantic_fn,
+        source_titles={"SRC-TEST": "Test"},
+    )
+    # API NEVER called because cache hit on every anchored claim
+    assert semantic_fn.call_count == 0
+    assert metrics.semantic_grounded >= 1
+    assert all(g.reasoning == "from cache" for g in grounding if not g.skipped)
+
+
+def test_cache_invalidates_on_content_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Modify a claim text → cache key changes → API called fresh."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=True)
+
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(aud, "CACHE_DIR", cache_dir)
+
+    # 1st run with canned-true
+    class _CR:
+        layer = "semantic"
+        passed = True
+        detail = "grounded=True conf=0.85 — initial"
+
+    semantic_fn = MagicMock(return_value=_CR())
+    aud.run_audit(
+        kb,
+        enable_semantic=True,
+        use_cache=True,
+        semantic_fn=semantic_fn,
+        source_titles={"SRC-TEST": "Test"},
+    )
+    first_count = semantic_fn.call_count
+    assert first_count >= 1
+
+    # 2nd run unchanged → all hits cached
+    aud.run_audit(
+        kb,
+        enable_semantic=True,
+        use_cache=True,
+        semantic_fn=semantic_fn,
+        source_titles={"SRC-TEST": "Test"},
+    )
+    assert semantic_fn.call_count == first_count, "expected pure cache hit"
+
+    # 3rd run after content edit → cache miss, semantic_fn called again
+    ind_path = kb / "indications" / "ind_test.yaml"
+    data = yaml.safe_load(ind_path.read_text(encoding="utf-8"))
+    data["rationale"] = "DIFFERENT rationale text triggering new hash."
+    ind_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    aud.run_audit(
+        kb,
+        enable_semantic=True,
+        use_cache=True,
+        semantic_fn=semantic_fn,
+        source_titles={"SRC-TEST": "Test"},
+    )
+    assert semantic_fn.call_count > first_count
+
+
+def test_cache_ttl_expiry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stale (>30d) cache entries are ignored."""
+    kb = tmp_path / "kb"
+    _build_synthetic_kb(kb, with_anchor=True)
+
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(aud, "CACHE_DIR", cache_dir)
+
+    clear_load_cache()
+    lr = load_content(kb)
+    from knowledge_base.engine._claim_extraction import extract_claims as _extract
+    pre_claims = [c for c in _extract(lr.entities_by_id) if c.has_anchor]
+    stale_ts = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+    for c in pre_claims:
+        h = aud._claim_hash(c.text, c.cited_sources)
+        path = aud._cache_path(c.entity_id, c.field, h)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "cached_at": stale_ts,
+            "result": {
+                "entity_type": c.entity_type,
+                "entity_id": c.entity_id,
+                "field": c.field,
+                "grounded": True,
+                "confidence": 0.99,
+                "reasoning": "old",
+                "raw_detail": "grounded=True conf=0.99 — old",
+                "skipped": False,
+                "skip_reason": "",
+            },
+        }), encoding="utf-8")
+
+    class _CR:
+        layer = "semantic"
+        passed = True
+        detail = "grounded=True conf=0.7 — fresh"
+
+    semantic_fn = MagicMock(return_value=_CR())
+    aud.run_audit(
+        kb,
+        enable_semantic=True,
+        use_cache=True,
+        semantic_fn=semantic_fn,
+        source_titles={"SRC-TEST": "Test"},
+    )
+    # All cache entries were stale → all required fresh API calls
+    assert semantic_fn.call_count == len(pre_claims)
+
+
+# ---------- 7: smoke ----------
+
+def test_audit_script_smoke(tmp_path: Path) -> None:
+    """`audit_claim_grounding --limit 3 --no-cache` against real KB exits 0."""
+    if not REAL_KB.is_dir():
+        pytest.skip("real KB not present in this checkout")
+
+    md_target = tmp_path / "report.md"
+    json_target = tmp_path / "report.json"
+
+    # Direct in-process call: subprocess wouldn't see our overrides, and
+    # we want to verify report files written somewhere we can clean up.
+    rc_code = aud.main([
+        "--limit", "3", "--no-cache",
+    ])
+    assert rc_code == 0
+    # The script writes to the canonical docs/ paths; ensure they exist
+    assert aud.REPORT_MD.is_file()
+    assert aud.REPORT_JSON.is_file()
+    payload = json.loads(aud.REPORT_JSON.read_text(encoding="utf-8"))
+    assert "metrics" in payload
+    assert payload["metrics"]["total_claims"] >= 1
+
+
+# ---------- additional coverage ----------
+
+def test_main_unknown_kb_root(tmp_path: Path, capsys) -> None:
+    rc = aud.main(["--kb-root", str(tmp_path / "does-not-exist")])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not a directory" in err
+
+
+def test_grounding_from_check_result_skip_paths() -> None:
+    """Detail strings that signal skip → GroundingResult.skipped=True."""
+    class _C:
+        detail = "skipped (no API key)"
+
+    class _Claim:
+        entity_type = "indications"
+        entity_id = "IND-X"
+        field = "notes"
+
+    g = aud._grounding_from_check_result(_Claim(), _C())
+    assert g.skipped is True
+    assert g.grounded is None


### PR DESCRIPTION
## TL;DR

Offline audit script per KB Data Quality Plan Q4 task #3 ("claim-level source anchors"). Detection-mode (default, no API) reports anchor-coverage; \`--semantic\` mode (opt-in) calls Anthropic Citations API for grounding score.

Reuses \`scripts/tasktorrent/verify_citations.check_semantic\` from PR #32 (single source of truth for the API integration).

## What

- \`scripts/audit_claim_grounding.py\` — CLI orchestrator with cache (\`.cache/citation-grounding/\`, 30d TTL, content-hash keyed) + markdown + JSON report
- \`engine/_claim_extraction.py\` — \`ExtractedClaim\` dataclass + \`extract_claims(kb_resolved)\` for Indication/Regimen/BMA
- \`.github/workflows/claim-grounding-audit.yml\` — Mondays 06:00 UTC + workflow_dispatch (semantic opt-in); commits report
- \`docs/kb-claim-grounding-report.md\` — initial baseline

## Baseline finding

**Entity-level anchor coverage: 100%** (2,112 / 2,112 claim-bearing fields cite ≥1 source). Already above v1.0 ≥90% target. Loader contracts (BMA \`primary_sources\` required, Indications/Regimens have \`sources:\` lists) handle this surface cleanly.

The deeper Q4 surface (per-claim-sentence anchoring — "trial X showed Y" without specific SRC) requires NLP claim extraction; out of scope for this PR. This PR is the infrastructure scaffold; semantic-mode \`--semantic\` opt-in covers grounding strength when run.

## Tests

11/11 pass (extraction units, mocked-API, cache hit/invalidate/TTL, smoke, CLI). Adjacent suites unaffected.

## Plan reference

\`docs/plans/kb_data_quality_plan_2026-04-29.md\` Q4 + Q5