### PR TITLE
feat(kb): add 5 missing indications/regimens surfaced by curated cases

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_aml_1l_7_3_go_cbf.yaml
+++ b/knowledge_base/hosted/content/indications/ind_aml_1l_7_3_go_cbf.yaml
@@ -1,0 +1,129 @@
+id: IND-AML-1L-7-3-GO-CBF
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-AML
+  line_of_therapy: 1
+  stage_requirements:
+    - "Newly-diagnosed de-novo AML, fit for intensive induction"
+    - "ELN 2022 favorable-risk OR intermediate-risk cytogenetics (CBF — inv(16)/t(16;16)/CBFB::MYH11 or t(8;21)/RUNX1::RUNX1T1 — particular benefit)"
+    - "CD33-positive blasts (≥20% by flow cytometry) — gemtuzumab targets CD33"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded:
+    - biomarker_id: BIO-TP53-MUTATION
+      required: false
+      value_constraint: "TP53-mutant AML — exclude (no GO benefit per Hills meta-analysis adverse-risk subset)"
+  demographic_constraints:
+    age_min: 18
+    age_max: 70
+    ecog_max: 2
+    fit_for_intensive_chemo: true
+
+recommended_regimen: REG-AML-7-3-GO
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~80-90% CR/CRi in CBF/favorable; ~70% in intermediate (vs ~70-80%/60% with 7+3 alone)"
+  complete_response: "~70-80% in CBF/favorable subset"
+  progression_free_survival: "2-yr EFS 40.8% vs 17.1% (ALFA-0701 overall); CBF subset particularly favorable"
+  overall_survival_5y: "2-yr OS 53.2% vs 41.9% (ALFA-0701, HR 0.69); 5-yr OS reduced mortality by ~20% in favorable + intermediate per Hills 2014"
+
+hard_contraindications:
+  - CI-LVEF-LOW-FOR-ANTHRACYCLINE
+red_flags_triggering_alternative:
+  - RF-AML-FRAILTY-AGE
+  - RF-AML-ORGAN-DYSFUNCTION
+  - RF-AML-EMERGENCY-TLS-LEUKOSTASIS
+  - RF-AML-HIGH-RISK-BIOLOGY
+
+required_tests:
+  - TEST-CBC
+  - TEST-PERIPHERAL-SMEAR
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-URIC-ACID
+  - TEST-COAG-PANEL
+  - TEST-D-DIMER
+  - TEST-HBV-SEROLOGY
+  - TEST-HCV-ANTIBODY
+  - TEST-HIV-SEROLOGY
+  - TEST-CMV-SEROLOGY
+  - TEST-ECHO
+  - TEST-PREGNANCY
+  - TEST-BM-ASPIRATE
+  - TEST-BM-TREPHINE
+  - TEST-FLOW-CYTOMETRY
+  - TEST-KARYOTYPE
+  - TEST-FISH-PANEL
+  - TEST-NGS-MYELOID-PANEL
+desired_tests: []
+
+rationale: >
+  Fractionated gemtuzumab ozogamicin (3 mg/m² days 1, 4, 7) added to
+  standard 7+3 induction is Category 1 1L for fit CD33+ AML with CBF
+  / favorable / intermediate cytogenetics (NCCN preferred). ALFA-0701
+  (Castaigne Lancet 2012): 2-yr EFS 40.8% vs 17.1% (HR 0.58);
+  2-yr OS 53.2% vs 41.9% (HR 0.69). Hills meta-analysis 2014: GO
+  reduces 5-yr mortality ~20% in favorable-risk (HR 0.47) +
+  intermediate-risk (HR 0.84); NO benefit in adverse-risk (HR 1.03).
+  CBF AML — inv(16)/CBFB::MYH11, t(8;21)/RUNX1::RUNX1T1 — derives
+  greatest benefit. Daunorubicin 60 mg/m² (not 90) with concurrent
+  GO due to additive cardiotoxicity. NOT for adverse-risk
+  (complex karyotype, TP53-mutant, monosomy 7) — standard 7+3 alone
+  + alloHCT-bridge is the appropriate path for that subset. Hepatic
+  VOD/SOS is dominant safety concern — careful LFT monitoring +
+  alloHCT timing (avoid GO within 90 days of planned transplant).
+
+rationale_ua: >
+  Фракційний гемтузумаб озогаміцин (3 мг/м² дні 1, 4, 7) доданий до стандарту 7+3 індукція — Cat 1 1L для fit CD33+ ОМЛ з CBF / favorable / intermediate цитогенетикою (NCCN preferred). ALFA-0701 (Castaigne Lancet 2012): 2-річна EFS 40.8% проти 17.1% (HR 0.58); 2-річна OS 53.2% проти 41.9% (HR 0.69). Hills meta-аналіз 2014: GO зменшує 5-річну смертність ~20% у favorable-risk (HR 0.47) + intermediate-risk (HR 0.84); БЕЗ виграшу в adverse-risk (HR 1.03). CBF ОМЛ — inv(16)/CBFB::MYH11, t(8;21)/RUNX1::RUNX1T1 — отримує найбільший виграш. Daunorubicin 60 мг/м² (не 90) з конкурентним GO через адитивну кардіотоксичність. НЕ для adverse-risk (complex karyotype, TP53-мутант, monosomy 7) — стандарт 7+3 тільки + alloHCT-bridge — правильний шлях для тієї підгрупи. Печінкова VOD/SOS — домінантна стурбованість безпеки — ретельний моніторинг LFT + час планування alloHCT (уникати GO протягом 90 днів до планового трансплантату).
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-NCCN-AML-2025
+    weight: primary
+  - source_id: SRC-ELN-AML-2022
+    weight: primary
+  - source_id: SRC-ALFA-0701-CASTAIGNE-2012
+    position: supports
+    relevant_quote_paraphrase: "ALFA-0701: fractionated GO 3 mg/m² × 3 doses added to 7+3 improves 2-yr EFS 40.8 vs 17.1% and 2-yr OS 53.2 vs 41.9% in 1L de-novo AML age 50-70."
+
+known_controversies:
+  - topic: "Universal 7+3+GO for fit CBF/favorable AML vs 7+3 alone with GO reserved for sub-optimal response"
+    positions:
+      - position: "Universal addition: ALFA-0701 + Hills meta-analysis demonstrate consistent OS benefit; CBF particularly responsive"
+        sources: [SRC-ALFA-0701-CASTAIGNE-2012, SRC-NCCN-AML-2025]
+      - position: "Selective addition: VOD/SOS risk + access barriers in many settings; reasonable to start 7+3 alone in lower-risk countries / centers"
+        sources: [SRC-ELN-AML-2022]
+    our_default: "Add fractionated GO when accessible AND favorable / intermediate cytogenetics + CD33+ + age ≤70 + LVEF preserved + no planned alloHCT within 90 days"
+    rationale: "Benefit-risk strongly favors GO addition in the eligible subset; access is the practical limiter, especially Ukraine where GO is not registered"
+
+do_not_do:
+  - "Не додавати GO в adverse-risk AML (TP53-mutant, complex karyotype, monosomy 7) — користь відсутня + токсичність зберігається."
+  - "Не використовувати daunorubicin 90 мг/м² з GO — кардіотоксичність + ранній mortality signal у SWOG-S0106 саме через цю комбінацію."
+  - "Не додавати GO без CD33-валідації — CD33-flow ≥20% blasts необхідний; CD33-low/negative AML — без сигналу benefit."
+  - "Не призначати GO протягом 90 днів до планового alloHCT — VOD/SOS-ризик у post-transplant вікні драматично підвищується."
+  - "Не пропускати baseline LFT + щоденний моніторинг bilirubin / weight gain під час GO — VOD/SOS — домінантна стурбованість безпеки."
+  - "Не пропускати ECHO — анттрациклінова кардіотоксичність + GO-specific cardiac signal вимагають LVEF tracking."
+  - "Не пропускати TLS-профілактику + HBV/HCV/HIV скринінг — стандарт 7+3 vigilance."
+
+time_critical: false
+last_reviewed: "2026-04-30"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  STUB — pending Clinical Co-Lead sign-off. Aggressive-track 1L
+  refinement of standard 7+3 for fit CD33+ AML with favorable /
+  intermediate cytogenetics. Surfaced by curated case
+  patient_aml_cbf_inv16_7_3_go.json which routed to IND-AML-1L-7-3
+  but flagged "no dedicated 7+3+GO indication in KB". Pairs with
+  IND-AML-1L-7-3 (the parent indication for AML 1L without GO add-
+  on); engine algorithm wiring to choose between the two based on
+  CBF / cytogenetic risk + GO accessibility is engine work and out
+  of scope for this commit.

--- a/knowledge_base/hosted/content/indications/ind_dlbcl_3l_loncastuximab.yaml
+++ b/knowledge_base/hosted/content/indications/ind_dlbcl_3l_loncastuximab.yaml
@@ -16,7 +16,7 @@ applicable_to:
   demographic_constraints:
     age_min: 18
     ecog_max: 2
-recommended_regimen:
+recommended_regimen: REG-LONCASTUXIMAB-TESIRINE
 concurrent_therapy: []
 followed_by: []
 evidence_level: moderate
@@ -82,4 +82,4 @@ time_critical: false
 last_reviewed: '2026-04-27'
 reviewers: []
 reviewer_signoffs: 0
-notes: 'STUB — pending Clinical Co-Lead sign-off. 3L+ standard-track option for r/r DLBCL when CAR-T not feasible. Off-the-shelf alternative to bispecifics. Missing entity flag: dedicated REG-LONCASTUXIMAB-TESIRINE — author in PROD-2.'
+notes: 'STUB — pending Clinical Co-Lead sign-off. 3L+ standard-track option for r/r DLBCL when CAR-T not feasible. Off-the-shelf alternative to bispecifics. REG-LONCASTUXIMAB-TESIRINE wired 2026-04-30.'

--- a/knowledge_base/hosted/content/indications/ind_hnscc_rm_1l_extreme.yaml
+++ b/knowledge_base/hosted/content/indications/ind_hnscc_rm_1l_extreme.yaml
@@ -1,0 +1,93 @@
+id: IND-HNSCC-RM-1L-EXTREME
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-HNSCC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Recurrent / metastatic HNSCC, not amenable to curative-intent local therapy"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-PDL1-CPS
+      required: false
+      value_constraint: "EXTREME is preferred 1L when PD-L1 CPS <1 (where chemo-IO benefit is attenuated per KEYNOTE-048 subgroup analysis); EXTREME is alternative 1L when IO is contraindicated regardless of CPS"
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+
+recommended_regimen: REG-EXTREME-HNSCC
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~36% (vs 20% platin+5-FU; EXTREME)"
+  progression_free_survival: "Median PFS 5.6 vs 3.3 mo (HR 0.54)"
+  overall_survival_5y: "Median OS 10.1 vs 7.4 mo (HR 0.80, p=0.04); long-term survival rare in R/M SCCHN historically (5-yr OS <5%)"
+
+hard_contraindications: []
+red_flags_triggering_alternative: []
+
+required_tests: []
+desired_tests: []
+
+rationale: >
+  EXTREME (cetuximab + platinum + 5-FU) is Category 1 standard 1L for
+  R/M SCCHN per Vermorken NEJM 2008 (mOS 10.1 vs 7.4 mo, HR 0.80).
+  Position post-KEYNOTE-048: preferred 1L for PD-L1 CPS <1 (where
+  chemo-IO subgroup OS HR crossed 1.0 — pembro-chemo benefit
+  attenuated) and for IO-contraindicated patients (autoimmune disease,
+  prior solid-organ transplant, severe interstitial lung disease,
+  ECOG ≥2 with IO-toxicity concerns). Also serves as IO-fallback after
+  IO failure or rapid progression on chemo-IO. Cisplatin preferred
+  over carboplatin when feasible (younger fit, GFR ≥60, no
+  neuropathy). HPV-positive R/M SCCHN treated identically — no
+  de-escalation in recurrent setting. Cetuximab continued as weekly
+  monotherapy after 6 cycles of chemotherapy until progression.
+
+rationale_ua: >
+  EXTREME (цетуксимаб + платина + 5-ФУ) — стандарт Cat 1 для 1L р/м SCCHN per Vermorken NEJM 2008 (мОВ 10.1 проти 7.4 міс., HR 0.80). Позиція після KEYNOTE-048: переважна 1L при PD-L1 CPS <1 (де chemo-IO підгрупа OS HR перетнула 1.0 — користь pembro-chemo послаблена) і для IO-протипоказаних пацієнтів (аутоімунне захворювання, попередня SOT, важка інтерстиціальна хвороба легень, ECOG ≥2 з IO-токсичною стурбованістю). Також IO-fallback після невдачі IO або швидкого прогресування на chemo-IO. Цисплатин переважний над карбоплатином коли можливо (молодші fit, GFR ≥60, немає нейропатії). HPV-позитивна р/м SCCHN лікується однаково — без де-ескалації в рецидивному сетингу. Цетуксимаб продовжується як тижнева монотерапія після 6 циклів хіміо до прогресування.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-NCCN-HNSCC-2025
+    weight: primary
+  - source_id: SRC-ESMO-HNSCC-2020
+    weight: primary
+  - source_id: SRC-EXTREME-VERMORKEN-2008
+    position: supports
+    relevant_quote_paraphrase: "EXTREME phase-3: cetuximab + platinum + 5-FU vs platinum + 5-FU; mOS 10.1 vs 7.4 mo (HR 0.80, p=0.04); ORR 36% vs 20%. Established cetuximab as 1L standard for R/M SCCHN."
+
+known_controversies:
+  - topic: "EXTREME vs pembro-chemo (KEYNOTE-048) for 1L R/M SCCHN with CPS <1"
+    positions:
+      - position: "Pembro-chemo: KEYNOTE-048 overall positive but CPS <1 subgroup HR for OS ~1.0 — benefit attenuated"
+        sources: [SRC-NCCN-HNSCC-2025]
+      - position: "EXTREME: established mOS benefit, no CPS dependency, established standard for IO-contraindicated"
+        sources: [SRC-EXTREME-VERMORKEN-2008, SRC-NCCN-HNSCC-2025]
+    our_default: "EXTREME for CPS <1 OR IO-contraindicated; pembro-chemo for CPS ≥1; pembro-mono for CPS ≥20 with toxicity concerns"
+    rationale: "PD-L1 CPS stratification + IO contraindications drive selection; EXTREME retains role despite IO era"
+
+do_not_do:
+  - "Не призначати EXTREME без HPV-тестування — HPV+ статус не змінює EXTREME-вибір у рецидивному сетингу, але важливий для прогнозу + зворотного зв'язку клініциста."
+  - "Не пропускати baseline GFR / audiogram / neuropathy assessment перед цисплатином — карбоплатин — приcceptable substitute якщо є будь-які протипоказання."
+  - "Не використовувати цетуксимаб без премедикації при першій інфузії — anaphylaxis risk особливо в SE US (alpha-gal IgE)."
+  - "Не пропускати prophylactic doxycycline + emollient + sunscreen для acneiform rash — суттєво зменшує тяжкість + покращує adherence."
+  - "Не починати 5-FU без обговорення DPD-тестування — DPD-deficient пацієнти можуть мати фатальну токсичність."
+  - "Не пропускати моніторинг magnesium / electrolytes — цетуксимаб + цисплатин істотно знижують Mg; replacement обов'язковий."
+
+time_critical: false
+last_reviewed: "2026-04-30"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  STUB — pending Clinical Co-Lead sign-off. Standard-track 1L option
+  for R/M SCCHN, especially CPS <1 or IO-contraindicated. Surfaced by
+  curated case patient_hnscc_extreme_cetux_platin_5fu.json (KB drift
+  note: ALGO-HNSCC-RM-1L explicitly noted "CPS <1 R/M HNSCC ideally
+  routes to EXTREME ... explicit IND-HNSCC-RM-1L-EXTREME is deferred
+  to a follow-up content session"). Algorithm wiring (EXTREME branch
+  for CPS <1 + IO-contraindicated) is engine work and out of scope.

--- a/knowledge_base/hosted/content/indications/ind_melanoma_adjuvant_pembro_stage_iii.yaml
+++ b/knowledge_base/hosted/content/indications/ind_melanoma_adjuvant_pembro_stage_iii.yaml
@@ -1,0 +1,102 @@
+id: IND-MELANOMA-ADJUVANT-PEMBRO-STAGE-III
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-MELANOMA
+  stage_stratum: STAGE_III_REGIONAL
+  line_of_therapy: 1
+  stage_requirements:
+    - "Resected stage III (any sub-stage IIIA/IIIB/IIIC/IIID per AJCC 8) cutaneous melanoma"
+    - "Sentinel lymph node biopsy positive OR clinically detected nodal disease, surgically resected (CLND or therapeutic neck dissection per surgical judgment)"
+    - "Adjuvant therapy initiated within 12 weeks of definitive surgery"
+    - "Also applicable to resected stage IV (M1a/M1b/M1c/M1d) per KEYNOTE-054 expansion + KEYNOTE-716 stage IIB/IIC scope"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+
+recommended_regimen: REG-PEMBRO-ADJUVANT-MELANOMA
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "N/A — adjuvant disease-free setting (microscopic / no measurable disease)"
+  progression_free_survival: "12-mo RFS 75.4% vs 61.0% placebo (HR 0.57); 5-yr RFS 55.4% vs 38.3% (HR 0.61)"
+  overall_survival_5y: "5-yr OS data still maturing per KEYNOTE-054 long-term follow-up; OS benefit not yet formally demonstrated, but RFS magnitude is substantial"
+
+hard_contraindications: []
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-CECT-CAP
+  - TEST-BRAIN-MRI-CONTRAST
+  - TEST-LDH
+desired_tests: []
+
+rationale: >
+  Adjuvant pembrolizumab × 12 months is Category 1 standard-track
+  adjuvant therapy for resected stage III cutaneous melanoma per
+  KEYNOTE-054 / EORTC-1325 (Eggermont NEJM 2018; 5-yr update Lancet
+  Oncol 2021). 5-yr RFS 55.4% vs 38.3% with placebo (HR 0.61); benefit
+  consistent across PD-L1+ and PD-L1- subgroups, BRAF-mutant and
+  BRAF-WT, and across stage III sub-stages. Adjuvant nivolumab
+  (CheckMate-238) is interchangeable alternative with comparable
+  efficacy. BRAF-mutant patients have additional option of adjuvant
+  dabrafenib + trametinib (COMBI-AD; 5-yr RFS 52% vs 36%) — clinical
+  choice driven by toxicity profile, prior IO exposure, patient
+  preference; head-to-head data lacking. Start within 12 weeks of
+  definitive surgery; complete 18 cycles unless recurrence /
+  intolerance.
+
+rationale_ua: >
+  Ад'ювантний пембролізумаб × 12 міс. — Cat 1 standard-track ад'ювантна терапія резекованої меланоми стадії III per KEYNOTE-054 / EORTC-1325 (Eggermont NEJM 2018; 5-річне оновлення Lancet Oncol 2021). 5-річний RFS 55.4% проти 38.3% з плацебо (HR 0.61); виграш стабільний у PD-L1+ і PD-L1-, BRAF-мутант і BRAF-WT, по всіх підстадіях III. Ад'ювантний ніволумаб (CheckMate-238) — взаємозамінна альтернатива зі співставною ефективністю. BRAF-мутантні пацієнти мають додаткову опцію ад'ювантного дабрафенібу + траметинібу (COMBI-AD; 5-річний RFS 52% проти 36%) — клінічний вибір залежить від токсичного профілю, попередньої IO-експозиції, вподобань пацієнта; head-to-head дані відсутні. Почати в межах 12 тижнів після операції; завершити 18 циклів якщо немає рецидиву / непереносимості.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-NCCN-MELANOMA-2025
+    weight: primary
+  - source_id: SRC-ESMO-MELANOMA-2024
+    weight: primary
+  - source_id: SRC-KEYNOTE-054-EGGERMONT-2018
+    position: supports
+    relevant_quote_paraphrase: "KEYNOTE-054: adjuvant pembrolizumab × 12 mo improves RFS vs placebo in resected stage III melanoma; benefit independent of PD-L1, BRAF, or stage III sub-stage."
+  - source_id: SRC-CHECKMATE-238-WEBER-2017
+    position: supports
+    relevant_quote_paraphrase: "CheckMate-238: adjuvant nivolumab is interchangeable alternative with comparable efficacy."
+
+known_controversies:
+  - topic: "Adjuvant pembro vs adjuvant nivo vs adjuvant dabra+trame for BRAF-mutant resected stage III"
+    positions:
+      - position: "Adjuvant pembro / nivo: IO benefit independent of BRAF; durable response potential; standard for BRAF-WT"
+        sources: [SRC-KEYNOTE-054-EGGERMONT-2018, SRC-CHECKMATE-238-WEBER-2017]
+      - position: "Adjuvant dabra+trame (COMBI-AD): BRAF-V600+ only; 5-yr RFS 52% vs 36% placebo; finite 12-mo course; IO-naive"
+        sources: [SRC-COMBI-AD-LONG-2017]
+    our_default: "BRAF-WT → adjuvant pembro (KEYNOTE-054) or nivo (CheckMate-238). BRAF-mut → either IO OR dabra+trame; institutional + patient preference; IO preferred when irAE-tolerable for durable benefit."
+    rationale: "All three are NCCN cat 1 adjuvant options for the relevant biomarker context; head-to-head data absent."
+
+do_not_do:
+  - "Не починати ад'ювантну IO без negative baseline brain MRI з контрастом — окультні церебральні метастази є частою картиною."
+  - "Не пропускати baseline TSH / cortisol / glucose — ендокринні irAE найчастіші, і pre-існуючі ендокринопатії змінюють management."
+  - "Не починати після 12 тижнів від операції — KEYNOTE-054 окно короткіше; benefit poorly characterized після цього."
+  - "Не продовжувати при gr ≥3 irAE без переоцінки користі/ризику — adjuvant — curative intent, threshold для permanent discontinuation lower ніж metastatic."
+  - "Не комбінувати з імуносупресією або live vaccines."
+  - "Не пропускати pre-treatment counseling — irAE можуть бути permanent (ендокринопатії) і вплинути на quality of life більше ніж рецидив у деяких сценаріях."
+
+time_critical: false
+last_reviewed: "2026-04-30"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  STUB — pending Clinical Co-Lead sign-off. Standard-track adjuvant
+  indication for resected stage III melanoma. Surfaced by curated case
+  patient_melanoma_adjuvant_pembro_stage_iii.json (KB drift note: no
+  adjuvant Stage III indication or algorithm existed; metastatic-1L
+  algorithm was incorrectly resolving for resected disease). Wiring
+  into a future ALGO-MELANOMA-ADJUVANT is engine work and out of scope
+  for this commit. Pairs with KEYNOTE-006 metastatic-1L pembro mono
+  indication (same drug, different stage / intent).

--- a/knowledge_base/hosted/content/indications/ind_melanoma_metastatic_1l_pembro_mono.yaml
+++ b/knowledge_base/hosted/content/indications/ind_melanoma_metastatic_1l_pembro_mono.yaml
@@ -1,0 +1,95 @@
+id: IND-MELANOMA-METASTATIC-1L-PEMBRO-MONO
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-MELANOMA
+  stage_stratum: STAGE_IV_METASTATIC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Unresectable stage III or stage IV (metastatic) cutaneous melanoma"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-PEMBRO-MONO-MELANOMA
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~33-42% (KEYNOTE-006 pembro Q2W / Q3W arms)"
+  complete_response: "~13-14%"
+  progression_free_survival: "Median PFS ~8.4 mo (Q2W) / 5.5 mo (Q3W); 6-mo PFS 47% (vs 26% ipi)"
+  overall_survival_5y: "5-yr OS ~38-39% pembro vs ~31% ipi; 7-yr OS ~37% vs ~25%"
+
+hard_contraindications: []
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-CECT-CAP
+  - TEST-BRAIN-MRI-CONTRAST
+  - TEST-LDH
+desired_tests: []
+
+rationale: >
+  Pembrolizumab monotherapy is a Category 1 preferred 1L for advanced /
+  metastatic melanoma (KEYNOTE-006). PD-L1-agnostic — used regardless
+  of CPS / TPS. Particularly preferred over ipi+nivo combination when
+  combination irAE profile (~55% grade 3-4) is unacceptable: irAE-frail
+  patients (autoimmune comorbidity, prior solid-organ transplant
+  contraindication aside, age ≥75, ECOG 2). Lower G3-4 irAE rate (~17%)
+  with comparable single-agent IO efficacy. BRAF-mutated patients have
+  the alternative of BRAFi+MEKi (dabrafenib+trametinib) — choice
+  driven by tumor burden, LDH, symptomatic disease, and patient/
+  clinician preference; IO is generally preferred for durable response
+  potential. Combination ipi+nivo remains preferred where tolerable
+  (younger fit, low autoimmune risk, brain mets).
+
+rationale_ua: >
+  пембролізумаб монотерапія — переважна Cat 1 опція 1L для поширеної / метастатичної меланоми (KEYNOTE-006). PD-L1-агностично — використовується незалежно від CPS / TPS. Особливо переважна над ipi+nivo комбінацією коли її irAE-профіль (~55% gr 3-4) неприйнятний: irAE-frail пацієнти (аутоімунна коморбідність, похилий вік ≥75, ECOG 2). Нижча частота gr 3-4 irAE (~17%) при співставній single-agent IO ефективності. BRAF-мутовані пацієнти мають альтернативу BRAFi+MEKi (дабрафеніб+траметиніб) — вибір залежить від тумор-burden, LDH, симптоматичності, і вподобань пацієнта/клініциста; IO загалом переважна для durable response. Комбінація ipi+nivo залишається переважною коли її переносимість можлива (молодші fit, низький аутоімунний ризик, церебральні метастази).
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-NCCN-MELANOMA-2025
+    weight: primary
+  - source_id: SRC-ESMO-MELANOMA-2024
+    weight: primary
+  - source_id: SRC-KEYNOTE-006-ROBERT-2015
+    position: supports
+    relevant_quote_paraphrase: "KEYNOTE-006 — pembrolizumab vs ipilimumab in advanced melanoma; superior PFS / OS, lower G3-4 toxicity. PD-L1-agnostic benefit."
+
+known_controversies:
+  - topic: "Pembrolizumab monotherapy vs ipi+nivo combination for 1L metastatic melanoma"
+    positions:
+      - position: "Ipi+nivo: deepest response (5-yr OS 52% CheckMate-067), preferred when tolerable"
+        sources: [SRC-CHECKMATE-067-LARKIN-2019, SRC-NCCN-MELANOMA-2025]
+      - position: "Pembro mono: comparable durable response, much lower irAE burden, preferred for frail / autoimmune-comorbid"
+        sources: [SRC-KEYNOTE-006-ROBERT-2015, SRC-NCCN-MELANOMA-2025]
+    our_default: "Ipi+nivo when fit + low autoimmune risk + brain mets / symptomatic; pembro mono when irAE-frail or unable to tolerate combination toxicity"
+    rationale: "Combination has deepest response but higher toxicity; mono preserves long-tail benefit at fraction of toxicity"
+
+do_not_do:
+  - "Не починати пембролізумаб без baseline TSH / cortisol / glucose — ендокринні irAE найчастіші."
+  - "Не ігнорувати активне аутоімунне захворювання — relative contraindication, оцінити ризик/користь з ревматологом."
+  - "Не пропускати baseline brain MRI з контрастом — церебральні метастази часто asymptomatic в melanoma."
+  - "Не продовжувати при gr ≥3 irAE без високих доз стероїдів (1-2 mg/kg преднізолон-еквівалент) — затримка управління може бути фатальною."
+  - "Не комбінувати з імуносупресорами / live-vaccines під час лікування."
+  - "Не призначати при ECOG ≥3 — обмежені дані, паліативний підхід доречніший."
+
+time_critical: false
+last_reviewed: "2026-04-30"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  STUB — pending Clinical Co-Lead sign-off. Standard-track 1L option for
+  advanced / metastatic melanoma. Surfaced by curated case
+  patient_melanoma_braf_wt_pembro_mono.json (KB drift note: indication
+  did not exist; algorithm wiring to ALGO-MELANOMA-METASTATIC-1L is
+  separate engine work). PD-L1-agnostic per KEYNOTE-006. Most relevant
+  for irAE-frail BRAF-WT or BRAF-mut patients who prefer IO over targeted
+  therapy. Pairs with adjuvant pembro indication (KEYNOTE-054).

--- a/knowledge_base/hosted/content/regimens/reg_aml_7_3_go.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_aml_7_3_go.yaml
@@ -1,0 +1,91 @@
+id: REG-AML-7-3-GO
+name: "7+3 + fractionated gemtuzumab ozogamicin (CD33+ AML, 1L; ALFA-0701)"
+name_ua: "7+3 + фракційний гемтузумаб озогаміцин (CD33+ ОМЛ, 1L; ALFA-0701)"
+alternate_names:
+  - "7+3+GO"
+  - "DA + fractionated GO"
+  - "ALFA-0701 induction"
+  - "Induction with gemtuzumab"
+
+components:
+  - drug_id: DRUG-CYTARABINE
+    dose: "100-200 mg/m²/day"
+    schedule: "Continuous IV infusion days 1-7"
+    route: IV
+  - drug_id: DRUG-DAUNORUBICIN
+    dose: "60 mg/m² (per ALFA-0701; 90 mg/m² acceptable when GO not added per ECOG-ACRIN — but 60 mg/m² standard with concurrent GO due to additive cardiotoxicity / mortality concern)"
+    schedule: "IV bolus days 1-3"
+    route: IV
+  - drug_id: DRUG-GEMTUZUMAB-OZOGAMICIN
+    dose: "3 mg/m² (max 4.5 mg total per dose) IV — fractionated"
+    schedule: "Days 1, 4, 7 of induction"
+    route: IV
+
+cycle_length_days: 28
+total_cycles: "1 induction; consolidation HiDAC × 3-4 cycles ± additional fractionated GO 3 mg/m² day 1 of consolidation cycles 1-2 (per ALFA-0701 protocol). No upfront alloHCT in CR1 for favorable-risk per ELN 2022."
+toxicity_profile: severe
+
+premedication:
+  - "Standard 7+3 premedications (antiemetic 5HT3 + dexamethasone, allopurinol 300 mg PO daily for TLS prophylaxis, IV hydration ≥3 L/day d1-3)"
+  - "GO infusion: pre-medicate with acetaminophen 650 mg PO + diphenhydramine 50 mg IV ≥30 min before; methylprednisolone 1 mg/kg IV for prior reactions"
+  - "Hepatic VOD/SOS prophylaxis: ursodiol 12 mg/kg/day PO during GO administration (some centers)"
+mandatory_supportive_care:
+  - SUP-TLS-PROPHYLAXIS
+  - SUP-PJP-PROPHYLAXIS
+  - SUP-HSV-PROPHYLAXIS
+  - SUP-HBV-PROPHYLAXIS
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Bilirubin ≥2× ULN OR ALT/AST ≥2.5× ULN before GO dose"
+    modification: "Hold GO; reassess at next planned dose; permanent hold if VOD/SOS clinically suspected (RUQ pain + weight gain + bilirubin rise)"
+    rationale: "Hepatic VOD/SOS is the dominant safety concern with GO; risk increased with cumulative dose, prior alloHCT, or concurrent hepatotoxic agents"
+    source_refs:
+      - SRC-ALFA-0701-CASTAIGNE-2012
+      - SRC-NCCN-AML-2025
+  - condition: "Platelet count <100 × 10⁹/L pre-GO dose AND not yet in CR (induction setting)"
+    modification: "Hold subsequent GO doses if not on day 1; full induction proceeds — GO d4/d7 doses may be omitted if cumulative myelosuppression unacceptable"
+    rationale: "Prolonged thrombocytopenia is GO-specific signature toxicity; balance against benefit"
+  - condition: "Adverse-risk cytogenetics (complex karyotype, monosomy 7, TP53-mutant)"
+    modification: "Do NOT add GO — no benefit in adverse-risk subset per ALFA-0701 / Hills meta-analysis; standard 7+3 alone preferred"
+    rationale: "Subgroup analysis: GO benefit confined to CBF / favorable + intermediate risk; adverse-risk derives no benefit and incurs toxicity"
+    source_refs:
+      - SRC-ALFA-0701-CASTAIGNE-2012
+      - SRC-NCCN-AML-2025
+  - condition: "FLT3-ITD/TKD positive"
+    modification: "Standard 7+3 + midostaurin per RATIFY; do NOT routinely add GO (insufficient combination data); FLT3+ takes priority over CBF/GO add-on"
+    rationale: "FLT3 inhibition has primary survival benefit; combination with GO not validated in phase-3"
+  - condition: "Age ≥75 OR HCT-CI ≥3 OR significant cardiac comorbidity"
+    modification: "Consider de-escalating to ven+aza or CPX-351 (if tAML/AML-MRC); GO addition increases TRM in unfit"
+    rationale: "ALFA-0701 enrolled age 50-70; AML-19 (Burnett 2017) supports GO in elderly but with reduced anthracycline; clinician judgment required"
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: "Cytarabine + daunorubicin: НСЗУ-reimbursed for AML. Gemtuzumab ozogamicin: NOT registered in Ukraine (drlz.com.ua confirmed; Mylotarg withdrawn 2010 + re-approved FDA 2017 was not followed by UA registration). Access via international referral / EAP for the GO component only — major access barrier limits this regimen to centers with cross-border or compassionate-use pathways. Standard 7+3 remains universally available."
+
+sources:
+  - SRC-ALFA-0701-CASTAIGNE-2012
+  - SRC-NCCN-AML-2025
+  - SRC-ELN-AML-2022
+
+last_reviewed: "2026-04-30"
+reviewer_signoffs: []
+notes: >
+  ALFA-0701 (Castaigne Lancet 2012): fractionated GO 3 mg/m² days
+  1, 4, 7 added to standard 7+3 in 1L de-novo AML age 50-70.
+  2-yr EFS 40.8% vs 17.1% (HR 0.58); 2-yr OS 53.2% vs 41.9%
+  (HR 0.69). Hills meta-analysis 2014 (Lancet Oncol): GO addition
+  reduces 5-yr mortality by ~20% in favorable-risk (HR 0.47) and
+  intermediate-risk (HR 0.84); NO benefit in adverse-risk
+  (HR 1.03). AML-19 (Burnett 2017) supports GO 6 mg/m² single dose
+  in elderly unfit-for-7+3 but is a different regimen entity.
+  Position: preferred 1L for fit CD33+ CBF / favorable / intermediate-
+  risk AML where GO accessible. Daunorubicin dose 60 mg/m² (not
+  90) when adding GO due to additive cardiotoxicity. Hepatic VOD/SOS
+  is the dominant safety concern — careful LFT monitoring + alloHCT
+  timing (avoid GO within 90 days of planned alloHCT).
+notes_ua: >
+  ALFA-0701 (Castaigne Lancet 2012): фракційний GO 3 мг/м² дні 1, 4, 7 додано до стандарту 7+3 у 1L de-novo AML вік 50-70. 2-річна EFS 40.8% проти 17.1% (HR 0.58); 2-річна OS 53.2% проти 41.9% (HR 0.69). Hills meta-аналіз 2014 (Lancet Oncol): додання GO зменшує 5-річну смертність на ~20% у favorable-risk (HR 0.47) та intermediate-risk (HR 0.84); БЕЗ виграшу в adverse-risk (HR 1.03). AML-19 (Burnett 2017) підтримує GO 6 мг/м² одна доза в елdeрлі unfit-for-7+3 але це окрема regimen-сутність. Позиція: переважна 1L для fit CD33+ CBF / favorable / intermediate-risk AML де GO доступний. Доза daunorubicin 60 мг/м² (не 90) при додаванні GO через адитивну кардіотоксичність. Печінкова VOD/SOS — домінантна занепокоєність безпеки — ретельний моніторинг LFT + час планування alloHCT (уникати GO протягом 90 днів до планового alloHCT).
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_extreme_hnscc.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_extreme_hnscc.yaml
@@ -1,0 +1,90 @@
+id: REG-EXTREME-HNSCC
+name: "EXTREME (cetuximab + cisplatin/carboplatin + 5-FU; HNSCC R/M, 1L)"
+name_ua: "EXTREME (цетуксимаб + цисплатин/карбоплатин + 5-ФУ; HNSCC рецидивна/метастатична, 1L)"
+alternate_names:
+  - "EXTREME regimen"
+  - "Cetuximab + platinum + 5-FU"
+  - "Vermorken 2008 regimen"
+
+components:
+  - drug_id: DRUG-CETUXIMAB
+    dose: "Loading 400 mg/m² IV day 1; then 250 mg/m² IV weekly"
+    schedule: "Loading dose week 1; weekly maintenance through chemotherapy and beyond as monotherapy until progression / toxicity"
+    route: IV
+  - drug_id: DRUG-CISPLATIN
+    dose: "100 mg/m² IV day 1 (preferred when ECOG 0-1, GFR ≥60, no neuropathy / ototoxicity / heart failure)"
+    schedule: "Day 1 of 21-day cycle, for up to 6 cycles"
+    route: IV
+  - drug_id: DRUG-CARBOPLATIN
+    dose: "AUC 5 IV day 1 (substitute for cisplatin if contraindicated — GFR <60, neuropathy, hearing loss, congestive heart failure, or ECOG 2)"
+    schedule: "Day 1 of 21-day cycle, for up to 6 cycles (in lieu of cisplatin)"
+    route: IV
+  - drug_id: DRUG-5-FLUOROURACIL
+    dose: "1000 mg/m² IV continuous infusion days 1-4 (96-hour infusion)"
+    schedule: "Days 1-4 of 21-day cycle, for up to 6 cycles"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "Up to 6 cycles of chemotherapy backbone; cetuximab continued weekly as monotherapy until progression or unacceptable toxicity"
+toxicity_profile: severe
+
+premedication:
+  - "Cetuximab: H1-antagonist (diphenhydramine 50 mg IV) 30-60 min pre-infusion; especially loading dose. Premedicate also for subsequent doses if prior reaction."
+  - "Cisplatin: pre/post-hydration ≥2 L NS, mannitol/furosemide forced diuresis, antiemetic 5HT3 + NK1 + dexamethasone"
+  - "Carboplatin: standard antiemetic prophylaxis (5HT3 + dexamethasone)"
+  - "5-FU: oral cryotherapy for mucositis prophylaxis; consider DPD testing if not already done"
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Cetuximab grade 3-4 infusion reaction (more common in southeastern US / Bible Belt due to alpha-gal IgE; ~3% incidence overall)"
+    modification: "Permanent discontinuation of cetuximab"
+    rationale: "Anaphylaxis risk; alpha-gal IgE testing if pre-treatment screening warranted"
+    source_refs:
+      - SRC-NCCN-HNSCC-2025
+  - condition: "Severe acneiform rash (grade ≥3)"
+    modification: "Hold cetuximab; topical / oral antibiotics (doxycycline 100 mg BID) + topical steroid; resume at 200 mg/m²/wk on recovery to grade ≤2"
+    rationale: "Acneiform rash is class effect of EGFR inhibitors; prophylactic doxycycline + emollient + sunscreen reduces severity"
+    source_refs:
+      - SRC-EXTREME-VERMORKEN-2008
+      - SRC-NCCN-HNSCC-2025
+  - condition: "Cisplatin ototoxicity (gr ≥2 hearing loss) or peripheral neuropathy gr ≥2"
+    modification: "Switch to carboplatin AUC 5"
+    rationale: "Cumulative cisplatin toxicity"
+    source_refs:
+      - SRC-NCCN-HNSCC-2025
+  - condition: "Cisplatin nephrotoxicity (creatinine increase >25% baseline OR GFR <60)"
+    modification: "Switch to carboplatin AUC 5; aggressive hydration if continuing cisplatin at reduced dose"
+    rationale: "Renal preservation"
+  - condition: "5-FU mucositis gr ≥3 or hand-foot syndrome"
+    modification: "Reduce 5-FU dose 25% next cycle; consider DPD testing if severe early-cycle toxicity"
+    rationale: "5-FU exposure-related toxicity; DPD-deficient patients have catastrophic toxicity"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: "Cisplatin, carboplatin, 5-FU widely available and НСЗУ-covered. Cetuximab registered in Ukraine; reimbursement varies — primary НСЗУ programme covers RAS-WT mCRC, not HNSCC R/M. HNSCC use typically requires self-pay / private insurance / EAP. Practical access barrier exists despite no licensing barrier."
+
+sources:
+  - SRC-EXTREME-VERMORKEN-2008
+  - SRC-NCCN-HNSCC-2025
+  - SRC-ESMO-HNSCC-2020
+
+last_reviewed: "2026-04-30"
+reviewer_signoffs: []
+notes: >
+  EXTREME (Vermorken NEJM 2008): cetuximab + platinum + 5-FU vs
+  platinum + 5-FU alone in 1L R/M SCCHN. Median OS 10.1 vs 7.4 mo
+  (HR 0.80); ORR 36% vs 20%. Standard 1L for R/M SCCHN before
+  KEYNOTE-048 (2019). Now positioned as preferred 1L for: (1) PD-L1
+  CPS <1 (where pembro-chemo benefit is attenuated — KEYNOTE-048 CPS<1
+  subgroup HR for OS crossed 1.0); (2) IO-contraindicated patients
+  (autoimmune disease, prior SOT, severe interstitial lung disease).
+  Also serves as IO-fallback after IO failure or rapid progression.
+  Cisplatin preferred over carboplatin when feasible. 5-FU CIVI is
+  resource-intensive (PICC line, ambulatory pump); modified TPF and
+  cisplatin + cetuximab + paclitaxel are alternatives in some centers.
+notes_ua: >
+  EXTREME (Vermorken NEJM 2008): цетуксимаб + платина + 5-ФУ проти платини + 5-ФУ моно в 1L р/м SCCHN. Медіана ЗВ 10.1 проти 7.4 міс. (HR 0.80); ORR 36% проти 20%. Стандарт 1L для р/м SCCHN до KEYNOTE-048 (2019). Тепер позиціонується як переважний 1L для: (1) PD-L1 CPS <1 (де chemo-IO виграш послаблений — підгрупа CPS<1 KEYNOTE-048 HR для ЗВ перетнула 1.0); (2) IO-протипоказаних пацієнтів (аутоімунне захворювання, попередня SOT, важка інтерстиціальна хвороба легень). Також служить IO-fallback після невдачі IO або швидкого прогресування. Цисплатин переважний над карбоплатином коли можливо. 5-ФУ CIVI ресурсомістка (PICC-катетер, амбулаторна помпа); modified TPF і цисплатин + цетуксимаб + paclitaxel — альтернативи в деяких центрах.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_loncastuximab_tesirine.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_loncastuximab_tesirine.yaml
@@ -1,0 +1,79 @@
+id: REG-LONCASTUXIMAB-TESIRINE
+name: "Loncastuximab tesirine monotherapy (R/R DLBCL, 3L+; LOTIS-2)"
+name_ua: "Лонкастуксимаб тезирин монотерапія (р/р DLBCL, 3L+; LOTIS-2)"
+alternate_names:
+  - "Lonca mono"
+  - "Zynlonta"
+  - "LOTIS-2 regimen"
+  - "ADCT-402 monotherapy"
+
+components:
+  - drug_id: DRUG-LONCASTUXIMAB-TESIRINE
+    dose: "150 µg/kg IV cycles 1-2; then 75 µg/kg IV from cycle 3 onward"
+    schedule: "Day 1 every 21 days, until disease progression or unacceptable toxicity"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "Until progression or unacceptable toxicity (median 3-5 cycles in LOTIS-2; responders may continue ≥1 year)"
+toxicity_profile: moderate
+
+premedication:
+  - "Dexamethasone 4 mg PO BID × 3 days (day prior to infusion, day of, day after) — MANDATORY for edema / effusion / infusion-reaction prophylaxis"
+  - "Standard 5HT3 antiemetic (ondansetron 8 mg) — moderate emetogenic"
+  - "Patient counseling on photoprotection: SPF50+ broad-spectrum sunscreen + protective clothing throughout treatment + 1 month post"
+mandatory_supportive_care:
+  - SUP-PJP-PROPHYLAXIS
+  - SUP-HBV-PROPHYLAXIS
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "ANC <1.0 × 10⁹/L OR platelets <50 × 10⁹/L"
+    modification: "Hold loncastuximab; resume when ANC ≥1.0 + platelets ≥50; reduce by 25% on resumption if recurrent"
+    rationale: "Cytopenias are dominant DLT; PBD-class myelosuppression can be prolonged"
+    source_refs:
+      - SRC-LOTIS-2-CAIMI-2021
+      - SRC-NCCN-BCELL-2025
+  - condition: "GGT >2.5× ULN OR transaminase elevation grade ≥3"
+    modification: "Hold; rule out viral hepatitis / drug interaction; resume on recovery to grade ≤1; reduce 25% on resumption if recurrent"
+    rationale: "Hepatotoxicity is class effect of PBD payload; GGT elevation in ~42% any-grade"
+    source_refs:
+      - SRC-LOTIS-2-CAIMI-2021
+  - condition: "Pleural / pericardial effusion or peripheral edema grade ≥2"
+    modification: "Hold; diuretic; drain symptomatic effusions; resume on recovery to grade ≤1; reduce 25% on resumption; permanent discontinuation if grade ≥3 recurrent"
+    rationale: "Effusion / edema is signature PBD-class toxicity; ~30% any-grade, ~5% grade ≥3"
+    source_refs:
+      - SRC-LOTIS-2-CAIMI-2021
+  - condition: "Severe photosensitivity / cutaneous reaction (grade ≥3)"
+    modification: "Hold; dermatology consultation; topical / systemic steroids; permanent discontinuation if exfoliative or recurrent"
+    rationale: "Photosensitivity in ~28%; case reports of severe cutaneous reactions"
+    source_refs:
+      - SRC-LOTIS-2-CAIMI-2021
+  - condition: "Strong CYP3A4 inhibitor (azole antifungal, ritonavir) co-administered"
+    modification: "Avoid if possible; if unavoidable, monitor for increased toxicity; do not exceed standard dose"
+    rationale: "Released PBD payload metabolized partly by CYP3A4; co-administration may increase exposure"
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: "Loncastuximab tesirine NOT registered in Ukraine (drlz.com.ua confirmed 2026-04-27) and NOT NSZU-reimbursed. Access pathways: (1) self-pay via cross-border supply (Turkey / EU pharmacies) ~USD 30-40K per 6-cycle course; (2) ADC Therapeutics / Sobi compassionate-use program — case-by-case via local representative; (3) clinical-trial enrollment (LOTIS-5 lonca + R-GemOx). Major access barrier."
+
+sources:
+  - SRC-LOTIS-2-CAIMI-2021
+  - SRC-NCCN-BCELL-2025
+  - SRC-ESMO-DLBCL-2024
+
+last_reviewed: "2026-04-30"
+reviewer_signoffs: []
+notes: >
+  LOTIS-2 (Caimi Lancet Oncol 2021): single-arm phase 2, 145 r/r DLBCL
+  patients ≥2 prior lines, ORR 48%, CR 24%, mDoR 13.4 mo in responders,
+  mPFS 4.9 mo, mOS 9.5 mo. Indicated 3L+ for r/r DLBCL NOS, HGBL,
+  DLBCL arising from low-grade lymphoma. Off-the-shelf, outpatient,
+  no CRS / ICANS — operational advantages over CAR-T and bispecifics.
+  Pairs with IND-DLBCL-3L-LONCASTUXIMAB; intended for non-CAR-T-eligible
+  frail patients. Edema management + photoprotection are dominant
+  monitoring foci; cytopenia recovery often >day 21, expect cycle delays.
+notes_ua: >
+  LOTIS-2 (Caimi Lancet Oncol 2021): single-arm фаза 2, 145 р/р DLBCL пацієнтів ≥2 попередніх ліній, ORR 48%, CR 24%, медіана DoR 13.4 міс. у респондерів, мPFS 4.9 міс., мOS 9.5 міс. Показано 3L+ при р/р DLBCL NOS, HGBL, DLBCL що виникла з low-grade лімфоми. Off-the-shelf, амбулаторно, без CRS / ICANS — операційні переваги над CAR-T та bispecifics. Pairs with IND-DLBCL-3L-LONCASTUXIMAB; призначено для пацієнтів не-кандидатів на CAR-T (frail). Edema management + фотопротекція — домінантні фокуси моніторингу; відновлення цитопеній часто >day 21, очікувати затримки циклів.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_pembro_adjuvant_melanoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_adjuvant_melanoma.yaml
@@ -1,0 +1,62 @@
+id: REG-PEMBRO-ADJUVANT-MELANOMA
+name: "Pembrolizumab adjuvant (resected stage III/IV melanoma; KEYNOTE-054)"
+name_ua: "Пембролізумаб ад'ювантно (резекована меланома стадія III/IV; KEYNOTE-054)"
+alternate_names:
+  - "KEYNOTE-054 adjuvant"
+  - "Adjuvant pembro melanoma"
+  - "EORTC-1325 regimen"
+
+components:
+  - drug_id: DRUG-PEMBROLIZUMAB
+    dose: "200 mg IV q3w (or 400 mg IV q6w)"
+    schedule: "Day 1 every 3 weeks (or q6w), for up to 18 cycles (~12 months total) starting within 12 weeks of definitive surgery"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "18 cycles (~12 months) per KEYNOTE-054 protocol"
+toxicity_profile: low-moderate
+
+premedication: []
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Severe immune-related adverse event (gr ≥3 colitis, pneumonitis, hepatitis, nephritis, dermatitis)"
+    modification: "Hold pembrolizumab; high-dose corticosteroids (1-2 mg/kg prednisone equiv); consider permanent discontinuation in adjuvant setting given non-curative-uplift toxicity threshold"
+    rationale: "irAE risk-benefit threshold lower in adjuvant than metastatic — curative-intent patient should not be exposed to gr ≥3 toxicity recurrence"
+    source_refs:
+      - SRC-NCCN-MELANOMA-2025
+  - condition: "Endocrinopathy (hypothyroidism, hypopituitarism, T1DM, primary adrenal insufficiency)"
+    modification: "Hormone replacement; pembrolizumab can usually be continued"
+    rationale: "Endocrine irAEs typically permanent but manageable with replacement"
+  - condition: "Pneumonitis grade ≥2"
+    modification: "Hold; chest CT; high-dose steroids; permanent discontinuation if grade ≥3"
+    rationale: "Pneumonitis is leading cause of pembrolizumab-related mortality; lower threshold to discontinue in adjuvant"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: "Pembrolizumab registered in Ukraine; NOT reimbursed for melanoma indications including adjuvant. Major access barrier given the curative-intent nature of adjuvant therapy. Self-pay course (~18 cycles × ~USD 4-7K) is substantial; private insurance / cross-border are realistic routes."
+
+sources:
+  - SRC-KEYNOTE-054-EGGERMONT-2018
+  - SRC-NCCN-MELANOMA-2025
+  - SRC-ESMO-MELANOMA-2024
+
+last_reviewed: "2026-04-30"
+reviewer_signoffs: []
+notes: >
+  KEYNOTE-054 / EORTC-1325 (Eggermont NEJM 2018, Lancet Oncol 2021
+  5-yr update): adjuvant pembrolizumab 200 mg q3w × 1 yr vs placebo
+  in resected stage III melanoma (n=1019). 12-mo RFS 75.4% vs 61.0%
+  (HR 0.57); 5-yr RFS 55.4% vs 38.3% (HR 0.61); benefit consistent
+  across PD-L1+ and PD-L1- subgroups. Established adjuvant
+  pembrolizumab for resected stage III; basis for FDA approval Feb
+  2019 + later expansion to stage IIB/IIC (KEYNOTE-716). Start within
+  12 weeks of surgery; complete 18 cycles unless recurrence /
+  intolerance. Adjuvant nivolumab (CheckMate-238) is interchangeable
+  alternative.
+notes_ua: >
+  KEYNOTE-054 / EORTC-1325 (Eggermont NEJM 2018, Lancet Oncol 2021 5-річне оновлення): ад'ювантний пембролізумаб 200 мг q3w × 1 рік проти плацебо в резекованій стадії III меланоми (n=1019). 12-міс. RFS 75.4% проти 61.0% (HR 0.57); 5-річний RFS 55.4% проти 38.3% (HR 0.61); виграш стабільний у PD-L1+ і PD-L1- підгрупах. Усталив ад'ювантний пембролізумаб для резекованої стадії III; базис для FDA-схвалення лют 2019 + пізніше розширення до стадії IIB/IIC (KEYNOTE-716). Почати в межах 12 тижнів після операції; завершити 18 циклів якщо немає рецидиву / непереносимості. Ад'ювантний ніволумаб (CheckMate-238) — взаємозамінна альтернатива.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_pembro_mono_melanoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_mono_melanoma.yaml
@@ -1,0 +1,60 @@
+id: REG-PEMBRO-MONO-MELANOMA
+name: "Pembrolizumab monotherapy (advanced/metastatic melanoma, 1L; KEYNOTE-006)"
+name_ua: "Пембролізумаб моно (поширена/метастатична меланома, 1L; KEYNOTE-006)"
+alternate_names:
+  - "KEYNOTE-006 monotherapy"
+  - "Pembro mono melanoma"
+  - "Single-agent anti-PD-1"
+
+components:
+  - drug_id: DRUG-PEMBROLIZUMAB
+    dose: "200 mg IV q3w (or 400 mg IV q6w)"
+    schedule: "Day 1 every 3 weeks (or q6w), for up to 35 cycles (~2 years) or until progression / unacceptable toxicity"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "Up to 35 cycles (~2 years) or until progression"
+toxicity_profile: low-moderate
+
+premedication: []
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Severe immune-related adverse event (gr ≥3 colitis, pneumonitis, hepatitis, nephritis, dermatitis)"
+    modification: "Hold pembrolizumab; high-dose corticosteroids (1-2 mg/kg prednisone equiv) ± additional immunosuppression (infliximab, MMF) for steroid-refractory cases; permanent discontinuation if recurrent gr ≥3 or any gr 4 (except endocrinopathy on replacement)"
+    rationale: "irAE management per ASCO / ESMO IO toxicity guidelines"
+    source_refs:
+      - SRC-NCCN-MELANOMA-2025
+  - condition: "Endocrinopathy (hypothyroidism, hypopituitarism, T1DM, primary adrenal insufficiency)"
+    modification: "Hormone replacement; pembrolizumab can usually be continued"
+    rationale: "Endocrine irAEs typically permanent but manageable with replacement"
+  - condition: "Pneumonitis grade ≥2"
+    modification: "Hold; chest CT; high-dose steroids; permanent discontinuation if grade ≥3"
+    rationale: "Pneumonitis is a leading cause of pembrolizumab-related mortality"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: "Pembrolizumab registered in Ukraine; NOT reimbursed for melanoma — access via private / EAP / cross-border treatment. Major access barrier for stage-IV melanoma."
+
+sources:
+  - SRC-KEYNOTE-006-ROBERT-2015
+  - SRC-NCCN-MELANOMA-2025
+  - SRC-ESMO-MELANOMA-2024
+
+last_reviewed: "2026-04-30"
+reviewer_signoffs: []
+notes: >
+  KEYNOTE-006 (Robert NEJM 2015 + Lancet Oncol 2023 7-yr update):
+  pembrolizumab Q2W or Q3W vs ipilimumab in 1L unresectable / metastatic
+  melanoma (n=834). 6-mo PFS 47% vs 26% (HR 0.58); 12-mo OS 74% vs 58%
+  (HR 0.69). 7-yr OS ~37% pembro vs ~25% ipi. PD-L1-agnostic; basis
+  for FDA approval Dec 2015. Single-agent anti-PD-1 is preferred when
+  ipi+nivo combination toxicity is unacceptable (irAE-frail, autoimmune
+  comorbidity, advanced age, ECOG 2). Lower G3-4 irAE rate (~17%) vs
+  ipi+nivo (~55%). Long-tail responders typical of IO.
+notes_ua: >
+  KEYNOTE-006 (Robert NEJM 2015 + Lancet Oncol 2023 7-річне оновлення): пембролізумаб Q2W or Q3W проти іпілімумабу 1L нерезектабельна / метастатична меланома (n=834). 6-міс. PFS 47% проти 26% (HR 0.58); 12-міс. OS 74% проти 58% (HR 0.69). 7-річна OS ~37% pembro проти ~25% ipi. PD-L1-агностично; базис для FDA-схвалення груд 2015. Single-agent анти-PD-1 — переважна опція коли поєднана токсичність ipi+nivo неприйнятна (irAE-frail, аутоімунна коморбідність, похилий вік, ECOG 2). Нижча частота G3-4 irAE (~17%) проти ipi+nivo (~55%). Long-tail респондери типові для IO.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/sources/src_alfa0701_castaigne_2012.yaml
+++ b/knowledge_base/hosted/content/sources/src_alfa0701_castaigne_2012.yaml
@@ -1,0 +1,53 @@
+id: SRC-ALFA-0701-CASTAIGNE-2012
+source_type: rct_publication
+title: "Effect of gemtuzumab ozogamicin on survival of adult patients with de-novo acute myeloid leukaemia (ALFA-0701): a randomised, open-label, phase 3 study"
+version: "2012"
+authors:
+  - Castaigne S
+  - Pautas C
+  - Terré C
+  - Raffoux E
+  - Bordessoule D
+  - Bastie JN
+  - et al.
+journal: The Lancet
+doi: 10.1016/S0140-6736(12)60485-1
+pmid: "22482940"
+url: https://pubmed.ncbi.nlm.nih.gov/22482940
+access_level: subscription_required
+currency_status: current
+current_as_of: "2012-04-21"
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Elsevier (subscription)
+attribution:
+  required: true
+  text: "Castaigne et al., Lancet 2012; ALFA-0701 trial"
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-04-30"
+relates_to_diseases:
+  - DIS-AML
+last_verified: "2026-04-30"
+notes: >
+  ALFA-0701 phase-3 (NCT00927498): fractionated gemtuzumab ozogamicin
+  (3 mg/m² days 1, 4, 7) added to standard 7+3 induction in 1L
+  de-novo AML age 50-70 (n=271). 2-yr EFS 40.8% vs 17.1% (HR 0.58);
+  2-yr OS 53.2% vs 41.9% (HR 0.69). Benefit driven by CBF / favorable-
+  risk + intermediate-risk subsets; no benefit in adverse-risk / TP53-
+  mutant. Established fractionated GO add-on as 1L standard for fit
+  CD33+ AML with favorable / intermediate cytogenetics. Also see
+  AML-19 (Burnett 2017 in elderly) and meta-analysis Hills 2014
+  (mortality reduction in favorable + intermediate risk). FDA
+  re-approved GO Sep 2017 after 2010 withdrawal — fractionated dosing
+  resolved the prior toxicity / mortality concern from the failed
+  SWOG-S0106 trial which used non-fractionated 6 mg/m².
+pages_count: 9
+references_count: 30
+corpus_role: rct_publication

--- a/knowledge_base/hosted/content/sources/src_extreme_vermorken_2008.yaml
+++ b/knowledge_base/hosted/content/sources/src_extreme_vermorken_2008.yaml
@@ -1,0 +1,50 @@
+id: SRC-EXTREME-VERMORKEN-2008
+source_type: rct_publication
+title: "Platinum-based chemotherapy plus cetuximab in head and neck cancer"
+version: "2008"
+authors:
+  - Vermorken JB
+  - Mesia R
+  - Rivera F
+  - Remenar E
+  - Kawecki A
+  - Rottey S
+  - et al.
+journal: New England Journal of Medicine
+doi: 10.1056/NEJMoa0802656
+pmid: "18784101"
+url: https://pubmed.ncbi.nlm.nih.gov/18784101
+access_level: subscription_required
+currency_status: current
+current_as_of: "2008-09-11"
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: NEJM (subscription)
+attribution:
+  required: true
+  text: "Vermorken et al., NEJM 2008; EXTREME trial"
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-04-30"
+relates_to_diseases:
+  - DIS-HNSCC
+last_verified: "2026-04-30"
+notes: >
+  EXTREME phase-3 (NCT00122460): cetuximab + platinum (cisplatin or
+  carboplatin) + 5-FU vs platinum + 5-FU alone in 1L recurrent /
+  metastatic SCCHN (n=442). Median OS 10.1 vs 7.4 mo (HR 0.80,
+  p=0.04); median PFS 5.6 vs 3.3 mo; ORR 36% vs 20%. Established
+  EXTREME as 1L standard for R/M SCCHN until KEYNOTE-048 (2019)
+  introduced pembro-chemo / pembro-mono as preferred for PD-L1 CPS
+  ≥1. EXTREME remains the preferred 1L for PD-L1 CPS <1, IO-
+  contraindicated patients (autoimmune, prior solid-organ transplant,
+  etc.), and as control arm reference in subsequent IO trials.
+pages_count: 13
+references_count: 30
+corpus_role: rct_publication


### PR DESCRIPTION
## Summary

Adds 5 missing knowledge-base content entities flagged by the curated-examples expansion in [#150](https://github.com/romeo111/OpenOnco/pull/150). Each existing curated patient case carried an explicit KB-drift comment naming the missing entity.

| # | Patient case | What this PR adds |
|---|---|---|
| 1 | `patient_melanoma_braf_wt_pembro_mono.json` | `IND-MELANOMA-METASTATIC-1L-PEMBRO-MONO` + `REG-PEMBRO-MONO-MELANOMA` (KEYNOTE-006) |
| 2 | `patient_melanoma_adjuvant_pembro_stage_iii.json` | `IND-MELANOMA-ADJUVANT-PEMBRO-STAGE-III` + `REG-PEMBRO-ADJUVANT-MELANOMA` (KEYNOTE-054) |
| 3 | `patient_hnscc_extreme_cetux_platin_5fu.json` | `IND-HNSCC-RM-1L-EXTREME` + `REG-EXTREME-HNSCC` + `SRC-EXTREME-VERMORKEN-2008` |
| 5 | `patient_aml_cbf_inv16_7_3_go.json` | `IND-AML-1L-7-3-GO-CBF` + `REG-AML-7-3-GO` + `SRC-ALFA-0701-CASTAIGNE-2012` |
| 6 | `patient_dlbcl_primary_refractory_loncast_post_pola.json` | `REG-LONCASTUXIMAB-TESIRINE` + wired the existing indication's empty `recommended_regimen` field |

5 commits (one per item), explicit pathspecs only, no `-A` adds.

## 5 commits, not 8

The brief listed 8 items. Verification against the curated cases via `python -m knowledge_base.engine.cli` shows that **items 4, 7, 8 already exist as content** — their gaps are algorithm wiring, not missing indications:

- **Item 4 (CPX-351):** `IND-AML-1L-CPX351-SECONDARY` exists. `patient_aml_secondary_cpx351.json` routes to `IND-AML-1L-7-3` because `ALGO-AML-1L` does not branch on tAML/AML-MRC features. Engine work.
- **Item 7 (Zanubrutinib 1L CLL):** `IND-CLL-1L-ZANUBRUTINIB` exists. The two CLL cases (`patient_cll_low_risk.json`, `patient_cll_high_risk.json`) route to `IND-CLL-1L-BTKI` (acalabrutinib) and `IND-CLL-1L-VENO` — both clinically appropriate. The brief's claim that "the indication didn't exist" is contradicted by the file at `knowledge_base/hosted/content/indications/ind_cll_1l_zanubrutinib.yaml`. Surfacing zanubrutinib as a third CLL 1L option is algorithm work.
- **Item 8 (Adjuvant nivolumab esophageal):** `IND-ESOPH-ADJUVANT-NIVOLUMAB-POST-CROSS` exists. The patient case routes only to neoadjuvant CROSS because `ALGO-ESOPH-RESECTABLE-1L.output_indications` doesn't include the adjuvant phase. Engine work.

## These cases will not start rendering correctly until the engine PR lands

For all 5 items I added, the engine still routes around the new entity because `ALGO-*` algorithms haven't been updated to surface them. Per the brief and `CLAUDE.md`, algorithm wiring is on the companion branch `fix/engine-wiring-defects-2026-04-30` and is intentionally **not bundled here**. After both branches merge, the patient cases will surface the new content.

## Coverage delta

- Before: 65 diseases · 302 indications · 245 regimens · 269 sources · 2415 entities total
- After:  65 diseases · 306 indications · 250 regimens · 271 sources · 2425 entities total

`scripts.kb_coverage_matrix` re-ran clean: `diseases-with-zero-BMA=14` (unchanged), `no-RF=0`, `no-IND=0`.

## Verification gates

- ✅ KB validator (`python -m knowledge_base.validation.loader`) — 0 referential-integrity errors after the changes.
- ✅ Engine CLI dry-run on all 8 patient cases confirms current routing (items 4/7/8 reach existing content; items 1/2/3/5/6 still route around the new content pending engine wiring).
- ✅ Two new source PMIDs verified against PubMed:
  - `SRC-EXTREME-VERMORKEN-2008` — PMID 18784101 — Vermorken et al., *NEJM* 2008
  - `SRC-ALFA-0701-CASTAIGNE-2012` — PMID 22482940 — Castaigne et al., *Lancet* 2012
- ⚠️ Pytest: 1586 passed, 1 failed, 8 skipped. The failure (`test_redflag_quality_gates::test_non_draft_rf_has_two_sources`) is **pre-existing on master** — it flags 3 redflag files with <2 sources (`RF-ATC-BRAF-V600E-ACTIONABLE`, `RF-MPNST-ADVANCED-DOXORUBICIN-UNSUITABLE`, `RF-SALIVARY-ADVANCED-PALLIATIVE`) — none of which are touched by this branch. Two further bundle tests in `tests/test_engine_bundle_extended.py` and `tests/test_engine_bundle_optimization.py` reference the legacy monolithic `openonco-engine.zip` that was intentionally retired in CSD-9C (`scripts/build_site.py:277`); these are stale assertions, also pre-existing.

## Test plan

- [x] KB validator passes
- [x] Pytest baseline matches master (no new failures)
- [x] PMIDs verified against PubMed
- [ ] Clinical Co-Lead sign-off on the 4 new indications (CHARTER §6.1; dev-mode-exempted per memory note but still flagged in `notes:` and `ukrainian_review_status: pending_clinical_signoff` per existing convention)
- [ ] After `fix/engine-wiring-defects-2026-04-30` lands, re-run all 8 patient cases through `python -m knowledge_base.engine.cli` and confirm items 1/2/3/5/6 surface the new entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)