### PR TITLE
fix(gallery): group disease tiles by disease.id (33 → 65 visible diseases)

### DIFF
--- a/docs/en/gallery.html
+++ b/docs/en/gallery.html
@@ -39,42 +39,75 @@
       <input type="search" id="diseaseSearch" class="disease-search"
              placeholder="Search disease…" autocomplete="off"
              aria-label="Search disease…">
-      <span class="disease-search-count" id="diseaseSearchCount">33</span>
+      <span class="disease-search-count" id="diseaseSearchCount">66</span>
     </div>
     <div class="disease-tile-grid" id="diseaseTileGrid">
-    <button type="button" class="disease-tile" data-disease-id="DIS-AML" data-search="гострий мієлоїдний лейкоз (не-apl) acute myeloid leukemia"><span class="dt-label">Acute Myeloid Leukemia</span><span class="dt-count">5 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-APL" data-search="гострий промієлоцитарний лейкоз (pml-rara) acute promyelocytic leukemia"><span class="dt-label">Acute Promyelocytic Leukemia</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-ATLL" data-search="дорослий t-клітинний лейкоз/лімфома adult t-cell leukemia/lymphoma"><span class="dt-label">Adult T-Cell Leukemia/Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-ALCL" data-search="анапластична великоклітинна лімфома (системна) anaplastic large cell lymphoma, systemic"><span class="dt-label">Anaplastic Large Cell Lymphoma, Systemic</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-AITL" data-search="ангіоімунобластна t-клітинна лімфома / нодальна tfh-лімфома angioimmunoblastic t-cell lymphoma"><span class="dt-label">Angioimmunoblastic T-Cell Lymphoma</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-B-ALL" data-search="b-лімфобластна лейкемія/лімфома b-lymphoblastic leukemia/lymphoma"><span class="dt-label">B-Lymphoblastic Leukemia/Lymphoma</span><span class="dt-count">1 example</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-BURKITT" data-search="лімфома беркітта burkitt lymphoma"><span class="dt-label">Burkitt Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-CLL" data-search="хронічна лімфоцитарна лейкемія / дрібноклітинна лімфоцитарна лімфома chronic lymphocytic leukemia / small lymphocytic lymphoma"><span class="dt-label">Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma</span><span class="dt-count">4 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-CML" data-search="хронічна мієлоїдна лейкемія (bcr-abl1) chronic myeloid leukemia"><span class="dt-label">Chronic Myeloid Leukemia</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-CHL" data-search="класична лімфома ходжкіна classical hodgkin lymphoma"><span class="dt-label">Classical Hodgkin Lymphoma</span><span class="dt-count">4 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-EATL" data-search="ентеропатія-асоційована t-клітинна лімфома enteropathy-associated t-cell lymphoma"><span class="dt-label">Enteropathy-Associated T-Cell Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-ET" data-search="есенціальна тромбоцитемія essential thrombocythemia"><span class="dt-label">Essential Thrombocythemia</span><span class="dt-count">1 example</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-NK-T-NASAL" data-search="екстранодальна nk/t-клітинна лімфома, назального типу extranodal nk/t-cell lymphoma, nasal type"><span class="dt-label">Extranodal NK/T-Cell Lymphoma, Nasal Type</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-FL" data-search="фолікулярна лімфома follicular lymphoma"><span class="dt-label">Follicular Lymphoma</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-HCL" data-search="волосатоклітинний лейкоз hairy cell leukemia"><span class="dt-label">Hairy Cell Leukemia</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-HSTCL" data-search="гепатоспленічна t-клітинна лімфома hepatosplenic t-cell lymphoma"><span class="dt-label">Hepatosplenic T-Cell Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MCL" data-search="лімфома з клітин зони мантії mantle cell lymphoma"><span class="dt-label">Mantle Cell Lymphoma</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MM" data-search="множинна мієлома multiple myeloma"><span class="dt-label">Multiple Myeloma</span><span class="dt-count">4 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MF-SEZARY" data-search="грибоподібний мікоз / синдром сезарі mycosis fungoides / sézary syndrome"><span class="dt-label">Mycosis Fungoides / Sézary Syndrome</span><span class="dt-count">4 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MDS-LR" data-search="мієлодиспластичні синдроми, низький ризик (ipss-r дуже низький / низький / проміжний) myelodysplastic syndromes — lower risk"><span class="dt-label">Myelodysplastic Syndromes — Lower Risk</span><span class="dt-count">5 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-NODAL-MZL" data-search="нодальна лімфома маргінальної зони nodal marginal zone lymphoma"><span class="dt-label">Nodal Marginal Zone Lymphoma</span><span class="dt-count">5 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-NLPBL" data-search="нодулярна лімфоцит-домінантна b-клітинна лімфома (раніше nlphl) nodular lymphocyte-predominant b-cell lymphoma"><span class="dt-label">Nodular Lymphocyte-Predominant B-cell Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="OTHER" data-search="інше / без класифікації other / unclassified"><span class="dt-label">Other / unclassified</span><span class="dt-count">489 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PTCL-NOS" data-search="периферична t-клітинна лімфома, неуточнена peripheral t-cell lymphoma, nos"><span class="dt-label">Peripheral T-Cell Lymphoma, NOS</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PV" data-search="справжня поліцитемія polycythemia vera"><span class="dt-label">Polycythemia Vera</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PTLD" data-search="посттрансплантаційні лімфопроліферативні захворювання post-transplant lymphoproliferative disorder"><span class="dt-label">Post-Transplant Lymphoproliferative Disorder</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PCNSL" data-search="первинна дифузна великоклітинна b-клітинна лімфома центральної нервової системи primary cns lymphoma"><span class="dt-label">Primary CNS Lymphoma</span><span class="dt-count">11 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PMBCL" data-search="первинна медіастинальна (тимічна) b-великоклітинна лімфома primary mediastinal large b-cell lymphoma"><span class="dt-label">Primary Mediastinal Large B-Cell Lymphoma</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PMF" data-search="первинний мієлофіброз primary myelofibrosis"><span class="dt-label">Primary Myelofibrosis</span><span class="dt-count">3 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-SPLENIC-MZL" data-search="селезінкова лімфома маргінальної зони splenic marginal zone lymphoma"><span class="dt-label">Splenic Marginal Zone Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-T-PLL" data-search="t-клітинна пролімфоцитарна лейкемія t-cell prolymphocytic leukemia"><span class="dt-label">T-Cell Prolymphocytic Leukemia</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-T-ALL" data-search="t-лімфобластна лейкемія/лімфома t-lymphoblastic leukemia/lymphoma"><span class="dt-label">T-Lymphoblastic Leukemia/Lymphoma</span><span class="dt-count">2 examples</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-WM" data-search="макроглобулінемія вальденстрема / лімфоплазмоцитарна лімфома waldenström macroglobulinemia / lymphoplasmacytic lymphoma"><span class="dt-label">Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma</span><span class="dt-count">2 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-AML" data-search="гострий мієлоїдний лейкоз (не-apl) acute myeloid leukemia"><span class="dt-label">Acute Myeloid Leukemia</span><span class="dt-count">14 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-APL" data-search="гострий промієлоцитарний лейкоз (pml-rara) acute promyelocytic leukemia"><span class="dt-label">Acute Promyelocytic Leukemia</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ATLL" data-search="дорослий t-клітинний лейкоз/лімфома adult t-cell leukemia/lymphoma"><span class="dt-label">Adult T-Cell Leukemia/Lymphoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MASTOCYTOSIS" data-search="поширений системний мастоцитоз advanced systemic mastocytosis"><span class="dt-label">Advanced systemic mastocytosis</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ALCL" data-search="анапластична великоклітинна лімфома (системна) anaplastic large cell lymphoma, systemic"><span class="dt-label">Anaplastic Large Cell Lymphoma, Systemic</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-THYROID-ANAPLASTIC" data-search="анапластична карцинома щитовидної залози anaplastic thyroid carcinoma"><span class="dt-label">Anaplastic thyroid carcinoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-AITL" data-search="ангіоімунобластна t-клітинна лімфома / нодальна tfh-лімфома angioimmunoblastic t-cell lymphoma"><span class="dt-label">Angioimmunoblastic T-Cell Lymphoma</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-B-ALL" data-search="b-лімфобластна лейкемія/лімфома b-lymphoblastic leukemia/lymphoma"><span class="dt-label">B-Lymphoblastic Leukemia/Lymphoma</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-BURKITT" data-search="лімфома беркітта burkitt lymphoma"><span class="dt-label">Burkitt Lymphoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CERVICAL" data-search="карцинома шийки матки cervical carcinoma"><span class="dt-label">Cervical carcinoma</span><span class="dt-count">7 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CHOLANGIOCARCINOMA" data-search="холангіокарцинома (рак жовчних проток) cholangiocarcinoma"><span class="dt-label">Cholangiocarcinoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CHONDROSARCOMA" data-search="хондросаркома chondrosarcoma"><span class="dt-label">Chondrosarcoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CLL" data-search="хронічна лімфоцитарна лейкемія / дрібноклітинна лімфоцитарна лімфома chronic lymphocytic leukemia / small lymphocytic lymphoma"><span class="dt-label">Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma</span><span class="dt-count">11 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CML" data-search="хронічна мієлоїдна лейкемія (bcr-abl1) chronic myeloid leukemia"><span class="dt-label">Chronic Myeloid Leukemia</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CHL" data-search="класична лімфома ходжкіна classical hodgkin lymphoma"><span class="dt-label">Classical Hodgkin Lymphoma</span><span class="dt-count">11 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CRC" data-search="колоректальний рак colorectal carcinoma"><span class="dt-label">Colorectal carcinoma</span><span class="dt-count">13 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MELANOMA" data-search="шкірна меланома cutaneous melanoma"><span class="dt-label">Cutaneous melanoma</span><span class="dt-count">12 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-DLBCL-NOS" data-search="дифузна b-великоклітинна лімфома, неуточнена (dlbcl nos) diffuse large b-cell lymphoma, not otherwise specified"><span class="dt-label">Diffuse Large B-Cell Lymphoma, Not Otherwise Specified</span><span class="dt-count">12 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ENDOMETRIAL" data-search="карцинома ендометрія endometrial carcinoma"><span class="dt-label">Endometrial carcinoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-EATL" data-search="ентеропатія-асоційована t-клітинна лімфома enteropathy-associated t-cell lymphoma"><span class="dt-label">Enteropathy-Associated T-Cell Lymphoma</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ESOPHAGEAL" data-search="карцинома стравоходу (плоскоклітинна + аденокарцинома) esophageal carcinoma"><span class="dt-label">Esophageal carcinoma</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ET" data-search="есенціальна тромбоцитемія essential thrombocythemia"><span class="dt-label">Essential Thrombocythemia</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NK-T-NASAL" data-search="екстранодальна nk/t-клітинна лімфома, назального типу extranodal nk/t-cell lymphoma, nasal type"><span class="dt-label">Extranodal NK/T-Cell Lymphoma, Nasal Type</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-FL" data-search="фолікулярна лімфома follicular lymphoma"><span class="dt-label">Follicular Lymphoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GASTRIC" data-search="аденокарцинома шлунка / gej gastric and gastroesophageal junction adenocarcinoma"><span class="dt-label">Gastric and gastroesophageal junction adenocarcinoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GIST" data-search="гастроінтестинальна стромальна пухлина (gist) gastrointestinal stromal tumor"><span class="dt-label">Gastrointestinal stromal tumor</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GBM" data-search="гліобластома (idh-wt, who grade 4) glioblastoma"><span class="dt-label">Glioblastoma</span><span class="dt-count">7 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HCL" data-search="волосатоклітинний лейкоз hairy cell leukemia"><span class="dt-label">Hairy Cell Leukemia</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HCV-MZL" data-search="лімфома маргінальної зони, асоційована з hcv hcv-associated marginal zone lymphoma"><span class="dt-label">HCV-associated Marginal Zone Lymphoma</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HNSCC" data-search="плоскоклітинна карцинома голови та шиї head and neck squamous cell carcinoma"><span class="dt-label">Head and neck squamous cell carcinoma</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HCC" data-search="гепатоцелюлярна карцинома hepatocellular carcinoma"><span class="dt-label">Hepatocellular carcinoma</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HSTCL" data-search="гепатоспленічна t-клітинна лімфома hepatosplenic t-cell lymphoma"><span class="dt-label">Hepatosplenic T-Cell Lymphoma</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HGBL-DH" data-search="високозлоякісна b-клітинна лімфома з myc + bcl2/bcl6 (double-hit / triple-hit) high-grade b-cell lymphoma, double-hit / triple-hit"><span class="dt-label">High-Grade B-Cell Lymphoma, Double-Hit / Triple-Hit</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-IFS" data-search="інфантильна фібросаркома infantile fibrosarcoma"><span class="dt-label">Infantile fibrosarcoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-IMT" data-search="запальна міофібробластична пухлина inflammatory myofibroblastic tumor"><span class="dt-label">Inflammatory myofibroblastic tumor</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-BREAST" data-search="інвазивний рак молочної залози invasive breast cancer"><span class="dt-label">Invasive breast cancer</span><span class="dt-count">15 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GLIOMA-LOW-GRADE" data-search="гліома низького ступеня (who grade 2 — idh-мутантна) low-grade glioma"><span class="dt-label">Low-grade glioma</span><span class="dt-count">1 example</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MPNST" data-search="злоякісна пухлина оболонки периферичного нерва malignant peripheral nerve sheath tumor"><span class="dt-label">Malignant peripheral nerve sheath tumor</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MCL" data-search="лімфома з клітин зони мантії mantle cell lymphoma"><span class="dt-label">Mantle Cell Lymphoma</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MTC" data-search="медулярна карцинома щитовидної залози medullary thyroid carcinoma"><span class="dt-label">Medullary thyroid carcinoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MM" data-search="множинна мієлома multiple myeloma"><span class="dt-label">Multiple Myeloma</span><span class="dt-count">11 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MF-SEZARY" data-search="грибоподібний мікоз / синдром сезарі mycosis fungoides / sézary syndrome"><span class="dt-label">Mycosis Fungoides / Sézary Syndrome</span><span class="dt-count">11 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MDS-HR" data-search="мієлодиспластичні синдроми, високий ризик (ipss-r високий / дуже високий; включає mds-eb) myelodysplastic syndromes — higher risk"><span class="dt-label">Myelodysplastic Syndromes — Higher Risk</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MDS-LR" data-search="мієлодиспластичні синдроми, низький ризик (ipss-r дуже низький / низький / проміжний) myelodysplastic syndromes — lower risk"><span class="dt-label">Myelodysplastic Syndromes — Lower Risk</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NODAL-MZL" data-search="нодальна лімфома маргінальної зони nodal marginal zone lymphoma"><span class="dt-label">Nodal Marginal Zone Lymphoma</span><span class="dt-count">12 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NLPBL" data-search="нодулярна лімфоцит-домінантна b-клітинна лімфома (раніше nlphl) nodular lymphocyte-predominant b-cell lymphoma"><span class="dt-label">Nodular Lymphocyte-Predominant B-cell Lymphoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NSCLC" data-search="недрібноклітинний рак легені non-small cell lung cancer"><span class="dt-label">Non-small cell lung cancer</span><span class="dt-count">19 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="OTHER" data-search="інше / без класифікації other / unclassified"><span class="dt-label">Other / unclassified</span><span class="dt-count">4 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-OVARIAN" data-search="карцинома яєчників (переважно high-grade серозна) ovarian carcinoma"><span class="dt-label">Ovarian carcinoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PDAC" data-search="протокова аденокарцинома підшлункової залози pancreatic ductal adenocarcinoma"><span class="dt-label">Pancreatic ductal adenocarcinoma</span><span class="dt-count">7 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-THYROID-PAPILLARY" data-search="папілярна карцинома щитовидної залози papillary thyroid carcinoma"><span class="dt-label">Papillary thyroid carcinoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PTCL-NOS" data-search="периферична t-клітинна лімфома, неуточнена peripheral t-cell lymphoma, nos"><span class="dt-label">Peripheral T-Cell Lymphoma, NOS</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PV" data-search="справжня поліцитемія polycythemia vera"><span class="dt-label">Polycythemia Vera</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PTLD" data-search="посттрансплантаційні лімфопроліферативні захворювання post-transplant lymphoproliferative disorder"><span class="dt-label">Post-Transplant Lymphoproliferative Disorder</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PCNSL" data-search="первинна дифузна великоклітинна b-клітинна лімфома центральної нервової системи primary cns lymphoma"><span class="dt-label">Primary CNS Lymphoma</span><span class="dt-count">13 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PMBCL" data-search="первинна медіастинальна (тимічна) b-великоклітинна лімфома primary mediastinal large b-cell lymphoma"><span class="dt-label">Primary Mediastinal Large B-Cell Lymphoma</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PMF" data-search="первинний мієлофіброз primary myelofibrosis"><span class="dt-label">Primary Myelofibrosis</span><span class="dt-count">10 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PROSTATE" data-search="аденокарцинома передміхурової залози prostate adenocarcinoma"><span class="dt-label">Prostate adenocarcinoma</span><span class="dt-count">7 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-RCC" data-search="нирково-клітинна карцинома renal cell carcinoma"><span class="dt-label">Renal cell carcinoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-SALIVARY" data-search="карцинома слинних залоз salivary gland carcinoma"><span class="dt-label">Salivary gland carcinoma</span><span class="dt-count">6 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-SCLC" data-search="дрібноклітинний рак легені small cell lung cancer"><span class="dt-label">Small cell lung cancer</span><span class="dt-count">8 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-SPLENIC-MZL" data-search="селезінкова лімфома маргінальної зони splenic marginal zone lymphoma"><span class="dt-label">Splenic Marginal Zone Lymphoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-T-PLL" data-search="t-клітинна пролімфоцитарна лейкемія t-cell prolymphocytic leukemia"><span class="dt-label">T-Cell Prolymphocytic Leukemia</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-T-ALL" data-search="t-лімфобластна лейкемія/лімфома t-lymphoblastic leukemia/lymphoma"><span class="dt-label">T-Lymphoblastic Leukemia/Lymphoma</span><span class="dt-count">9 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-UROTHELIAL" data-search="уротеліальна карцинома urothelial carcinoma"><span class="dt-label">Urothelial carcinoma</span><span class="dt-count">7 examples</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-WM" data-search="макроглобулінемія вальденстрема / лімфоплазмоцитарна лімфома waldenström macroglobulinemia / lymphoplasmacytic lymphoma"><span class="dt-label">Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma</span><span class="dt-count">9 examples</span></button>
     </div>
     <p class="disease-empty" id="diseaseEmpty" hidden>No diseases match your search.</p>
   </section>
@@ -86,7 +119,7 @@
     <section class="case-list" data-disease-id="DIS-AML" hidden>
   <header class="case-list-header">
     <h2>Acute Myeloid Leukemia</h2>
-    <span class="case-list-count">5 examples</span>
+    <span class="case-list-count">14 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/aml-fit-1l-7-3.html"
@@ -122,974 +155,6 @@
   <p>AML relapsed з FLT3-ITD/TKD — engine обирає gilteritinib mono (ADMIRAL: superior до salvage chemo); alloHCT для responders.</p>
   <div class="case-foot">patient_aml_flt3_relapse.json</div>
 </a>
-<a class="case-card" href="/en/cases/aml-flt3-itd-midostaurin.html"
-   data-default-order="574"
-   data-name="AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)</h3>
-  <p>Fit AML FLT3-ITD. Engine: ALGO-1L → IND-AML-1L-7-3 (default); midostaurin/RATIFY як regimen-layer note у comment.</p>
-  <div class="case-foot">patient_aml_flt3_itd_midostaurin_7_3.json</div>
-</a>
-<a class="case-card" href="/en/cases/aml-rr-gilteritinib.html"
-   data-default-order="577"
-   data-name="AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)</h3>
-  <p>Primary-refractory FLT3-TKD AML. Engine: ALGO-2L → IND-AML-2L-GILTERITINIB-FLT3 (ADMIRAL mOS 9.3 мо vs salvage chemo).</p>
-  <div class="case-foot">patient_aml_rr_gilteritinib.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-APL" hidden>
-  <header class="case-list-header">
-    <h2>Acute Promyelocytic Leukemia</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/apl-low-risk.html"
-   data-default-order="73"
-   data-name="APL · Low Risk (ATRA + ATO chemo-free)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>APL · Low Risk (ATRA + ATO chemo-free)</h3>
-  <p>APL з WBC &lt;10K (low-risk Sanz) — engine обирає ATRA+ATO chemo-free (APL0406: ~98% CR, без anthracycline).</p>
-  <div class="case-foot">patient_apl_low_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/apl-high-risk.html"
-   data-default-order="74"
-   data-name="APL · High Risk + DIC (ATRA + ATO + Idarubicin)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>APL · High Risk + DIC (ATRA + ATO + Idarubicin)</h3>
-  <p>APL з WBC &gt;10K + active DIC — RF-APL-DIC + RF-APL-HIGH-RISK fired. Engine додає idarubicin до ATRA+ATO; emergency cryoprecipitate/platelets.</p>
-  <div class="case-foot">patient_apl_high_risk.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-ATLL" hidden>
-  <header class="case-list-header">
-    <h2>Adult T-Cell Leukemia/Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/atll-acute.html"
-   data-default-order="59"
-   data-name="ATLL · Acute (mLSG15 / EPOCH)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ATLL · Acute (mLSG15 / EPOCH)</h3>
-  <p>Adult T-cell Leukemia/Lymphoma, acute subtype, HTLV-1+ — engine обирає intensive mLSG15 або EPOCH; alloHCT consolidation для responders.</p>
-  <div class="case-foot">patient_atll_acute.json</div>
-</a>
-<a class="case-card" href="/en/cases/atll-indolent-smoldering.html"
-   data-default-order="60"
-   data-name="ATLL · Indolent / Smoldering (Watchful Waiting)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ATLL · Indolent / Smoldering (Watchful Waiting)</h3>
-  <p>ATLL indolent/smoldering — engine обирає observation; system trigger для transformation.</p>
-  <div class="case-foot">patient_atll_indolent_smoldering.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-ALCL" hidden>
-  <header class="case-list-header">
-    <h2>Anaplastic Large Cell Lymphoma, Systemic</h2>
-    <span class="case-list-count">3 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/alcl-alk-negative.html"
-   data-default-order="24"
-   data-name="ALCL · ALK-negative (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ALCL · ALK-negative (CHP-Bv)</h3>
-  <p>Системна анапластична великоклітинна лімфома, ALK-negative — universally CD30+. Engine обирає CHP-Bv (ECHELON-2: brentuximab замість vincristine).</p>
-  <div class="case-foot">patient_alcl_alk_negative.json</div>
-</a>
-<a class="case-card" href="/en/cases/alcl-alk-positive-typical.html"
-   data-default-order="48"
-   data-name="ALCL · ALK-positive Typical (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ALCL · ALK-positive Typical (CHP-Bv)</h3>
-  <p>Молода особа з ALK+ ALCL — engine обирає CHP-Bv (ECHELON-2). ALK+ має значно кращий прогноз vs ALK-.</p>
-  <div class="case-foot">patient_alcl_alk_positive_typical.json</div>
-</a>
-<a class="case-card" href="/en/cases/alcl-relapsed-bv-naive.html"
-   data-default-order="49"
-   data-name="ALCL · Relapsed BV-naive (Brentuximab → autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ALCL · Relapsed BV-naive (Brentuximab → autoSCT)</h3>
-  <p>Relapsed ALCL без попереднього brentuximab — engine обирає brentuximab mono → autoSCT consolidation; BV maintenance per ECHELON-2 update.</p>
-  <div class="case-foot">patient_alcl_relapsed_bv_naive.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-AITL" hidden>
-  <header class="case-list-header">
-    <h2>Angioimmunoblastic T-Cell Lymphoma</h2>
-    <span class="case-list-count">3 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/aitl-cd30-positive.html"
-   data-default-order="26"
-   data-name="AITL · CD30-positive (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AITL · CD30-positive (CHP-Bv)</h3>
-  <p>Ангіоімунобластна T-клітинна лімфома, CD30+ — RF-TCELL-CD30-POSITIVE fired. Engine обирає CHP-Bv.</p>
-  <div class="case-foot">patient_aitl_cd30_positive.json</div>
-</a>
-<a class="case-card" href="/en/cases/aitl-cd30-negative.html"
-   data-default-order="30"
-   data-name="AITL · CD30-negative (CHOEP + AITL-specific workup)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AITL · CD30-negative (CHOEP + AITL-specific workup)</h3>
-  <p>AITL з CD30-negative біопсією — engine обирає AITL-specific CHOEP. Layered workup: EBER-ISH (EBV+ B-cell мікрооточення), IgG quant (paraneoplastic hypogamma), DAT (AIHA risk).</p>
-  <div class="case-foot">patient_aitl_cd30_negative.json</div>
-</a>
-<a class="case-card" href="/en/cases/aitl-relapsed-2l.html"
-   data-default-order="52"
-   data-name="AITL · Relapsed 2L (Azacitidine)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AITL · Relapsed 2L (Azacitidine)</h3>
-  <p>AITL relapsed з TET2/DNMT3A epigenetic profile — engine обирає azacitidine (epigenetic targeting; AITL — найбільш azacitidine-responsive TCL subtype).</p>
-  <div class="case-foot">patient_aitl_relapsed_2l.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-B-ALL" hidden>
-  <header class="case-list-header">
-    <h2>B-Lymphoblastic Leukemia/Lymphoma</h2>
-    <span class="case-list-count">1 example</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/b-all-mrd-positive.html"
-   data-default-order="92"
-   data-name="B-ALL · MRD-positive (Blinatumomab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>B-ALL · MRD-positive (Blinatumomab)</h3>
-  <p>B-ALL MRD-positive після induction — engine обирає blinatumomab (BLAST: MRD eradication у &gt;75%).</p>
-  <div class="case-foot">patient_b_all_mrd_positive.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-BURKITT" hidden>
-  <header class="case-list-header">
-    <h2>Burkitt Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/burkitt-low-risk.html"
-   data-default-order="19"
-   data-name="Burkitt · Low/Intermediate Risk (DA-EPOCH-R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Burkitt · Low/Intermediate Risk (DA-EPOCH-R)</h3>
-  <p>Burkitt без CNS+, LDH в нормі — engine обирає DA-EPOCH-R (CALGB 10002, ~90% CR including HIV+).</p>
-  <div class="case-foot">patient_burkitt_low_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/burkitt-high-risk.html"
-   data-default-order="20"
-   data-name="Burkitt · High Risk (CODOX-M / IVAC)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Burkitt · High Risk (CODOX-M / IVAC)</h3>
-  <p>Burkitt з CNS involvement + LDH &gt;3× ULN + bulky abdomen — RF-BURKITT-HIGH-RISK fired. Engine обирає Magrath protocol з HD-MTX + IT MTX/cytarabine.</p>
-  <div class="case-foot">patient_burkitt_high_risk.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-CLL" hidden>
-  <header class="case-list-header">
-    <h2>Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma</h2>
-    <span class="case-list-count">4 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/cll-low-risk.html"
-   data-default-order="12"
-   data-name="CLL/SLL · Low-Risk (BTKi continuous)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL/SLL · Low-Risk (BTKi continuous)</h3>
-  <p>ХЛЛ зі стандартним ризиком (no TP53/del 17p/IGHV-unmut) — engine обирає acalabrutinib continuous; modern era замість FCR/BR.</p>
-  <div class="case-foot">patient_cll_low_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/cll-high-risk.html"
-   data-default-order="13"
-   data-name="CLL/SLL · High-Risk (VenO time-limited)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL/SLL · High-Risk (VenO time-limited)</h3>
-  <p>ХЛЛ з TP53 mutation + IGHV-unmut + complex karyotype — RF-CLL-HIGH-RISK fired. Engine ескалує до venetoclax+obinutuzumab (CLL14).</p>
-  <div class="case-foot">patient_cll_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/cll-post-btki.html"
-   data-default-order="44"
-   data-name="CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)</h3>
-  <p>CLL з прогресією на covalent BTKi — engine обирає pirtobrutinib (BRUIN, non-covalent) або venetoclax+rituximab (MURANO).</p>
-  <div class="case-foot">patient_cll_post_btki_progression.json</div>
-</a>
-<a class="case-card" href="/en/cases/cll-venr-2l-murano.html"
-   data-default-order="581"
-   data-name="CLL · 2L post-BTKi · VenR fixed-duration (MURANO)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL · 2L post-BTKi · VenR fixed-duration (MURANO)</h3>
-  <p>Post-acalabrutinib PD без C481/BCL2-resistance. Engine: ALGO-CLL-2L step 2 (RF-PRIOR-BTKI-PROGRESSION) → IND-CLL-2L-VENR-MURANO (24-mo, mPFS 53.6 мо).</p>
-  <div class="case-foot">patient_cll_venr_2l_murano.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-CML" hidden>
-  <header class="case-list-header">
-    <h2>Chronic Myeloid Leukemia</h2>
-    <span class="case-list-count">3 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/cml-chronic-newdx.html"
-   data-default-order="75"
-   data-name="CML · Chronic Phase Newly Diagnosed (TKI 1L)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CML · Chronic Phase Newly Diagnosed (TKI 1L)</h3>
-  <p>Newly-diagnosed CML chronic phase, BCR-ABL1+ — engine обирає imatinib (low-risk Sokal) або 2G TKI (intermediate/high).</p>
-  <div class="case-foot">patient_cml_chronic_phase_newdx.json</div>
-</a>
-<a class="case-card" href="/en/cases/cml-t315i.html"
-   data-default-order="76"
-   data-name="CML · T315I-mutated (Ponatinib / Asciminib)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CML · T315I-mutated (Ponatinib / Asciminib)</h3>
-  <p>CML з T315I gatekeeper mutation post-2G TKI — engine обирає ponatinib (PACE) або asciminib (allosteric STAMP-inhibitor).</p>
-  <div class="case-foot">patient_cml_t315i.json</div>
-</a>
-<a class="case-card" href="/en/cases/cml-blast-crisis.html"
-   data-default-order="77"
-   data-name="CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)</h3>
-  <p>CML що дебютує як blast crisis — engine обирає TKI + intensive chemo bridge → urgent alloHCT (без alloHCT медіана OS &lt;12 mo).</p>
-  <div class="case-foot">patient_cml_blast_crisis_at_presentation.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-CHL" hidden>
-  <header class="case-list-header">
-    <h2>Classical Hodgkin Lymphoma</h2>
-    <span class="case-list-count">4 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/chl-advanced.html"
-   data-default-order="27"
-   data-name="Classical Hodgkin · Advanced (A+AVD)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Classical Hodgkin · Advanced (A+AVD)</h3>
-  <p>Стадія IV cHL — RF-CHL-ADVANCED-STAGE fired. Engine обирає A+AVD (ECHELON-1: brentuximab замість bleomycin, superior OS).</p>
-  <div class="case-foot">patient_chl_advanced.json</div>
-</a>
-<a class="case-card" href="/en/cases/chl-early.html"
-   data-default-order="28"
-   data-name="Classical Hodgkin · Early Stage (ABVD)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Classical Hodgkin · Early Stage (ABVD)</h3>
-  <p>Стадія IIA cHL, без advanced criteria — engine обирає ABVD × 2-4 + ISRT (response-adapted).</p>
-  <div class="case-foot">patient_chl_early.json</div>
-</a>
-<a class="case-card" href="/en/cases/chl-pediatric-bulky.html"
-   data-default-order="66"
-   data-name="cHL · AYA Stage IIB Bulky Mediastinal">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>cHL · AYA Stage IIB Bulky Mediastinal</h3>
-  <p>AYA пацієнт з cHL stage IIB + bulky mediastinal mass + B-symptoms — RF-CHL-BULKY-MEDIASTINAL fired. Response-adapted intensification.</p>
-  <div class="case-foot">patient_chl_pediatric_bulky_mediastinal.json</div>
-</a>
-<a class="case-card" href="/en/cases/chl-relapsed-salvage.html"
-   data-default-order="67"
-   data-name="cHL · Relapsed (Salvage → autoSCT + BV maint.)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>cHL · Relapsed (Salvage → autoSCT + BV maint.)</h3>
-  <p>cHL relapsed після ABVD/A+AVD — engine обирає salvage chemo (ICE/DHAP) → autoSCT → brentuximab maintenance (AETHERA).</p>
-  <div class="case-foot">patient_chl_relapsed_for_salvage.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-EATL" hidden>
-  <header class="case-list-header">
-    <h2>Enteropathy-Associated T-Cell Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/eatl-typical.html"
-   data-default-order="53"
-   data-name="EATL · Typical (Celiac, CHOEP → autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>EATL · Typical (Celiac, CHOEP → autoSCT)</h3>
-  <p>EATL у пацієнта з celiac disease — engine обирає CHOEP induction → autoSCT consolidation (NLG-T-01).</p>
-  <div class="case-foot">patient_eatl_typical.json</div>
-</a>
-<a class="case-card" href="/en/cases/eatl-relapsed-post-choep.html"
-   data-default-order="54"
-   data-name="EATL · Relapsed post-CHOEP (ICE Salvage)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>EATL · Relapsed post-CHOEP (ICE Salvage)</h3>
-  <p>EATL relapsed після CHOEP — engine обирає ICE salvage; alloHCT для chemosensitive.</p>
-  <div class="case-foot">patient_eatl_relapsed_post_choep.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-ET" hidden>
-  <header class="case-list-header">
-    <h2>Essential Thrombocythemia</h2>
-    <span class="case-list-count">1 example</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/et-high-risk-hu.html"
-   data-default-order="87"
-   data-name="Essential Thrombocythemia · High Risk (HU)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Essential Thrombocythemia · High Risk (HU)</h3>
-  <p>ET high-risk (age &gt;60 + JAK2+ + thrombosis) — engine обирає hydroxyurea + ASA; anagrelide як 2L (PT-1).</p>
-  <div class="case-foot">patient_et_high_risk_hu.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-NK-T-NASAL" hidden>
-  <header class="case-list-header">
-    <h2>Extranodal NK/T-Cell Lymphoma, Nasal Type</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/nk-t-nasal-localized.html"
-   data-default-order="61"
-   data-name="NK/T-Nasal · Localized (P-GEMOX + RT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NK/T-Nasal · Localized (P-GEMOX + RT)</h3>
-  <p>Localized extranodal NK/T-cell lymphoma, nasal type — engine обирає concurrent P-GEMOX + RT (anthracycline-resistant biology).</p>
-  <div class="case-foot">patient_nk_t_nasal_localized.json</div>
-</a>
-<a class="case-card" href="/en/cases/nk-t-nasal-relapsed.html"
-   data-default-order="62"
-   data-name="NK/T-Nasal · Relapsed (Avelumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NK/T-Nasal · Relapsed (Avelumab)</h3>
-  <p>NK/T-nasal relapsed — engine обирає avelumab (NCCN-listed PD-L1 inhibitor; promoted from stub).</p>
-  <div class="case-foot">patient_nk_t_nasal_relapsed.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-FL" hidden>
-  <header class="case-list-header">
-    <h2>Follicular Lymphoma</h2>
-    <span class="case-list-count">3 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/fl-low-burden.html"
-   data-default-order="9"
-   data-name="Follicular · Low Burden (Watch-and-Wait)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Follicular · Low Burden (Watch-and-Wait)</h3>
-  <p>FL grade 1-2, asymptomatic, no GELF criteria — engine обирає surveillance трек (3 plans usable side-by-side, default = W&amp;W).</p>
-  <div class="case-foot">patient_fl_low_burden.json</div>
-</a>
-<a class="case-card" href="/en/cases/fl-high-burden.html"
-   data-default-order="10"
-   data-name="Follicular · High Burden (BR)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Follicular · High Burden (BR)</h3>
-  <p>FL з 8 cm масою + B-symptoms + LDH↑ — RF-FL-HIGH-TUMOR-BURDEN-GELF fired. Engine обирає BR (бендамустин + ритуксимаб); reuse REG-BR-STANDARD з HCV-MZL.</p>
-  <div class="case-foot">patient_fl_high_burden.json</div>
-</a>
-<a class="case-card" href="/en/cases/fl-transformation.html"
-   data-default-order="11"
-   data-name="Follicular · Transformation Suspect (R-CHOP)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Follicular · Transformation Suspect (R-CHOP)</h3>
-  <p>FL з rapid progression + LDH doubling — RF-FL-TRANSFORMATION-SUSPECT fired. Engine обирає R-CHOP (трактує як DLBCL pathway).</p>
-  <div class="case-foot">patient_fl_transformation.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-HCL" hidden>
-  <header class="case-list-header">
-    <h2>Hairy Cell Leukemia</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/hcl-typical.html"
-   data-default-order="21"
-   data-name="Hairy Cell Leukemia (Cladribine 7-day)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Hairy Cell Leukemia (Cladribine 7-day)</h3>
-  <p>Волосатоклітинний лейкоз з cytopenia + splenomegaly — engine обирає 1 курс cladribine 7 днів. ~85% durable CR.</p>
-  <div class="case-foot">patient_hcl_typical.json</div>
-</a>
-<a class="case-card" href="/en/cases/hcl-relapsed-braf.html"
-   data-default-order="45"
-   data-name="HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)</h3>
-  <p>HCL relapsed з BRAF-V600E+ — engine обирає vemurafenib+rituximab (Tiacci); BRAF-WT route → cladribine retreatment.</p>
-  <div class="case-foot">patient_hcl_relapsed_braf.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-HSTCL" hidden>
-  <header class="case-list-header">
-    <h2>Hepatosplenic T-Cell Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/hstcl-fit-younger.html"
-   data-default-order="55"
-   data-name="HSTCL · Fit Younger (ICE/IVAC → alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HSTCL · Fit Younger (ICE/IVAC → alloHCT)</h3>
-  <p>Hepatosplenic T-cell Lymphoma у молодої особи, ECOG 0 — engine обирає intensive ICE/IVAC → upfront alloHCT (CHOP неадекватний).</p>
-  <div class="case-foot">patient_hstcl_fit_younger.json</div>
-</a>
-<a class="case-card" href="/en/cases/hstcl-iatrogenic-ibd.html"
-   data-default-order="56"
-   data-name="HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)</h3>
-  <p>HSTCL у IBD-пацієнта на тривалій thiopurine+anti-TNF therapy — engine припиняє imunosuppression + CHOEP-unfit fallback з branching algorithm.</p>
-  <div class="case-foot">patient_hstcl_iatrogenic_ibd.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MCL" hidden>
-  <header class="case-list-header">
-    <h2>Mantle Cell Lymphoma</h2>
-    <span class="case-list-count">3 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/mcl-fit-younger.html"
-   data-default-order="14"
-   data-name="Mantle Cell · Fit Younger (Intensive + autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Mantle Cell · Fit Younger (Intensive + autoSCT)</h3>
-  <p>MCL вік 58, ECOG 0, TP53-wt — engine обирає intensive R-CHOP/R-DHAP × 6 + autoSCT + R-maintenance × 3 years (Nordic protocol).</p>
-  <div class="case-foot">patient_mcl_fit_younger.json</div>
-</a>
-<a class="case-card" href="/en/cases/mcl-unfit-tp53.html"
-   data-default-order="15"
-   data-name="Mantle Cell · Unfit / TP53-mutant (BTKi+R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Mantle Cell · Unfit / TP53-mutant (BTKi+R)</h3>
-  <p>MCL вік 71, ECOG 2, TP53 mutation — RF-MCL-BLASTOID-OR-TP53 fired. Engine обирає acalabrutinib + rituximab (BTKi-based).</p>
-  <div class="case-foot">patient_mcl_unfit_or_tp53.json</div>
-</a>
-<a class="case-card" href="/en/cases/mcl-pirtobrutinib-3l.html"
-   data-default-order="582"
-   data-name="MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)</h3>
-  <p>Post-covalent-BTKi прогрес з LVEF 38% (CAR-T ineligible). Drift: ALGO-MCL-2L step 3 free-text; engine default = acalabrutinib; BRUIN анкер у comment.</p>
-  <div class="case-foot">patient_mcl_pirtobrutinib_3l_post_btki.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MM" hidden>
-  <header class="case-list-header">
-    <h2>Multiple Myeloma</h2>
-    <span class="case-list-count">4 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/mm-standard-risk.html"
-   data-default-order="3"
-   data-name="Multiple Myeloma · Standard-Risk">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · Standard-Risk</h3>
-  <p>Newly-diagnosed MM, t(11;14) + hyperdiploid, R-ISS II — engine обирає триплет VRd як default.</p>
-  <div class="case-foot">patient_mm_standard_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/mm-high-risk.html"
-   data-default-order="4"
-   data-name="Multiple Myeloma · High-Risk">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · High-Risk</h3>
-  <p>Newly-diagnosed MM, t(4;14) + gain 1q21, R2-ISS III — RF-MM-HIGH-RISK-CYTOGENETICS, engine обирає квадруплет D-VRd.</p>
-  <div class="case-foot">patient_mm_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/mm-post-vrd-progression.html"
-   data-default-order="68"
-   data-name="Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)</h3>
-  <p>MM relapsed після VRd induction — engine обирає daratumumab+pomalidomide+dex (APOLLO) або isatuximab+Pd (ICARIA).</p>
-  <div class="case-foot">patient_mm_post_vrd_progression.json</div>
-</a>
-<a class="case-card" href="/en/cases/mm-triple-class-refractory.html"
-   data-default-order="69"
-   data-name="Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)</h3>
-  <p>MM triple-class refractory (PI + IMiD + anti-CD38) — engine обирає cilta-cel/ide-cel CAR-T або teclistamab BCMA-T-cell engager.</p>
-  <div class="case-foot">patient_mm_triple_class_refractory.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MF-SEZARY" hidden>
-  <header class="case-list-header">
-    <h2>Mycosis Fungoides / Sézary Syndrome</h2>
-    <span class="case-list-count">4 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/mf-early-stage.html"
-   data-default-order="31"
-   data-name="Mycosis Fungoides · Early Stage (Skin-Directed)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Mycosis Fungoides · Early Stage (Skin-Directed)</h3>
-  <p>MF stage IB без B2/LCT — engine обирає skin-directed (NBUVB / topicals / TSEBT). Жодного системного режиму — preserves chemo для прогресу. Workup rules out occult Sézary (B2 count) + LCT.</p>
-  <div class="case-foot">patient_mf_early_stage.json</div>
-</a>
-<a class="case-card" href="/en/cases/sezary-advanced.html"
-   data-default-order="32"
-   data-name="Sézary Syndrome · Advanced (Mogamulizumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Sézary Syndrome · Advanced (Mogamulizumab)</h3>
-  <p>Sézary syndrome (B2 leukemic, generalized erythroderma) — RF-MF-SEZARY-LEUKEMIC fired. Engine обирає mogamulizumab (MAVORIC: anti-CCR4 ADCC, найкраща blood-compartment відповідь).</p>
-  <div class="case-foot">patient_sezary_advanced.json</div>
-</a>
-<a class="case-card" href="/en/cases/mf-advanced-cd30.html"
-   data-default-order="33"
-   data-name="MF · Advanced + CD30+ LCT (Brentuximab mono)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MF · Advanced + CD30+ LCT (Brentuximab mono)</h3>
-  <p>Advanced MF stage IIB з large-cell transformation, CD30+ — RF-MF-LARGE-CELL-TRANSFORMATION + RF-TCELL-CD30-POSITIVE fired. Engine обирає brentuximab vedotin monotherapy (ALCANZA).</p>
-  <div class="case-foot">patient_mf_advanced_cd30.json</div>
-</a>
-<a class="case-card" href="/en/cases/mf-relapsed-post-moga.html"
-   data-default-order="63"
-   data-name="MF · Relapsed post-Mogamulizumab (Bexarotene)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MF · Relapsed post-Mogamulizumab (Bexarotene)</h3>
-  <p>MF/Sézary relapsed після mogamulizumab — engine обирає bexarotene 2L з low-dose maintenance (RXR-targeted oral retinoid).</p>
-  <div class="case-foot">patient_mf_relapsed_post_moga.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MDS-LR" hidden>
-  <header class="case-list-header">
-    <h2>Myelodysplastic Syndromes — Lower Risk</h2>
-    <span class="case-list-count">5 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/mds-hr-transplant-eligible.html"
-   data-default-order="78"
-   data-name="MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)</h3>
-  <p>MDS IPSS-R high, fit, donor available — engine обирає azacitidine bridge → upfront alloHCT (curative).</p>
-  <div class="case-foot">patient_mds_hr_transplant_eligible.json</div>
-</a>
-<a class="case-card" href="/en/cases/mds-hr-unfit-aza.html"
-   data-default-order="79"
-   data-name="MDS-HR · Unfit (Azacitidine Maintenance)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-HR · Unfit (Azacitidine Maintenance)</h3>
-  <p>MDS-HR transplant-ineligible — engine обирає azacitidine indefinite (AZA-001: median OS 24 mo vs 15 mo для conventional care).</p>
-  <div class="case-foot">patient_mds_hr_unfit_aza.json</div>
-</a>
-<a class="case-card" href="/en/cases/mds-hr-progression-aml.html"
-   data-default-order="80"
-   data-name="MDS-HR · Progression to Secondary AML">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-HR · Progression to Secondary AML</h3>
-  <p>MDS на azacitidine з progression до sAML — engine реагує AML-reroute: ven+aza або 7+3 induction (за fitness).</p>
-  <div class="case-foot">patient_mds_hr_progression_to_aml.json</div>
-</a>
-<a class="case-card" href="/en/cases/mds-lr-del5q.html"
-   data-default-order="81"
-   data-name="MDS-LR · del(5q) (Lenalidomide)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-LR · del(5q) (Lenalidomide)</h3>
-  <p>MDS-LR з isolated del(5q) syndrome — engine обирає lenalidomide (MDS-004: ~67% transfusion-independence).</p>
-  <div class="case-foot">patient_mds_lr_del5q.json</div>
-</a>
-<a class="case-card" href="/en/cases/mds-lr-hypoplastic-ist.html"
-   data-default-order="83"
-   data-name="MDS-LR · Hypoplastic / IST candidate">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-LR · Hypoplastic / IST candidate</h3>
-  <p>Hypoplastic MDS, mimics aplastic anemia — engine обирає immunosuppressive therapy (ATG+CsA) як alternative до transfusion-only.</p>
-  <div class="case-foot">patient_mds_lr_hypoplastic_ist.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-NODAL-MZL" hidden>
-  <header class="case-list-header">
-    <h2>Nodal Marginal Zone Lymphoma</h2>
-    <span class="case-list-count">5 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/hcv-mzl-reference.html"
-   data-default-order="0"
-   data-name="HCV-MZL · Reference Case (Patient Zero)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCV-MZL · Reference Case (Patient Zero)</h3>
-  <p>Чоловік 49, ECOG 1, 5.3 см ураження кореня язика, HCV генотип 1b, indolent presentation. Acceptance test для P0.</p>
-  <div class="case-foot">patient_zero_reference_case.json</div>
-</a>
-<a class="case-card" href="/en/cases/hcv-mzl-bulky.html"
-   data-default-order="1"
-   data-name="HCV-MZL · Aggressive Burden (BR + concurrent DAA)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCV-MZL · Aggressive Burden (BR + concurrent DAA)</h3>
-  <p>HCV-MZL із bulky disease (&gt;7 см) — RF-BULKY-DISEASE fired. Engine обирає BR (бендамустин+ритуксимаб) + concurrent DAA. Поєднує колишні patient_zero_bulky та новий fixture aggressive_burden.</p>
-  <div class="case-foot">patient_hcv_mzl_aggressive_burden.json</div>
-</a>
-<a class="case-card" href="/en/cases/hcv-mzl-post-daa.html"
-   data-default-order="2"
-   data-name="HCV-MZL · Post-DAA Responder (Surveillance)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCV-MZL · Post-DAA Responder (Surveillance)</h3>
-  <p>Пацієнт post-DAA з SVR12 + lymphoma response — engine обирає surveillance only; план для re-treatment trigger при relapse.</p>
-  <div class="case-foot">patient_hcv_mzl_post_daa_responder.json</div>
-</a>
-<a class="case-card" href="/en/cases/diagnostic-lymphoma-confirmed.html"
-   data-default-order="6"
-   data-name="Lymphoma Confirmed · Post-Biopsy (Treatment Plan)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Lymphoma Confirmed · Post-Biopsy (Treatment Plan)</h3>
-  <p>Той самий пацієнт після підтвердження гістології — diagnostic→treatment promotion через revise_plan.</p>
-  <div class="case-foot">patient_diagnostic_lymphoma_confirmed.json</div>
-</a>
-<a class="case-card" href="/en/cases/nmzl-high-burden.html"
-   data-default-order="47"
-   data-name="Nodal MZL · High Burden (BR)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Nodal MZL · High Burden (BR)</h3>
-  <p>Нодальна MZL з GELF+ — engine обирає BR (1L); 2L після rituximab/W&amp;W failure теж BR.</p>
-  <div class="case-foot">patient_nmzl_high_burden.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-NLPBL" hidden>
-  <header class="case-list-header">
-    <h2>Nodular Lymphocyte-Predominant B-cell Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/nlpbl-early.html"
-   data-default-order="29"
-   data-name="NLPBL · Early Stage (Observation / RT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NLPBL · Early Stage (Observation / RT)</h3>
-  <p>Нодулярна лімфоцит-домінантна B-клітинна лімфома (перекласифіковано WHO 5th-ed з NLPHL у B-cell) — early stage. Engine обирає observation / ISRT alone.</p>
-  <div class="case-foot">patient_nlpbl_early.json</div>
-</a>
-<a class="case-card" href="/en/cases/nlpbl-ia-rituximab.html"
-   data-default-order="34"
-   data-name="NLPBL · IA + RT-contraindicated (Rituximab mono)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NLPBL · IA + RT-contraindicated (Rituximab mono)</h3>
-  <p>NLPBL stage IA у молодої жінки з cervical adenopathy — RT-contraindicated через breast/thyroid field overlap. Engine обирає rituximab monotherapy alternative (CD20+ B-cell biology, НЕ ABVD).</p>
-  <div class="case-foot">patient_nlpbl_ia_rituximab.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="OTHER" hidden>
-  <header class="case-list-header">
-    <h2>Other / unclassified</h2>
-    <span class="case-list-count">489 examples</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/en/cases/diagnostic-lymphoma-suspect.html"
-   data-default-order="5"
-   data-name="Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-diag">Diagnostic Brief</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)</h3>
-  <p>Pre-biopsy режим — engine генерує Workup Brief, не Treatment Plan (CHARTER §15.2 C7 — без histology немає лікування).</p>
-  <div class="case-foot">patient_diagnostic_lymphoma_suspect.json</div>
-</a>
-<a class="case-card" href="/en/cases/nmzl-low-burden.html"
-   data-default-order="18"
-   data-name="Nodal MZL · Low Burden (W&amp;W)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Nodal MZL · Low Burden (W&amp;W)</h3>
-  <p>Нодальна MZL без GELF-критеріїв — engine обирає surveillance трек (повторює FL-парадигму).</p>
-  <div class="case-foot">patient_nmzl_low_burden.json</div>
-</a>
-<a class="case-card" href="/en/cases/hgbl-double-hit.html"
-   data-default-order="23"
-   data-name="HGBL · Double-Hit (DA-EPOCH-R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>HGBL · Double-Hit (DA-EPOCH-R)</h3>
-  <p>High-Grade B-Cell Lymphoma з MYC + BCL2 break-apart — engine обирає DA-EPOCH-R (substantial OS improvement vs R-CHOP); reuse схеми з Burkitt.</p>
-  <div class="case-foot">patient_hgbl_double_hit.json</div>
-</a>
-<a class="case-card" href="/en/cases/mds-lr-rs-luspatercept.html"
-   data-default-order="82"
-   data-name="MDS-LR · RS+ EPO-failure (Luspatercept)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>MDS-LR · RS+ EPO-failure (Luspatercept)</h3>
-  <p>MDS-LR з ring sideroblasts + EPO-high (&gt;500) → ESA-failure — engine обирає luspatercept (COMMANDS).</p>
-  <div class="case-foot">patient_mds_lr_rs_luspatercept.json</div>
-</a>
-<a class="case-card" href="/en/cases/b-all-ph-pos-adult.html"
-   data-default-order="91"
-   data-name="B-ALL · Ph+ Adult (TKI + Chemo)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>B-ALL · Ph+ Adult (TKI + Chemo)</h3>
-  <p>Adult B-ALL Ph+ (BCR-ABL1+) — engine обирає dasatinib + chemo (hyper-CVAD або pediatric-inspired); alloHCT для CR1 high-risk.</p>
-  <div class="case-foot">patient_b_all_ph_pos_adult.json</div>
-</a>
-<a class="case-card" href="/en/cases/b-all-t315i-post-tki.html"
-   data-default-order="93"
-   data-name="B-ALL · T315I-mutated post-TKI (Ponatinib + alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>B-ALL · T315I-mutated post-TKI (Ponatinib + alloHCT)</h3>
-  <p>Ph+ B-ALL relapsed з T315I gatekeeper — engine обирає ponatinib + chemo bridge → alloHCT.</p>
-  <div class="case-foot">patient_b_all_t315i_post_tki.json</div>
-</a>
-<a class="case-card" href="/en/cases/cervical-locally-advanced.html"
-   data-default-order="96"
-   data-name="Cervical · Locally Advanced (CCRT + Pembrolizumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Cervical · Locally Advanced (CCRT + Pembrolizumab)</h3>
-  <p>Locally advanced cervical cancer (FIGO IIB-IVA) — engine обирає cisplatin-based CCRT + brachytherapy; pembrolizumab maintenance (KEYNOTE-A18).</p>
-  <div class="case-foot">patient_cervical_locally_advanced.json</div>
-</a>
-<a class="case-card" href="/en/cases/gbm-stupp.html"
-   data-default-order="97"
-   data-name="Glioblastoma · Newly Diagnosed (Stupp Protocol)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Glioblastoma · Newly Diagnosed (Stupp Protocol)</h3>
-  <p>GBM IDH-WT WHO grade 4 — engine обирає Stupp: maximal safe resection → RT + concurrent TMZ → adjuvant TMZ × 6; TTFields для MGMT-methylated.</p>
-  <div class="case-foot">patient_gbm_newly_diagnosed_stupp.json</div>
-</a>
-<a class="case-card" href="/en/cases/ovarian-advanced-hrd.html"
-   data-default-order="98"
-   data-name="Ovarian · Advanced HRD+ (PARPi maintenance)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Ovarian · Advanced HRD+ (PARPi maintenance)</h3>
-  <p>Advanced high-grade serous ovarian, HRD+ — engine обирає platinum-doublet → PARPi maintenance (olaparib/niraparib; SOLO-1, PRIMA).</p>
-  <div class="case-foot">patient_ovarian_advanced_hrd.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-aitl.html"
-   data-default-order="99"
-   data-name="DIS-AITL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Angioimmunoblastic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_aitl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-alcl.html"
-   data-default-order="100"
-   data-name="DIS-ALCL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Anaplastic Large Cell Lymphoma, Systemic. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_alcl.json</div>
-</a>
 <a class="case-card" href="/en/cases/auto-aml.html"
    data-default-order="101"
    data-name="DIS-AML — Auto-stub (75% наповненість)">
@@ -1100,820 +165,6 @@
   <h3>DIS-AML — Auto-stub (75% наповненість)</h3>
   <p>Автогенерований мінімальний профіль для Acute Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
   <div class="case-foot">auto_aml.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-apl.html"
-   data-default-order="102"
-   data-name="DIS-APL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-APL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Acute Promyelocytic Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_apl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-atll.html"
-   data-default-order="103"
-   data-name="DIS-ATLL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Adult T-Cell Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_atll.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-b_all.html"
-   data-default-order="104"
-   data-name="DIS-B-ALL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-B-ALL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для B-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_b_all.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-breast.html"
-   data-default-order="105"
-   data-name="DIS-BREAST — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Invasive breast cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_breast.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-burkitt.html"
-   data-default-order="106"
-   data-name="DIS-BURKITT — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Burkitt Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_burkitt.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-cervical.html"
-   data-default-order="107"
-   data-name="DIS-CERVICAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Cervical carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cervical.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-chl.html"
-   data-default-order="108"
-   data-name="DIS-CHL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Classical Hodgkin Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_chl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-cholangiocarcinoma.html"
-   data-default-order="109"
-   data-name="DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Cholangiocarcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cholangiocarcinoma.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-chondrosarcoma.html"
-   data-default-order="110"
-   data-name="DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Chondrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_chondrosarcoma.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-cll.html"
-   data-default-order="111"
-   data-name="DIS-CLL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CLL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cll.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-cml.html"
-   data-default-order="112"
-   data-name="DIS-CML — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CML — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Chronic Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cml.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-crc.html"
-   data-default-order="113"
-   data-name="DIS-CRC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CRC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Colorectal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_crc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-dlbcl_nos.html"
-   data-default-order="114"
-   data-name="DIS-DLBCL-NOS — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Diffuse Large B-Cell Lymphoma, Not Otherwise Specified. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_dlbcl_nos.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-eatl.html"
-   data-default-order="115"
-   data-name="DIS-EATL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-EATL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Enteropathy-Associated T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_eatl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-endometrial.html"
-   data-default-order="116"
-   data-name="DIS-ENDOMETRIAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Endometrial carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_endometrial.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-esophageal.html"
-   data-default-order="117"
-   data-name="DIS-ESOPHAGEAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Esophageal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_esophageal.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-et.html"
-   data-default-order="118"
-   data-name="DIS-ET — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Essential Thrombocythemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_et.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-fl.html"
-   data-default-order="119"
-   data-name="DIS-FL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-FL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Follicular Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_fl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-gastric.html"
-   data-default-order="120"
-   data-name="DIS-GASTRIC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Gastric and gastroesophageal junction adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_gastric.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-gbm.html"
-   data-default-order="121"
-   data-name="DIS-GBM — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GBM — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Glioblastoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_gbm.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-gist.html"
-   data-default-order="122"
-   data-name="DIS-GIST — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GIST — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Gastrointestinal stromal tumor. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_gist.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-glioma_low_grade.html"
-   data-default-order="123"
-   data-name="DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Low-grade glioma. Фактична наповненість бази для цієї хвороби — 50%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_glioma_low_grade.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-hcc.html"
-   data-default-order="124"
-   data-name="DIS-HCC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Hepatocellular carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hcc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-hcl.html"
-   data-default-order="125"
-   data-name="DIS-HCL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Hairy Cell Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hcl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-hcv_mzl.html"
-   data-default-order="126"
-   data-name="DIS-HCV-MZL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для HCV-associated Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hcv_mzl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-hgbl_dh.html"
-   data-default-order="127"
-   data-name="DIS-HGBL-DH — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для High-Grade B-Cell Lymphoma, Double-Hit / Triple-Hit. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hgbl_dh.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-hnscc.html"
-   data-default-order="128"
-   data-name="DIS-HNSCC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Head and neck squamous cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hnscc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-hstcl.html"
-   data-default-order="129"
-   data-name="DIS-HSTCL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Hepatosplenic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hstcl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-ifs.html"
-   data-default-order="130"
-   data-name="DIS-IFS — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IFS — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Infantile fibrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ifs.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-imt.html"
-   data-default-order="131"
-   data-name="DIS-IMT — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IMT — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Inflammatory myofibroblastic tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_imt.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mastocytosis.html"
-   data-default-order="132"
-   data-name="DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Advanced systemic mastocytosis. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mastocytosis.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mcl.html"
-   data-default-order="133"
-   data-name="DIS-MCL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Mantle Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mcl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mds_hr.html"
-   data-default-order="134"
-   data-name="DIS-MDS-HR — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Higher Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mds_hr.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mds_lr.html"
-   data-default-order="135"
-   data-name="DIS-MDS-LR — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Lower Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mds_lr.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-melanoma.html"
-   data-default-order="136"
-   data-name="DIS-MELANOMA — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Cutaneous melanoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_melanoma.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mf_sezary.html"
-   data-default-order="137"
-   data-name="DIS-MF-SEZARY — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Mycosis Fungoides / Sézary Syndrome. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mf_sezary.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mm.html"
-   data-default-order="138"
-   data-name="DIS-MM — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MM — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Multiple Myeloma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mm.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mpnst.html"
-   data-default-order="139"
-   data-name="DIS-MPNST — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Malignant peripheral nerve sheath tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mpnst.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-mtc.html"
-   data-default-order="140"
-   data-name="DIS-MTC — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MTC — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Medullary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mtc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-nk_t_nasal.html"
-   data-default-order="141"
-   data-name="DIS-NK-T-NASAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Extranodal NK/T-Cell Lymphoma, Nasal Type. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nk_t_nasal.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-nlpbl.html"
-   data-default-order="142"
-   data-name="DIS-NLPBL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Nodular Lymphocyte-Predominant B-cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nlpbl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-nodal_mzl.html"
-   data-default-order="143"
-   data-name="DIS-NODAL-MZL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Nodal Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nodal_mzl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-nsclc.html"
-   data-default-order="144"
-   data-name="DIS-NSCLC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Non-small cell lung cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nsclc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-ovarian.html"
-   data-default-order="145"
-   data-name="DIS-OVARIAN — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Ovarian carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ovarian.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-pcnsl.html"
-   data-default-order="146"
-   data-name="DIS-PCNSL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Primary CNS Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pcnsl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-pdac.html"
-   data-default-order="147"
-   data-name="DIS-PDAC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Pancreatic ductal adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pdac.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-pmbcl.html"
-   data-default-order="148"
-   data-name="DIS-PMBCL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Primary Mediastinal Large B-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pmbcl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-pmf.html"
-   data-default-order="149"
-   data-name="DIS-PMF — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Primary Myelofibrosis. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pmf.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-prostate.html"
-   data-default-order="150"
-   data-name="DIS-PROSTATE — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Prostate adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_prostate.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-ptcl_nos.html"
-   data-default-order="151"
-   data-name="DIS-PTCL-NOS — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Peripheral T-Cell Lymphoma, NOS. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ptcl_nos.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-ptld.html"
-   data-default-order="152"
-   data-name="DIS-PTLD — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Post-Transplant Lymphoproliferative Disorder. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ptld.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-pv.html"
-   data-default-order="153"
-   data-name="DIS-PV — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Polycythemia Vera. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pv.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-rcc.html"
-   data-default-order="154"
-   data-name="DIS-RCC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Renal cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_rcc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-salivary.html"
-   data-default-order="155"
-   data-name="DIS-SALIVARY — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Salivary gland carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_salivary.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-sclc.html"
-   data-default-order="156"
-   data-name="DIS-SCLC — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Small cell lung cancer. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_sclc.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-splenic_mzl.html"
-   data-default-order="157"
-   data-name="DIS-SPLENIC-MZL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Splenic Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_splenic_mzl.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-t_all.html"
-   data-default-order="158"
-   data-name="DIS-T-ALL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для T-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_t_all.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-t_pll.html"
-   data-default-order="159"
-   data-name="DIS-T-PLL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для T-Cell Prolymphocytic Leukemia. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_t_pll.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-thyroid_anaplastic.html"
-   data-default-order="160"
-   data-name="DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Anaplastic thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_thyroid_anaplastic.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-thyroid_papillary.html"
-   data-default-order="161"
-   data-name="DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Papillary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 62%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_thyroid_papillary.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-urothelial.html"
-   data-default-order="162"
-   data-name="DIS-UROTHELIAL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Urothelial carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_urothelial.json</div>
-</a>
-<a class="case-card" href="/en/cases/auto-wm.html"
-   data-default-order="163"
-   data-name="DIS-WM — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_wm.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-aitl-frail.html"
-   data-default-order="164"
-   data-name="DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-aitl-organ-dysf.html"
-   data-default-order="165"
-   data-name="DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-aitl-infection-hbv.html"
-   data-default-order="166"
-   data-name="DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-aitl-relapsed-2l.html"
-   data-default-order="167"
-   data-name="DIS-AITL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-aitl-biomarker-act.html"
-   data-default-order="168"
-   data-name="DIS-AITL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-aitl-high-risk.html"
-   data-default-order="169"
-   data-name="DIS-AITL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-alcl-frail.html"
-   data-default-order="170"
-   data-name="DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-alcl-organ-dysf.html"
-   data-default-order="171"
-   data-name="DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-alcl-infection-hbv.html"
-   data-default-order="172"
-   data-name="DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-alcl-relapsed-2l.html"
-   data-default-order="173"
-   data-name="DIS-ALCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-alcl-biomarker-act.html"
-   data-default-order="174"
-   data-name="DIS-ALCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-alcl-high-risk.html"
-   data-default-order="175"
-   data-name="DIS-ALCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_high_risk.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-aml-frail.html"
    data-default-order="176"
@@ -1981,6 +232,91 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_aml_high_risk.json</div>
 </a>
+<a class="case-card" href="/en/cases/aml-flt3-itd-midostaurin.html"
+   data-default-order="574"
+   data-name="AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)</h3>
+  <p>Fit AML FLT3-ITD. Engine: ALGO-1L → IND-AML-1L-7-3 (default); midostaurin/RATIFY як regimen-layer note у comment.</p>
+  <div class="case-foot">patient_aml_flt3_itd_midostaurin_7_3.json</div>
+</a>
+<a class="case-card" href="/en/cases/aml-cbf-inv16-7-3-go.html"
+   data-default-order="575"
+   data-name="AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)</h3>
+  <p>Fit CBF AML. Drift: 7+3+GO indication відсутня; engine default = 7+3 plain; ALFA-0701 анкер у comment.</p>
+  <div class="case-foot">patient_aml_cbf_inv16_7_3_go.json</div>
+</a>
+<a class="case-card" href="/en/cases/aml-secondary-cpx351.html"
+   data-default-order="576"
+   data-name="AML · secondary/t-AML · CPX-351 (Vyxeos)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>AML · secondary/t-AML · CPX-351 (Vyxeos)</h3>
+  <p>Secondary AML post-MDS. Drift: CPX-351 indication відсутня у ALGO-1L; engine default = 7+3; Vyxeos анкер у comment.</p>
+  <div class="case-foot">patient_aml_secondary_cpx351.json</div>
+</a>
+<a class="case-card" href="/en/cases/aml-rr-gilteritinib.html"
+   data-default-order="577"
+   data-name="AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)</h3>
+  <p>Primary-refractory FLT3-TKD AML. Engine: ALGO-2L → IND-AML-2L-GILTERITINIB-FLT3 (ADMIRAL mOS 9.3 мо vs salvage chemo).</p>
+  <div class="case-foot">patient_aml_rr_gilteritinib.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-APL" hidden>
+  <header class="case-list-header">
+    <h2>Acute Promyelocytic Leukemia</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/apl-low-risk.html"
+   data-default-order="73"
+   data-name="APL · Low Risk (ATRA + ATO chemo-free)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>APL · Low Risk (ATRA + ATO chemo-free)</h3>
+  <p>APL з WBC &lt;10K (low-risk Sanz) — engine обирає ATRA+ATO chemo-free (APL0406: ~98% CR, без anthracycline).</p>
+  <div class="case-foot">patient_apl_low_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/apl-high-risk.html"
+   data-default-order="74"
+   data-name="APL · High Risk + DIC (ATRA + ATO + Idarubicin)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>APL · High Risk + DIC (ATRA + ATO + Idarubicin)</h3>
+  <p>APL з WBC &gt;10K + active DIC — RF-APL-DIC + RF-APL-HIGH-RISK fired. Engine додає idarubicin до ATRA+ATO; emergency cryoprecipitate/platelets.</p>
+  <div class="case-foot">patient_apl_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-apl.html"
+   data-default-order="102"
+   data-name="DIS-APL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-APL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Acute Promyelocytic Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_apl.json</div>
+</a>
 <a class="case-card" href="/en/cases/variant-apl-frail.html"
    data-default-order="182"
    data-name="DIS-APL · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -2046,6 +382,47 @@
   <h3>DIS-APL · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_apl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ATLL" hidden>
+  <header class="case-list-header">
+    <h2>Adult T-Cell Leukemia/Lymphoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/atll-acute.html"
+   data-default-order="59"
+   data-name="ATLL · Acute (mLSG15 / EPOCH)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ATLL · Acute (mLSG15 / EPOCH)</h3>
+  <p>Adult T-cell Leukemia/Lymphoma, acute subtype, HTLV-1+ — engine обирає intensive mLSG15 або EPOCH; alloHCT consolidation для responders.</p>
+  <div class="case-foot">patient_atll_acute.json</div>
+</a>
+<a class="case-card" href="/en/cases/atll-indolent-smoldering.html"
+   data-default-order="60"
+   data-name="ATLL · Indolent / Smoldering (Watchful Waiting)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ATLL · Indolent / Smoldering (Watchful Waiting)</h3>
+  <p>ATLL indolent/smoldering — engine обирає observation; system trigger для transformation.</p>
+  <div class="case-foot">patient_atll_indolent_smoldering.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-atll.html"
+   data-default-order="103"
+   data-name="DIS-ATLL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Adult T-Cell Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_atll.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-atll-frail.html"
    data-default-order="188"
@@ -2113,6 +490,442 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_atll_high_risk.json</div>
 </a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MASTOCYTOSIS" hidden>
+  <header class="case-list-header">
+    <h2>Advanced systemic mastocytosis</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-mastocytosis.html"
+   data-default-order="132"
+   data-name="DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Advanced systemic mastocytosis. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mastocytosis.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mastocytosis-frail.html"
+   data-default-order="344"
+   data-name="DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mastocytosis-organ-dysf.html"
+   data-default-order="345"
+   data-name="DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mastocytosis-infection-hbv.html"
+   data-default-order="346"
+   data-name="DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mastocytosis-biomarker-act.html"
+   data-default-order="347"
+   data-name="DIS-MASTOCYTOSIS · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mastocytosis-high-risk.html"
+   data-default-order="348"
+   data-name="DIS-MASTOCYTOSIS · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ALCL" hidden>
+  <header class="case-list-header">
+    <h2>Anaplastic Large Cell Lymphoma, Systemic</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/alcl-alk-negative.html"
+   data-default-order="24"
+   data-name="ALCL · ALK-negative (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ALCL · ALK-negative (CHP-Bv)</h3>
+  <p>Системна анапластична великоклітинна лімфома, ALK-negative — universally CD30+. Engine обирає CHP-Bv (ECHELON-2: brentuximab замість vincristine).</p>
+  <div class="case-foot">patient_alcl_alk_negative.json</div>
+</a>
+<a class="case-card" href="/en/cases/alcl-alk-positive-typical.html"
+   data-default-order="48"
+   data-name="ALCL · ALK-positive Typical (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ALCL · ALK-positive Typical (CHP-Bv)</h3>
+  <p>Молода особа з ALK+ ALCL — engine обирає CHP-Bv (ECHELON-2). ALK+ має значно кращий прогноз vs ALK-.</p>
+  <div class="case-foot">patient_alcl_alk_positive_typical.json</div>
+</a>
+<a class="case-card" href="/en/cases/alcl-relapsed-bv-naive.html"
+   data-default-order="49"
+   data-name="ALCL · Relapsed BV-naive (Brentuximab → autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ALCL · Relapsed BV-naive (Brentuximab → autoSCT)</h3>
+  <p>Relapsed ALCL без попереднього brentuximab — engine обирає brentuximab mono → autoSCT consolidation; BV maintenance per ECHELON-2 update.</p>
+  <div class="case-foot">patient_alcl_relapsed_bv_naive.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-alcl.html"
+   data-default-order="100"
+   data-name="DIS-ALCL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Anaplastic Large Cell Lymphoma, Systemic. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_alcl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-alcl-frail.html"
+   data-default-order="170"
+   data-name="DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-alcl-organ-dysf.html"
+   data-default-order="171"
+   data-name="DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-alcl-infection-hbv.html"
+   data-default-order="172"
+   data-name="DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-alcl-relapsed-2l.html"
+   data-default-order="173"
+   data-name="DIS-ALCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-alcl-biomarker-act.html"
+   data-default-order="174"
+   data-name="DIS-ALCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-alcl-high-risk.html"
+   data-default-order="175"
+   data-name="DIS-ALCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-THYROID-ANAPLASTIC" hidden>
+  <header class="case-list-header">
+    <h2>Anaplastic thyroid carcinoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-thyroid_anaplastic.html"
+   data-default-order="160"
+   data-name="DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Anaplastic thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_thyroid_anaplastic.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-frail.html"
+   data-default-order="505"
+   data-name="DIS-THYROID-ANAPLASTIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_anaplastic_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-organ-dysf.html"
+   data-default-order="506"
+   data-name="DIS-THYROID-ANAPLASTIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_anaplastic_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-infection-hbv.html"
+   data-default-order="507"
+   data-name="DIS-THYROID-ANAPLASTIC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_anaplastic_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-biomarker-act.html"
+   data-default-order="508"
+   data-name="DIS-THYROID-ANAPLASTIC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_anaplastic_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-high-risk.html"
+   data-default-order="509"
+   data-name="DIS-THYROID-ANAPLASTIC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_anaplastic_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-AITL" hidden>
+  <header class="case-list-header">
+    <h2>Angioimmunoblastic T-Cell Lymphoma</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/aitl-cd30-positive.html"
+   data-default-order="26"
+   data-name="AITL · CD30-positive (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AITL · CD30-positive (CHP-Bv)</h3>
+  <p>Ангіоімунобластна T-клітинна лімфома, CD30+ — RF-TCELL-CD30-POSITIVE fired. Engine обирає CHP-Bv.</p>
+  <div class="case-foot">patient_aitl_cd30_positive.json</div>
+</a>
+<a class="case-card" href="/en/cases/aitl-cd30-negative.html"
+   data-default-order="30"
+   data-name="AITL · CD30-negative (CHOEP + AITL-specific workup)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AITL · CD30-negative (CHOEP + AITL-specific workup)</h3>
+  <p>AITL з CD30-negative біопсією — engine обирає AITL-specific CHOEP. Layered workup: EBER-ISH (EBV+ B-cell мікрооточення), IgG quant (paraneoplastic hypogamma), DAT (AIHA risk).</p>
+  <div class="case-foot">patient_aitl_cd30_negative.json</div>
+</a>
+<a class="case-card" href="/en/cases/aitl-relapsed-2l.html"
+   data-default-order="52"
+   data-name="AITL · Relapsed 2L (Azacitidine)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AITL · Relapsed 2L (Azacitidine)</h3>
+  <p>AITL relapsed з TET2/DNMT3A epigenetic profile — engine обирає azacitidine (epigenetic targeting; AITL — найбільш azacitidine-responsive TCL subtype).</p>
+  <div class="case-foot">patient_aitl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-aitl.html"
+   data-default-order="99"
+   data-name="DIS-AITL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Angioimmunoblastic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_aitl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-aitl-frail.html"
+   data-default-order="164"
+   data-name="DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-aitl-organ-dysf.html"
+   data-default-order="165"
+   data-name="DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-aitl-infection-hbv.html"
+   data-default-order="166"
+   data-name="DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-aitl-relapsed-2l.html"
+   data-default-order="167"
+   data-name="DIS-AITL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-aitl-biomarker-act.html"
+   data-default-order="168"
+   data-name="DIS-AITL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-aitl-high-risk.html"
+   data-default-order="169"
+   data-name="DIS-AITL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-B-ALL" hidden>
+  <header class="case-list-header">
+    <h2>B-Lymphoblastic Leukemia/Lymphoma</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/b-all-ph-pos-adult.html"
+   data-default-order="91"
+   data-name="B-ALL · Ph+ Adult (TKI + Chemo)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>B-ALL · Ph+ Adult (TKI + Chemo)</h3>
+  <p>Adult B-ALL Ph+ (BCR-ABL1+) — engine обирає dasatinib + chemo (hyper-CVAD або pediatric-inspired); alloHCT для CR1 high-risk.</p>
+  <div class="case-foot">patient_b_all_ph_pos_adult.json</div>
+</a>
+<a class="case-card" href="/en/cases/b-all-mrd-positive.html"
+   data-default-order="92"
+   data-name="B-ALL · MRD-positive (Blinatumomab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>B-ALL · MRD-positive (Blinatumomab)</h3>
+  <p>B-ALL MRD-positive після induction — engine обирає blinatumomab (BLAST: MRD eradication у &gt;75%).</p>
+  <div class="case-foot">patient_b_all_mrd_positive.json</div>
+</a>
+<a class="case-card" href="/en/cases/b-all-t315i-post-tki.html"
+   data-default-order="93"
+   data-name="B-ALL · T315I-mutated post-TKI (Ponatinib + alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>B-ALL · T315I-mutated post-TKI (Ponatinib + alloHCT)</h3>
+  <p>Ph+ B-ALL relapsed з T315I gatekeeper — engine обирає ponatinib + chemo bridge → alloHCT.</p>
+  <div class="case-foot">patient_b_all_t315i_post_tki.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-b_all.html"
+   data-default-order="104"
+   data-name="DIS-B-ALL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-B-ALL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для B-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_b_all.json</div>
+</a>
 <a class="case-card" href="/en/cases/variant-b_all-frail.html"
    data-default-order="194"
    data-name="DIS-B-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -2179,71 +992,46 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_b_all_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-breast-frail.html"
-   data-default-order="200"
-   data-name="DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_frail.json</div>
+</section>
+<section class="case-list" data-disease-id="DIS-BURKITT" hidden>
+  <header class="case-list-header">
+    <h2>Burkitt Lymphoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/burkitt-low-risk.html"
+   data-default-order="19"
+   data-name="Burkitt · Low/Intermediate Risk (DA-EPOCH-R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Burkitt · Low/Intermediate Risk (DA-EPOCH-R)</h3>
+  <p>Burkitt без CNS+, LDH в нормі — engine обирає DA-EPOCH-R (CALGB 10002, ~90% CR including HIV+).</p>
+  <div class="case-foot">patient_burkitt_low_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-breast-organ-dysf.html"
-   data-default-order="201"
-   data-name="DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/burkitt-high-risk.html"
+   data-default-order="20"
+   data-name="Burkitt · High Risk (CODOX-M / IVAC)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
   </div>
-  <h3>DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_organ_dysf.json</div>
+  <h3>Burkitt · High Risk (CODOX-M / IVAC)</h3>
+  <p>Burkitt з CNS involvement + LDH &gt;3× ULN + bulky abdomen — RF-BURKITT-HIGH-RISK fired. Engine обирає Magrath protocol з HD-MTX + IT MTX/cytarabine.</p>
+  <div class="case-foot">patient_burkitt_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-breast-infection-hbv.html"
-   data-default-order="202"
-   data-name="DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/auto-burkitt.html"
+   data-default-order="106"
+   data-name="DIS-BURKITT — Auto-stub (88% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-stub">Auto-stub</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-breast-relapsed-2l.html"
-   data-default-order="203"
-   data-name="DIS-BREAST · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-breast-biomarker-act.html"
-   data-default-order="204"
-   data-name="DIS-BREAST · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-breast-high-risk.html"
-   data-default-order="205"
-   data-name="DIS-BREAST · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_high_risk.json</div>
+  <h3>DIS-BURKITT — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Burkitt Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_burkitt.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-burkitt-frail.html"
    data-default-order="206"
@@ -2311,6 +1099,36 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_burkitt_high_risk.json</div>
 </a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CERVICAL" hidden>
+  <header class="case-list-header">
+    <h2>Cervical carcinoma</h2>
+    <span class="case-list-count">7 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/cervical-locally-advanced.html"
+   data-default-order="96"
+   data-name="Cervical · Locally Advanced (CCRT + Pembrolizumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Cervical · Locally Advanced (CCRT + Pembrolizumab)</h3>
+  <p>Locally advanced cervical cancer (FIGO IIB-IVA) — engine обирає cisplatin-based CCRT + brachytherapy; pembrolizumab maintenance (KEYNOTE-A18).</p>
+  <div class="case-foot">patient_cervical_locally_advanced.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-cervical.html"
+   data-default-order="107"
+   data-name="DIS-CERVICAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Cervical carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cervical.json</div>
+</a>
 <a class="case-card" href="/en/cases/variant-cervical-frail.html"
    data-default-order="212"
    data-name="DIS-CERVICAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -2366,71 +1184,24 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_cervical_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-chl-frail.html"
-   data-default-order="217"
-   data-name="DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CHOLANGIOCARCINOMA" hidden>
+  <header class="case-list-header">
+    <h2>Cholangiocarcinoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-cholangiocarcinoma.html"
+   data-default-order="109"
+   data-name="DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-stub">Auto-stub</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-chl-organ-dysf.html"
-   data-default-order="218"
-   data-name="DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-chl-infection-hbv.html"
-   data-default-order="219"
-   data-name="DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-chl-relapsed-2l.html"
-   data-default-order="220"
-   data-name="DIS-CHL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-chl-biomarker-act.html"
-   data-default-order="221"
-   data-name="DIS-CHL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-chl-high-risk.html"
-   data-default-order="222"
-   data-name="DIS-CHL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_high_risk.json</div>
+  <h3>DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Cholangiocarcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cholangiocarcinoma.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-cholangiocarcinoma-frail.html"
    data-default-order="223"
@@ -2487,6 +1258,25 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_cholangiocarcinoma_high_risk.json</div>
 </a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CHONDROSARCOMA" hidden>
+  <header class="case-list-header">
+    <h2>Chondrosarcoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-chondrosarcoma.html"
+   data-default-order="110"
+   data-name="DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Chondrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_chondrosarcoma.json</div>
+</a>
 <a class="case-card" href="/en/cases/variant-chondrosarcoma-frail.html"
    data-default-order="228"
    data-name="DIS-CHONDROSARCOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -2541,6 +1331,58 @@
   <h3>DIS-CHONDROSARCOMA · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_chondrosarcoma_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CLL" hidden>
+  <header class="case-list-header">
+    <h2>Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma</h2>
+    <span class="case-list-count">11 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/cll-low-risk.html"
+   data-default-order="12"
+   data-name="CLL/SLL · Low-Risk (BTKi continuous)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL/SLL · Low-Risk (BTKi continuous)</h3>
+  <p>ХЛЛ зі стандартним ризиком (no TP53/del 17p/IGHV-unmut) — engine обирає acalabrutinib continuous; modern era замість FCR/BR.</p>
+  <div class="case-foot">patient_cll_low_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/cll-high-risk.html"
+   data-default-order="13"
+   data-name="CLL/SLL · High-Risk (VenO time-limited)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL/SLL · High-Risk (VenO time-limited)</h3>
+  <p>ХЛЛ з TP53 mutation + IGHV-unmut + complex karyotype — RF-CLL-HIGH-RISK fired. Engine ескалує до venetoclax+obinutuzumab (CLL14).</p>
+  <div class="case-foot">patient_cll_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/cll-post-btki.html"
+   data-default-order="44"
+   data-name="CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)</h3>
+  <p>CLL з прогресією на covalent BTKi — engine обирає pirtobrutinib (BRUIN, non-covalent) або venetoclax+rituximab (MURANO).</p>
+  <div class="case-foot">patient_cll_post_btki_progression.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-cll.html"
+   data-default-order="111"
+   data-name="DIS-CLL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CLL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cll.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-cll-frail.html"
    data-default-order="233"
@@ -2608,6 +1450,69 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_cll_high_risk.json</div>
 </a>
+<a class="case-card" href="/en/cases/cll-venr-2l-murano.html"
+   data-default-order="581"
+   data-name="CLL · 2L post-BTKi · VenR fixed-duration (MURANO)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL · 2L post-BTKi · VenR fixed-duration (MURANO)</h3>
+  <p>Post-acalabrutinib PD без C481/BCL2-resistance. Engine: ALGO-CLL-2L step 2 (RF-PRIOR-BTKI-PROGRESSION) → IND-CLL-2L-VENR-MURANO (24-mo, mPFS 53.6 мо).</p>
+  <div class="case-foot">patient_cll_venr_2l_murano.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CML" hidden>
+  <header class="case-list-header">
+    <h2>Chronic Myeloid Leukemia</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/cml-chronic-newdx.html"
+   data-default-order="75"
+   data-name="CML · Chronic Phase Newly Diagnosed (TKI 1L)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CML · Chronic Phase Newly Diagnosed (TKI 1L)</h3>
+  <p>Newly-diagnosed CML chronic phase, BCR-ABL1+ — engine обирає imatinib (low-risk Sokal) або 2G TKI (intermediate/high).</p>
+  <div class="case-foot">patient_cml_chronic_phase_newdx.json</div>
+</a>
+<a class="case-card" href="/en/cases/cml-t315i.html"
+   data-default-order="76"
+   data-name="CML · T315I-mutated (Ponatinib / Asciminib)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CML · T315I-mutated (Ponatinib / Asciminib)</h3>
+  <p>CML з T315I gatekeeper mutation post-2G TKI — engine обирає ponatinib (PACE) або asciminib (allosteric STAMP-inhibitor).</p>
+  <div class="case-foot">patient_cml_t315i.json</div>
+</a>
+<a class="case-card" href="/en/cases/cml-blast-crisis.html"
+   data-default-order="77"
+   data-name="CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)</h3>
+  <p>CML що дебютує як blast crisis — engine обирає TKI + intensive chemo bridge → urgent alloHCT (без alloHCT медіана OS &lt;12 mo).</p>
+  <div class="case-foot">patient_cml_blast_crisis_at_presentation.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-cml.html"
+   data-default-order="112"
+   data-name="DIS-CML — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CML — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Chronic Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cml.json</div>
+</a>
 <a class="case-card" href="/en/cases/variant-cml-frail.html"
    data-default-order="239"
    data-name="DIS-CML · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -2673,6 +1578,154 @@
   <h3>DIS-CML · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_cml_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CHL" hidden>
+  <header class="case-list-header">
+    <h2>Classical Hodgkin Lymphoma</h2>
+    <span class="case-list-count">11 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/chl-advanced.html"
+   data-default-order="27"
+   data-name="Classical Hodgkin · Advanced (A+AVD)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Classical Hodgkin · Advanced (A+AVD)</h3>
+  <p>Стадія IV cHL — RF-CHL-ADVANCED-STAGE fired. Engine обирає A+AVD (ECHELON-1: brentuximab замість bleomycin, superior OS).</p>
+  <div class="case-foot">patient_chl_advanced.json</div>
+</a>
+<a class="case-card" href="/en/cases/chl-early.html"
+   data-default-order="28"
+   data-name="Classical Hodgkin · Early Stage (ABVD)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Classical Hodgkin · Early Stage (ABVD)</h3>
+  <p>Стадія IIA cHL, без advanced criteria — engine обирає ABVD × 2-4 + ISRT (response-adapted).</p>
+  <div class="case-foot">patient_chl_early.json</div>
+</a>
+<a class="case-card" href="/en/cases/chl-pediatric-bulky.html"
+   data-default-order="66"
+   data-name="cHL · AYA Stage IIB Bulky Mediastinal">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>cHL · AYA Stage IIB Bulky Mediastinal</h3>
+  <p>AYA пацієнт з cHL stage IIB + bulky mediastinal mass + B-symptoms — RF-CHL-BULKY-MEDIASTINAL fired. Response-adapted intensification.</p>
+  <div class="case-foot">patient_chl_pediatric_bulky_mediastinal.json</div>
+</a>
+<a class="case-card" href="/en/cases/chl-relapsed-salvage.html"
+   data-default-order="67"
+   data-name="cHL · Relapsed (Salvage → autoSCT + BV maint.)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>cHL · Relapsed (Salvage → autoSCT + BV maint.)</h3>
+  <p>cHL relapsed після ABVD/A+AVD — engine обирає salvage chemo (ICE/DHAP) → autoSCT → brentuximab maintenance (AETHERA).</p>
+  <div class="case-foot">patient_chl_relapsed_for_salvage.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-chl.html"
+   data-default-order="108"
+   data-name="DIS-CHL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Classical Hodgkin Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_chl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-chl-frail.html"
+   data-default-order="217"
+   data-name="DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-chl-organ-dysf.html"
+   data-default-order="218"
+   data-name="DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-chl-infection-hbv.html"
+   data-default-order="219"
+   data-name="DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-chl-relapsed-2l.html"
+   data-default-order="220"
+   data-name="DIS-CHL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-chl-biomarker-act.html"
+   data-default-order="221"
+   data-name="DIS-CHL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-chl-high-risk.html"
+   data-default-order="222"
+   data-name="DIS-CHL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CRC" hidden>
+  <header class="case-list-header">
+    <h2>Colorectal carcinoma</h2>
+    <span class="case-list-count">13 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-crc.html"
+   data-default-order="113"
+   data-name="DIS-CRC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-CRC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Colorectal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_crc.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-crc-frail.html"
    data-default-order="245"
@@ -2740,1281 +1793,90 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_crc_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-dlbcl_nos-frail.html"
-   data-default-order="251"
-   data-name="DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+<a class="case-card" href="/en/cases/crc-stage-iii-adjuvant-folfox.html"
+   data-default-order="546"
+   data-name="CRC · stage III adjuvant FOLFOX (MOSAIC)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_frail.json</div>
+  <h3>CRC · stage III adjuvant FOLFOX (MOSAIC)</h3>
+  <p>Stage III після резекції. Drift: KB не має adjuvant CRC algo; engine default = mCRC FOLFOX+bev (анкер MOSAIC у comment).</p>
+  <div class="case-foot">patient_crc_stage_iii_adjuvant_folfox.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-dlbcl_nos-organ-dysf.html"
-   data-default-order="252"
-   data-name="DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/crc-mcrc-ras-wt-left-folfox-cetux.html"
+   data-default-order="547"
+   data-name="mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_organ_dysf.json</div>
+  <h3>mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)</h3>
+  <p>RAS-WT левобічна mCRC. Engine: ALGO step 2 → IND-CRC-METASTATIC-1L-RAS-WT-LEFT (CRYSTAL/FIRE-3).</p>
+  <div class="case-foot">patient_crc_metastatic_ras_wt_left_folfox_cetux.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-dlbcl_nos-infection-hbv.html"
-   data-default-order="253"
-   data-name="DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/crc-mcrc-ras-mut-folfox-bev.html"
+   data-default-order="548"
+   data-name="mCRC · RAS-mutated 1L · FOLFOX+bevacizumab">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_infection_hbv.json</div>
+  <h3>mCRC · RAS-mutated 1L · FOLFOX+bevacizumab</h3>
+  <p>KRAS-мутована mCRC, 1L FOLFOX+bevacizumab. Engine: ALGO default → IND-CRC-METASTATIC-1L-FOLFOX-BEV.</p>
+  <div class="case-foot">patient_crc_metastatic_ras_mut_folfox_bev.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-dlbcl_nos-relapsed-2l.html"
-   data-default-order="254"
-   data-name="DIS-DLBCL-NOS · Релапс / 2-а лінія">
+<a class="case-card" href="/en/cases/crc-mcrc-msi-h-pembro.html"
+   data-default-order="549"
+   data-name="mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-DLBCL-NOS · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_relapsed_2l.json</div>
+  <h3>mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)</h3>
+  <p>MSI-high mCRC. Engine: ALGO step 1 (MSI-H fires) → IND-CRC-METASTATIC-1L-MSI-H-PEMBRO (KEYNOTE-177 mPFS 16.5 мо).</p>
+  <div class="case-foot">patient_crc_metastatic_msi_h_pembro_mono.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-dlbcl_nos-biomarker-act.html"
-   data-default-order="255"
-   data-name="DIS-DLBCL-NOS · Actionable біомаркер present">
+<a class="case-card" href="/en/cases/crc-mcrc-2l-folfiri-bev.html"
+   data-default-order="550"
+   data-name="mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-DLBCL-NOS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_biomarker_act.json</div>
+  <h3>mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)</h3>
+  <p>Прогрес на FOLFOX+bev 1L. Engine: ALGO-2L → IND-CRC-METASTATIC-2L-FOLFIRI-BEV (continuum-of-care).</p>
+  <div class="case-foot">patient_crc_metastatic_2l_folfiri_bev.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-dlbcl_nos-high-risk.html"
-   data-default-order="256"
-   data-name="DIS-DLBCL-NOS · High-risk biology / bulky disease">
+<a class="case-card" href="/en/cases/crc-mcrc-3l-regorafenib.html"
+   data-default-order="551"
+   data-name="mCRC · 3L+ Regorafenib (CORRECT)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-DLBCL-NOS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_high_risk.json</div>
+  <h3>mCRC · 3L+ Regorafenib (CORRECT)</h3>
+  <p>Хеморефрактерна mCRC. Drift: engine default = TAS-102+bev (SUNLIGHT); regorafenib як alternative track.</p>
+  <div class="case-foot">patient_crc_metastatic_3l_regorafenib.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-eatl-frail.html"
-   data-default-order="257"
-   data-name="DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-eatl-organ-dysf.html"
-   data-default-order="258"
-   data-name="DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-eatl-infection-hbv.html"
-   data-default-order="259"
-   data-name="DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-eatl-biomarker-act.html"
-   data-default-order="260"
-   data-name="DIS-EATL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-eatl-high-risk.html"
-   data-default-order="261"
-   data-name="DIS-EATL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-endometrial-frail.html"
-   data-default-order="262"
-   data-name="DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-endometrial-organ-dysf.html"
-   data-default-order="263"
-   data-name="DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-endometrial-infection-hbv.html"
-   data-default-order="264"
-   data-name="DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-endometrial-relapsed-2l.html"
-   data-default-order="265"
-   data-name="DIS-ENDOMETRIAL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-endometrial-biomarker-act.html"
-   data-default-order="266"
-   data-name="DIS-ENDOMETRIAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-endometrial-high-risk.html"
-   data-default-order="267"
-   data-name="DIS-ENDOMETRIAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-esophageal-frail.html"
-   data-default-order="268"
-   data-name="DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-esophageal-organ-dysf.html"
-   data-default-order="269"
-   data-name="DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-esophageal-infection-hbv.html"
-   data-default-order="270"
-   data-name="DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-esophageal-relapsed-2l.html"
-   data-default-order="271"
-   data-name="DIS-ESOPHAGEAL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-esophageal-biomarker-act.html"
-   data-default-order="272"
-   data-name="DIS-ESOPHAGEAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-esophageal-high-risk.html"
-   data-default-order="273"
-   data-name="DIS-ESOPHAGEAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-et-frail.html"
-   data-default-order="274"
-   data-name="DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-et-organ-dysf.html"
-   data-default-order="275"
-   data-name="DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-et-infection-hbv.html"
-   data-default-order="276"
-   data-name="DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-et-relapsed-2l.html"
-   data-default-order="277"
-   data-name="DIS-ET · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-et-biomarker-act.html"
-   data-default-order="278"
-   data-name="DIS-ET · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-et-high-risk.html"
-   data-default-order="279"
-   data-name="DIS-ET · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-ET · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-fl-frail.html"
-   data-default-order="280"
-   data-name="DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-fl-organ-dysf.html"
-   data-default-order="281"
-   data-name="DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-fl-infection-hbv.html"
-   data-default-order="282"
-   data-name="DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-fl-biomarker-act.html"
-   data-default-order="283"
-   data-name="DIS-FL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-FL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-fl-high-risk.html"
-   data-default-order="284"
-   data-name="DIS-FL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-FL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gastric-frail.html"
-   data-default-order="285"
-   data-name="DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gastric-organ-dysf.html"
-   data-default-order="286"
-   data-name="DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gastric-infection-hbv.html"
-   data-default-order="287"
-   data-name="DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gastric-relapsed-2l.html"
-   data-default-order="288"
-   data-name="DIS-GASTRIC · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gastric-biomarker-act.html"
-   data-default-order="289"
-   data-name="DIS-GASTRIC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gastric-high-risk.html"
-   data-default-order="290"
-   data-name="DIS-GASTRIC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gbm-frail.html"
-   data-default-order="291"
-   data-name="DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gbm-organ-dysf.html"
-   data-default-order="292"
-   data-name="DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gbm-infection-hbv.html"
-   data-default-order="293"
-   data-name="DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gbm-biomarker-act.html"
-   data-default-order="294"
-   data-name="DIS-GBM · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gbm-high-risk.html"
-   data-default-order="295"
-   data-name="DIS-GBM · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gist-frail.html"
-   data-default-order="296"
-   data-name="DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gist-organ-dysf.html"
-   data-default-order="297"
-   data-name="DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gist-infection-hbv.html"
-   data-default-order="298"
-   data-name="DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gist-biomarker-act.html"
-   data-default-order="299"
-   data-name="DIS-GIST · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-gist-high-risk.html"
-   data-default-order="300"
-   data-name="DIS-GIST · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcc-frail.html"
-   data-default-order="301"
-   data-name="DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcc-organ-dysf.html"
-   data-default-order="302"
-   data-name="DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcc-infection-hbv.html"
-   data-default-order="303"
-   data-name="DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcc-biomarker-act.html"
-   data-default-order="304"
-   data-name="DIS-HCC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcc-high-risk.html"
-   data-default-order="305"
-   data-name="DIS-HCC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcl-frail.html"
-   data-default-order="306"
-   data-name="DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcl-organ-dysf.html"
-   data-default-order="307"
-   data-name="DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcl-infection-hbv.html"
-   data-default-order="308"
-   data-name="DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcl-relapsed-2l.html"
-   data-default-order="309"
-   data-name="DIS-HCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcl-biomarker-act.html"
-   data-default-order="310"
-   data-name="DIS-HCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcl-high-risk.html"
-   data-default-order="311"
-   data-name="DIS-HCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcv_mzl-frail.html"
-   data-default-order="312"
-   data-name="DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcv_mzl-organ-dysf.html"
-   data-default-order="313"
-   data-name="DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcv_mzl-infection-hbv.html"
-   data-default-order="314"
-   data-name="DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcv_mzl-relapsed-2l.html"
-   data-default-order="315"
-   data-name="DIS-HCV-MZL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcv_mzl-biomarker-act.html"
-   data-default-order="316"
-   data-name="DIS-HCV-MZL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hcv_mzl-high-risk.html"
-   data-default-order="317"
-   data-name="DIS-HCV-MZL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hgbl_dh-frail.html"
-   data-default-order="318"
-   data-name="DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hgbl_dh-organ-dysf.html"
-   data-default-order="319"
-   data-name="DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hgbl_dh-infection-hbv.html"
-   data-default-order="320"
-   data-name="DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hgbl_dh-relapsed-2l.html"
-   data-default-order="321"
-   data-name="DIS-HGBL-DH · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hgbl_dh-biomarker-act.html"
-   data-default-order="322"
-   data-name="DIS-HGBL-DH · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hgbl_dh-high-risk.html"
-   data-default-order="323"
-   data-name="DIS-HGBL-DH · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hnscc-frail.html"
-   data-default-order="324"
-   data-name="DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hnscc-organ-dysf.html"
-   data-default-order="325"
-   data-name="DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hnscc-infection-hbv.html"
-   data-default-order="326"
-   data-name="DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hnscc-biomarker-act.html"
-   data-default-order="327"
-   data-name="DIS-HNSCC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hnscc-high-risk.html"
-   data-default-order="328"
-   data-name="DIS-HNSCC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hstcl-frail.html"
-   data-default-order="329"
-   data-name="DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hstcl-organ-dysf.html"
-   data-default-order="330"
-   data-name="DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hstcl-infection-hbv.html"
-   data-default-order="331"
-   data-name="DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hstcl-biomarker-act.html"
-   data-default-order="332"
-   data-name="DIS-HSTCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-hstcl-high-risk.html"
-   data-default-order="333"
-   data-name="DIS-HSTCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ifs-frail.html"
-   data-default-order="334"
-   data-name="DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ifs-organ-dysf.html"
-   data-default-order="335"
-   data-name="DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ifs-infection-hbv.html"
-   data-default-order="336"
-   data-name="DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ifs-biomarker-act.html"
-   data-default-order="337"
-   data-name="DIS-IFS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ifs-high-risk.html"
-   data-default-order="338"
-   data-name="DIS-IFS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-IFS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-imt-frail.html"
-   data-default-order="339"
-   data-name="DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-imt-organ-dysf.html"
-   data-default-order="340"
-   data-name="DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-imt-infection-hbv.html"
-   data-default-order="341"
-   data-name="DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-imt-biomarker-act.html"
-   data-default-order="342"
-   data-name="DIS-IMT · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-imt-high-risk.html"
-   data-default-order="343"
-   data-name="DIS-IMT · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mastocytosis-frail.html"
-   data-default-order="344"
-   data-name="DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mastocytosis-organ-dysf.html"
-   data-default-order="345"
-   data-name="DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mastocytosis-infection-hbv.html"
-   data-default-order="346"
-   data-name="DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mastocytosis-biomarker-act.html"
-   data-default-order="347"
-   data-name="DIS-MASTOCYTOSIS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mastocytosis-high-risk.html"
-   data-default-order="348"
-   data-name="DIS-MASTOCYTOSIS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mcl-frail.html"
-   data-default-order="349"
-   data-name="DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mcl-organ-dysf.html"
-   data-default-order="350"
-   data-name="DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mcl-infection-hbv.html"
-   data-default-order="351"
-   data-name="DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mcl-relapsed-2l.html"
-   data-default-order="352"
-   data-name="DIS-MCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mcl-biomarker-act.html"
-   data-default-order="353"
-   data-name="DIS-MCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mcl-high-risk.html"
-   data-default-order="354"
-   data-name="DIS-MCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_hr-frail.html"
-   data-default-order="355"
-   data-name="DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_hr-organ-dysf.html"
-   data-default-order="356"
-   data-name="DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_hr-infection-hbv.html"
-   data-default-order="357"
-   data-name="DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_hr-relapsed-2l.html"
-   data-default-order="358"
-   data-name="DIS-MDS-HR · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_hr-biomarker-act.html"
-   data-default-order="359"
-   data-name="DIS-MDS-HR · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_hr-high-risk.html"
-   data-default-order="360"
-   data-name="DIS-MDS-HR · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_lr-frail.html"
-   data-default-order="361"
-   data-name="DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_lr-organ-dysf.html"
-   data-default-order="362"
-   data-name="DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_lr-infection-hbv.html"
-   data-default-order="363"
-   data-name="DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_lr-relapsed-2l.html"
-   data-default-order="364"
-   data-name="DIS-MDS-LR · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_lr-biomarker-act.html"
-   data-default-order="365"
-   data-name="DIS-MDS-LR · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-mds_lr-high-risk.html"
-   data-default-order="366"
-   data-name="DIS-MDS-LR · High-risk biology / bulky disease">
+</section>
+<section class="case-list" data-disease-id="DIS-MELANOMA" hidden>
+  <header class="case-list-header">
+    <h2>Cutaneous melanoma</h2>
+    <span class="case-list-count">12 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-melanoma.html"
+   data-default-order="136"
+   data-name="DIS-MELANOMA — Auto-stub (88% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-stub">Auto-stub</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MDS-LR · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_high_risk.json</div>
+  <h3>DIS-MELANOMA — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Cutaneous melanoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_melanoma.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-melanoma-frail.html"
    data-default-order="367"
@@ -4082,247 +1944,636 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_melanoma_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mf_sezary-frail.html"
-   data-default-order="373"
-   data-name="DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+<a class="case-card" href="/en/cases/melanoma-braf-v600-dab-tram.html"
+   data-default-order="552"
+   data-name="Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_frail.json</div>
+  <h3>Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)</h3>
+  <p>BRAF V600 метастатична. Engine: → IND-MELANOMA-BRAF-METASTATIC-1L-DABRA-TRAME (COMBI-d/v).</p>
+  <div class="case-foot">patient_melanoma_braf_v600_dab_tram.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mf_sezary-organ-dysf.html"
-   data-default-order="374"
-   data-name="DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/melanoma-braf-v600-nivo-ipi.html"
+   data-default-order="553"
+   data-name="Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_organ_dysf.json</div>
+  <h3>Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)</h3>
+  <p>BRAF V600 метастатична, IO doublet. Engine: → IND-MELANOMA-METASTATIC-1L-NIVO-IPI (CM-067 5-yr OS 52%).</p>
+  <div class="case-foot">patient_melanoma_braf_v600_nivo_ipi.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mf_sezary-infection-hbv.html"
-   data-default-order="375"
-   data-name="DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/melanoma-braf-wt-pembro-mono.html"
+   data-default-order="554"
+   data-name="Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_infection_hbv.json</div>
+  <h3>Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)</h3>
+  <p>BRAF-WT метастатична. Drift: KEYNOTE-006 не wired у KB; engine fallback до nivo+ipi; анкер у comment.</p>
+  <div class="case-foot">patient_melanoma_braf_wt_pembro_mono.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mf_sezary-relapsed-2l.html"
-   data-default-order="376"
-   data-name="DIS-MF-SEZARY · Релапс / 2-а лінія">
+<a class="case-card" href="/en/cases/melanoma-nivo-relatlimab.html"
+   data-default-order="555"
+   data-name="Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MF-SEZARY · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_relapsed_2l.json</div>
+  <h3>Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)</h3>
+  <p>Drift: KB scopeє nivo+rela до 2L post-BRAFi; модельовано як 2L з frailty. RELATIVITY-047 анкер 1L FDA.</p>
+  <div class="case-foot">patient_melanoma_nivo_relatlimab.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mf_sezary-biomarker-act.html"
-   data-default-order="377"
-   data-name="DIS-MF-SEZARY · Actionable біомаркер present">
+<a class="case-card" href="/en/cases/melanoma-adjuvant-pembro-stage-iii.html"
+   data-default-order="556"
+   data-name="Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MF-SEZARY · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_biomarker_act.json</div>
+  <h3>Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)</h3>
+  <p>Drift: adjuvant melanoma algo не існує в KB; engine output = met-1L IO doublet. KEYNOTE-054 анкер у comment, motivation для майбутнього ALGO-MELANOMA-ADJUVANT.</p>
+  <div class="case-foot">patient_melanoma_adjuvant_pembro_stage_iii.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mf_sezary-high-risk.html"
-   data-default-order="378"
-   data-name="DIS-MF-SEZARY · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MF-SEZARY · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_high_risk.json</div>
+</section>
+<section class="case-list" data-disease-id="DIS-DLBCL-NOS" hidden>
+  <header class="case-list-header">
+    <h2>Diffuse Large B-Cell Lymphoma, Not Otherwise Specified</h2>
+    <span class="case-list-count">12 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/dlbcl-chemorefractory-cart.html"
+   data-default-order="35"
+   data-name="DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)</h3>
+  <p>DLBCL з primary refractory disease (PD на R-CHOP) — engine обирає axi-cel CAR-T (ZUMA-7: 2L CAR-T &gt; salvage+autoSCT для early-failure).</p>
+  <div class="case-foot">patient_dlbcl_chemorefractory_for_cart.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mm-frail.html"
-   data-default-order="379"
-   data-name="DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)">
+<a class="case-card" href="/en/cases/dlbcl-relapsed-te-ineligible.html"
+   data-default-order="36"
+   data-name="DLBCL NOS · Relapsed (Transplant-Ineligible)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL NOS · Relapsed (Transplant-Ineligible)</h3>
+  <p>DLBCL relapsed, transplant-ineligible через age + comorbidity — engine обирає Pola-BR (POLARGO) або loncastuximab tesirine.</p>
+  <div class="case-foot">patient_dlbcl_relapsed_transplant_ineligible.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-dlbcl_nos.html"
+   data-default-order="114"
+   data-name="DIS-DLBCL-NOS — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Diffuse Large B-Cell Lymphoma, Not Otherwise Specified. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_dlbcl_nos.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-dlbcl_nos-frail.html"
+   data-default-order="251"
+   data-name="DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <h3>DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
   <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_frail.json</div>
+  <div class="case-foot">variant_dlbcl_nos_frail.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mm-organ-dysf.html"
-   data-default-order="380"
-   data-name="DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/variant-dlbcl_nos-organ-dysf.html"
+   data-default-order="252"
+   data-name="DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <h3>DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
   <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_organ_dysf.json</div>
+  <div class="case-foot">variant_dlbcl_nos_organ_dysf.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mm-infection-hbv.html"
-   data-default-order="381"
-   data-name="DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/variant-dlbcl_nos-infection-hbv.html"
+   data-default-order="253"
+   data-name="DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <h3>DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
   <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_infection_hbv.json</div>
+  <div class="case-foot">variant_dlbcl_nos_infection_hbv.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mm-relapsed-2l.html"
-   data-default-order="382"
-   data-name="DIS-MM · Релапс / 2-а лінія">
+<a class="case-card" href="/en/cases/variant-dlbcl_nos-relapsed-2l.html"
+   data-default-order="254"
+   data-name="DIS-DLBCL-NOS · Релапс / 2-а лінія">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MM · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_relapsed_2l.json</div>
+  <h3>DIS-DLBCL-NOS · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_relapsed_2l.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mm-biomarker-act.html"
-   data-default-order="383"
-   data-name="DIS-MM · Actionable біомаркер present">
+<a class="case-card" href="/en/cases/variant-dlbcl_nos-biomarker-act.html"
+   data-default-order="255"
+   data-name="DIS-DLBCL-NOS · Actionable біомаркер present">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MM · Actionable біомаркер present</h3>
+  <h3>DIS-DLBCL-NOS · Actionable біомаркер present</h3>
   <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_biomarker_act.json</div>
+  <div class="case-foot">variant_dlbcl_nos_biomarker_act.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mm-high-risk.html"
-   data-default-order="384"
-   data-name="DIS-MM · High-risk biology / bulky disease">
+<a class="case-card" href="/en/cases/variant-dlbcl_nos-high-risk.html"
+   data-default-order="256"
+   data-name="DIS-DLBCL-NOS · High-risk biology / bulky disease">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MM · High-risk biology / bulky disease</h3>
+  <h3>DIS-DLBCL-NOS · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_high_risk.json</div>
+  <div class="case-foot">variant_dlbcl_nos_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mpnst-frail.html"
-   data-default-order="385"
-   data-name="DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+<a class="case-card" href="/en/cases/dlbcl-2l-pola-r-b.html"
+   data-default-order="578"
+   data-name="DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)</h3>
+  <p>ASCT-ineligible cardiac-comorbidity, late relapse. Engine: ALGO-2L → IND-DLBCL-2L-POLA-R-BENDAMUSTINE (distinct від існуючого relapsed_transplant_ineligible).</p>
+  <div class="case-foot">patient_dlbcl_2l_pola_r_b.json</div>
+</a>
+<a class="case-card" href="/en/cases/dlbcl-3l-axi-cel.html"
+   data-default-order="579"
+   data-name="DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)</h3>
+  <p>Прогрес після RCHOP→Pola-BR. Engine: ALGO-2L default = Pola-BR; axi-cel surfaces як aggressive alternative track. Distinct від chemorefractory_for_cart.</p>
+  <div class="case-foot">patient_dlbcl_3l_axi_cel.json</div>
+</a>
+<a class="case-card" href="/en/cases/dlbcl-primary-refractory-loncast.html"
+   data-default-order="580"
+   data-name="DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)</h3>
+  <p>Primary-refractory frail non-CAR-T-eligible. Drift: REG-LONCASTUXIMAB-TESIRINE відсутній; engine default = Pola-BR (re-MMAE inappropriate); LOTIS-2 анкер у comment.</p>
+  <div class="case-foot">patient_dlbcl_primary_refractory_loncast_post_pola.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ENDOMETRIAL" hidden>
+  <header class="case-list-header">
+    <h2>Endometrial carcinoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-endometrial.html"
+   data-default-order="116"
+   data-name="DIS-ENDOMETRIAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Endometrial carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_endometrial.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-endometrial-frail.html"
+   data-default-order="262"
+   data-name="DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <h3>DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-endometrial-organ-dysf.html"
+   data-default-order="263"
+   data-name="DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-endometrial-infection-hbv.html"
+   data-default-order="264"
+   data-name="DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-endometrial-relapsed-2l.html"
+   data-default-order="265"
+   data-name="DIS-ENDOMETRIAL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-endometrial-biomarker-act.html"
+   data-default-order="266"
+   data-name="DIS-ENDOMETRIAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-endometrial-high-risk.html"
+   data-default-order="267"
+   data-name="DIS-ENDOMETRIAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/endometrial-dmmr-pembro-kn775.html"
+   data-default-order="561"
+   data-name="Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)</h3>
+  <p>Advanced/recurrent dMMR endometrial. Engine: → IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO (NRG-GY018 mPFS NR vs 7.6).</p>
+  <div class="case-foot">patient_endometrial_dmmr_pembro_kn775.json</div>
+</a>
+<a class="case-card" href="/en/cases/endometrial-p53-abn-dosta-ruby.html"
+   data-default-order="562"
+   data-name="Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)</h3>
+  <p>Advanced p53-abnormal endometrial. Drift: engine default = pembro+chemo; RUBY dostarlimab анкер у comment.</p>
+  <div class="case-foot">patient_endometrial_p53_abn_dosta_kn775.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-EATL" hidden>
+  <header class="case-list-header">
+    <h2>Enteropathy-Associated T-Cell Lymphoma</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/eatl-typical.html"
+   data-default-order="53"
+   data-name="EATL · Typical (Celiac, CHOEP → autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>EATL · Typical (Celiac, CHOEP → autoSCT)</h3>
+  <p>EATL у пацієнта з celiac disease — engine обирає CHOEP induction → autoSCT consolidation (NLG-T-01).</p>
+  <div class="case-foot">patient_eatl_typical.json</div>
+</a>
+<a class="case-card" href="/en/cases/eatl-relapsed-post-choep.html"
+   data-default-order="54"
+   data-name="EATL · Relapsed post-CHOEP (ICE Salvage)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>EATL · Relapsed post-CHOEP (ICE Salvage)</h3>
+  <p>EATL relapsed після CHOEP — engine обирає ICE salvage; alloHCT для chemosensitive.</p>
+  <div class="case-foot">patient_eatl_relapsed_post_choep.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-eatl.html"
+   data-default-order="115"
+   data-name="DIS-EATL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-EATL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Enteropathy-Associated T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_eatl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-eatl-frail.html"
+   data-default-order="257"
+   data-name="DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
   <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_frail.json</div>
+  <div class="case-foot">variant_eatl_frail.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mpnst-organ-dysf.html"
-   data-default-order="386"
-   data-name="DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/variant-eatl-organ-dysf.html"
+   data-default-order="258"
+   data-name="DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <h3>DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
   <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_organ_dysf.json</div>
+  <div class="case-foot">variant_eatl_organ_dysf.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mpnst-infection-hbv.html"
-   data-default-order="387"
-   data-name="DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/variant-eatl-infection-hbv.html"
+   data-default-order="259"
+   data-name="DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <h3>DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
   <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_infection_hbv.json</div>
+  <div class="case-foot">variant_eatl_infection_hbv.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mpnst-biomarker-act.html"
-   data-default-order="388"
-   data-name="DIS-MPNST · Actionable біомаркер present">
+<a class="case-card" href="/en/cases/variant-eatl-biomarker-act.html"
+   data-default-order="260"
+   data-name="DIS-EATL · Actionable біомаркер present">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MPNST · Actionable біомаркер present</h3>
+  <h3>DIS-EATL · Actionable біомаркер present</h3>
   <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_biomarker_act.json</div>
+  <div class="case-foot">variant_eatl_biomarker_act.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mpnst-high-risk.html"
-   data-default-order="389"
-   data-name="DIS-MPNST · High-risk biology / bulky disease">
+<a class="case-card" href="/en/cases/variant-eatl-high-risk.html"
+   data-default-order="261"
+   data-name="DIS-EATL · High-risk biology / bulky disease">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MPNST · High-risk biology / bulky disease</h3>
+  <h3>DIS-EATL · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_high_risk.json</div>
+  <div class="case-foot">variant_eatl_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mtc-frail.html"
-   data-default-order="390"
-   data-name="DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ESOPHAGEAL" hidden>
+  <header class="case-list-header">
+    <h2>Esophageal carcinoma</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-esophageal.html"
+   data-default-order="117"
+   data-name="DIS-ESOPHAGEAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Esophageal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_esophageal.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-esophageal-frail.html"
+   data-default-order="268"
+   data-name="DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <h3>DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
   <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_frail.json</div>
+  <div class="case-foot">variant_esophageal_frail.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mtc-organ-dysf.html"
-   data-default-order="391"
-   data-name="DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/variant-esophageal-organ-dysf.html"
+   data-default-order="269"
+   data-name="DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <h3>DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
   <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_organ_dysf.json</div>
+  <div class="case-foot">variant_esophageal_organ_dysf.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mtc-infection-hbv.html"
-   data-default-order="392"
-   data-name="DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/variant-esophageal-infection-hbv.html"
+   data-default-order="270"
+   data-name="DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <h3>DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
   <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_infection_hbv.json</div>
+  <div class="case-foot">variant_esophageal_infection_hbv.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mtc-biomarker-act.html"
-   data-default-order="393"
-   data-name="DIS-MTC · Actionable біомаркер present">
+<a class="case-card" href="/en/cases/variant-esophageal-relapsed-2l.html"
+   data-default-order="271"
+   data-name="DIS-ESOPHAGEAL · Релапс / 2-а лінія">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MTC · Actionable біомаркер present</h3>
+  <h3>DIS-ESOPHAGEAL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-esophageal-biomarker-act.html"
+   data-default-order="272"
+   data-name="DIS-ESOPHAGEAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · Actionable біомаркер present</h3>
   <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_biomarker_act.json</div>
+  <div class="case-foot">variant_esophageal_biomarker_act.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-mtc-high-risk.html"
-   data-default-order="394"
-   data-name="DIS-MTC · High-risk biology / bulky disease">
+<a class="case-card" href="/en/cases/variant-esophageal-high-risk.html"
+   data-default-order="273"
+   data-name="DIS-ESOPHAGEAL · High-risk biology / bulky disease">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-MTC · High-risk biology / bulky disease</h3>
+  <h3>DIS-ESOPHAGEAL · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_high_risk.json</div>
+  <div class="case-foot">variant_esophageal_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/esophageal-cross-then-nivo.html"
+   data-default-order="568"
+   data-name="Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)</h3>
+  <p>Resectable adeno з ypT+/ypN+ residual. Drift: ALGO-1L emit only CROSS-NEOADJUVANT; CheckMate-577 adjuvant nivo неreachable (PROPOSAL §17 territory).</p>
+  <div class="case-foot">patient_esophageal_adeno_neoadj_cross_then_nivo.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ET" hidden>
+  <header class="case-list-header">
+    <h2>Essential Thrombocythemia</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/et-high-risk-hu.html"
+   data-default-order="87"
+   data-name="Essential Thrombocythemia · High Risk (HU)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Essential Thrombocythemia · High Risk (HU)</h3>
+  <p>ET high-risk (age &gt;60 + JAK2+ + thrombosis) — engine обирає hydroxyurea + ASA; anagrelide як 2L (PT-1).</p>
+  <div class="case-foot">patient_et_high_risk_hu.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-et.html"
+   data-default-order="118"
+   data-name="DIS-ET — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Essential Thrombocythemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_et.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-et-frail.html"
+   data-default-order="274"
+   data-name="DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-et-organ-dysf.html"
+   data-default-order="275"
+   data-name="DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-et-infection-hbv.html"
+   data-default-order="276"
+   data-name="DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-et-relapsed-2l.html"
+   data-default-order="277"
+   data-name="DIS-ET · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-et-biomarker-act.html"
+   data-default-order="278"
+   data-name="DIS-ET · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-et-high-risk.html"
+   data-default-order="279"
+   data-name="DIS-ET · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-ET · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NK-T-NASAL" hidden>
+  <header class="case-list-header">
+    <h2>Extranodal NK/T-Cell Lymphoma, Nasal Type</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/nk-t-nasal-localized.html"
+   data-default-order="61"
+   data-name="NK/T-Nasal · Localized (P-GEMOX + RT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NK/T-Nasal · Localized (P-GEMOX + RT)</h3>
+  <p>Localized extranodal NK/T-cell lymphoma, nasal type — engine обирає concurrent P-GEMOX + RT (anthracycline-resistant biology).</p>
+  <div class="case-foot">patient_nk_t_nasal_localized.json</div>
+</a>
+<a class="case-card" href="/en/cases/nk-t-nasal-relapsed.html"
+   data-default-order="62"
+   data-name="NK/T-Nasal · Relapsed (Avelumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NK/T-Nasal · Relapsed (Avelumab)</h3>
+  <p>NK/T-nasal relapsed — engine обирає avelumab (NCCN-listed PD-L1 inhibitor; promoted from stub).</p>
+  <div class="case-foot">patient_nk_t_nasal_relapsed.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-nk_t_nasal.html"
+   data-default-order="141"
+   data-name="DIS-NK-T-NASAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Extranodal NK/T-Cell Lymphoma, Nasal Type. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nk_t_nasal.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-nk_t_nasal-frail.html"
    data-default-order="395"
@@ -4390,71 +2641,2139 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_nk_t_nasal_high_risk.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-nlpbl-frail.html"
-   data-default-order="401"
-   data-name="DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-FL" hidden>
+  <header class="case-list-header">
+    <h2>Follicular Lymphoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/fl-low-burden.html"
+   data-default-order="9"
+   data-name="Follicular · Low Burden (Watch-and-Wait)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Follicular · Low Burden (Watch-and-Wait)</h3>
+  <p>FL grade 1-2, asymptomatic, no GELF criteria — engine обирає surveillance трек (3 plans usable side-by-side, default = W&amp;W).</p>
+  <div class="case-foot">patient_fl_low_burden.json</div>
+</a>
+<a class="case-card" href="/en/cases/fl-high-burden.html"
+   data-default-order="10"
+   data-name="Follicular · High Burden (BR)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Follicular · High Burden (BR)</h3>
+  <p>FL з 8 cm масою + B-symptoms + LDH↑ — RF-FL-HIGH-TUMOR-BURDEN-GELF fired. Engine обирає BR (бендамустин + ритуксимаб); reuse REG-BR-STANDARD з HCV-MZL.</p>
+  <div class="case-foot">patient_fl_high_burden.json</div>
+</a>
+<a class="case-card" href="/en/cases/fl-transformation.html"
+   data-default-order="11"
+   data-name="Follicular · Transformation Suspect (R-CHOP)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Follicular · Transformation Suspect (R-CHOP)</h3>
+  <p>FL з rapid progression + LDH doubling — RF-FL-TRANSFORMATION-SUSPECT fired. Engine обирає R-CHOP (трактує як DLBCL pathway).</p>
+  <div class="case-foot">patient_fl_transformation.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-fl.html"
+   data-default-order="119"
+   data-name="DIS-FL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-FL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Follicular Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_fl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-fl-frail.html"
+   data-default-order="280"
+   data-name="DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <h3>DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
   <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_frail.json</div>
+  <div class="case-foot">variant_fl_frail.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-nlpbl-organ-dysf.html"
-   data-default-order="402"
-   data-name="DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/en/cases/variant-fl-organ-dysf.html"
+   data-default-order="281"
+   data-name="DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <h3>DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
   <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_organ_dysf.json</div>
+  <div class="case-foot">variant_fl_organ_dysf.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-nlpbl-infection-hbv.html"
-   data-default-order="403"
-   data-name="DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/en/cases/variant-fl-infection-hbv.html"
+   data-default-order="282"
+   data-name="DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <h3>DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
   <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_infection_hbv.json</div>
+  <div class="case-foot">variant_fl_infection_hbv.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-nlpbl-relapsed-2l.html"
-   data-default-order="404"
-   data-name="DIS-NLPBL · Релапс / 2-а лінія">
+<a class="case-card" href="/en/cases/variant-fl-biomarker-act.html"
+   data-default-order="283"
+   data-name="DIS-FL · Actionable біомаркер present">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-NLPBL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-nlpbl-biomarker-act.html"
-   data-default-order="405"
-   data-name="DIS-NLPBL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · Actionable біомаркер present</h3>
+  <h3>DIS-FL · Actionable біомаркер present</h3>
   <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_biomarker_act.json</div>
+  <div class="case-foot">variant_fl_biomarker_act.json</div>
 </a>
-<a class="case-card" href="/en/cases/variant-nlpbl-high-risk.html"
-   data-default-order="406"
-   data-name="DIS-NLPBL · High-risk biology / bulky disease">
+<a class="case-card" href="/en/cases/variant-fl-high-risk.html"
+   data-default-order="284"
+   data-name="DIS-FL · High-risk biology / bulky disease">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DIS-NLPBL · High-risk biology / bulky disease</h3>
+  <h3>DIS-FL · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_high_risk.json</div>
+  <div class="case-foot">variant_fl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GASTRIC" hidden>
+  <header class="case-list-header">
+    <h2>Gastric and gastroesophageal junction adenocarcinoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-gastric.html"
+   data-default-order="120"
+   data-name="DIS-GASTRIC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Gastric and gastroesophageal junction adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_gastric.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gastric-frail.html"
+   data-default-order="285"
+   data-name="DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gastric-organ-dysf.html"
+   data-default-order="286"
+   data-name="DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gastric-infection-hbv.html"
+   data-default-order="287"
+   data-name="DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gastric-relapsed-2l.html"
+   data-default-order="288"
+   data-name="DIS-GASTRIC · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gastric-biomarker-act.html"
+   data-default-order="289"
+   data-name="DIS-GASTRIC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gastric-high-risk.html"
+   data-default-order="290"
+   data-name="DIS-GASTRIC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/gastric-her2-pos-toga.html"
+   data-default-order="566"
+   data-name="Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)</h3>
+  <p>Метастатична HER2+ gastric. Engine: RF-HIGH-RISK-BIOLOGY → IND-GASTRIC-METASTATIC-1L-HER2-TOGA (TOGA mOS 13.8 мо).</p>
+  <div class="case-foot">patient_gastric_her2_pos_toga.json</div>
+</a>
+<a class="case-card" href="/en/cases/gastric-pdl1-cps-chemo-nivo.html"
+   data-default-order="567"
+   data-name="Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)</h3>
+  <p>Метастатична HER2- CPS≥5 gastric. Engine: HER2- step 2 → IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI (CM-649 mOS 14.4 мо).</p>
+  <div class="case-foot">patient_gastric_pdl1_cps_high_chemo_nivo.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GIST" hidden>
+  <header class="case-list-header">
+    <h2>Gastrointestinal stromal tumor</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-gist.html"
+   data-default-order="122"
+   data-name="DIS-GIST — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GIST — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Gastrointestinal stromal tumor. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_gist.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gist-frail.html"
+   data-default-order="296"
+   data-name="DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gist-organ-dysf.html"
+   data-default-order="297"
+   data-name="DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gist-infection-hbv.html"
+   data-default-order="298"
+   data-name="DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gist-biomarker-act.html"
+   data-default-order="299"
+   data-name="DIS-GIST · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gist-high-risk.html"
+   data-default-order="300"
+   data-name="DIS-GIST · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GBM" hidden>
+  <header class="case-list-header">
+    <h2>Glioblastoma</h2>
+    <span class="case-list-count">7 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/gbm-stupp.html"
+   data-default-order="97"
+   data-name="Glioblastoma · Newly Diagnosed (Stupp Protocol)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Glioblastoma · Newly Diagnosed (Stupp Protocol)</h3>
+  <p>GBM IDH-WT WHO grade 4 — engine обирає Stupp: maximal safe resection → RT + concurrent TMZ → adjuvant TMZ × 6; TTFields для MGMT-methylated.</p>
+  <div class="case-foot">patient_gbm_newly_diagnosed_stupp.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-gbm.html"
+   data-default-order="121"
+   data-name="DIS-GBM — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GBM — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Glioblastoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_gbm.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gbm-frail.html"
+   data-default-order="291"
+   data-name="DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gbm-organ-dysf.html"
+   data-default-order="292"
+   data-name="DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gbm-infection-hbv.html"
+   data-default-order="293"
+   data-name="DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gbm-biomarker-act.html"
+   data-default-order="294"
+   data-name="DIS-GBM · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-gbm-high-risk.html"
+   data-default-order="295"
+   data-name="DIS-GBM · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HCL" hidden>
+  <header class="case-list-header">
+    <h2>Hairy Cell Leukemia</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/hcl-typical.html"
+   data-default-order="21"
+   data-name="Hairy Cell Leukemia (Cladribine 7-day)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Hairy Cell Leukemia (Cladribine 7-day)</h3>
+  <p>Волосатоклітинний лейкоз з cytopenia + splenomegaly — engine обирає 1 курс cladribine 7 днів. ~85% durable CR.</p>
+  <div class="case-foot">patient_hcl_typical.json</div>
+</a>
+<a class="case-card" href="/en/cases/hcl-relapsed-braf.html"
+   data-default-order="45"
+   data-name="HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)</h3>
+  <p>HCL relapsed з BRAF-V600E+ — engine обирає vemurafenib+rituximab (Tiacci); BRAF-WT route → cladribine retreatment.</p>
+  <div class="case-foot">patient_hcl_relapsed_braf.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-hcl.html"
+   data-default-order="125"
+   data-name="DIS-HCL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Hairy Cell Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hcl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcl-frail.html"
+   data-default-order="306"
+   data-name="DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcl-organ-dysf.html"
+   data-default-order="307"
+   data-name="DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcl-infection-hbv.html"
+   data-default-order="308"
+   data-name="DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcl-relapsed-2l.html"
+   data-default-order="309"
+   data-name="DIS-HCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcl-biomarker-act.html"
+   data-default-order="310"
+   data-name="DIS-HCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcl-high-risk.html"
+   data-default-order="311"
+   data-name="DIS-HCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HCV-MZL" hidden>
+  <header class="case-list-header">
+    <h2>HCV-associated Marginal Zone Lymphoma</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/diagnostic-lymphoma-confirmed.html"
+   data-default-order="6"
+   data-name="Lymphoma Confirmed · Post-Biopsy (Treatment Plan)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Lymphoma Confirmed · Post-Biopsy (Treatment Plan)</h3>
+  <p>Той самий пацієнт після підтвердження гістології — diagnostic→treatment promotion через revise_plan.</p>
+  <div class="case-foot">patient_diagnostic_lymphoma_confirmed.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-hcv_mzl.html"
+   data-default-order="126"
+   data-name="DIS-HCV-MZL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для HCV-associated Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hcv_mzl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcv_mzl-frail.html"
+   data-default-order="312"
+   data-name="DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcv_mzl-organ-dysf.html"
+   data-default-order="313"
+   data-name="DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcv_mzl-infection-hbv.html"
+   data-default-order="314"
+   data-name="DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcv_mzl-relapsed-2l.html"
+   data-default-order="315"
+   data-name="DIS-HCV-MZL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcv_mzl-biomarker-act.html"
+   data-default-order="316"
+   data-name="DIS-HCV-MZL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcv_mzl-high-risk.html"
+   data-default-order="317"
+   data-name="DIS-HCV-MZL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HNSCC" hidden>
+  <header class="case-list-header">
+    <h2>Head and neck squamous cell carcinoma</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-hnscc.html"
+   data-default-order="128"
+   data-name="DIS-HNSCC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Head and neck squamous cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hnscc.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hnscc-frail.html"
+   data-default-order="324"
+   data-name="DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hnscc-organ-dysf.html"
+   data-default-order="325"
+   data-name="DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hnscc-infection-hbv.html"
+   data-default-order="326"
+   data-name="DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hnscc-biomarker-act.html"
+   data-default-order="327"
+   data-name="DIS-HNSCC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hnscc-high-risk.html"
+   data-default-order="328"
+   data-name="DIS-HNSCC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/hnscc-cps-high-pembro-mono.html"
+   data-default-order="572"
+   data-name="HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)</h3>
+  <p>R/M HNSCC CPS≥20. Engine: → IND-HNSCC-RM-1L-PEMBRO-MONO-CPS-HIGH (KEYNOTE-048 mOS 14.9 мо).</p>
+  <div class="case-foot">patient_hnscc_cps_high_pembro_mono.json</div>
+</a>
+<a class="case-card" href="/en/cases/hnscc-extreme-cetux-platin.html"
+   data-default-order="573"
+   data-name="HNSCC · R/M EXTREME · Cetux+platin+5FU">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>HNSCC · R/M EXTREME · Cetux+platin+5FU</h3>
+  <p>Drift: IND-HNSCC-RM-1L-EXTREME не authored у KB; engine fallback = pembro+chemo. EXTREME анкер у comment, highest content gap.</p>
+  <div class="case-foot">patient_hnscc_extreme_cetux_platin_5fu.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HCC" hidden>
+  <header class="case-list-header">
+    <h2>Hepatocellular carcinoma</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-hcc.html"
+   data-default-order="124"
+   data-name="DIS-HCC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Hepatocellular carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hcc.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcc-frail.html"
+   data-default-order="301"
+   data-name="DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcc-organ-dysf.html"
+   data-default-order="302"
+   data-name="DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcc-infection-hbv.html"
+   data-default-order="303"
+   data-name="DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcc-biomarker-act.html"
+   data-default-order="304"
+   data-name="DIS-HCC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hcc-high-risk.html"
+   data-default-order="305"
+   data-name="DIS-HCC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/hcc-atezo-bev-imbrave150.html"
+   data-default-order="564"
+   data-name="HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)</h3>
+  <p>HCC Child-Pugh A, fit. Engine: → IND-HCC-SYSTEMIC-1L-ATEZO-BEV (IMbrave150 mOS 19.2 мо).</p>
+  <div class="case-foot">patient_hcc_atezo_bev_imbrave150.json</div>
+</a>
+<a class="case-card" href="/en/cases/hcc-durva-treme-stride.html"
+   data-default-order="565"
+   data-name="HCC · 1L · Durva+treme (HIMALAYA STRIDE)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>HCC · 1L · Durva+treme (HIMALAYA STRIDE)</h3>
+  <p>HCC з high-risk varices. Engine: RF-HCC-VARICEAL-BLEED step 1 → IND-HCC-SYSTEMIC-1L-DURVA-TREME (HIMALAYA mOS 16.4 мо).</p>
+  <div class="case-foot">patient_hcc_durva_treme_stride.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HSTCL" hidden>
+  <header class="case-list-header">
+    <h2>Hepatosplenic T-Cell Lymphoma</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/hstcl-fit-younger.html"
+   data-default-order="55"
+   data-name="HSTCL · Fit Younger (ICE/IVAC → alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HSTCL · Fit Younger (ICE/IVAC → alloHCT)</h3>
+  <p>Hepatosplenic T-cell Lymphoma у молодої особи, ECOG 0 — engine обирає intensive ICE/IVAC → upfront alloHCT (CHOP неадекватний).</p>
+  <div class="case-foot">patient_hstcl_fit_younger.json</div>
+</a>
+<a class="case-card" href="/en/cases/hstcl-iatrogenic-ibd.html"
+   data-default-order="56"
+   data-name="HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)</h3>
+  <p>HSTCL у IBD-пацієнта на тривалій thiopurine+anti-TNF therapy — engine припиняє imunosuppression + CHOEP-unfit fallback з branching algorithm.</p>
+  <div class="case-foot">patient_hstcl_iatrogenic_ibd.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-hstcl.html"
+   data-default-order="129"
+   data-name="DIS-HSTCL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Hepatosplenic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hstcl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hstcl-frail.html"
+   data-default-order="329"
+   data-name="DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hstcl-organ-dysf.html"
+   data-default-order="330"
+   data-name="DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hstcl-infection-hbv.html"
+   data-default-order="331"
+   data-name="DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hstcl-biomarker-act.html"
+   data-default-order="332"
+   data-name="DIS-HSTCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hstcl-high-risk.html"
+   data-default-order="333"
+   data-name="DIS-HSTCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HGBL-DH" hidden>
+  <header class="case-list-header">
+    <h2>High-Grade B-Cell Lymphoma, Double-Hit / Triple-Hit</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/hgbl-double-hit.html"
+   data-default-order="23"
+   data-name="HGBL · Double-Hit (DA-EPOCH-R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>HGBL · Double-Hit (DA-EPOCH-R)</h3>
+  <p>High-Grade B-Cell Lymphoma з MYC + BCL2 break-apart — engine обирає DA-EPOCH-R (substantial OS improvement vs R-CHOP); reuse схеми з Burkitt.</p>
+  <div class="case-foot">patient_hgbl_double_hit.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-hgbl_dh.html"
+   data-default-order="127"
+   data-name="DIS-HGBL-DH — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для High-Grade B-Cell Lymphoma, Double-Hit / Triple-Hit. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hgbl_dh.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hgbl_dh-frail.html"
+   data-default-order="318"
+   data-name="DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hgbl_dh-organ-dysf.html"
+   data-default-order="319"
+   data-name="DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hgbl_dh-infection-hbv.html"
+   data-default-order="320"
+   data-name="DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hgbl_dh-relapsed-2l.html"
+   data-default-order="321"
+   data-name="DIS-HGBL-DH · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hgbl_dh-biomarker-act.html"
+   data-default-order="322"
+   data-name="DIS-HGBL-DH · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-hgbl_dh-high-risk.html"
+   data-default-order="323"
+   data-name="DIS-HGBL-DH · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-IFS" hidden>
+  <header class="case-list-header">
+    <h2>Infantile fibrosarcoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-ifs.html"
+   data-default-order="130"
+   data-name="DIS-IFS — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IFS — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Infantile fibrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ifs.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ifs-frail.html"
+   data-default-order="334"
+   data-name="DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ifs-organ-dysf.html"
+   data-default-order="335"
+   data-name="DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ifs-infection-hbv.html"
+   data-default-order="336"
+   data-name="DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ifs-biomarker-act.html"
+   data-default-order="337"
+   data-name="DIS-IFS · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IFS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ifs-high-risk.html"
+   data-default-order="338"
+   data-name="DIS-IFS · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IFS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-IMT" hidden>
+  <header class="case-list-header">
+    <h2>Inflammatory myofibroblastic tumor</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-imt.html"
+   data-default-order="131"
+   data-name="DIS-IMT — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IMT — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Inflammatory myofibroblastic tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_imt.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-imt-frail.html"
+   data-default-order="339"
+   data-name="DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-imt-organ-dysf.html"
+   data-default-order="340"
+   data-name="DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-imt-infection-hbv.html"
+   data-default-order="341"
+   data-name="DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-imt-biomarker-act.html"
+   data-default-order="342"
+   data-name="DIS-IMT · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-imt-high-risk.html"
+   data-default-order="343"
+   data-name="DIS-IMT · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-BREAST" hidden>
+  <header class="case-list-header">
+    <h2>Invasive breast cancer</h2>
+    <span class="case-list-count">15 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-breast.html"
+   data-default-order="105"
+   data-name="DIS-BREAST — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Invasive breast cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_breast.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-breast-frail.html"
+   data-default-order="200"
+   data-name="DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-breast-organ-dysf.html"
+   data-default-order="201"
+   data-name="DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-breast-infection-hbv.html"
+   data-default-order="202"
+   data-name="DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-breast-relapsed-2l.html"
+   data-default-order="203"
+   data-name="DIS-BREAST · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-breast-biomarker-act.html"
+   data-default-order="204"
+   data-name="DIS-BREAST · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-breast-high-risk.html"
+   data-default-order="205"
+   data-name="DIS-BREAST · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-hr-pos-met-1l-cdk46i.html"
+   data-default-order="538"
+   data-name="Breast · HR+/HER2- met 1L · AI+palbociclib (PALOMA-2)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · HR+/HER2- met 1L · AI+palbociclib (PALOMA-2)</h3>
+  <p>Метастатична HR+/HER2-, postmenopausal. Engine: ALGO-1L → IND-BREAST-HR-POS-MET-1L-CDKI (PALOMA-2 mPFS 27.6 мо).</p>
+  <div class="case-foot">patient_breast_hr_pos_her2_neg_met_1l_cdk46i.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-hr-pos-pik3ca-alpelisib.html"
+   data-default-order="539"
+   data-name="Breast · HR+ post-CDK4/6i · PIK3CA H1047R · Alpelisib (SOLAR-1)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · HR+ post-CDK4/6i · PIK3CA H1047R · Alpelisib (SOLAR-1)</h3>
+  <p>Прогрес на CDK4/6i, PIK3CA H1047R hot-spot. Engine drift: HER2-2L дефолт; alpelisib+fulvestrant анкер у comment.</p>
+  <div class="case-foot">patient_breast_hr_pos_post_cdk46i_pik3ca_alpelisib.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-her2-pos-early-katherine.html"
+   data-default-order="540"
+   data-name="Breast · HER2+ early · Neoadj TCHP → KATHERINE T-DM1">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · HER2+ early · Neoadj TCHP → KATHERINE T-DM1</h3>
+  <p>HER2+ early-stage, неоадʼювантна TCHP → adjuvant T-DM1 при non-pCR (KATHERINE 50% iDFS benefit). Drift: engine routes до met-1L.</p>
+  <div class="case-foot">patient_breast_her2_pos_early_neoadj_kn522_path.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-her2-pos-met-1l-thp.html"
+   data-default-order="541"
+   data-name="Breast · HER2+ met 1L · Docetaxel+THP (CLEOPATRA)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · HER2+ met 1L · Docetaxel+THP (CLEOPATRA)</h3>
+  <p>HER2+ метастатична 1L, docetaxel+trastuzumab+pertuzumab. Engine: ALGO-1L → IND-BREAST-HER2-POS-MET-1L-THP (CLEOPATRA mOS 57 мо).</p>
+  <div class="case-foot">patient_breast_her2_pos_met_1l_thp.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-her2-pos-met-2l-tdxd.html"
+   data-default-order="542"
+   data-name="Breast · HER2+ met 2L · T-DXd (DESTINY-Breast03)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · HER2+ met 2L · T-DXd (DESTINY-Breast03)</h3>
+  <p>HER2+ метастатична 2L після THP. Engine: ALGO-HER2-POS-2L → IND-BREAST-HER2-POS-MET-2L-TDXD (DB03 mPFS 28.8 мо).</p>
+  <div class="case-foot">patient_breast_her2_pos_met_2l_tdxd.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-tnbc-neoadj-kn522.html"
+   data-default-order="543"
+   data-name="Breast · TNBC stage II-III · Neoadj pembro+chemo (KEYNOTE-522)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · TNBC stage II-III · Neoadj pembro+chemo (KEYNOTE-522)</h3>
+  <p>TNBC II-III, неоадʼювантна pembro+carbo+pacli→AC (pCR 64%). Drift: engine routes до HR+ default; clinical anchor у comment.</p>
+  <div class="case-foot">patient_breast_tnbc_neoadj_kn522_pembro_chemo.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-brca-germline-olaparib.html"
+   data-default-order="544"
+   data-name="Breast · BRCA1 germline met · Olaparib (OlympiAD)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · BRCA1 germline met · Olaparib (OlympiAD)</h3>
+  <p>BRCA1 germline pathogenic, метастатична HER2-. PARPi мono. Drift: engine routes до HR+/HER2- 1L CDK4/6i default; clinical anchor у comment.</p>
+  <div class="case-foot">patient_breast_brca_germline_met_olaparib.json</div>
+</a>
+<a class="case-card" href="/en/cases/breast-tnbc-met-2l-sacituzumab.html"
+   data-default-order="545"
+   data-name="Breast · TNBC met 2L · Sacituzumab govitecan (ASCENT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Breast · TNBC met 2L · Sacituzumab govitecan (ASCENT)</h3>
+  <p>TNBC метастатична 2L+. Drift: engine routes до HER2-2L default; sacituzumab анкер у comment.</p>
+  <div class="case-foot">patient_breast_tnbc_met_sacituzumab_2l.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GLIOMA-LOW-GRADE" hidden>
+  <header class="case-list-header">
+    <h2>Low-grade glioma</h2>
+    <span class="case-list-count">1 example</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-glioma_low_grade.html"
+   data-default-order="123"
+   data-name="DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Low-grade glioma. Фактична наповненість бази для цієї хвороби — 50%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_glioma_low_grade.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MPNST" hidden>
+  <header class="case-list-header">
+    <h2>Malignant peripheral nerve sheath tumor</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-mpnst.html"
+   data-default-order="139"
+   data-name="DIS-MPNST — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Malignant peripheral nerve sheath tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mpnst.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mpnst-frail.html"
+   data-default-order="385"
+   data-name="DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mpnst-organ-dysf.html"
+   data-default-order="386"
+   data-name="DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mpnst-infection-hbv.html"
+   data-default-order="387"
+   data-name="DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mpnst-biomarker-act.html"
+   data-default-order="388"
+   data-name="DIS-MPNST · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mpnst-high-risk.html"
+   data-default-order="389"
+   data-name="DIS-MPNST · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MCL" hidden>
+  <header class="case-list-header">
+    <h2>Mantle Cell Lymphoma</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/mcl-fit-younger.html"
+   data-default-order="14"
+   data-name="Mantle Cell · Fit Younger (Intensive + autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Mantle Cell · Fit Younger (Intensive + autoSCT)</h3>
+  <p>MCL вік 58, ECOG 0, TP53-wt — engine обирає intensive R-CHOP/R-DHAP × 6 + autoSCT + R-maintenance × 3 years (Nordic protocol).</p>
+  <div class="case-foot">patient_mcl_fit_younger.json</div>
+</a>
+<a class="case-card" href="/en/cases/mcl-unfit-tp53.html"
+   data-default-order="15"
+   data-name="Mantle Cell · Unfit / TP53-mutant (BTKi+R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Mantle Cell · Unfit / TP53-mutant (BTKi+R)</h3>
+  <p>MCL вік 71, ECOG 2, TP53 mutation — RF-MCL-BLASTOID-OR-TP53 fired. Engine обирає acalabrutinib + rituximab (BTKi-based).</p>
+  <div class="case-foot">patient_mcl_unfit_or_tp53.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-mcl.html"
+   data-default-order="133"
+   data-name="DIS-MCL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Mantle Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mcl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mcl-frail.html"
+   data-default-order="349"
+   data-name="DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mcl-organ-dysf.html"
+   data-default-order="350"
+   data-name="DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mcl-infection-hbv.html"
+   data-default-order="351"
+   data-name="DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mcl-relapsed-2l.html"
+   data-default-order="352"
+   data-name="DIS-MCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mcl-biomarker-act.html"
+   data-default-order="353"
+   data-name="DIS-MCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mcl-high-risk.html"
+   data-default-order="354"
+   data-name="DIS-MCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/mcl-pirtobrutinib-3l.html"
+   data-default-order="582"
+   data-name="MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)</h3>
+  <p>Post-covalent-BTKi прогрес з LVEF 38% (CAR-T ineligible). Drift: ALGO-MCL-2L step 3 free-text; engine default = acalabrutinib; BRUIN анкер у comment.</p>
+  <div class="case-foot">patient_mcl_pirtobrutinib_3l_post_btki.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MTC" hidden>
+  <header class="case-list-header">
+    <h2>Medullary thyroid carcinoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-mtc.html"
+   data-default-order="140"
+   data-name="DIS-MTC — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MTC — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Medullary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mtc.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mtc-frail.html"
+   data-default-order="390"
+   data-name="DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mtc-organ-dysf.html"
+   data-default-order="391"
+   data-name="DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mtc-infection-hbv.html"
+   data-default-order="392"
+   data-name="DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mtc-biomarker-act.html"
+   data-default-order="393"
+   data-name="DIS-MTC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mtc-high-risk.html"
+   data-default-order="394"
+   data-name="DIS-MTC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MM" hidden>
+  <header class="case-list-header">
+    <h2>Multiple Myeloma</h2>
+    <span class="case-list-count">11 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/mm-standard-risk.html"
+   data-default-order="3"
+   data-name="Multiple Myeloma · Standard-Risk">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · Standard-Risk</h3>
+  <p>Newly-diagnosed MM, t(11;14) + hyperdiploid, R-ISS II — engine обирає триплет VRd як default.</p>
+  <div class="case-foot">patient_mm_standard_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/mm-high-risk.html"
+   data-default-order="4"
+   data-name="Multiple Myeloma · High-Risk">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · High-Risk</h3>
+  <p>Newly-diagnosed MM, t(4;14) + gain 1q21, R2-ISS III — RF-MM-HIGH-RISK-CYTOGENETICS, engine обирає квадруплет D-VRd.</p>
+  <div class="case-foot">patient_mm_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/mm-post-vrd-progression.html"
+   data-default-order="68"
+   data-name="Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)</h3>
+  <p>MM relapsed після VRd induction — engine обирає daratumumab+pomalidomide+dex (APOLLO) або isatuximab+Pd (ICARIA).</p>
+  <div class="case-foot">patient_mm_post_vrd_progression.json</div>
+</a>
+<a class="case-card" href="/en/cases/mm-triple-class-refractory.html"
+   data-default-order="69"
+   data-name="Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)</h3>
+  <p>MM triple-class refractory (PI + IMiD + anti-CD38) — engine обирає cilta-cel/ide-cel CAR-T або teclistamab BCMA-T-cell engager.</p>
+  <div class="case-foot">patient_mm_triple_class_refractory.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-mm.html"
+   data-default-order="138"
+   data-name="DIS-MM — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Multiple Myeloma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mm.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mm-frail.html"
+   data-default-order="379"
+   data-name="DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mm-organ-dysf.html"
+   data-default-order="380"
+   data-name="DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mm-infection-hbv.html"
+   data-default-order="381"
+   data-name="DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mm-relapsed-2l.html"
+   data-default-order="382"
+   data-name="DIS-MM · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mm-biomarker-act.html"
+   data-default-order="383"
+   data-name="DIS-MM · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mm-high-risk.html"
+   data-default-order="384"
+   data-name="DIS-MM · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MM · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MF-SEZARY" hidden>
+  <header class="case-list-header">
+    <h2>Mycosis Fungoides / Sézary Syndrome</h2>
+    <span class="case-list-count">11 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/mf-early-stage.html"
+   data-default-order="31"
+   data-name="Mycosis Fungoides · Early Stage (Skin-Directed)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Mycosis Fungoides · Early Stage (Skin-Directed)</h3>
+  <p>MF stage IB без B2/LCT — engine обирає skin-directed (NBUVB / topicals / TSEBT). Жодного системного режиму — preserves chemo для прогресу. Workup rules out occult Sézary (B2 count) + LCT.</p>
+  <div class="case-foot">patient_mf_early_stage.json</div>
+</a>
+<a class="case-card" href="/en/cases/sezary-advanced.html"
+   data-default-order="32"
+   data-name="Sézary Syndrome · Advanced (Mogamulizumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Sézary Syndrome · Advanced (Mogamulizumab)</h3>
+  <p>Sézary syndrome (B2 leukemic, generalized erythroderma) — RF-MF-SEZARY-LEUKEMIC fired. Engine обирає mogamulizumab (MAVORIC: anti-CCR4 ADCC, найкраща blood-compartment відповідь).</p>
+  <div class="case-foot">patient_sezary_advanced.json</div>
+</a>
+<a class="case-card" href="/en/cases/mf-advanced-cd30.html"
+   data-default-order="33"
+   data-name="MF · Advanced + CD30+ LCT (Brentuximab mono)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MF · Advanced + CD30+ LCT (Brentuximab mono)</h3>
+  <p>Advanced MF stage IIB з large-cell transformation, CD30+ — RF-MF-LARGE-CELL-TRANSFORMATION + RF-TCELL-CD30-POSITIVE fired. Engine обирає brentuximab vedotin monotherapy (ALCANZA).</p>
+  <div class="case-foot">patient_mf_advanced_cd30.json</div>
+</a>
+<a class="case-card" href="/en/cases/mf-relapsed-post-moga.html"
+   data-default-order="63"
+   data-name="MF · Relapsed post-Mogamulizumab (Bexarotene)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MF · Relapsed post-Mogamulizumab (Bexarotene)</h3>
+  <p>MF/Sézary relapsed після mogamulizumab — engine обирає bexarotene 2L з low-dose maintenance (RXR-targeted oral retinoid).</p>
+  <div class="case-foot">patient_mf_relapsed_post_moga.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-mf_sezary.html"
+   data-default-order="137"
+   data-name="DIS-MF-SEZARY — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Mycosis Fungoides / Sézary Syndrome. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mf_sezary.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mf_sezary-frail.html"
+   data-default-order="373"
+   data-name="DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mf_sezary-organ-dysf.html"
+   data-default-order="374"
+   data-name="DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mf_sezary-infection-hbv.html"
+   data-default-order="375"
+   data-name="DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mf_sezary-relapsed-2l.html"
+   data-default-order="376"
+   data-name="DIS-MF-SEZARY · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mf_sezary-biomarker-act.html"
+   data-default-order="377"
+   data-name="DIS-MF-SEZARY · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mf_sezary-high-risk.html"
+   data-default-order="378"
+   data-name="DIS-MF-SEZARY · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MDS-HR" hidden>
+  <header class="case-list-header">
+    <h2>Myelodysplastic Syndromes — Higher Risk</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/mds-hr-transplant-eligible.html"
+   data-default-order="78"
+   data-name="MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)</h3>
+  <p>MDS IPSS-R high, fit, donor available — engine обирає azacitidine bridge → upfront alloHCT (curative).</p>
+  <div class="case-foot">patient_mds_hr_transplant_eligible.json</div>
+</a>
+<a class="case-card" href="/en/cases/mds-hr-unfit-aza.html"
+   data-default-order="79"
+   data-name="MDS-HR · Unfit (Azacitidine Maintenance)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-HR · Unfit (Azacitidine Maintenance)</h3>
+  <p>MDS-HR transplant-ineligible — engine обирає azacitidine indefinite (AZA-001: median OS 24 mo vs 15 mo для conventional care).</p>
+  <div class="case-foot">patient_mds_hr_unfit_aza.json</div>
+</a>
+<a class="case-card" href="/en/cases/mds-hr-progression-aml.html"
+   data-default-order="80"
+   data-name="MDS-HR · Progression to Secondary AML">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-HR · Progression to Secondary AML</h3>
+  <p>MDS на azacitidine з progression до sAML — engine реагує AML-reroute: ven+aza або 7+3 induction (за fitness).</p>
+  <div class="case-foot">patient_mds_hr_progression_to_aml.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-mds_hr.html"
+   data-default-order="134"
+   data-name="DIS-MDS-HR — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Higher Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mds_hr.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_hr-frail.html"
+   data-default-order="355"
+   data-name="DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_hr-organ-dysf.html"
+   data-default-order="356"
+   data-name="DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_hr-infection-hbv.html"
+   data-default-order="357"
+   data-name="DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_hr-relapsed-2l.html"
+   data-default-order="358"
+   data-name="DIS-MDS-HR · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_hr-biomarker-act.html"
+   data-default-order="359"
+   data-name="DIS-MDS-HR · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_hr-high-risk.html"
+   data-default-order="360"
+   data-name="DIS-MDS-HR · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MDS-LR" hidden>
+  <header class="case-list-header">
+    <h2>Myelodysplastic Syndromes — Lower Risk</h2>
+    <span class="case-list-count">10 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/mds-lr-del5q.html"
+   data-default-order="81"
+   data-name="MDS-LR · del(5q) (Lenalidomide)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-LR · del(5q) (Lenalidomide)</h3>
+  <p>MDS-LR з isolated del(5q) syndrome — engine обирає lenalidomide (MDS-004: ~67% transfusion-independence).</p>
+  <div class="case-foot">patient_mds_lr_del5q.json</div>
+</a>
+<a class="case-card" href="/en/cases/mds-lr-rs-luspatercept.html"
+   data-default-order="82"
+   data-name="MDS-LR · RS+ EPO-failure (Luspatercept)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>MDS-LR · RS+ EPO-failure (Luspatercept)</h3>
+  <p>MDS-LR з ring sideroblasts + EPO-high (&gt;500) → ESA-failure — engine обирає luspatercept (COMMANDS).</p>
+  <div class="case-foot">patient_mds_lr_rs_luspatercept.json</div>
+</a>
+<a class="case-card" href="/en/cases/mds-lr-hypoplastic-ist.html"
+   data-default-order="83"
+   data-name="MDS-LR · Hypoplastic / IST candidate">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-LR · Hypoplastic / IST candidate</h3>
+  <p>Hypoplastic MDS, mimics aplastic anemia — engine обирає immunosuppressive therapy (ATG+CsA) як alternative до transfusion-only.</p>
+  <div class="case-foot">patient_mds_lr_hypoplastic_ist.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-mds_lr.html"
+   data-default-order="135"
+   data-name="DIS-MDS-LR — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Lower Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mds_lr.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_lr-frail.html"
+   data-default-order="361"
+   data-name="DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_lr-organ-dysf.html"
+   data-default-order="362"
+   data-name="DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_lr-infection-hbv.html"
+   data-default-order="363"
+   data-name="DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_lr-relapsed-2l.html"
+   data-default-order="364"
+   data-name="DIS-MDS-LR · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_lr-biomarker-act.html"
+   data-default-order="365"
+   data-name="DIS-MDS-LR · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-mds_lr-high-risk.html"
+   data-default-order="366"
+   data-name="DIS-MDS-LR · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NODAL-MZL" hidden>
+  <header class="case-list-header">
+    <h2>Nodal Marginal Zone Lymphoma</h2>
+    <span class="case-list-count">12 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/hcv-mzl-reference.html"
+   data-default-order="0"
+   data-name="HCV-MZL · Reference Case (Patient Zero)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCV-MZL · Reference Case (Patient Zero)</h3>
+  <p>Чоловік 49, ECOG 1, 5.3 см ураження кореня язика, HCV генотип 1b, indolent presentation. Acceptance test для P0.</p>
+  <div class="case-foot">patient_zero_reference_case.json</div>
+</a>
+<a class="case-card" href="/en/cases/hcv-mzl-bulky.html"
+   data-default-order="1"
+   data-name="HCV-MZL · Aggressive Burden (BR + concurrent DAA)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCV-MZL · Aggressive Burden (BR + concurrent DAA)</h3>
+  <p>HCV-MZL із bulky disease (&gt;7 см) — RF-BULKY-DISEASE fired. Engine обирає BR (бендамустин+ритуксимаб) + concurrent DAA. Поєднує колишні patient_zero_bulky та новий fixture aggressive_burden.</p>
+  <div class="case-foot">patient_hcv_mzl_aggressive_burden.json</div>
+</a>
+<a class="case-card" href="/en/cases/hcv-mzl-post-daa.html"
+   data-default-order="2"
+   data-name="HCV-MZL · Post-DAA Responder (Surveillance)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCV-MZL · Post-DAA Responder (Surveillance)</h3>
+  <p>Пацієнт post-DAA з SVR12 + lymphoma response — engine обирає surveillance only; план для re-treatment trigger при relapse.</p>
+  <div class="case-foot">patient_hcv_mzl_post_daa_responder.json</div>
+</a>
+<a class="case-card" href="/en/cases/nmzl-low-burden.html"
+   data-default-order="18"
+   data-name="Nodal MZL · Low Burden (W&amp;W)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Nodal MZL · Low Burden (W&amp;W)</h3>
+  <p>Нодальна MZL без GELF-критеріїв — engine обирає surveillance трек (повторює FL-парадигму).</p>
+  <div class="case-foot">patient_nmzl_low_burden.json</div>
+</a>
+<a class="case-card" href="/en/cases/nmzl-high-burden.html"
+   data-default-order="47"
+   data-name="Nodal MZL · High Burden (BR)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Nodal MZL · High Burden (BR)</h3>
+  <p>Нодальна MZL з GELF+ — engine обирає BR (1L); 2L після rituximab/W&amp;W failure теж BR.</p>
+  <div class="case-foot">patient_nmzl_high_burden.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-nodal_mzl.html"
+   data-default-order="143"
+   data-name="DIS-NODAL-MZL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Nodal Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nodal_mzl.json</div>
 </a>
 <a class="case-card" href="/en/cases/variant-nodal_mzl-frail.html"
    data-default-order="407"
@@ -4522,6 +4841,132 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_nodal_mzl_high_risk.json</div>
 </a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NLPBL" hidden>
+  <header class="case-list-header">
+    <h2>Nodular Lymphocyte-Predominant B-cell Lymphoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/nlpbl-early.html"
+   data-default-order="29"
+   data-name="NLPBL · Early Stage (Observation / RT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NLPBL · Early Stage (Observation / RT)</h3>
+  <p>Нодулярна лімфоцит-домінантна B-клітинна лімфома (перекласифіковано WHO 5th-ed з NLPHL у B-cell) — early stage. Engine обирає observation / ISRT alone.</p>
+  <div class="case-foot">patient_nlpbl_early.json</div>
+</a>
+<a class="case-card" href="/en/cases/nlpbl-ia-rituximab.html"
+   data-default-order="34"
+   data-name="NLPBL · IA + RT-contraindicated (Rituximab mono)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NLPBL · IA + RT-contraindicated (Rituximab mono)</h3>
+  <p>NLPBL stage IA у молодої жінки з cervical adenopathy — RT-contraindicated через breast/thyroid field overlap. Engine обирає rituximab monotherapy alternative (CD20+ B-cell biology, НЕ ABVD).</p>
+  <div class="case-foot">patient_nlpbl_ia_rituximab.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-nlpbl.html"
+   data-default-order="142"
+   data-name="DIS-NLPBL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Nodular Lymphocyte-Predominant B-cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nlpbl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-nlpbl-frail.html"
+   data-default-order="401"
+   data-name="DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-nlpbl-organ-dysf.html"
+   data-default-order="402"
+   data-name="DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-nlpbl-infection-hbv.html"
+   data-default-order="403"
+   data-name="DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-nlpbl-relapsed-2l.html"
+   data-default-order="404"
+   data-name="DIS-NLPBL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-nlpbl-biomarker-act.html"
+   data-default-order="405"
+   data-name="DIS-NLPBL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-nlpbl-high-risk.html"
+   data-default-order="406"
+   data-name="DIS-NLPBL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NSCLC" hidden>
+  <header class="case-list-header">
+    <h2>Non-small cell lung cancer</h2>
+    <span class="case-list-count">19 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-nsclc.html"
+   data-default-order="144"
+   data-name="DIS-NSCLC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Non-small cell lung cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nsclc.json</div>
+</a>
 <a class="case-card" href="/en/cases/variant-nsclc-frail.html"
    data-default-order="413"
    data-name="DIS-NSCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -4587,1183 +5032,6 @@
   <h3>DIS-NSCLC · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_nsclc_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ovarian-frail.html"
-   data-default-order="419"
-   data-name="DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ovarian-organ-dysf.html"
-   data-default-order="420"
-   data-name="DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ovarian-infection-hbv.html"
-   data-default-order="421"
-   data-name="DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ovarian-relapsed-2l.html"
-   data-default-order="422"
-   data-name="DIS-OVARIAN · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 9 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ovarian-biomarker-act.html"
-   data-default-order="423"
-   data-name="DIS-OVARIAN · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ovarian-high-risk.html"
-   data-default-order="424"
-   data-name="DIS-OVARIAN · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pcnsl-frail.html"
-   data-default-order="425"
-   data-name="DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pcnsl-organ-dysf.html"
-   data-default-order="426"
-   data-name="DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pcnsl-infection-hbv.html"
-   data-default-order="427"
-   data-name="DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pcnsl-relapsed-2l.html"
-   data-default-order="428"
-   data-name="DIS-PCNSL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pcnsl-biomarker-act.html"
-   data-default-order="429"
-   data-name="DIS-PCNSL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pcnsl-high-risk.html"
-   data-default-order="430"
-   data-name="DIS-PCNSL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pdac-frail.html"
-   data-default-order="431"
-   data-name="DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pdac-organ-dysf.html"
-   data-default-order="432"
-   data-name="DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pdac-infection-hbv.html"
-   data-default-order="433"
-   data-name="DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pdac-biomarker-act.html"
-   data-default-order="434"
-   data-name="DIS-PDAC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pdac-high-risk.html"
-   data-default-order="435"
-   data-name="DIS-PDAC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmbcl-frail.html"
-   data-default-order="436"
-   data-name="DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmbcl-organ-dysf.html"
-   data-default-order="437"
-   data-name="DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmbcl-infection-hbv.html"
-   data-default-order="438"
-   data-name="DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmbcl-relapsed-2l.html"
-   data-default-order="439"
-   data-name="DIS-PMBCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmbcl-biomarker-act.html"
-   data-default-order="440"
-   data-name="DIS-PMBCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmbcl-high-risk.html"
-   data-default-order="441"
-   data-name="DIS-PMBCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmf-frail.html"
-   data-default-order="442"
-   data-name="DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmf-organ-dysf.html"
-   data-default-order="443"
-   data-name="DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmf-infection-hbv.html"
-   data-default-order="444"
-   data-name="DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmf-relapsed-2l.html"
-   data-default-order="445"
-   data-name="DIS-PMF · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmf-biomarker-act.html"
-   data-default-order="446"
-   data-name="DIS-PMF · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pmf-high-risk.html"
-   data-default-order="447"
-   data-name="DIS-PMF · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-prostate-frail.html"
-   data-default-order="448"
-   data-name="DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-prostate-organ-dysf.html"
-   data-default-order="449"
-   data-name="DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-prostate-infection-hbv.html"
-   data-default-order="450"
-   data-name="DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-prostate-biomarker-act.html"
-   data-default-order="451"
-   data-name="DIS-PROSTATE · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-prostate-high-risk.html"
-   data-default-order="452"
-   data-name="DIS-PROSTATE · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptcl_nos-frail.html"
-   data-default-order="453"
-   data-name="DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptcl_nos-organ-dysf.html"
-   data-default-order="454"
-   data-name="DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptcl_nos-infection-hbv.html"
-   data-default-order="455"
-   data-name="DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptcl_nos-relapsed-2l.html"
-   data-default-order="456"
-   data-name="DIS-PTCL-NOS · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptcl_nos-biomarker-act.html"
-   data-default-order="457"
-   data-name="DIS-PTCL-NOS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptcl_nos-high-risk.html"
-   data-default-order="458"
-   data-name="DIS-PTCL-NOS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptld-frail.html"
-   data-default-order="459"
-   data-name="DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptld-organ-dysf.html"
-   data-default-order="460"
-   data-name="DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptld-infection-hbv.html"
-   data-default-order="461"
-   data-name="DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptld-relapsed-2l.html"
-   data-default-order="462"
-   data-name="DIS-PTLD · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptld-biomarker-act.html"
-   data-default-order="463"
-   data-name="DIS-PTLD · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-ptld-high-risk.html"
-   data-default-order="464"
-   data-name="DIS-PTLD · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pv-frail.html"
-   data-default-order="465"
-   data-name="DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pv-organ-dysf.html"
-   data-default-order="466"
-   data-name="DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pv-infection-hbv.html"
-   data-default-order="467"
-   data-name="DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pv-relapsed-2l.html"
-   data-default-order="468"
-   data-name="DIS-PV · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pv-biomarker-act.html"
-   data-default-order="469"
-   data-name="DIS-PV · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-pv-high-risk.html"
-   data-default-order="470"
-   data-name="DIS-PV · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-PV · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-rcc-frail.html"
-   data-default-order="471"
-   data-name="DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-rcc-organ-dysf.html"
-   data-default-order="472"
-   data-name="DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-rcc-infection-hbv.html"
-   data-default-order="473"
-   data-name="DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-rcc-relapsed-2l.html"
-   data-default-order="474"
-   data-name="DIS-RCC · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-rcc-biomarker-act.html"
-   data-default-order="475"
-   data-name="DIS-RCC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-rcc-high-risk.html"
-   data-default-order="476"
-   data-name="DIS-RCC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-salivary-frail.html"
-   data-default-order="477"
-   data-name="DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-salivary-organ-dysf.html"
-   data-default-order="478"
-   data-name="DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-salivary-infection-hbv.html"
-   data-default-order="479"
-   data-name="DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-salivary-biomarker-act.html"
-   data-default-order="480"
-   data-name="DIS-SALIVARY · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-salivary-high-risk.html"
-   data-default-order="481"
-   data-name="DIS-SALIVARY · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-sclc-frail.html"
-   data-default-order="482"
-   data-name="DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-sclc-organ-dysf.html"
-   data-default-order="483"
-   data-name="DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-sclc-infection-hbv.html"
-   data-default-order="484"
-   data-name="DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-sclc-biomarker-act.html"
-   data-default-order="485"
-   data-name="DIS-SCLC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-sclc-high-risk.html"
-   data-default-order="486"
-   data-name="DIS-SCLC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-splenic_mzl-frail.html"
-   data-default-order="487"
-   data-name="DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-splenic_mzl-organ-dysf.html"
-   data-default-order="488"
-   data-name="DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-splenic_mzl-infection-hbv.html"
-   data-default-order="489"
-   data-name="DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-splenic_mzl-relapsed-2l.html"
-   data-default-order="490"
-   data-name="DIS-SPLENIC-MZL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-splenic_mzl-biomarker-act.html"
-   data-default-order="491"
-   data-name="DIS-SPLENIC-MZL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-splenic_mzl-high-risk.html"
-   data-default-order="492"
-   data-name="DIS-SPLENIC-MZL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_all-frail.html"
-   data-default-order="493"
-   data-name="DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_all-organ-dysf.html"
-   data-default-order="494"
-   data-name="DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_all-infection-hbv.html"
-   data-default-order="495"
-   data-name="DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_all-relapsed-2l.html"
-   data-default-order="496"
-   data-name="DIS-T-ALL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_all-biomarker-act.html"
-   data-default-order="497"
-   data-name="DIS-T-ALL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_all-high-risk.html"
-   data-default-order="498"
-   data-name="DIS-T-ALL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_pll-frail.html"
-   data-default-order="499"
-   data-name="DIS-T-PLL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_pll_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_pll-organ-dysf.html"
-   data-default-order="500"
-   data-name="DIS-T-PLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_pll_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_pll-infection-hbv.html"
-   data-default-order="501"
-   data-name="DIS-T-PLL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_pll_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_pll-relapsed-2l.html"
-   data-default-order="502"
-   data-name="DIS-T-PLL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_pll_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_pll-biomarker-act.html"
-   data-default-order="503"
-   data-name="DIS-T-PLL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_pll_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-t_pll-high-risk.html"
-   data-default-order="504"
-   data-name="DIS-T-PLL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_pll_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-frail.html"
-   data-default-order="505"
-   data-name="DIS-THYROID-ANAPLASTIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_anaplastic_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-organ-dysf.html"
-   data-default-order="506"
-   data-name="DIS-THYROID-ANAPLASTIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_anaplastic_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-infection-hbv.html"
-   data-default-order="507"
-   data-name="DIS-THYROID-ANAPLASTIC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_anaplastic_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-biomarker-act.html"
-   data-default-order="508"
-   data-name="DIS-THYROID-ANAPLASTIC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_anaplastic_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_anaplastic-high-risk.html"
-   data-default-order="509"
-   data-name="DIS-THYROID-ANAPLASTIC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_anaplastic_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_papillary-frail.html"
-   data-default-order="510"
-   data-name="DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_papillary-organ-dysf.html"
-   data-default-order="511"
-   data-name="DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_papillary-infection-hbv.html"
-   data-default-order="512"
-   data-name="DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_papillary-biomarker-act.html"
-   data-default-order="513"
-   data-name="DIS-THYROID-PAPILLARY · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-thyroid_papillary-high-risk.html"
-   data-default-order="514"
-   data-name="DIS-THYROID-PAPILLARY · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-urothelial-frail.html"
-   data-default-order="515"
-   data-name="DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-urothelial-organ-dysf.html"
-   data-default-order="516"
-   data-name="DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-urothelial-infection-hbv.html"
-   data-default-order="517"
-   data-name="DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-urothelial-biomarker-act.html"
-   data-default-order="518"
-   data-name="DIS-UROTHELIAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-urothelial-high-risk.html"
-   data-default-order="519"
-   data-name="DIS-UROTHELIAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_high_risk.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-wm-frail.html"
-   data-default-order="520"
-   data-name="DIS-WM · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_wm_frail.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-wm-organ-dysf.html"
-   data-default-order="521"
-   data-name="DIS-WM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_wm_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-wm-infection-hbv.html"
-   data-default-order="522"
-   data-name="DIS-WM · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_wm_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-wm-relapsed-2l.html"
-   data-default-order="523"
-   data-name="DIS-WM · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_wm_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-wm-biomarker-act.html"
-   data-default-order="524"
-   data-name="DIS-WM · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_wm_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/en/cases/variant-wm-high-risk.html"
-   data-default-order="525"
-   data-name="DIS-WM · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>DIS-WM · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_wm_high_risk.json</div>
 </a>
 <a class="case-card" href="/en/cases/nsclc-egfr-ex19del-1l.html"
    data-default-order="526"
@@ -5897,423 +5165,24 @@
   <p>KIF5B-RET виявлено на RNA-NGS rebiopsy. Engine: step 13 → IND-NSCLC-2L-RET-FUSION-SELPERCATINIB (intracranial ORR 91%).</p>
   <div class="case-foot">patient_nsclc_ret_fusion_2l_selpercatinib.json</div>
 </a>
-<a class="case-card" href="/en/cases/breast-hr-pos-met-1l-cdk46i.html"
-   data-default-order="538"
-   data-name="Breast · HR+/HER2- met 1L · AI+palbociclib (PALOMA-2)">
+  </div>
+</section>
+<section class="case-list" data-disease-id="OTHER" hidden>
+  <header class="case-list-header">
+    <h2>Other / unclassified</h2>
+    <span class="case-list-count">4 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/diagnostic-lymphoma-suspect.html"
+   data-default-order="5"
+   data-name="Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-diag">Diagnostic Brief</div>
     <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>Breast · HR+/HER2- met 1L · AI+palbociclib (PALOMA-2)</h3>
-  <p>Метастатична HR+/HER2-, postmenopausal. Engine: ALGO-1L → IND-BREAST-HR-POS-MET-1L-CDKI (PALOMA-2 mPFS 27.6 мо).</p>
-  <div class="case-foot">patient_breast_hr_pos_her2_neg_met_1l_cdk46i.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-hr-pos-pik3ca-alpelisib.html"
-   data-default-order="539"
-   data-name="Breast · HR+ post-CDK4/6i · PIK3CA H1047R · Alpelisib (SOLAR-1)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · HR+ post-CDK4/6i · PIK3CA H1047R · Alpelisib (SOLAR-1)</h3>
-  <p>Прогрес на CDK4/6i, PIK3CA H1047R hot-spot. Engine drift: HER2-2L дефолт; alpelisib+fulvestrant анкер у comment.</p>
-  <div class="case-foot">patient_breast_hr_pos_post_cdk46i_pik3ca_alpelisib.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-her2-pos-early-katherine.html"
-   data-default-order="540"
-   data-name="Breast · HER2+ early · Neoadj TCHP → KATHERINE T-DM1">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · HER2+ early · Neoadj TCHP → KATHERINE T-DM1</h3>
-  <p>HER2+ early-stage, неоадʼювантна TCHP → adjuvant T-DM1 при non-pCR (KATHERINE 50% iDFS benefit). Drift: engine routes до met-1L.</p>
-  <div class="case-foot">patient_breast_her2_pos_early_neoadj_kn522_path.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-her2-pos-met-1l-thp.html"
-   data-default-order="541"
-   data-name="Breast · HER2+ met 1L · Docetaxel+THP (CLEOPATRA)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · HER2+ met 1L · Docetaxel+THP (CLEOPATRA)</h3>
-  <p>HER2+ метастатична 1L, docetaxel+trastuzumab+pertuzumab. Engine: ALGO-1L → IND-BREAST-HER2-POS-MET-1L-THP (CLEOPATRA mOS 57 мо).</p>
-  <div class="case-foot">patient_breast_her2_pos_met_1l_thp.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-her2-pos-met-2l-tdxd.html"
-   data-default-order="542"
-   data-name="Breast · HER2+ met 2L · T-DXd (DESTINY-Breast03)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · HER2+ met 2L · T-DXd (DESTINY-Breast03)</h3>
-  <p>HER2+ метастатична 2L після THP. Engine: ALGO-HER2-POS-2L → IND-BREAST-HER2-POS-MET-2L-TDXD (DB03 mPFS 28.8 мо).</p>
-  <div class="case-foot">patient_breast_her2_pos_met_2l_tdxd.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-tnbc-neoadj-kn522.html"
-   data-default-order="543"
-   data-name="Breast · TNBC stage II-III · Neoadj pembro+chemo (KEYNOTE-522)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · TNBC stage II-III · Neoadj pembro+chemo (KEYNOTE-522)</h3>
-  <p>TNBC II-III, неоадʼювантна pembro+carbo+pacli→AC (pCR 64%). Drift: engine routes до HR+ default; clinical anchor у comment.</p>
-  <div class="case-foot">patient_breast_tnbc_neoadj_kn522_pembro_chemo.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-brca-germline-olaparib.html"
-   data-default-order="544"
-   data-name="Breast · BRCA1 germline met · Olaparib (OlympiAD)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · BRCA1 germline met · Olaparib (OlympiAD)</h3>
-  <p>BRCA1 germline pathogenic, метастатична HER2-. PARPi мono. Drift: engine routes до HR+/HER2- 1L CDK4/6i default; clinical anchor у comment.</p>
-  <div class="case-foot">patient_breast_brca_germline_met_olaparib.json</div>
-</a>
-<a class="case-card" href="/en/cases/breast-tnbc-met-2l-sacituzumab.html"
-   data-default-order="545"
-   data-name="Breast · TNBC met 2L · Sacituzumab govitecan (ASCENT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Breast · TNBC met 2L · Sacituzumab govitecan (ASCENT)</h3>
-  <p>TNBC метастатична 2L+. Drift: engine routes до HER2-2L default; sacituzumab анкер у comment.</p>
-  <div class="case-foot">patient_breast_tnbc_met_sacituzumab_2l.json</div>
-</a>
-<a class="case-card" href="/en/cases/crc-stage-iii-adjuvant-folfox.html"
-   data-default-order="546"
-   data-name="CRC · stage III adjuvant FOLFOX (MOSAIC)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>CRC · stage III adjuvant FOLFOX (MOSAIC)</h3>
-  <p>Stage III після резекції. Drift: KB не має adjuvant CRC algo; engine default = mCRC FOLFOX+bev (анкер MOSAIC у comment).</p>
-  <div class="case-foot">patient_crc_stage_iii_adjuvant_folfox.json</div>
-</a>
-<a class="case-card" href="/en/cases/crc-mcrc-ras-wt-left-folfox-cetux.html"
-   data-default-order="547"
-   data-name="mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)</h3>
-  <p>RAS-WT левобічна mCRC. Engine: ALGO step 2 → IND-CRC-METASTATIC-1L-RAS-WT-LEFT (CRYSTAL/FIRE-3).</p>
-  <div class="case-foot">patient_crc_metastatic_ras_wt_left_folfox_cetux.json</div>
-</a>
-<a class="case-card" href="/en/cases/crc-mcrc-ras-mut-folfox-bev.html"
-   data-default-order="548"
-   data-name="mCRC · RAS-mutated 1L · FOLFOX+bevacizumab">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>mCRC · RAS-mutated 1L · FOLFOX+bevacizumab</h3>
-  <p>KRAS-мутована mCRC, 1L FOLFOX+bevacizumab. Engine: ALGO default → IND-CRC-METASTATIC-1L-FOLFOX-BEV.</p>
-  <div class="case-foot">patient_crc_metastatic_ras_mut_folfox_bev.json</div>
-</a>
-<a class="case-card" href="/en/cases/crc-mcrc-msi-h-pembro.html"
-   data-default-order="549"
-   data-name="mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)</h3>
-  <p>MSI-high mCRC. Engine: ALGO step 1 (MSI-H fires) → IND-CRC-METASTATIC-1L-MSI-H-PEMBRO (KEYNOTE-177 mPFS 16.5 мо).</p>
-  <div class="case-foot">patient_crc_metastatic_msi_h_pembro_mono.json</div>
-</a>
-<a class="case-card" href="/en/cases/crc-mcrc-2l-folfiri-bev.html"
-   data-default-order="550"
-   data-name="mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)</h3>
-  <p>Прогрес на FOLFOX+bev 1L. Engine: ALGO-2L → IND-CRC-METASTATIC-2L-FOLFIRI-BEV (continuum-of-care).</p>
-  <div class="case-foot">patient_crc_metastatic_2l_folfiri_bev.json</div>
-</a>
-<a class="case-card" href="/en/cases/crc-mcrc-3l-regorafenib.html"
-   data-default-order="551"
-   data-name="mCRC · 3L+ Regorafenib (CORRECT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>mCRC · 3L+ Regorafenib (CORRECT)</h3>
-  <p>Хеморефрактерна mCRC. Drift: engine default = TAS-102+bev (SUNLIGHT); regorafenib як alternative track.</p>
-  <div class="case-foot">patient_crc_metastatic_3l_regorafenib.json</div>
-</a>
-<a class="case-card" href="/en/cases/melanoma-braf-v600-dab-tram.html"
-   data-default-order="552"
-   data-name="Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)</h3>
-  <p>BRAF V600 метастатична. Engine: → IND-MELANOMA-BRAF-METASTATIC-1L-DABRA-TRAME (COMBI-d/v).</p>
-  <div class="case-foot">patient_melanoma_braf_v600_dab_tram.json</div>
-</a>
-<a class="case-card" href="/en/cases/melanoma-braf-v600-nivo-ipi.html"
-   data-default-order="553"
-   data-name="Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)</h3>
-  <p>BRAF V600 метастатична, IO doublet. Engine: → IND-MELANOMA-METASTATIC-1L-NIVO-IPI (CM-067 5-yr OS 52%).</p>
-  <div class="case-foot">patient_melanoma_braf_v600_nivo_ipi.json</div>
-</a>
-<a class="case-card" href="/en/cases/melanoma-braf-wt-pembro-mono.html"
-   data-default-order="554"
-   data-name="Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)</h3>
-  <p>BRAF-WT метастатична. Drift: KEYNOTE-006 не wired у KB; engine fallback до nivo+ipi; анкер у comment.</p>
-  <div class="case-foot">patient_melanoma_braf_wt_pembro_mono.json</div>
-</a>
-<a class="case-card" href="/en/cases/melanoma-nivo-relatlimab.html"
-   data-default-order="555"
-   data-name="Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)</h3>
-  <p>Drift: KB scopeє nivo+rela до 2L post-BRAFi; модельовано як 2L з frailty. RELATIVITY-047 анкер 1L FDA.</p>
-  <div class="case-foot">patient_melanoma_nivo_relatlimab.json</div>
-</a>
-<a class="case-card" href="/en/cases/melanoma-adjuvant-pembro-stage-iii.html"
-   data-default-order="556"
-   data-name="Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)</h3>
-  <p>Drift: adjuvant melanoma algo не існує в KB; engine output = met-1L IO doublet. KEYNOTE-054 анкер у comment, motivation для майбутнього ALGO-MELANOMA-ADJUVANT.</p>
-  <div class="case-foot">patient_melanoma_adjuvant_pembro_stage_iii.json</div>
-</a>
-<a class="case-card" href="/en/cases/prostate-mcrpc-brca-olaparib.html"
-   data-default-order="557"
-   data-name="Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)</h3>
-  <p>mCRPC з BRCA-pathogenic, PARPi мono. Engine: ALGO-PROSTATE-MCRPC-1L step 1 → IND-PROSTATE-MCRPC-1L-PARPI (PROfound mPFS 7.4 мо).</p>
-  <div class="case-foot">patient_prostate_mcrpc_brca_olaparib_profound.json</div>
-</a>
-<a class="case-card" href="/en/cases/rcc-imdc-int-nivo-ipi.html"
-   data-default-order="558"
-   data-name="RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)</h3>
-  <p>Clear-cell RCC IMDC intermediate-poor. Drift: engine default = pembro+axi; nivo+ipi анкер CM-214 у comment.</p>
-  <div class="case-foot">patient_rcc_imdc_int_nivo_ipi.json</div>
-</a>
-<a class="case-card" href="/en/cases/rcc-imdc-fav-axi-pembro.html"
-   data-default-order="559"
-   data-name="RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)</h3>
-  <p>Clear-cell RCC IMDC favorable. Engine: → IND-RCC-METASTATIC-1L-PEMBRO-AXI (KEYNOTE-426 5-yr OS).</p>
-  <div class="case-foot">patient_rcc_imdc_fav_axi_pembro.json</div>
-</a>
-<a class="case-card" href="/en/cases/urothelial-muc-ev-pembro.html"
-   data-default-order="560"
-   data-name="Urothelial · mUC 1L · EV+pembro (EV-302)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Urothelial · mUC 1L · EV+pembro (EV-302)</h3>
-  <p>Метастатична мUC. Drift: free-text condition unevaluable; engine default = platinum+avelumab; EV-302 анкер у comment.</p>
-  <div class="case-foot">patient_urothelial_muc_ev_pembro.json</div>
-</a>
-<a class="case-card" href="/en/cases/endometrial-dmmr-pembro-kn775.html"
-   data-default-order="561"
-   data-name="Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)</h3>
-  <p>Advanced/recurrent dMMR endometrial. Engine: → IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO (NRG-GY018 mPFS NR vs 7.6).</p>
-  <div class="case-foot">patient_endometrial_dmmr_pembro_kn775.json</div>
-</a>
-<a class="case-card" href="/en/cases/endometrial-p53-abn-dosta-ruby.html"
-   data-default-order="562"
-   data-name="Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)</h3>
-  <p>Advanced p53-abnormal endometrial. Drift: engine default = pembro+chemo; RUBY dostarlimab анкер у comment.</p>
-  <div class="case-foot">patient_endometrial_p53_abn_dosta_kn775.json</div>
-</a>
-<a class="case-card" href="/en/cases/ovarian-hrd-neg-no-parpi.html"
-   data-default-order="563"
-   data-name="Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance</h3>
-  <p>HRD-negative ovarian (контраст до patient_ovarian_advanced_hrd). Engine: → IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-NEG.</p>
-  <div class="case-foot">patient_ovarian_hrd_neg_carbo_pacli_no_parpi.json</div>
-</a>
-<a class="case-card" href="/en/cases/hcc-atezo-bev-imbrave150.html"
-   data-default-order="564"
-   data-name="HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)</h3>
-  <p>HCC Child-Pugh A, fit. Engine: → IND-HCC-SYSTEMIC-1L-ATEZO-BEV (IMbrave150 mOS 19.2 мо).</p>
-  <div class="case-foot">patient_hcc_atezo_bev_imbrave150.json</div>
-</a>
-<a class="case-card" href="/en/cases/hcc-durva-treme-stride.html"
-   data-default-order="565"
-   data-name="HCC · 1L · Durva+treme (HIMALAYA STRIDE)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>HCC · 1L · Durva+treme (HIMALAYA STRIDE)</h3>
-  <p>HCC з high-risk varices. Engine: RF-HCC-VARICEAL-BLEED step 1 → IND-HCC-SYSTEMIC-1L-DURVA-TREME (HIMALAYA mOS 16.4 мо).</p>
-  <div class="case-foot">patient_hcc_durva_treme_stride.json</div>
-</a>
-<a class="case-card" href="/en/cases/gastric-her2-pos-toga.html"
-   data-default-order="566"
-   data-name="Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)</h3>
-  <p>Метастатична HER2+ gastric. Engine: RF-HIGH-RISK-BIOLOGY → IND-GASTRIC-METASTATIC-1L-HER2-TOGA (TOGA mOS 13.8 мо).</p>
-  <div class="case-foot">patient_gastric_her2_pos_toga.json</div>
-</a>
-<a class="case-card" href="/en/cases/gastric-pdl1-cps-chemo-nivo.html"
-   data-default-order="567"
-   data-name="Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)</h3>
-  <p>Метастатична HER2- CPS≥5 gastric. Engine: HER2- step 2 → IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI (CM-649 mOS 14.4 мо).</p>
-  <div class="case-foot">patient_gastric_pdl1_cps_high_chemo_nivo.json</div>
-</a>
-<a class="case-card" href="/en/cases/esophageal-cross-then-nivo.html"
-   data-default-order="568"
-   data-name="Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)</h3>
-  <p>Resectable adeno з ypT+/ypN+ residual. Drift: ALGO-1L emit only CROSS-NEOADJUVANT; CheckMate-577 adjuvant nivo неreachable (PROPOSAL §17 territory).</p>
-  <div class="case-foot">patient_esophageal_adeno_neoadj_cross_then_nivo.json</div>
-</a>
-<a class="case-card" href="/en/cases/pdac-folfirinox-fit.html"
-   data-default-order="569"
-   data-name="PDAC · met fit · FOLFIRINOX (PRODIGE-4)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>PDAC · met fit · FOLFIRINOX (PRODIGE-4)</h3>
-  <p>Fit метастатична PDAC. Drift: ALGO step 3 condition free-text; engine default = gem-nab-pac; FOLFIRINOX як alternative track.</p>
-  <div class="case-foot">patient_pdac_metastatic_folfirinox_fit.json</div>
-</a>
-<a class="case-card" href="/en/cases/sclc-ls-chemo-rt.html"
-   data-default-order="570"
-   data-name="SCLC · LS · Chemo + concurrent RT">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>SCLC · LS · Chemo + concurrent RT</h3>
-  <p>Limited-stage SCLC. RT не modellable per CHARTER §17 — engine emit chemo backbone EP, RT як free-text. Drift: engine default = ES-1L.</p>
-  <div class="case-foot">patient_sclc_ls_chemo_rt.json</div>
-</a>
-<a class="case-card" href="/en/cases/sclc-es-atezo-impower133.html"
-   data-default-order="571"
-   data-name="SCLC · ES · Atezo+carbo+etoposide (IMpower133)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>SCLC · ES · Atezo+carbo+etoposide (IMpower133)</h3>
-  <p>Extensive-stage SCLC. Engine: → IND-SCLC-EXTENSIVE-1L. Drift: дефолт REG-EP-DURVA не IMpower133 атезо; атезо regimen не wired.</p>
-  <div class="case-foot">patient_sclc_es_atezo_chemo_impower133.json</div>
-</a>
-<a class="case-card" href="/en/cases/hnscc-cps-high-pembro-mono.html"
-   data-default-order="572"
-   data-name="HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)</h3>
-  <p>R/M HNSCC CPS≥20. Engine: → IND-HNSCC-RM-1L-PEMBRO-MONO-CPS-HIGH (KEYNOTE-048 mOS 14.9 мо).</p>
-  <div class="case-foot">patient_hnscc_cps_high_pembro_mono.json</div>
-</a>
-<a class="case-card" href="/en/cases/hnscc-extreme-cetux-platin.html"
-   data-default-order="573"
-   data-name="HNSCC · R/M EXTREME · Cetux+platin+5FU">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>HNSCC · R/M EXTREME · Cetux+platin+5FU</h3>
-  <p>Drift: IND-HNSCC-RM-1L-EXTREME не authored у KB; engine fallback = pembro+chemo. EXTREME анкер у comment, highest content gap.</p>
-  <div class="case-foot">patient_hnscc_extreme_cetux_platin_5fu.json</div>
-</a>
-<a class="case-card" href="/en/cases/aml-cbf-inv16-7-3-go.html"
-   data-default-order="575"
-   data-name="AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)</h3>
-  <p>Fit CBF AML. Drift: 7+3+GO indication відсутня; engine default = 7+3 plain; ALFA-0701 анкер у comment.</p>
-  <div class="case-foot">patient_aml_cbf_inv16_7_3_go.json</div>
-</a>
-<a class="case-card" href="/en/cases/aml-secondary-cpx351.html"
-   data-default-order="576"
-   data-name="AML · secondary/t-AML · CPX-351 (Vyxeos)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
-  </div>
-  <h3>AML · secondary/t-AML · CPX-351 (Vyxeos)</h3>
-  <p>Secondary AML post-MDS. Drift: CPX-351 indication відсутня у ALGO-1L; engine default = 7+3; Vyxeos анкер у comment.</p>
-  <div class="case-foot">patient_aml_secondary_cpx351.json</div>
+  <h3>Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)</h3>
+  <p>Pre-biopsy режим — engine генерує Workup Brief, не Treatment Plan (CHARTER §15.2 C7 — без histology немає лікування).</p>
+  <div class="case-foot">patient_diagnostic_lymphoma_suspect.json</div>
 </a>
 <a class="case-card" href="/en/cases/diagnostic-breast-lump-prebiopsy.html"
    data-default-order="583"
@@ -6350,10 +5219,276 @@
 </a>
   </div>
 </section>
+<section class="case-list" data-disease-id="DIS-OVARIAN" hidden>
+  <header class="case-list-header">
+    <h2>Ovarian carcinoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/ovarian-advanced-hrd.html"
+   data-default-order="98"
+   data-name="Ovarian · Advanced HRD+ (PARPi maintenance)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Ovarian · Advanced HRD+ (PARPi maintenance)</h3>
+  <p>Advanced high-grade serous ovarian, HRD+ — engine обирає platinum-doublet → PARPi maintenance (olaparib/niraparib; SOLO-1, PRIMA).</p>
+  <div class="case-foot">patient_ovarian_advanced_hrd.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-ovarian.html"
+   data-default-order="145"
+   data-name="DIS-OVARIAN — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Ovarian carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ovarian.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ovarian-frail.html"
+   data-default-order="419"
+   data-name="DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ovarian-organ-dysf.html"
+   data-default-order="420"
+   data-name="DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ovarian-infection-hbv.html"
+   data-default-order="421"
+   data-name="DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ovarian-relapsed-2l.html"
+   data-default-order="422"
+   data-name="DIS-OVARIAN · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 9 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ovarian-biomarker-act.html"
+   data-default-order="423"
+   data-name="DIS-OVARIAN · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ovarian-high-risk.html"
+   data-default-order="424"
+   data-name="DIS-OVARIAN · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/ovarian-hrd-neg-no-parpi.html"
+   data-default-order="563"
+   data-name="Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance</h3>
+  <p>HRD-negative ovarian (контраст до patient_ovarian_advanced_hrd). Engine: → IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-NEG.</p>
+  <div class="case-foot">patient_ovarian_hrd_neg_carbo_pacli_no_parpi.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PDAC" hidden>
+  <header class="case-list-header">
+    <h2>Pancreatic ductal adenocarcinoma</h2>
+    <span class="case-list-count">7 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-pdac.html"
+   data-default-order="147"
+   data-name="DIS-PDAC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Pancreatic ductal adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pdac.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pdac-frail.html"
+   data-default-order="431"
+   data-name="DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pdac-organ-dysf.html"
+   data-default-order="432"
+   data-name="DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pdac-infection-hbv.html"
+   data-default-order="433"
+   data-name="DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pdac-biomarker-act.html"
+   data-default-order="434"
+   data-name="DIS-PDAC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pdac-high-risk.html"
+   data-default-order="435"
+   data-name="DIS-PDAC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/pdac-folfirinox-fit.html"
+   data-default-order="569"
+   data-name="PDAC · met fit · FOLFIRINOX (PRODIGE-4)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>PDAC · met fit · FOLFIRINOX (PRODIGE-4)</h3>
+  <p>Fit метастатична PDAC. Drift: ALGO step 3 condition free-text; engine default = gem-nab-pac; FOLFIRINOX як alternative track.</p>
+  <div class="case-foot">patient_pdac_metastatic_folfirinox_fit.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-THYROID-PAPILLARY" hidden>
+  <header class="case-list-header">
+    <h2>Papillary thyroid carcinoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-thyroid_papillary.html"
+   data-default-order="161"
+   data-name="DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Papillary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 62%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_thyroid_papillary.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_papillary-frail.html"
+   data-default-order="510"
+   data-name="DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_papillary-organ-dysf.html"
+   data-default-order="511"
+   data-name="DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_papillary-infection-hbv.html"
+   data-default-order="512"
+   data-name="DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_papillary-biomarker-act.html"
+   data-default-order="513"
+   data-name="DIS-THYROID-PAPILLARY · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-thyroid_papillary-high-risk.html"
+   data-default-order="514"
+   data-name="DIS-THYROID-PAPILLARY · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_high_risk.json</div>
+</a>
+  </div>
+</section>
 <section class="case-list" data-disease-id="DIS-PTCL-NOS" hidden>
   <header class="case-list-header">
     <h2>Peripheral T-Cell Lymphoma, NOS</h2>
-    <span class="case-list-count">3 examples</span>
+    <span class="case-list-count">10 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/ptcl-cd30-negative.html"
@@ -6389,12 +5524,89 @@
   <p>PTCL NOS relapsed після autoSCT — engine обирає romidepsin або pralatrexate; alloHCT як curative-intent для chemosensitive.</p>
   <div class="case-foot">patient_ptcl_relapsed.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-ptcl_nos.html"
+   data-default-order="151"
+   data-name="DIS-PTCL-NOS — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Peripheral T-Cell Lymphoma, NOS. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ptcl_nos.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptcl_nos-frail.html"
+   data-default-order="453"
+   data-name="DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptcl_nos-organ-dysf.html"
+   data-default-order="454"
+   data-name="DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptcl_nos-infection-hbv.html"
+   data-default-order="455"
+   data-name="DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptcl_nos-relapsed-2l.html"
+   data-default-order="456"
+   data-name="DIS-PTCL-NOS · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptcl_nos-biomarker-act.html"
+   data-default-order="457"
+   data-name="DIS-PTCL-NOS · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptcl_nos-high-risk.html"
+   data-default-order="458"
+   data-name="DIS-PTCL-NOS · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_high_risk.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-PV" hidden>
   <header class="case-list-header">
     <h2>Polycythemia Vera</h2>
-    <span class="case-list-count">3 examples</span>
+    <span class="case-list-count">10 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/pv-high-risk-hu.html"
@@ -6430,12 +5642,89 @@
   <p>Reproductive-age жінка з PV, planning pregnancy — engine обирає peg-IFN α-2a (non-teratogenic, fetus-safe).</p>
   <div class="case-foot">patient_pv_pregnancy_planning.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-pv.html"
+   data-default-order="153"
+   data-name="DIS-PV — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Polycythemia Vera. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pv-frail.html"
+   data-default-order="465"
+   data-name="DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pv-organ-dysf.html"
+   data-default-order="466"
+   data-name="DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pv-infection-hbv.html"
+   data-default-order="467"
+   data-name="DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pv-relapsed-2l.html"
+   data-default-order="468"
+   data-name="DIS-PV · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pv-biomarker-act.html"
+   data-default-order="469"
+   data-name="DIS-PV · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pv-high-risk.html"
+   data-default-order="470"
+   data-name="DIS-PV · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PV · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_high_risk.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-PTLD" hidden>
   <header class="case-list-header">
     <h2>Post-Transplant Lymphoproliferative Disorder</h2>
-    <span class="case-list-count">2 examples</span>
+    <span class="case-list-count">9 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/ptld-polymorphic-ebv.html"
@@ -6460,12 +5749,89 @@
   <p>Monomorphic PTLD з DLBCL morphology — engine обирає R-CHOP після RIS-failure; sequential treatment per PTLD-1.</p>
   <div class="case-foot">patient_ptld_monomorphic_dlbcl_like.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-ptld.html"
+   data-default-order="152"
+   data-name="DIS-PTLD — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Post-Transplant Lymphoproliferative Disorder. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ptld.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptld-frail.html"
+   data-default-order="459"
+   data-name="DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptld-organ-dysf.html"
+   data-default-order="460"
+   data-name="DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptld-infection-hbv.html"
+   data-default-order="461"
+   data-name="DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptld-relapsed-2l.html"
+   data-default-order="462"
+   data-name="DIS-PTLD · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptld-biomarker-act.html"
+   data-default-order="463"
+   data-name="DIS-PTLD · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-ptld-high-risk.html"
+   data-default-order="464"
+   data-name="DIS-PTLD · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_high_risk.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-PCNSL" hidden>
   <header class="case-list-header">
     <h2>Primary CNS Lymphoma</h2>
-    <span class="case-list-count">11 examples</span>
+    <span class="case-list-count">13 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/dlbcl-low-ipi.html"
@@ -6489,28 +5855,6 @@
   <h3>DLBCL NOS · High-IPI (Pola-R-CHP)</h3>
   <p>Жінка 67, IPI 4, multiple extranodal — RF-DLBCL-HIGH-IPI fired. Engine ескалує до Pola-R-CHP (POLARIX trial); Ukraine-funding caveat.</p>
   <div class="case-foot">patient_dlbcl_high_ipi.json</div>
-</a>
-<a class="case-card" href="/en/cases/dlbcl-chemorefractory-cart.html"
-   data-default-order="35"
-   data-name="DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)</h3>
-  <p>DLBCL з primary refractory disease (PD на R-CHOP) — engine обирає axi-cel CAR-T (ZUMA-7: 2L CAR-T &gt; salvage+autoSCT для early-failure).</p>
-  <div class="case-foot">patient_dlbcl_chemorefractory_for_cart.json</div>
-</a>
-<a class="case-card" href="/en/cases/dlbcl-relapsed-te-ineligible.html"
-   data-default-order="36"
-   data-name="DLBCL NOS · Relapsed (Transplant-Ineligible)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL NOS · Relapsed (Transplant-Ineligible)</h3>
-  <p>DLBCL relapsed, transplant-ineligible через age + comorbidity — engine обирає Pola-BR (POLARGO) або loncastuximab tesirine.</p>
-  <div class="case-foot">patient_dlbcl_relapsed_transplant_ineligible.json</div>
 </a>
 <a class="case-card" href="/en/cases/hgbl-primary-refractory.html"
    data-default-order="37"
@@ -6556,45 +5900,89 @@
   <p>PCNSL у HIV+/post-transplant пацієнта, EBER+ — engine додає immune-restoration (HAART / RIS) перед HD-MTX; rituximab якщо CD20+.</p>
   <div class="case-foot">patient_pcnsl_immunocompromised_ebv.json</div>
 </a>
-<a class="case-card" href="/en/cases/dlbcl-2l-pola-r-b.html"
-   data-default-order="578"
-   data-name="DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)">
+<a class="case-card" href="/en/cases/auto-pcnsl.html"
+   data-default-order="146"
+   data-name="DIS-PCNSL — Auto-stub (88% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)</h3>
-  <p>ASCT-ineligible cardiac-comorbidity, late relapse. Engine: ALGO-2L → IND-DLBCL-2L-POLA-R-BENDAMUSTINE (distinct від існуючого relapsed_transplant_ineligible).</p>
-  <div class="case-foot">patient_dlbcl_2l_pola_r_b.json</div>
+  <h3>DIS-PCNSL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Primary CNS Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pcnsl.json</div>
 </a>
-<a class="case-card" href="/en/cases/dlbcl-3l-axi-cel.html"
-   data-default-order="579"
-   data-name="DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)">
+<a class="case-card" href="/en/cases/variant-pcnsl-frail.html"
+   data-default-order="425"
+   data-name="DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)</h3>
-  <p>Прогрес після RCHOP→Pola-BR. Engine: ALGO-2L default = Pola-BR; axi-cel surfaces як aggressive alternative track. Distinct від chemorefractory_for_cart.</p>
-  <div class="case-foot">patient_dlbcl_3l_axi_cel.json</div>
+  <h3>DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_frail.json</div>
 </a>
-<a class="case-card" href="/en/cases/dlbcl-primary-refractory-loncast.html"
-   data-default-order="580"
-   data-name="DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)">
+<a class="case-card" href="/en/cases/variant-pcnsl-organ-dysf.html"
+   data-default-order="426"
+   data-name="DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
   </div>
-  <h3>DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)</h3>
-  <p>Primary-refractory frail non-CAR-T-eligible. Drift: REG-LONCASTUXIMAB-TESIRINE відсутній; engine default = Pola-BR (re-MMAE inappropriate); LOTIS-2 анкер у comment.</p>
-  <div class="case-foot">patient_dlbcl_primary_refractory_loncast_post_pola.json</div>
+  <h3>DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pcnsl-infection-hbv.html"
+   data-default-order="427"
+   data-name="DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pcnsl-relapsed-2l.html"
+   data-default-order="428"
+   data-name="DIS-PCNSL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pcnsl-biomarker-act.html"
+   data-default-order="429"
+   data-name="DIS-PCNSL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pcnsl-high-risk.html"
+   data-default-order="430"
+   data-name="DIS-PCNSL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_high_risk.json</div>
 </a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-PMBCL" hidden>
   <header class="case-list-header">
     <h2>Primary Mediastinal Large B-Cell Lymphoma</h2>
-    <span class="case-list-count">3 examples</span>
+    <span class="case-list-count">10 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/pmbcl-typical.html"
@@ -6630,12 +6018,89 @@
   <p>PMBCL relapsed/refractory після R-CHOP — engine обирає R-ICE+autoSCT (eligible) або pembrolizumab (KEYNOTE-170, ineligible/refractory).</p>
   <div class="case-foot">patient_pmbcl_relapsed_post_rchop.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-pmbcl.html"
+   data-default-order="148"
+   data-name="DIS-PMBCL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Primary Mediastinal Large B-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pmbcl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmbcl-frail.html"
+   data-default-order="436"
+   data-name="DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmbcl-organ-dysf.html"
+   data-default-order="437"
+   data-name="DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmbcl-infection-hbv.html"
+   data-default-order="438"
+   data-name="DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmbcl-relapsed-2l.html"
+   data-default-order="439"
+   data-name="DIS-PMBCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmbcl-biomarker-act.html"
+   data-default-order="440"
+   data-name="DIS-PMBCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmbcl-high-risk.html"
+   data-default-order="441"
+   data-name="DIS-PMBCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_high_risk.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-PMF" hidden>
   <header class="case-list-header">
     <h2>Primary Myelofibrosis</h2>
-    <span class="case-list-count">3 examples</span>
+    <span class="case-list-count">10 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/pmf-anemia-dominant.html"
@@ -6671,12 +6136,451 @@
   <p>PMF post-ruxolitinib failure з massive splenomegaly + transfusion-dependence — engine обирає alloHCT bridge (curative-intent, urgent).</p>
   <div class="case-foot">patient_pmf_post_rux_allohct_bridge.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-pmf.html"
+   data-default-order="149"
+   data-name="DIS-PMF — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Primary Myelofibrosis. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pmf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmf-frail.html"
+   data-default-order="442"
+   data-name="DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmf-organ-dysf.html"
+   data-default-order="443"
+   data-name="DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmf-infection-hbv.html"
+   data-default-order="444"
+   data-name="DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmf-relapsed-2l.html"
+   data-default-order="445"
+   data-name="DIS-PMF · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmf-biomarker-act.html"
+   data-default-order="446"
+   data-name="DIS-PMF · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-pmf-high-risk.html"
+   data-default-order="447"
+   data-name="DIS-PMF · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PROSTATE" hidden>
+  <header class="case-list-header">
+    <h2>Prostate adenocarcinoma</h2>
+    <span class="case-list-count">7 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-prostate.html"
+   data-default-order="150"
+   data-name="DIS-PROSTATE — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Prostate adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_prostate.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-prostate-frail.html"
+   data-default-order="448"
+   data-name="DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-prostate-organ-dysf.html"
+   data-default-order="449"
+   data-name="DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-prostate-infection-hbv.html"
+   data-default-order="450"
+   data-name="DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-prostate-biomarker-act.html"
+   data-default-order="451"
+   data-name="DIS-PROSTATE · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-prostate-high-risk.html"
+   data-default-order="452"
+   data-name="DIS-PROSTATE · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/prostate-mcrpc-brca-olaparib.html"
+   data-default-order="557"
+   data-name="Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)</h3>
+  <p>mCRPC з BRCA-pathogenic, PARPi мono. Engine: ALGO-PROSTATE-MCRPC-1L step 1 → IND-PROSTATE-MCRPC-1L-PARPI (PROfound mPFS 7.4 мо).</p>
+  <div class="case-foot">patient_prostate_mcrpc_brca_olaparib_profound.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-RCC" hidden>
+  <header class="case-list-header">
+    <h2>Renal cell carcinoma</h2>
+    <span class="case-list-count">9 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-rcc.html"
+   data-default-order="154"
+   data-name="DIS-RCC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Renal cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_rcc.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-rcc-frail.html"
+   data-default-order="471"
+   data-name="DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-rcc-organ-dysf.html"
+   data-default-order="472"
+   data-name="DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-rcc-infection-hbv.html"
+   data-default-order="473"
+   data-name="DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-rcc-relapsed-2l.html"
+   data-default-order="474"
+   data-name="DIS-RCC · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-rcc-biomarker-act.html"
+   data-default-order="475"
+   data-name="DIS-RCC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-rcc-high-risk.html"
+   data-default-order="476"
+   data-name="DIS-RCC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/rcc-imdc-int-nivo-ipi.html"
+   data-default-order="558"
+   data-name="RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)</h3>
+  <p>Clear-cell RCC IMDC intermediate-poor. Drift: engine default = pembro+axi; nivo+ipi анкер CM-214 у comment.</p>
+  <div class="case-foot">patient_rcc_imdc_int_nivo_ipi.json</div>
+</a>
+<a class="case-card" href="/en/cases/rcc-imdc-fav-axi-pembro.html"
+   data-default-order="559"
+   data-name="RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)</h3>
+  <p>Clear-cell RCC IMDC favorable. Engine: → IND-RCC-METASTATIC-1L-PEMBRO-AXI (KEYNOTE-426 5-yr OS).</p>
+  <div class="case-foot">patient_rcc_imdc_fav_axi_pembro.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-SALIVARY" hidden>
+  <header class="case-list-header">
+    <h2>Salivary gland carcinoma</h2>
+    <span class="case-list-count">6 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-salivary.html"
+   data-default-order="155"
+   data-name="DIS-SALIVARY — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Salivary gland carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_salivary.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-salivary-frail.html"
+   data-default-order="477"
+   data-name="DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-salivary-organ-dysf.html"
+   data-default-order="478"
+   data-name="DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-salivary-infection-hbv.html"
+   data-default-order="479"
+   data-name="DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-salivary-biomarker-act.html"
+   data-default-order="480"
+   data-name="DIS-SALIVARY · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-salivary-high-risk.html"
+   data-default-order="481"
+   data-name="DIS-SALIVARY · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-SCLC" hidden>
+  <header class="case-list-header">
+    <h2>Small cell lung cancer</h2>
+    <span class="case-list-count">8 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-sclc.html"
+   data-default-order="156"
+   data-name="DIS-SCLC — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Small cell lung cancer. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_sclc.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-sclc-frail.html"
+   data-default-order="482"
+   data-name="DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-sclc-organ-dysf.html"
+   data-default-order="483"
+   data-name="DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-sclc-infection-hbv.html"
+   data-default-order="484"
+   data-name="DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-sclc-biomarker-act.html"
+   data-default-order="485"
+   data-name="DIS-SCLC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-sclc-high-risk.html"
+   data-default-order="486"
+   data-name="DIS-SCLC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/sclc-ls-chemo-rt.html"
+   data-default-order="570"
+   data-name="SCLC · LS · Chemo + concurrent RT">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>SCLC · LS · Chemo + concurrent RT</h3>
+  <p>Limited-stage SCLC. RT не modellable per CHARTER §17 — engine emit chemo backbone EP, RT як free-text. Drift: engine default = ES-1L.</p>
+  <div class="case-foot">patient_sclc_ls_chemo_rt.json</div>
+</a>
+<a class="case-card" href="/en/cases/sclc-es-atezo-impower133.html"
+   data-default-order="571"
+   data-name="SCLC · ES · Atezo+carbo+etoposide (IMpower133)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>SCLC · ES · Atezo+carbo+etoposide (IMpower133)</h3>
+  <p>Extensive-stage SCLC. Engine: → IND-SCLC-EXTENSIVE-1L. Drift: дефолт REG-EP-DURVA не IMpower133 атезо; атезо regimen не wired.</p>
+  <div class="case-foot">patient_sclc_es_atezo_chemo_impower133.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-SPLENIC-MZL" hidden>
   <header class="case-list-header">
     <h2>Splenic Marginal Zone Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
+    <span class="case-list-count">9 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/smzl-hcv-positive.html"
@@ -6701,12 +6605,89 @@
   <p>Селезінкова MZL HCV-negative — engine обирає rituximab monotherapy (4 weekly + 2-year maintenance).</p>
   <div class="case-foot">patient_smzl_hcv_negative.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-splenic_mzl.html"
+   data-default-order="157"
+   data-name="DIS-SPLENIC-MZL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Splenic Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_splenic_mzl.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-splenic_mzl-frail.html"
+   data-default-order="487"
+   data-name="DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-splenic_mzl-organ-dysf.html"
+   data-default-order="488"
+   data-name="DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-splenic_mzl-infection-hbv.html"
+   data-default-order="489"
+   data-name="DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-splenic_mzl-relapsed-2l.html"
+   data-default-order="490"
+   data-name="DIS-SPLENIC-MZL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-splenic_mzl-biomarker-act.html"
+   data-default-order="491"
+   data-name="DIS-SPLENIC-MZL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-splenic_mzl-high-risk.html"
+   data-default-order="492"
+   data-name="DIS-SPLENIC-MZL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_high_risk.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-T-PLL" hidden>
   <header class="case-list-header">
     <h2>T-Cell Prolymphocytic Leukemia</h2>
-    <span class="case-list-count">2 examples</span>
+    <span class="case-list-count">9 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/t-pll-typical.html"
@@ -6731,12 +6712,89 @@
   <p>T-PLL refractory до alemtuzumab mono — engine обирає venetoclax + alemtuzumab combo (Boidol/Hampel).</p>
   <div class="case-foot">patient_t_pll_alemtuzumab_refractory.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-t_pll.html"
+   data-default-order="159"
+   data-name="DIS-T-PLL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для T-Cell Prolymphocytic Leukemia. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_t_pll.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_pll-frail.html"
+   data-default-order="499"
+   data-name="DIS-T-PLL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_pll_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_pll-organ-dysf.html"
+   data-default-order="500"
+   data-name="DIS-T-PLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_pll_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_pll-infection-hbv.html"
+   data-default-order="501"
+   data-name="DIS-T-PLL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_pll_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_pll-relapsed-2l.html"
+   data-default-order="502"
+   data-name="DIS-T-PLL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_pll_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_pll-biomarker-act.html"
+   data-default-order="503"
+   data-name="DIS-T-PLL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_pll_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_pll-high-risk.html"
+   data-default-order="504"
+   data-name="DIS-T-PLL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-PLL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_pll_high_risk.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-T-ALL" hidden>
   <header class="case-list-header">
     <h2>T-Lymphoblastic Leukemia/Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
+    <span class="case-list-count">9 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/t-all-relapsed.html"
@@ -6761,12 +6819,174 @@
   <p>T-lymphoblastic lymphoma з mediastinal mass — engine обирає pediatric-inspired ALL regimen (CALGB 10403 / GMALL); CNS prophylaxis обов&#x27;язкове.</p>
   <div class="case-foot">patient_t_lbl_mediastinal.json</div>
 </a>
+<a class="case-card" href="/en/cases/auto-t_all.html"
+   data-default-order="158"
+   data-name="DIS-T-ALL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для T-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_t_all.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_all-frail.html"
+   data-default-order="493"
+   data-name="DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_all-organ-dysf.html"
+   data-default-order="494"
+   data-name="DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_all-infection-hbv.html"
+   data-default-order="495"
+   data-name="DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_all-relapsed-2l.html"
+   data-default-order="496"
+   data-name="DIS-T-ALL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_all-biomarker-act.html"
+   data-default-order="497"
+   data-name="DIS-T-ALL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-t_all-high-risk.html"
+   data-default-order="498"
+   data-name="DIS-T-ALL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-UROTHELIAL" hidden>
+  <header class="case-list-header">
+    <h2>Urothelial carcinoma</h2>
+    <span class="case-list-count">7 examples</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/en/cases/auto-urothelial.html"
+   data-default-order="162"
+   data-name="DIS-UROTHELIAL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Urothelial carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_urothelial.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-urothelial-frail.html"
+   data-default-order="515"
+   data-name="DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-urothelial-organ-dysf.html"
+   data-default-order="516"
+   data-name="DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-urothelial-infection-hbv.html"
+   data-default-order="517"
+   data-name="DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-urothelial-biomarker-act.html"
+   data-default-order="518"
+   data-name="DIS-UROTHELIAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-urothelial-high-risk.html"
+   data-default-order="519"
+   data-name="DIS-UROTHELIAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_high_risk.json</div>
+</a>
+<a class="case-card" href="/en/cases/urothelial-muc-ev-pembro.html"
+   data-default-order="560"
+   data-name="Urothelial · mUC 1L · EV+pembro (EV-302)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>Urothelial · mUC 1L · EV+pembro (EV-302)</h3>
+  <p>Метастатична мUC. Drift: free-text condition unevaluable; engine default = platinum+avelumab; EV-302 анкер у comment.</p>
+  <div class="case-foot">patient_urothelial_muc_ev_pembro.json</div>
+</a>
   </div>
 </section>
 <section class="case-list" data-disease-id="DIS-WM" hidden>
   <header class="case-list-header">
     <h2>Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma</h2>
-    <span class="case-list-count">2 examples</span>
+    <span class="case-list-count">9 examples</span>
   </header>
   <div class="case-grid">
 <a class="case-card" href="/en/cases/wm-myd88-positive.html"
@@ -6790,6 +7010,83 @@
   <h3>Waldenström · CXCR4-mutant (BR fixed-duration)</h3>
   <p>WM з MYD88+ AND CXCR4-mutant — RF-WM-CXCR4-MUT fired (CXCR4 знижує BTKi response). Engine обирає BR fixed-duration або zanubrutinib з extended observation.</p>
   <div class="case-foot">patient_wm_cxcr4_mut.json</div>
+</a>
+<a class="case-card" href="/en/cases/auto-wm.html"
+   data-default-order="163"
+   data-name="DIS-WM — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_wm.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-wm-frail.html"
+   data-default-order="520"
+   data-name="DIS-WM · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_wm_frail.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-wm-organ-dysf.html"
+   data-default-order="521"
+   data-name="DIS-WM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_wm_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-wm-infection-hbv.html"
+   data-default-order="522"
+   data-name="DIS-WM · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_wm_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-wm-relapsed-2l.html"
+   data-default-order="523"
+   data-name="DIS-WM · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_wm_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-wm-biomarker-act.html"
+   data-default-order="524"
+   data-name="DIS-WM · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_wm_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/en/cases/variant-wm-high-risk.html"
+   data-default-order="525"
+   data-name="DIS-WM · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Form not yet available — opens as JSON on Try-it">JSON-only</span>
+  </div>
+  <h3>DIS-WM · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_wm_high_risk.json</div>
 </a>
   </div>
 </section>
@@ -6864,7 +7161,7 @@
 </style>
 <div class="oo-widget" data-component="openonco-stats">
 <h2>OpenOnco — стан бази знань</h2>
-<div class="oo-sub">Зріз станом на 2026-04-30 17:20 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
+<div class="oo-sub">Зріз станом на 2026-04-30 19:26 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
 <div class="oo-grid">
 <div class="oo-card"><div class="oo-num">65</div><div class="oo-lbl">Хвороби</div></div>
 <div class="oo-card"><div class="oo-num">312</div><div class="oo-lbl">Показання</div></div>

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -39,42 +39,75 @@
       <input type="search" id="diseaseSearch" class="disease-search"
              placeholder="Шукати хворобу…" autocomplete="off"
              aria-label="Шукати хворобу…">
-      <span class="disease-search-count" id="diseaseSearchCount">33</span>
+      <span class="disease-search-count" id="diseaseSearchCount">66</span>
     </div>
     <div class="disease-tile-grid" id="diseaseTileGrid">
-    <button type="button" class="disease-tile" data-disease-id="DIS-B-ALL" data-search="b-лімфобластна лейкемія/лімфома b-lymphoblastic leukemia/lymphoma"><span class="dt-label">B-лімфобластна лейкемія/лімфома</span><span class="dt-count">1 приклад</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-T-PLL" data-search="t-клітинна пролімфоцитарна лейкемія t-cell prolymphocytic leukemia"><span class="dt-label">T-клітинна пролімфоцитарна лейкемія</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-T-ALL" data-search="t-лімфобластна лейкемія/лімфома t-lymphoblastic leukemia/lymphoma"><span class="dt-label">T-лімфобластна лейкемія/лімфома</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-ALCL" data-search="анапластична великоклітинна лімфома (системна) anaplastic large cell lymphoma, systemic"><span class="dt-label">Анапластична великоклітинна лімфома (системна)</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-AITL" data-search="ангіоімунобластна t-клітинна лімфома / нодальна tfh-лімфома angioimmunoblastic t-cell lymphoma"><span class="dt-label">Ангіоімунобластна T-клітинна лімфома / нодальна TFH-лімфома</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-HCL" data-search="волосатоклітинний лейкоз hairy cell leukemia"><span class="dt-label">Волосатоклітинний лейкоз</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-HSTCL" data-search="гепатоспленічна t-клітинна лімфома hepatosplenic t-cell lymphoma"><span class="dt-label">Гепатоспленічна T-клітинна лімфома</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-AML" data-search="гострий мієлоїдний лейкоз (не-apl) acute myeloid leukemia"><span class="dt-label">Гострий мієлоїдний лейкоз (не-APL)</span><span class="dt-count">5 прикладів</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-APL" data-search="гострий промієлоцитарний лейкоз (pml-rara) acute promyelocytic leukemia"><span class="dt-label">Гострий промієлоцитарний лейкоз (PML-RARA)</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MF-SEZARY" data-search="грибоподібний мікоз / синдром сезарі mycosis fungoides / sézary syndrome"><span class="dt-label">Грибоподібний мікоз / Синдром Сезарі</span><span class="dt-count">4 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-ATLL" data-search="дорослий t-клітинний лейкоз/лімфома adult t-cell leukemia/lymphoma"><span class="dt-label">Дорослий T-клітинний лейкоз/лімфома</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-NK-T-NASAL" data-search="екстранодальна nk/t-клітинна лімфома, назального типу extranodal nk/t-cell lymphoma, nasal type"><span class="dt-label">Екстранодальна NK/T-клітинна лімфома, назального типу</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-EATL" data-search="ентеропатія-асоційована t-клітинна лімфома enteropathy-associated t-cell lymphoma"><span class="dt-label">Ентеропатія-асоційована T-клітинна лімфома</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-ET" data-search="есенціальна тромбоцитемія essential thrombocythemia"><span class="dt-label">Есенціальна тромбоцитемія</span><span class="dt-count">1 приклад</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-CHL" data-search="класична лімфома ходжкіна classical hodgkin lymphoma"><span class="dt-label">Класична лімфома Ходжкіна</span><span class="dt-count">4 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-BURKITT" data-search="лімфома беркітта burkitt lymphoma"><span class="dt-label">Лімфома Беркітта</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MCL" data-search="лімфома з клітин зони мантії mantle cell lymphoma"><span class="dt-label">Лімфома з клітин зони мантії</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-WM" data-search="макроглобулінемія вальденстрема / лімфоплазмоцитарна лімфома waldenström macroglobulinemia / lymphoplasmacytic lymphoma"><span class="dt-label">Макроглобулінемія Вальденстрема / Лімфоплазмоцитарна лімфома</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MM" data-search="множинна мієлома multiple myeloma"><span class="dt-label">Множинна мієлома</span><span class="dt-count">4 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-MDS-LR" data-search="мієлодиспластичні синдроми, низький ризик (ipss-r дуже низький / низький / проміжний) myelodysplastic syndromes — lower risk"><span class="dt-label">Мієлодиспластичні синдроми, низький ризик (IPSS-R дуже низький / низький / проміжний)</span><span class="dt-count">5 прикладів</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-NODAL-MZL" data-search="нодальна лімфома маргінальної зони nodal marginal zone lymphoma"><span class="dt-label">Нодальна лімфома маргінальної зони</span><span class="dt-count">5 прикладів</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-NLPBL" data-search="нодулярна лімфоцит-домінантна b-клітинна лімфома (раніше nlphl) nodular lymphocyte-predominant b-cell lymphoma"><span class="dt-label">Нодулярна лімфоцит-домінантна B-клітинна лімфома (раніше NLPHL)</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PCNSL" data-search="первинна дифузна великоклітинна b-клітинна лімфома центральної нервової системи primary cns lymphoma"><span class="dt-label">Первинна дифузна великоклітинна B-клітинна лімфома центральної нервової системи</span><span class="dt-count">11 прикладів</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PMBCL" data-search="первинна медіастинальна (тимічна) b-великоклітинна лімфома primary mediastinal large b-cell lymphoma"><span class="dt-label">Первинна медіастинальна (тимічна) B-великоклітинна лімфома</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PMF" data-search="первинний мієлофіброз primary myelofibrosis"><span class="dt-label">Первинний мієлофіброз</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PTCL-NOS" data-search="периферична t-клітинна лімфома, неуточнена peripheral t-cell lymphoma, nos"><span class="dt-label">Периферична T-клітинна лімфома, неуточнена</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PTLD" data-search="посттрансплантаційні лімфопроліферативні захворювання post-transplant lymphoproliferative disorder"><span class="dt-label">Посттрансплантаційні лімфопроліферативні захворювання</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-SPLENIC-MZL" data-search="селезінкова лімфома маргінальної зони splenic marginal zone lymphoma"><span class="dt-label">Селезінкова лімфома маргінальної зони</span><span class="dt-count">2 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-PV" data-search="справжня поліцитемія polycythemia vera"><span class="dt-label">Справжня поліцитемія</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-FL" data-search="фолікулярна лімфома follicular lymphoma"><span class="dt-label">Фолікулярна лімфома</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-CLL" data-search="хронічна лімфоцитарна лейкемія / дрібноклітинна лімфоцитарна лімфома chronic lymphocytic leukemia / small lymphocytic lymphoma"><span class="dt-label">Хронічна лімфоцитарна лейкемія / Дрібноклітинна лімфоцитарна лімфома</span><span class="dt-count">4 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="DIS-CML" data-search="хронічна мієлоїдна лейкемія (bcr-abl1) chronic myeloid leukemia"><span class="dt-label">Хронічна мієлоїдна лейкемія (BCR-ABL1)</span><span class="dt-count">3 приклади</span></button>
-    <button type="button" class="disease-tile" data-disease-id="OTHER" data-search="інше / без класифікації other / unclassified"><span class="dt-label">Інше / без класифікації</span><span class="dt-count">489 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-B-ALL" data-search="b-лімфобластна лейкемія/лімфома b-lymphoblastic leukemia/lymphoma"><span class="dt-label">B-лімфобластна лейкемія/лімфома</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-T-PLL" data-search="t-клітинна пролімфоцитарна лейкемія t-cell prolymphocytic leukemia"><span class="dt-label">T-клітинна пролімфоцитарна лейкемія</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-T-ALL" data-search="t-лімфобластна лейкемія/лімфома t-lymphoblastic leukemia/lymphoma"><span class="dt-label">T-лімфобластна лейкемія/лімфома</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PROSTATE" data-search="аденокарцинома передміхурової залози prostate adenocarcinoma"><span class="dt-label">Аденокарцинома передміхурової залози</span><span class="dt-count">7 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GASTRIC" data-search="аденокарцинома шлунка / gej gastric and gastroesophageal junction adenocarcinoma"><span class="dt-label">Аденокарцинома шлунка / GEJ</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ALCL" data-search="анапластична великоклітинна лімфома (системна) anaplastic large cell lymphoma, systemic"><span class="dt-label">Анапластична великоклітинна лімфома (системна)</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-THYROID-ANAPLASTIC" data-search="анапластична карцинома щитовидної залози anaplastic thyroid carcinoma"><span class="dt-label">Анапластична карцинома щитовидної залози</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-AITL" data-search="ангіоімунобластна t-клітинна лімфома / нодальна tfh-лімфома angioimmunoblastic t-cell lymphoma"><span class="dt-label">Ангіоімунобластна T-клітинна лімфома / нодальна TFH-лімфома</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HGBL-DH" data-search="високозлоякісна b-клітинна лімфома з myc + bcl2/bcl6 (double-hit / triple-hit) high-grade b-cell lymphoma, double-hit / triple-hit"><span class="dt-label">Високозлоякісна B-клітинна лімфома з MYC + BCL2/BCL6 (double-hit / triple-hit)</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HCL" data-search="волосатоклітинний лейкоз hairy cell leukemia"><span class="dt-label">Волосатоклітинний лейкоз</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GIST" data-search="гастроінтестинальна стромальна пухлина (gist) gastrointestinal stromal tumor"><span class="dt-label">Гастроінтестинальна стромальна пухлина (GIST)</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HSTCL" data-search="гепатоспленічна t-клітинна лімфома hepatosplenic t-cell lymphoma"><span class="dt-label">Гепатоспленічна T-клітинна лімфома</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HCC" data-search="гепатоцелюлярна карцинома hepatocellular carcinoma"><span class="dt-label">Гепатоцелюлярна карцинома</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GBM" data-search="гліобластома (idh-wt, who grade 4) glioblastoma"><span class="dt-label">Гліобластома (IDH-WT, WHO grade 4)</span><span class="dt-count">7 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-GLIOMA-LOW-GRADE" data-search="гліома низького ступеня (who grade 2 — idh-мутантна) low-grade glioma"><span class="dt-label">Гліома низького ступеня (WHO grade 2 — IDH-мутантна)</span><span class="dt-count">1 приклад</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-AML" data-search="гострий мієлоїдний лейкоз (не-apl) acute myeloid leukemia"><span class="dt-label">Гострий мієлоїдний лейкоз (не-APL)</span><span class="dt-count">14 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-APL" data-search="гострий промієлоцитарний лейкоз (pml-rara) acute promyelocytic leukemia"><span class="dt-label">Гострий промієлоцитарний лейкоз (PML-RARA)</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MF-SEZARY" data-search="грибоподібний мікоз / синдром сезарі mycosis fungoides / sézary syndrome"><span class="dt-label">Грибоподібний мікоз / Синдром Сезарі</span><span class="dt-count">11 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-DLBCL-NOS" data-search="дифузна b-великоклітинна лімфома, неуточнена (dlbcl nos) diffuse large b-cell lymphoma, not otherwise specified"><span class="dt-label">Дифузна B-великоклітинна лімфома, неуточнена (DLBCL NOS)</span><span class="dt-count">12 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ATLL" data-search="дорослий t-клітинний лейкоз/лімфома adult t-cell leukemia/lymphoma"><span class="dt-label">Дорослий T-клітинний лейкоз/лімфома</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-SCLC" data-search="дрібноклітинний рак легені small cell lung cancer"><span class="dt-label">Дрібноклітинний рак легені</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NK-T-NASAL" data-search="екстранодальна nk/t-клітинна лімфома, назального типу extranodal nk/t-cell lymphoma, nasal type"><span class="dt-label">Екстранодальна NK/T-клітинна лімфома, назального типу</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-EATL" data-search="ентеропатія-асоційована t-клітинна лімфома enteropathy-associated t-cell lymphoma"><span class="dt-label">Ентеропатія-асоційована T-клітинна лімфома</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ET" data-search="есенціальна тромбоцитемія essential thrombocythemia"><span class="dt-label">Есенціальна тромбоцитемія</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-IMT" data-search="запальна міофібробластична пухлина inflammatory myofibroblastic tumor"><span class="dt-label">Запальна міофібробластична пухлина</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MPNST" data-search="злоякісна пухлина оболонки периферичного нерва malignant peripheral nerve sheath tumor"><span class="dt-label">Злоякісна пухлина оболонки периферичного нерва</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ENDOMETRIAL" data-search="карцинома ендометрія endometrial carcinoma"><span class="dt-label">Карцинома ендометрія</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-SALIVARY" data-search="карцинома слинних залоз salivary gland carcinoma"><span class="dt-label">Карцинома слинних залоз</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-ESOPHAGEAL" data-search="карцинома стравоходу (плоскоклітинна + аденокарцинома) esophageal carcinoma"><span class="dt-label">Карцинома стравоходу (плоскоклітинна + аденокарцинома)</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CERVICAL" data-search="карцинома шийки матки cervical carcinoma"><span class="dt-label">Карцинома шийки матки</span><span class="dt-count">7 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-OVARIAN" data-search="карцинома яєчників (переважно high-grade серозна) ovarian carcinoma"><span class="dt-label">Карцинома яєчників (переважно high-grade серозна)</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CHL" data-search="класична лімфома ходжкіна classical hodgkin lymphoma"><span class="dt-label">Класична лімфома Ходжкіна</span><span class="dt-count">11 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CRC" data-search="колоректальний рак colorectal carcinoma"><span class="dt-label">Колоректальний рак</span><span class="dt-count">13 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-BURKITT" data-search="лімфома беркітта burkitt lymphoma"><span class="dt-label">Лімфома Беркітта</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MCL" data-search="лімфома з клітин зони мантії mantle cell lymphoma"><span class="dt-label">Лімфома з клітин зони мантії</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HCV-MZL" data-search="лімфома маргінальної зони, асоційована з hcv hcv-associated marginal zone lymphoma"><span class="dt-label">Лімфома маргінальної зони, асоційована з HCV</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-WM" data-search="макроглобулінемія вальденстрема / лімфоплазмоцитарна лімфома waldenström macroglobulinemia / lymphoplasmacytic lymphoma"><span class="dt-label">Макроглобулінемія Вальденстрема / Лімфоплазмоцитарна лімфома</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MTC" data-search="медулярна карцинома щитовидної залози medullary thyroid carcinoma"><span class="dt-label">Медулярна карцинома щитовидної залози</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MM" data-search="множинна мієлома multiple myeloma"><span class="dt-label">Множинна мієлома</span><span class="dt-count">11 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MDS-HR" data-search="мієлодиспластичні синдроми, високий ризик (ipss-r високий / дуже високий; включає mds-eb) myelodysplastic syndromes — higher risk"><span class="dt-label">Мієлодиспластичні синдроми, високий ризик (IPSS-R високий / дуже високий; включає MDS-EB)</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MDS-LR" data-search="мієлодиспластичні синдроми, низький ризик (ipss-r дуже низький / низький / проміжний) myelodysplastic syndromes — lower risk"><span class="dt-label">Мієлодиспластичні синдроми, низький ризик (IPSS-R дуже низький / низький / проміжний)</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NSCLC" data-search="недрібноклітинний рак легені non-small cell lung cancer"><span class="dt-label">Недрібноклітинний рак легені</span><span class="dt-count">19 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-RCC" data-search="нирково-клітинна карцинома renal cell carcinoma"><span class="dt-label">Нирково-клітинна карцинома</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NODAL-MZL" data-search="нодальна лімфома маргінальної зони nodal marginal zone lymphoma"><span class="dt-label">Нодальна лімфома маргінальної зони</span><span class="dt-count">12 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-NLPBL" data-search="нодулярна лімфоцит-домінантна b-клітинна лімфома (раніше nlphl) nodular lymphocyte-predominant b-cell lymphoma"><span class="dt-label">Нодулярна лімфоцит-домінантна B-клітинна лімфома (раніше NLPHL)</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-THYROID-PAPILLARY" data-search="папілярна карцинома щитовидної залози papillary thyroid carcinoma"><span class="dt-label">Папілярна карцинома щитовидної залози</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PCNSL" data-search="первинна дифузна великоклітинна b-клітинна лімфома центральної нервової системи primary cns lymphoma"><span class="dt-label">Первинна дифузна великоклітинна B-клітинна лімфома центральної нервової системи</span><span class="dt-count">13 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PMBCL" data-search="первинна медіастинальна (тимічна) b-великоклітинна лімфома primary mediastinal large b-cell lymphoma"><span class="dt-label">Первинна медіастинальна (тимічна) B-великоклітинна лімфома</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PMF" data-search="первинний мієлофіброз primary myelofibrosis"><span class="dt-label">Первинний мієлофіброз</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PTCL-NOS" data-search="периферична t-клітинна лімфома, неуточнена peripheral t-cell lymphoma, nos"><span class="dt-label">Периферична T-клітинна лімфома, неуточнена</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-HNSCC" data-search="плоскоклітинна карцинома голови та шиї head and neck squamous cell carcinoma"><span class="dt-label">Плоскоклітинна карцинома голови та шиї</span><span class="dt-count">8 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PTLD" data-search="посттрансплантаційні лімфопроліферативні захворювання post-transplant lymphoproliferative disorder"><span class="dt-label">Посттрансплантаційні лімфопроліферативні захворювання</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MASTOCYTOSIS" data-search="поширений системний мастоцитоз advanced systemic mastocytosis"><span class="dt-label">Поширений системний мастоцитоз</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PDAC" data-search="протокова аденокарцинома підшлункової залози pancreatic ductal adenocarcinoma"><span class="dt-label">Протокова аденокарцинома підшлункової залози</span><span class="dt-count">7 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-SPLENIC-MZL" data-search="селезінкова лімфома маргінальної зони splenic marginal zone lymphoma"><span class="dt-label">Селезінкова лімфома маргінальної зони</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-PV" data-search="справжня поліцитемія polycythemia vera"><span class="dt-label">Справжня поліцитемія</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-UROTHELIAL" data-search="уротеліальна карцинома urothelial carcinoma"><span class="dt-label">Уротеліальна карцинома</span><span class="dt-count">7 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-FL" data-search="фолікулярна лімфома follicular lymphoma"><span class="dt-label">Фолікулярна лімфома</span><span class="dt-count">9 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CHOLANGIOCARCINOMA" data-search="холангіокарцинома (рак жовчних проток) cholangiocarcinoma"><span class="dt-label">Холангіокарцинома (рак жовчних проток)</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CHONDROSARCOMA" data-search="хондросаркома chondrosarcoma"><span class="dt-label">Хондросаркома</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CLL" data-search="хронічна лімфоцитарна лейкемія / дрібноклітинна лімфоцитарна лімфома chronic lymphocytic leukemia / small lymphocytic lymphoma"><span class="dt-label">Хронічна лімфоцитарна лейкемія / Дрібноклітинна лімфоцитарна лімфома</span><span class="dt-count">11 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-CML" data-search="хронічна мієлоїдна лейкемія (bcr-abl1) chronic myeloid leukemia"><span class="dt-label">Хронічна мієлоїдна лейкемія (BCR-ABL1)</span><span class="dt-count">10 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-MELANOMA" data-search="шкірна меланома cutaneous melanoma"><span class="dt-label">Шкірна меланома</span><span class="dt-count">12 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-BREAST" data-search="інвазивний рак молочної залози invasive breast cancer"><span class="dt-label">Інвазивний рак молочної залози</span><span class="dt-count">15 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="DIS-IFS" data-search="інфантильна фібросаркома infantile fibrosarcoma"><span class="dt-label">Інфантильна фібросаркома</span><span class="dt-count">6 прикладів</span></button>
+    <button type="button" class="disease-tile" data-disease-id="OTHER" data-search="інше / без класифікації other / unclassified"><span class="dt-label">Інше / без класифікації</span><span class="dt-count">4 приклади</span></button>
     </div>
     <p class="disease-empty" id="diseaseEmpty" hidden>Жодна хвороба не підходить під запит.</p>
   </section>
@@ -86,1376 +119,9 @@
     <section class="case-list" data-disease-id="DIS-B-ALL" hidden>
   <header class="case-list-header">
     <h2>B-лімфобластна лейкемія/лімфома</h2>
-    <span class="case-list-count">1 приклад</span>
+    <span class="case-list-count">10 прикладів</span>
   </header>
   <div class="case-grid">
-<a class="case-card" href="/cases/b-all-mrd-positive.html"
-   data-default-order="92"
-   data-name="B-ALL · MRD-positive (Blinatumomab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>B-ALL · MRD-positive (Blinatumomab)</h3>
-  <p>B-ALL MRD-positive після induction — engine обирає blinatumomab (BLAST: MRD eradication у &gt;75%).</p>
-  <div class="case-foot">patient_b_all_mrd_positive.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-T-PLL" hidden>
-  <header class="case-list-header">
-    <h2>T-клітинна пролімфоцитарна лейкемія</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/t-pll-typical.html"
-   data-default-order="57"
-   data-name="T-PLL · Typical (Alemtuzumab IV)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>T-PLL · Typical (Alemtuzumab IV)</h3>
-  <p>T-PLL з ATM mutation + TCL1A rearrangement — engine обирає alemtuzumab IV (~90% ORR) → alloHCT consolidation.</p>
-  <div class="case-foot">patient_t_pll_typical.json</div>
-</a>
-<a class="case-card" href="/cases/t-pll-alem-refractory.html"
-   data-default-order="58"
-   data-name="T-PLL · Alemtuzumab-refractory (Venetoclax + Alem)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>T-PLL · Alemtuzumab-refractory (Venetoclax + Alem)</h3>
-  <p>T-PLL refractory до alemtuzumab mono — engine обирає venetoclax + alemtuzumab combo (Boidol/Hampel).</p>
-  <div class="case-foot">patient_t_pll_alemtuzumab_refractory.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-T-ALL" hidden>
-  <header class="case-list-header">
-    <h2>T-лімфобластна лейкемія/лімфома</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/t-all-relapsed.html"
-   data-default-order="94"
-   data-name="T-ALL · Relapsed post-hyper-CVAD (Nelarabine)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>T-ALL · Relapsed post-hyper-CVAD (Nelarabine)</h3>
-  <p>T-ALL relapsed після hyper-CVAD — engine обирає nelarabine (T-cell selective; alloHCT consolidation).</p>
-  <div class="case-foot">patient_t_all_relapsed_post_hyper_cvad.json</div>
-</a>
-<a class="case-card" href="/cases/t-lbl-mediastinal.html"
-   data-default-order="95"
-   data-name="T-LBL · Mediastinal Mass (Pediatric-inspired ALL)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>T-LBL · Mediastinal Mass (Pediatric-inspired ALL)</h3>
-  <p>T-lymphoblastic lymphoma з mediastinal mass — engine обирає pediatric-inspired ALL regimen (CALGB 10403 / GMALL); CNS prophylaxis обов&#x27;язкове.</p>
-  <div class="case-foot">patient_t_lbl_mediastinal.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-ALCL" hidden>
-  <header class="case-list-header">
-    <h2>Анапластична великоклітинна лімфома (системна)</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/alcl-alk-negative.html"
-   data-default-order="24"
-   data-name="ALCL · ALK-negative (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ALCL · ALK-negative (CHP-Bv)</h3>
-  <p>Системна анапластична великоклітинна лімфома, ALK-negative — universally CD30+. Engine обирає CHP-Bv (ECHELON-2: brentuximab замість vincristine).</p>
-  <div class="case-foot">patient_alcl_alk_negative.json</div>
-</a>
-<a class="case-card" href="/cases/alcl-alk-positive-typical.html"
-   data-default-order="48"
-   data-name="ALCL · ALK-positive Typical (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ALCL · ALK-positive Typical (CHP-Bv)</h3>
-  <p>Молода особа з ALK+ ALCL — engine обирає CHP-Bv (ECHELON-2). ALK+ має значно кращий прогноз vs ALK-.</p>
-  <div class="case-foot">patient_alcl_alk_positive_typical.json</div>
-</a>
-<a class="case-card" href="/cases/alcl-relapsed-bv-naive.html"
-   data-default-order="49"
-   data-name="ALCL · Relapsed BV-naive (Brentuximab → autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ALCL · Relapsed BV-naive (Brentuximab → autoSCT)</h3>
-  <p>Relapsed ALCL без попереднього brentuximab — engine обирає brentuximab mono → autoSCT consolidation; BV maintenance per ECHELON-2 update.</p>
-  <div class="case-foot">patient_alcl_relapsed_bv_naive.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-AITL" hidden>
-  <header class="case-list-header">
-    <h2>Ангіоімунобластна T-клітинна лімфома / нодальна TFH-лімфома</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/aitl-cd30-positive.html"
-   data-default-order="26"
-   data-name="AITL · CD30-positive (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AITL · CD30-positive (CHP-Bv)</h3>
-  <p>Ангіоімунобластна T-клітинна лімфома, CD30+ — RF-TCELL-CD30-POSITIVE fired. Engine обирає CHP-Bv.</p>
-  <div class="case-foot">patient_aitl_cd30_positive.json</div>
-</a>
-<a class="case-card" href="/cases/aitl-cd30-negative.html"
-   data-default-order="30"
-   data-name="AITL · CD30-negative (CHOEP + AITL-specific workup)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AITL · CD30-negative (CHOEP + AITL-specific workup)</h3>
-  <p>AITL з CD30-negative біопсією — engine обирає AITL-specific CHOEP. Layered workup: EBER-ISH (EBV+ B-cell мікрооточення), IgG quant (paraneoplastic hypogamma), DAT (AIHA risk).</p>
-  <div class="case-foot">patient_aitl_cd30_negative.json</div>
-</a>
-<a class="case-card" href="/cases/aitl-relapsed-2l.html"
-   data-default-order="52"
-   data-name="AITL · Relapsed 2L (Azacitidine)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AITL · Relapsed 2L (Azacitidine)</h3>
-  <p>AITL relapsed з TET2/DNMT3A epigenetic profile — engine обирає azacitidine (epigenetic targeting; AITL — найбільш azacitidine-responsive TCL subtype).</p>
-  <div class="case-foot">patient_aitl_relapsed_2l.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-HCL" hidden>
-  <header class="case-list-header">
-    <h2>Волосатоклітинний лейкоз</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/hcl-typical.html"
-   data-default-order="21"
-   data-name="Hairy Cell Leukemia (Cladribine 7-day)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Hairy Cell Leukemia (Cladribine 7-day)</h3>
-  <p>Волосатоклітинний лейкоз з cytopenia + splenomegaly — engine обирає 1 курс cladribine 7 днів. ~85% durable CR.</p>
-  <div class="case-foot">patient_hcl_typical.json</div>
-</a>
-<a class="case-card" href="/cases/hcl-relapsed-braf.html"
-   data-default-order="45"
-   data-name="HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)</h3>
-  <p>HCL relapsed з BRAF-V600E+ — engine обирає vemurafenib+rituximab (Tiacci); BRAF-WT route → cladribine retreatment.</p>
-  <div class="case-foot">patient_hcl_relapsed_braf.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-HSTCL" hidden>
-  <header class="case-list-header">
-    <h2>Гепатоспленічна T-клітинна лімфома</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/hstcl-fit-younger.html"
-   data-default-order="55"
-   data-name="HSTCL · Fit Younger (ICE/IVAC → alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HSTCL · Fit Younger (ICE/IVAC → alloHCT)</h3>
-  <p>Hepatosplenic T-cell Lymphoma у молодої особи, ECOG 0 — engine обирає intensive ICE/IVAC → upfront alloHCT (CHOP неадекватний).</p>
-  <div class="case-foot">patient_hstcl_fit_younger.json</div>
-</a>
-<a class="case-card" href="/cases/hstcl-iatrogenic-ibd.html"
-   data-default-order="56"
-   data-name="HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)</h3>
-  <p>HSTCL у IBD-пацієнта на тривалій thiopurine+anti-TNF therapy — engine припиняє imunosuppression + CHOEP-unfit fallback з branching algorithm.</p>
-  <div class="case-foot">patient_hstcl_iatrogenic_ibd.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-AML" hidden>
-  <header class="case-list-header">
-    <h2>Гострий мієлоїдний лейкоз (не-APL)</h2>
-    <span class="case-list-count">5 прикладів</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/aml-fit-1l-7-3.html"
-   data-default-order="70"
-   data-name="AML · Fit 1L (7+3 Induction)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · Fit 1L (7+3 Induction)</h3>
-  <p>Newly-diagnosed AML, fit, ELN intermediate — engine обирає 7+3 induction (cytarabine + daunorubicin) → consolidation HiDAC.</p>
-  <div class="case-foot">patient_aml_fit_1l_seven_three.json</div>
-</a>
-<a class="case-card" href="/cases/aml-unfit-ven-aza.html"
-   data-default-order="71"
-   data-name="AML · Unfit (Venetoclax + Azacitidine)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · Unfit (Venetoclax + Azacitidine)</h3>
-  <p>AML вік 78, ECOG 2 — engine обирає ven+aza (VIALE-A: ~65% CR/CRi, OS 14.7 mo, краще ніж aza alone).</p>
-  <div class="case-foot">patient_aml_unfit_ven_aza.json</div>
-</a>
-<a class="case-card" href="/cases/aml-flt3-relapse.html"
-   data-default-order="72"
-   data-name="AML · FLT3-mutant Relapse (Gilteritinib)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · FLT3-mutant Relapse (Gilteritinib)</h3>
-  <p>AML relapsed з FLT3-ITD/TKD — engine обирає gilteritinib mono (ADMIRAL: superior до salvage chemo); alloHCT для responders.</p>
-  <div class="case-foot">patient_aml_flt3_relapse.json</div>
-</a>
-<a class="case-card" href="/cases/aml-flt3-itd-midostaurin.html"
-   data-default-order="574"
-   data-name="AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)</h3>
-  <p>Fit AML FLT3-ITD. Engine: ALGO-1L → IND-AML-1L-7-3 (default); midostaurin/RATIFY як regimen-layer note у comment.</p>
-  <div class="case-foot">patient_aml_flt3_itd_midostaurin_7_3.json</div>
-</a>
-<a class="case-card" href="/cases/aml-rr-gilteritinib.html"
-   data-default-order="577"
-   data-name="AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)</h3>
-  <p>Primary-refractory FLT3-TKD AML. Engine: ALGO-2L → IND-AML-2L-GILTERITINIB-FLT3 (ADMIRAL mOS 9.3 мо vs salvage chemo).</p>
-  <div class="case-foot">patient_aml_rr_gilteritinib.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-APL" hidden>
-  <header class="case-list-header">
-    <h2>Гострий промієлоцитарний лейкоз (PML-RARA)</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/apl-low-risk.html"
-   data-default-order="73"
-   data-name="APL · Low Risk (ATRA + ATO chemo-free)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>APL · Low Risk (ATRA + ATO chemo-free)</h3>
-  <p>APL з WBC &lt;10K (low-risk Sanz) — engine обирає ATRA+ATO chemo-free (APL0406: ~98% CR, без anthracycline).</p>
-  <div class="case-foot">patient_apl_low_risk.json</div>
-</a>
-<a class="case-card" href="/cases/apl-high-risk.html"
-   data-default-order="74"
-   data-name="APL · High Risk + DIC (ATRA + ATO + Idarubicin)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>APL · High Risk + DIC (ATRA + ATO + Idarubicin)</h3>
-  <p>APL з WBC &gt;10K + active DIC — RF-APL-DIC + RF-APL-HIGH-RISK fired. Engine додає idarubicin до ATRA+ATO; emergency cryoprecipitate/platelets.</p>
-  <div class="case-foot">patient_apl_high_risk.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MF-SEZARY" hidden>
-  <header class="case-list-header">
-    <h2>Грибоподібний мікоз / Синдром Сезарі</h2>
-    <span class="case-list-count">4 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/mf-early-stage.html"
-   data-default-order="31"
-   data-name="Mycosis Fungoides · Early Stage (Skin-Directed)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Mycosis Fungoides · Early Stage (Skin-Directed)</h3>
-  <p>MF stage IB без B2/LCT — engine обирає skin-directed (NBUVB / topicals / TSEBT). Жодного системного режиму — preserves chemo для прогресу. Workup rules out occult Sézary (B2 count) + LCT.</p>
-  <div class="case-foot">patient_mf_early_stage.json</div>
-</a>
-<a class="case-card" href="/cases/sezary-advanced.html"
-   data-default-order="32"
-   data-name="Sézary Syndrome · Advanced (Mogamulizumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Sézary Syndrome · Advanced (Mogamulizumab)</h3>
-  <p>Sézary syndrome (B2 leukemic, generalized erythroderma) — RF-MF-SEZARY-LEUKEMIC fired. Engine обирає mogamulizumab (MAVORIC: anti-CCR4 ADCC, найкраща blood-compartment відповідь).</p>
-  <div class="case-foot">patient_sezary_advanced.json</div>
-</a>
-<a class="case-card" href="/cases/mf-advanced-cd30.html"
-   data-default-order="33"
-   data-name="MF · Advanced + CD30+ LCT (Brentuximab mono)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MF · Advanced + CD30+ LCT (Brentuximab mono)</h3>
-  <p>Advanced MF stage IIB з large-cell transformation, CD30+ — RF-MF-LARGE-CELL-TRANSFORMATION + RF-TCELL-CD30-POSITIVE fired. Engine обирає brentuximab vedotin monotherapy (ALCANZA).</p>
-  <div class="case-foot">patient_mf_advanced_cd30.json</div>
-</a>
-<a class="case-card" href="/cases/mf-relapsed-post-moga.html"
-   data-default-order="63"
-   data-name="MF · Relapsed post-Mogamulizumab (Bexarotene)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MF · Relapsed post-Mogamulizumab (Bexarotene)</h3>
-  <p>MF/Sézary relapsed після mogamulizumab — engine обирає bexarotene 2L з low-dose maintenance (RXR-targeted oral retinoid).</p>
-  <div class="case-foot">patient_mf_relapsed_post_moga.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-ATLL" hidden>
-  <header class="case-list-header">
-    <h2>Дорослий T-клітинний лейкоз/лімфома</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/atll-acute.html"
-   data-default-order="59"
-   data-name="ATLL · Acute (mLSG15 / EPOCH)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ATLL · Acute (mLSG15 / EPOCH)</h3>
-  <p>Adult T-cell Leukemia/Lymphoma, acute subtype, HTLV-1+ — engine обирає intensive mLSG15 або EPOCH; alloHCT consolidation для responders.</p>
-  <div class="case-foot">patient_atll_acute.json</div>
-</a>
-<a class="case-card" href="/cases/atll-indolent-smoldering.html"
-   data-default-order="60"
-   data-name="ATLL · Indolent / Smoldering (Watchful Waiting)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>ATLL · Indolent / Smoldering (Watchful Waiting)</h3>
-  <p>ATLL indolent/smoldering — engine обирає observation; system trigger для transformation.</p>
-  <div class="case-foot">patient_atll_indolent_smoldering.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-NK-T-NASAL" hidden>
-  <header class="case-list-header">
-    <h2>Екстранодальна NK/T-клітинна лімфома, назального типу</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/nk-t-nasal-localized.html"
-   data-default-order="61"
-   data-name="NK/T-Nasal · Localized (P-GEMOX + RT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NK/T-Nasal · Localized (P-GEMOX + RT)</h3>
-  <p>Localized extranodal NK/T-cell lymphoma, nasal type — engine обирає concurrent P-GEMOX + RT (anthracycline-resistant biology).</p>
-  <div class="case-foot">patient_nk_t_nasal_localized.json</div>
-</a>
-<a class="case-card" href="/cases/nk-t-nasal-relapsed.html"
-   data-default-order="62"
-   data-name="NK/T-Nasal · Relapsed (Avelumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NK/T-Nasal · Relapsed (Avelumab)</h3>
-  <p>NK/T-nasal relapsed — engine обирає avelumab (NCCN-listed PD-L1 inhibitor; promoted from stub).</p>
-  <div class="case-foot">patient_nk_t_nasal_relapsed.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-EATL" hidden>
-  <header class="case-list-header">
-    <h2>Ентеропатія-асоційована T-клітинна лімфома</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/eatl-typical.html"
-   data-default-order="53"
-   data-name="EATL · Typical (Celiac, CHOEP → autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>EATL · Typical (Celiac, CHOEP → autoSCT)</h3>
-  <p>EATL у пацієнта з celiac disease — engine обирає CHOEP induction → autoSCT consolidation (NLG-T-01).</p>
-  <div class="case-foot">patient_eatl_typical.json</div>
-</a>
-<a class="case-card" href="/cases/eatl-relapsed-post-choep.html"
-   data-default-order="54"
-   data-name="EATL · Relapsed post-CHOEP (ICE Salvage)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>EATL · Relapsed post-CHOEP (ICE Salvage)</h3>
-  <p>EATL relapsed після CHOEP — engine обирає ICE salvage; alloHCT для chemosensitive.</p>
-  <div class="case-foot">patient_eatl_relapsed_post_choep.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-ET" hidden>
-  <header class="case-list-header">
-    <h2>Есенціальна тромбоцитемія</h2>
-    <span class="case-list-count">1 приклад</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/et-high-risk-hu.html"
-   data-default-order="87"
-   data-name="Essential Thrombocythemia · High Risk (HU)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Essential Thrombocythemia · High Risk (HU)</h3>
-  <p>ET high-risk (age &gt;60 + JAK2+ + thrombosis) — engine обирає hydroxyurea + ASA; anagrelide як 2L (PT-1).</p>
-  <div class="case-foot">patient_et_high_risk_hu.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-CHL" hidden>
-  <header class="case-list-header">
-    <h2>Класична лімфома Ходжкіна</h2>
-    <span class="case-list-count">4 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/chl-advanced.html"
-   data-default-order="27"
-   data-name="Classical Hodgkin · Advanced (A+AVD)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Classical Hodgkin · Advanced (A+AVD)</h3>
-  <p>Стадія IV cHL — RF-CHL-ADVANCED-STAGE fired. Engine обирає A+AVD (ECHELON-1: brentuximab замість bleomycin, superior OS).</p>
-  <div class="case-foot">patient_chl_advanced.json</div>
-</a>
-<a class="case-card" href="/cases/chl-early.html"
-   data-default-order="28"
-   data-name="Classical Hodgkin · Early Stage (ABVD)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Classical Hodgkin · Early Stage (ABVD)</h3>
-  <p>Стадія IIA cHL, без advanced criteria — engine обирає ABVD × 2-4 + ISRT (response-adapted).</p>
-  <div class="case-foot">patient_chl_early.json</div>
-</a>
-<a class="case-card" href="/cases/chl-pediatric-bulky.html"
-   data-default-order="66"
-   data-name="cHL · AYA Stage IIB Bulky Mediastinal">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>cHL · AYA Stage IIB Bulky Mediastinal</h3>
-  <p>AYA пацієнт з cHL stage IIB + bulky mediastinal mass + B-symptoms — RF-CHL-BULKY-MEDIASTINAL fired. Response-adapted intensification.</p>
-  <div class="case-foot">patient_chl_pediatric_bulky_mediastinal.json</div>
-</a>
-<a class="case-card" href="/cases/chl-relapsed-salvage.html"
-   data-default-order="67"
-   data-name="cHL · Relapsed (Salvage → autoSCT + BV maint.)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>cHL · Relapsed (Salvage → autoSCT + BV maint.)</h3>
-  <p>cHL relapsed після ABVD/A+AVD — engine обирає salvage chemo (ICE/DHAP) → autoSCT → brentuximab maintenance (AETHERA).</p>
-  <div class="case-foot">patient_chl_relapsed_for_salvage.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-BURKITT" hidden>
-  <header class="case-list-header">
-    <h2>Лімфома Беркітта</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/burkitt-low-risk.html"
-   data-default-order="19"
-   data-name="Burkitt · Low/Intermediate Risk (DA-EPOCH-R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Burkitt · Low/Intermediate Risk (DA-EPOCH-R)</h3>
-  <p>Burkitt без CNS+, LDH в нормі — engine обирає DA-EPOCH-R (CALGB 10002, ~90% CR including HIV+).</p>
-  <div class="case-foot">patient_burkitt_low_risk.json</div>
-</a>
-<a class="case-card" href="/cases/burkitt-high-risk.html"
-   data-default-order="20"
-   data-name="Burkitt · High Risk (CODOX-M / IVAC)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Burkitt · High Risk (CODOX-M / IVAC)</h3>
-  <p>Burkitt з CNS involvement + LDH &gt;3× ULN + bulky abdomen — RF-BURKITT-HIGH-RISK fired. Engine обирає Magrath protocol з HD-MTX + IT MTX/cytarabine.</p>
-  <div class="case-foot">patient_burkitt_high_risk.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MCL" hidden>
-  <header class="case-list-header">
-    <h2>Лімфома з клітин зони мантії</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/mcl-fit-younger.html"
-   data-default-order="14"
-   data-name="Mantle Cell · Fit Younger (Intensive + autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Mantle Cell · Fit Younger (Intensive + autoSCT)</h3>
-  <p>MCL вік 58, ECOG 0, TP53-wt — engine обирає intensive R-CHOP/R-DHAP × 6 + autoSCT + R-maintenance × 3 years (Nordic protocol).</p>
-  <div class="case-foot">patient_mcl_fit_younger.json</div>
-</a>
-<a class="case-card" href="/cases/mcl-unfit-tp53.html"
-   data-default-order="15"
-   data-name="Mantle Cell · Unfit / TP53-mutant (BTKi+R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Mantle Cell · Unfit / TP53-mutant (BTKi+R)</h3>
-  <p>MCL вік 71, ECOG 2, TP53 mutation — RF-MCL-BLASTOID-OR-TP53 fired. Engine обирає acalabrutinib + rituximab (BTKi-based).</p>
-  <div class="case-foot">patient_mcl_unfit_or_tp53.json</div>
-</a>
-<a class="case-card" href="/cases/mcl-pirtobrutinib-3l.html"
-   data-default-order="582"
-   data-name="MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)</h3>
-  <p>Post-covalent-BTKi прогрес з LVEF 38% (CAR-T ineligible). Drift: ALGO-MCL-2L step 3 free-text; engine default = acalabrutinib; BRUIN анкер у comment.</p>
-  <div class="case-foot">patient_mcl_pirtobrutinib_3l_post_btki.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-WM" hidden>
-  <header class="case-list-header">
-    <h2>Макроглобулінемія Вальденстрема / Лімфоплазмоцитарна лімфома</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/wm-myd88-positive.html"
-   data-default-order="22"
-   data-name="Waldenström · MYD88-positive (Zanubrutinib)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Waldenström · MYD88-positive (Zanubrutinib)</h3>
-  <p>WM з MYD88 L265P + iwWM treatment indication — engine обирає zanubrutinib (ASPEN — superior до ibrutinib).</p>
-  <div class="case-foot">patient_wm_myd88_positive.json</div>
-</a>
-<a class="case-card" href="/cases/wm-cxcr4-mut.html"
-   data-default-order="46"
-   data-name="Waldenström · CXCR4-mutant (BR fixed-duration)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Waldenström · CXCR4-mutant (BR fixed-duration)</h3>
-  <p>WM з MYD88+ AND CXCR4-mutant — RF-WM-CXCR4-MUT fired (CXCR4 знижує BTKi response). Engine обирає BR fixed-duration або zanubrutinib з extended observation.</p>
-  <div class="case-foot">patient_wm_cxcr4_mut.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MM" hidden>
-  <header class="case-list-header">
-    <h2>Множинна мієлома</h2>
-    <span class="case-list-count">4 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/mm-standard-risk.html"
-   data-default-order="3"
-   data-name="Multiple Myeloma · Standard-Risk">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · Standard-Risk</h3>
-  <p>Newly-diagnosed MM, t(11;14) + hyperdiploid, R-ISS II — engine обирає триплет VRd як default.</p>
-  <div class="case-foot">patient_mm_standard_risk.json</div>
-</a>
-<a class="case-card" href="/cases/mm-high-risk.html"
-   data-default-order="4"
-   data-name="Multiple Myeloma · High-Risk">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · High-Risk</h3>
-  <p>Newly-diagnosed MM, t(4;14) + gain 1q21, R2-ISS III — RF-MM-HIGH-RISK-CYTOGENETICS, engine обирає квадруплет D-VRd.</p>
-  <div class="case-foot">patient_mm_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/mm-post-vrd-progression.html"
-   data-default-order="68"
-   data-name="Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)</h3>
-  <p>MM relapsed після VRd induction — engine обирає daratumumab+pomalidomide+dex (APOLLO) або isatuximab+Pd (ICARIA).</p>
-  <div class="case-foot">patient_mm_post_vrd_progression.json</div>
-</a>
-<a class="case-card" href="/cases/mm-triple-class-refractory.html"
-   data-default-order="69"
-   data-name="Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)</h3>
-  <p>MM triple-class refractory (PI + IMiD + anti-CD38) — engine обирає cilta-cel/ide-cel CAR-T або teclistamab BCMA-T-cell engager.</p>
-  <div class="case-foot">patient_mm_triple_class_refractory.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-MDS-LR" hidden>
-  <header class="case-list-header">
-    <h2>Мієлодиспластичні синдроми, низький ризик (IPSS-R дуже низький / низький / проміжний)</h2>
-    <span class="case-list-count">5 прикладів</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/mds-hr-transplant-eligible.html"
-   data-default-order="78"
-   data-name="MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)</h3>
-  <p>MDS IPSS-R high, fit, donor available — engine обирає azacitidine bridge → upfront alloHCT (curative).</p>
-  <div class="case-foot">patient_mds_hr_transplant_eligible.json</div>
-</a>
-<a class="case-card" href="/cases/mds-hr-unfit-aza.html"
-   data-default-order="79"
-   data-name="MDS-HR · Unfit (Azacitidine Maintenance)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-HR · Unfit (Azacitidine Maintenance)</h3>
-  <p>MDS-HR transplant-ineligible — engine обирає azacitidine indefinite (AZA-001: median OS 24 mo vs 15 mo для conventional care).</p>
-  <div class="case-foot">patient_mds_hr_unfit_aza.json</div>
-</a>
-<a class="case-card" href="/cases/mds-hr-progression-aml.html"
-   data-default-order="80"
-   data-name="MDS-HR · Progression to Secondary AML">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-HR · Progression to Secondary AML</h3>
-  <p>MDS на azacitidine з progression до sAML — engine реагує AML-reroute: ven+aza або 7+3 induction (за fitness).</p>
-  <div class="case-foot">patient_mds_hr_progression_to_aml.json</div>
-</a>
-<a class="case-card" href="/cases/mds-lr-del5q.html"
-   data-default-order="81"
-   data-name="MDS-LR · del(5q) (Lenalidomide)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-LR · del(5q) (Lenalidomide)</h3>
-  <p>MDS-LR з isolated del(5q) syndrome — engine обирає lenalidomide (MDS-004: ~67% transfusion-independence).</p>
-  <div class="case-foot">patient_mds_lr_del5q.json</div>
-</a>
-<a class="case-card" href="/cases/mds-lr-hypoplastic-ist.html"
-   data-default-order="83"
-   data-name="MDS-LR · Hypoplastic / IST candidate">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>MDS-LR · Hypoplastic / IST candidate</h3>
-  <p>Hypoplastic MDS, mimics aplastic anemia — engine обирає immunosuppressive therapy (ATG+CsA) як alternative до transfusion-only.</p>
-  <div class="case-foot">patient_mds_lr_hypoplastic_ist.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-NODAL-MZL" hidden>
-  <header class="case-list-header">
-    <h2>Нодальна лімфома маргінальної зони</h2>
-    <span class="case-list-count">5 прикладів</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/hcv-mzl-reference.html"
-   data-default-order="0"
-   data-name="HCV-MZL · Reference Case (Patient Zero)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCV-MZL · Reference Case (Patient Zero)</h3>
-  <p>Чоловік 49, ECOG 1, 5.3 см ураження кореня язика, HCV генотип 1b, indolent presentation. Acceptance test для P0.</p>
-  <div class="case-foot">patient_zero_reference_case.json</div>
-</a>
-<a class="case-card" href="/cases/hcv-mzl-bulky.html"
-   data-default-order="1"
-   data-name="HCV-MZL · Aggressive Burden (BR + concurrent DAA)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCV-MZL · Aggressive Burden (BR + concurrent DAA)</h3>
-  <p>HCV-MZL із bulky disease (&gt;7 см) — RF-BULKY-DISEASE fired. Engine обирає BR (бендамустин+ритуксимаб) + concurrent DAA. Поєднує колишні patient_zero_bulky та новий fixture aggressive_burden.</p>
-  <div class="case-foot">patient_hcv_mzl_aggressive_burden.json</div>
-</a>
-<a class="case-card" href="/cases/hcv-mzl-post-daa.html"
-   data-default-order="2"
-   data-name="HCV-MZL · Post-DAA Responder (Surveillance)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HCV-MZL · Post-DAA Responder (Surveillance)</h3>
-  <p>Пацієнт post-DAA з SVR12 + lymphoma response — engine обирає surveillance only; план для re-treatment trigger при relapse.</p>
-  <div class="case-foot">patient_hcv_mzl_post_daa_responder.json</div>
-</a>
-<a class="case-card" href="/cases/diagnostic-lymphoma-confirmed.html"
-   data-default-order="6"
-   data-name="Lymphoma Confirmed · Post-Biopsy (Treatment Plan)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Lymphoma Confirmed · Post-Biopsy (Treatment Plan)</h3>
-  <p>Той самий пацієнт після підтвердження гістології — diagnostic→treatment promotion через revise_plan.</p>
-  <div class="case-foot">patient_diagnostic_lymphoma_confirmed.json</div>
-</a>
-<a class="case-card" href="/cases/nmzl-high-burden.html"
-   data-default-order="47"
-   data-name="Nodal MZL · High Burden (BR)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Nodal MZL · High Burden (BR)</h3>
-  <p>Нодальна MZL з GELF+ — engine обирає BR (1L); 2L після rituximab/W&amp;W failure теж BR.</p>
-  <div class="case-foot">patient_nmzl_high_burden.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-NLPBL" hidden>
-  <header class="case-list-header">
-    <h2>Нодулярна лімфоцит-домінантна B-клітинна лімфома (раніше NLPHL)</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/nlpbl-early.html"
-   data-default-order="29"
-   data-name="NLPBL · Early Stage (Observation / RT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NLPBL · Early Stage (Observation / RT)</h3>
-  <p>Нодулярна лімфоцит-домінантна B-клітинна лімфома (перекласифіковано WHO 5th-ed з NLPHL у B-cell) — early stage. Engine обирає observation / ISRT alone.</p>
-  <div class="case-foot">patient_nlpbl_early.json</div>
-</a>
-<a class="case-card" href="/cases/nlpbl-ia-rituximab.html"
-   data-default-order="34"
-   data-name="NLPBL · IA + RT-contraindicated (Rituximab mono)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>NLPBL · IA + RT-contraindicated (Rituximab mono)</h3>
-  <p>NLPBL stage IA у молодої жінки з cervical adenopathy — RT-contraindicated через breast/thyroid field overlap. Engine обирає rituximab monotherapy alternative (CD20+ B-cell biology, НЕ ABVD).</p>
-  <div class="case-foot">patient_nlpbl_ia_rituximab.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-PCNSL" hidden>
-  <header class="case-list-header">
-    <h2>Первинна дифузна великоклітинна B-клітинна лімфома центральної нервової системи</h2>
-    <span class="case-list-count">11 прикладів</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/dlbcl-low-ipi.html"
-   data-default-order="7"
-   data-name="DLBCL NOS · Low-IPI (R-CHOP standard)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL NOS · Low-IPI (R-CHOP standard)</h3>
-  <p>Чоловік 54, ECOG 1, IPI 1, GCB cell-of-origin — engine обирає R-CHOP × 6 циклів як default. Найпоширеніша агресивна лімфома (~30% NHL).</p>
-  <div class="case-foot">patient_dlbcl_low_ipi.json</div>
-</a>
-<a class="case-card" href="/cases/dlbcl-high-ipi.html"
-   data-default-order="8"
-   data-name="DLBCL NOS · High-IPI (Pola-R-CHP)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL NOS · High-IPI (Pola-R-CHP)</h3>
-  <p>Жінка 67, IPI 4, multiple extranodal — RF-DLBCL-HIGH-IPI fired. Engine ескалує до Pola-R-CHP (POLARIX trial); Ukraine-funding caveat.</p>
-  <div class="case-foot">patient_dlbcl_high_ipi.json</div>
-</a>
-<a class="case-card" href="/cases/dlbcl-chemorefractory-cart.html"
-   data-default-order="35"
-   data-name="DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)</h3>
-  <p>DLBCL з primary refractory disease (PD на R-CHOP) — engine обирає axi-cel CAR-T (ZUMA-7: 2L CAR-T &gt; salvage+autoSCT для early-failure).</p>
-  <div class="case-foot">patient_dlbcl_chemorefractory_for_cart.json</div>
-</a>
-<a class="case-card" href="/cases/dlbcl-relapsed-te-ineligible.html"
-   data-default-order="36"
-   data-name="DLBCL NOS · Relapsed (Transplant-Ineligible)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL NOS · Relapsed (Transplant-Ineligible)</h3>
-  <p>DLBCL relapsed, transplant-ineligible через age + comorbidity — engine обирає Pola-BR (POLARGO) або loncastuximab tesirine.</p>
-  <div class="case-foot">patient_dlbcl_relapsed_transplant_ineligible.json</div>
-</a>
-<a class="case-card" href="/cases/hgbl-primary-refractory.html"
-   data-default-order="37"
-   data-name="HGBL · Primary Refractory (Early CAR-T)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>HGBL · Primary Refractory (Early CAR-T)</h3>
-  <p>HGBL-DH що не відповів на DA-EPOCH-R — engine обирає axi-cel CAR-T (ZUMA-7); chemosensitivity-test позитивний для late-relapse → salvage+autoSCT.</p>
-  <div class="case-foot">patient_hgbl_primary_refractory.json</div>
-</a>
-<a class="case-card" href="/cases/pcnsl-typical.html"
-   data-default-order="41"
-   data-name="PCNSL · Typical (R-MPV → autoSCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PCNSL · Typical (R-MPV → autoSCT)</h3>
-  <p>Імунокомпетентний пацієнт з biopsy-confirmed PCNSL — engine обирає R-MPV induction → thiotepa-based autoSCT consolidation (MATRix/IELSG 32).</p>
-  <div class="case-foot">patient_pcnsl_typical.json</div>
-</a>
-<a class="case-card" href="/cases/pcnsl-elderly-frail.html"
-   data-default-order="42"
-   data-name="PCNSL · Elderly Frail (R-MTX-attenuated)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PCNSL · Elderly Frail (R-MTX-attenuated)</h3>
-  <p>PCNSL вік 75, ECOG 2 — engine обирає attenuated MTX-based induction без autoSCT consolidation; lenalidomide maintenance як альтернатива.</p>
-  <div class="case-foot">patient_pcnsl_elderly_frail.json</div>
-</a>
-<a class="case-card" href="/cases/pcnsl-immunocompromised-ebv.html"
-   data-default-order="43"
-   data-name="PCNSL · Immunocompromised + EBV+ (Restore Immunity)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PCNSL · Immunocompromised + EBV+ (Restore Immunity)</h3>
-  <p>PCNSL у HIV+/post-transplant пацієнта, EBER+ — engine додає immune-restoration (HAART / RIS) перед HD-MTX; rituximab якщо CD20+.</p>
-  <div class="case-foot">patient_pcnsl_immunocompromised_ebv.json</div>
-</a>
-<a class="case-card" href="/cases/dlbcl-2l-pola-r-b.html"
-   data-default-order="578"
-   data-name="DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)</h3>
-  <p>ASCT-ineligible cardiac-comorbidity, late relapse. Engine: ALGO-2L → IND-DLBCL-2L-POLA-R-BENDAMUSTINE (distinct від існуючого relapsed_transplant_ineligible).</p>
-  <div class="case-foot">patient_dlbcl_2l_pola_r_b.json</div>
-</a>
-<a class="case-card" href="/cases/dlbcl-3l-axi-cel.html"
-   data-default-order="579"
-   data-name="DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)</h3>
-  <p>Прогрес після RCHOP→Pola-BR. Engine: ALGO-2L default = Pola-BR; axi-cel surfaces як aggressive alternative track. Distinct від chemorefractory_for_cart.</p>
-  <div class="case-foot">patient_dlbcl_3l_axi_cel.json</div>
-</a>
-<a class="case-card" href="/cases/dlbcl-primary-refractory-loncast.html"
-   data-default-order="580"
-   data-name="DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)</h3>
-  <p>Primary-refractory frail non-CAR-T-eligible. Drift: REG-LONCASTUXIMAB-TESIRINE відсутній; engine default = Pola-BR (re-MMAE inappropriate); LOTIS-2 анкер у comment.</p>
-  <div class="case-foot">patient_dlbcl_primary_refractory_loncast_post_pola.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-PMBCL" hidden>
-  <header class="case-list-header">
-    <h2>Первинна медіастинальна (тимічна) B-великоклітинна лімфома</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/pmbcl-typical.html"
-   data-default-order="38"
-   data-name="PMBCL · Typical (DA-EPOCH-R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PMBCL · Typical (DA-EPOCH-R)</h3>
-  <p>Молода жінка з anterior mediastinal mass — engine обирає DA-EPOCH-R без RT (NCI 2013: ~93% EFS, обхід RT-токсичності для AYA).</p>
-  <div class="case-foot">patient_pmbcl_typical.json</div>
-</a>
-<a class="case-card" href="/cases/pmbcl-bulky-svc.html"
-   data-default-order="39"
-   data-name="PMBCL · Bulky + SVC Syndrome">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PMBCL · Bulky + SVC Syndrome</h3>
-  <p>PMBCL з bulky mediastinal mass + SVC compression — engine додає upfront pre-phase steroids + airway management до DA-EPOCH-R.</p>
-  <div class="case-foot">patient_pmbcl_bulky_svc.json</div>
-</a>
-<a class="case-card" href="/cases/pmbcl-relapsed-post-rchop.html"
-   data-default-order="40"
-   data-name="PMBCL · Relapsed post-R-CHOP (Pembrolizumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PMBCL · Relapsed post-R-CHOP (Pembrolizumab)</h3>
-  <p>PMBCL relapsed/refractory після R-CHOP — engine обирає R-ICE+autoSCT (eligible) або pembrolizumab (KEYNOTE-170, ineligible/refractory).</p>
-  <div class="case-foot">patient_pmbcl_relapsed_post_rchop.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-PMF" hidden>
-  <header class="case-list-header">
-    <h2>Первинний мієлофіброз</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/pmf-anemia-dominant.html"
-   data-default-order="88"
-   data-name="PMF · Anemia-Dominant (Momelotinib)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PMF · Anemia-Dominant (Momelotinib)</h3>
-  <p>PMF DIPSS-Plus int-1, anemia-dominant — engine обирає momelotinib (MOMENTUM: anemia-friendly JAKi).</p>
-  <div class="case-foot">patient_pmf_anemia_dominant.json</div>
-</a>
-<a class="case-card" href="/cases/pmf-int2-symptomatic-rux.html"
-   data-default-order="89"
-   data-name="PMF · Int-2 Symptomatic (Ruxolitinib)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PMF · Int-2 Symptomatic (Ruxolitinib)</h3>
-  <p>PMF DIPSS-Plus int-2 з splenomegaly + constitutional symptoms — engine обирає ruxolitinib (COMFORT-I/II).</p>
-  <div class="case-foot">patient_pmf_int2_symptomatic_ruxolitinib.json</div>
-</a>
-<a class="case-card" href="/cases/pmf-post-rux-allohct.html"
-   data-default-order="90"
-   data-name="PMF · Post-Rux alloHCT Bridge (Urgent)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PMF · Post-Rux alloHCT Bridge (Urgent)</h3>
-  <p>PMF post-ruxolitinib failure з massive splenomegaly + transfusion-dependence — engine обирає alloHCT bridge (curative-intent, urgent).</p>
-  <div class="case-foot">patient_pmf_post_rux_allohct_bridge.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-PTCL-NOS" hidden>
-  <header class="case-list-header">
-    <h2>Периферична T-клітинна лімфома, неуточнена</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/ptcl-cd30-negative.html"
-   data-default-order="25"
-   data-name="PTCL NOS · CD30-negative (CHOEP)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PTCL NOS · CD30-negative (CHOEP)</h3>
-  <p>Периферична T-клітинна лімфома, CD30-negative — engine обирає CHOEP (CHOP + etoposide). CD30+ варіант ескалював би до CHP-Bv.</p>
-  <div class="case-foot">patient_ptcl_cd30_negative.json</div>
-</a>
-<a class="case-card" href="/cases/ptcl-cd30-positive.html"
-   data-default-order="50"
-   data-name="PTCL NOS · CD30-positive (CHP-Bv)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PTCL NOS · CD30-positive (CHP-Bv)</h3>
-  <p>PTCL NOS, CD30≥10% — RF-TCELL-CD30-POSITIVE fired. Engine обирає CHP-Bv (ECHELON-2 inclusion threshold).</p>
-  <div class="case-foot">patient_ptcl_cd30_positive.json</div>
-</a>
-<a class="case-card" href="/cases/ptcl-relapsed.html"
-   data-default-order="51"
-   data-name="PTCL NOS · Relapsed post-autoSCT (Romidepsin / Pralatrexate)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PTCL NOS · Relapsed post-autoSCT (Romidepsin / Pralatrexate)</h3>
-  <p>PTCL NOS relapsed після autoSCT — engine обирає romidepsin або pralatrexate; alloHCT як curative-intent для chemosensitive.</p>
-  <div class="case-foot">patient_ptcl_relapsed.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-PTLD" hidden>
-  <header class="case-list-header">
-    <h2>Посттрансплантаційні лімфопроліферативні захворювання</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/ptld-polymorphic-ebv.html"
-   data-default-order="64"
-   data-name="PTLD · Polymorphic EBV+ (RIS + Rituximab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PTLD · Polymorphic EBV+ (RIS + Rituximab)</h3>
-  <p>Post-transplant LPD, polymorphic EBV+ — engine обирає RIS (reduce immunosuppression) + sequential PTLD-1 rituximab maintenance.</p>
-  <div class="case-foot">patient_ptld_polymorphic_ebv.json</div>
-</a>
-<a class="case-card" href="/cases/ptld-monomorphic-dlbcl-like.html"
-   data-default-order="65"
-   data-name="PTLD · Monomorphic DLBCL-like (R-CHOP)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PTLD · Monomorphic DLBCL-like (R-CHOP)</h3>
-  <p>Monomorphic PTLD з DLBCL morphology — engine обирає R-CHOP після RIS-failure; sequential treatment per PTLD-1.</p>
-  <div class="case-foot">patient_ptld_monomorphic_dlbcl_like.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-SPLENIC-MZL" hidden>
-  <header class="case-list-header">
-    <h2>Селезінкова лімфома маргінальної зони</h2>
-    <span class="case-list-count">2 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/smzl-hcv-positive.html"
-   data-default-order="16"
-   data-name="Splenic MZL · HCV-positive (DAA antiviral)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Splenic MZL · HCV-positive (DAA antiviral)</h3>
-  <p>Селезінкова MZL із HCV-позитивним статусом — engine обирає DAA antiviral (sofosbuvir/velpatasvir 12 тижнів) як 1L; reuse REG-DAA-SOF-VEL з HCV-MZL extranodal.</p>
-  <div class="case-foot">patient_smzl_hcv_positive.json</div>
-</a>
-<a class="case-card" href="/cases/smzl-hcv-negative.html"
-   data-default-order="17"
-   data-name="Splenic MZL · HCV-negative (Rituximab mono)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Splenic MZL · HCV-negative (Rituximab mono)</h3>
-  <p>Селезінкова MZL HCV-negative — engine обирає rituximab monotherapy (4 weekly + 2-year maintenance).</p>
-  <div class="case-foot">patient_smzl_hcv_negative.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-PV" hidden>
-  <header class="case-list-header">
-    <h2>Справжня поліцитемія</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/pv-high-risk-hu.html"
-   data-default-order="84"
-   data-name="Polycythemia Vera · High Risk (HU 1L)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Polycythemia Vera · High Risk (HU 1L)</h3>
-  <p>PV вік &gt;60 + thrombosis history — engine обирає phlebotomy + low-dose ASA + cytoreduction hydroxyurea.</p>
-  <div class="case-foot">patient_pv_high_risk_hu.json</div>
-</a>
-<a class="case-card" href="/cases/pv-hu-resistant-rux.html"
-   data-default-order="85"
-   data-name="PV · HU-resistant (Ruxolitinib 2L)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PV · HU-resistant (Ruxolitinib 2L)</h3>
-  <p>PV з HU-intolerance/resistance per ELN — engine обирає ruxolitinib (RESPONSE-2: hematocrit control + symptom relief).</p>
-  <div class="case-foot">patient_pv_hu_resistant_ruxolitinib.json</div>
-</a>
-<a class="case-card" href="/cases/pv-pregnancy-planning.html"
-   data-default-order="86"
-   data-name="PV · Pregnancy Planning (Peg-IFN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>PV · Pregnancy Planning (Peg-IFN)</h3>
-  <p>Reproductive-age жінка з PV, planning pregnancy — engine обирає peg-IFN α-2a (non-teratogenic, fetus-safe).</p>
-  <div class="case-foot">patient_pv_pregnancy_planning.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-FL" hidden>
-  <header class="case-list-header">
-    <h2>Фолікулярна лімфома</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/fl-low-burden.html"
-   data-default-order="9"
-   data-name="Follicular · Low Burden (Watch-and-Wait)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Follicular · Low Burden (Watch-and-Wait)</h3>
-  <p>FL grade 1-2, asymptomatic, no GELF criteria — engine обирає surveillance трек (3 plans usable side-by-side, default = W&amp;W).</p>
-  <div class="case-foot">patient_fl_low_burden.json</div>
-</a>
-<a class="case-card" href="/cases/fl-high-burden.html"
-   data-default-order="10"
-   data-name="Follicular · High Burden (BR)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Follicular · High Burden (BR)</h3>
-  <p>FL з 8 cm масою + B-symptoms + LDH↑ — RF-FL-HIGH-TUMOR-BURDEN-GELF fired. Engine обирає BR (бендамустин + ритуксимаб); reuse REG-BR-STANDARD з HCV-MZL.</p>
-  <div class="case-foot">patient_fl_high_burden.json</div>
-</a>
-<a class="case-card" href="/cases/fl-transformation.html"
-   data-default-order="11"
-   data-name="Follicular · Transformation Suspect (R-CHOP)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>Follicular · Transformation Suspect (R-CHOP)</h3>
-  <p>FL з rapid progression + LDH doubling — RF-FL-TRANSFORMATION-SUSPECT fired. Engine обирає R-CHOP (трактує як DLBCL pathway).</p>
-  <div class="case-foot">patient_fl_transformation.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-CLL" hidden>
-  <header class="case-list-header">
-    <h2>Хронічна лімфоцитарна лейкемія / Дрібноклітинна лімфоцитарна лімфома</h2>
-    <span class="case-list-count">4 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/cll-low-risk.html"
-   data-default-order="12"
-   data-name="CLL/SLL · Low-Risk (BTKi continuous)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL/SLL · Low-Risk (BTKi continuous)</h3>
-  <p>ХЛЛ зі стандартним ризиком (no TP53/del 17p/IGHV-unmut) — engine обирає acalabrutinib continuous; modern era замість FCR/BR.</p>
-  <div class="case-foot">patient_cll_low_risk.json</div>
-</a>
-<a class="case-card" href="/cases/cll-high-risk.html"
-   data-default-order="13"
-   data-name="CLL/SLL · High-Risk (VenO time-limited)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL/SLL · High-Risk (VenO time-limited)</h3>
-  <p>ХЛЛ з TP53 mutation + IGHV-unmut + complex karyotype — RF-CLL-HIGH-RISK fired. Engine ескалує до venetoclax+obinutuzumab (CLL14).</p>
-  <div class="case-foot">patient_cll_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/cll-post-btki.html"
-   data-default-order="44"
-   data-name="CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)</h3>
-  <p>CLL з прогресією на covalent BTKi — engine обирає pirtobrutinib (BRUIN, non-covalent) або venetoclax+rituximab (MURANO).</p>
-  <div class="case-foot">patient_cll_post_btki_progression.json</div>
-</a>
-<a class="case-card" href="/cases/cll-venr-2l-murano.html"
-   data-default-order="581"
-   data-name="CLL · 2L post-BTKi · VenR fixed-duration (MURANO)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CLL · 2L post-BTKi · VenR fixed-duration (MURANO)</h3>
-  <p>Post-acalabrutinib PD без C481/BCL2-resistance. Engine: ALGO-CLL-2L step 2 (RF-PRIOR-BTKI-PROGRESSION) → IND-CLL-2L-VENR-MURANO (24-mo, mPFS 53.6 мо).</p>
-  <div class="case-foot">patient_cll_venr_2l_murano.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="DIS-CML" hidden>
-  <header class="case-list-header">
-    <h2>Хронічна мієлоїдна лейкемія (BCR-ABL1)</h2>
-    <span class="case-list-count">3 приклади</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/cml-chronic-newdx.html"
-   data-default-order="75"
-   data-name="CML · Chronic Phase Newly Diagnosed (TKI 1L)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CML · Chronic Phase Newly Diagnosed (TKI 1L)</h3>
-  <p>Newly-diagnosed CML chronic phase, BCR-ABL1+ — engine обирає imatinib (low-risk Sokal) або 2G TKI (intermediate/high).</p>
-  <div class="case-foot">patient_cml_chronic_phase_newdx.json</div>
-</a>
-<a class="case-card" href="/cases/cml-t315i.html"
-   data-default-order="76"
-   data-name="CML · T315I-mutated (Ponatinib / Asciminib)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CML · T315I-mutated (Ponatinib / Asciminib)</h3>
-  <p>CML з T315I gatekeeper mutation post-2G TKI — engine обирає ponatinib (PACE) або asciminib (allosteric STAMP-inhibitor).</p>
-  <div class="case-foot">patient_cml_t315i.json</div>
-</a>
-<a class="case-card" href="/cases/cml-blast-crisis.html"
-   data-default-order="77"
-   data-name="CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    
-  </div>
-  <h3>CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)</h3>
-  <p>CML що дебютує як blast crisis — engine обирає TKI + intensive chemo bridge → urgent alloHCT (без alloHCT медіана OS &lt;12 mo).</p>
-  <div class="case-foot">patient_cml_blast_crisis_at_presentation.json</div>
-</a>
-  </div>
-</section>
-<section class="case-list" data-disease-id="OTHER" hidden>
-  <header class="case-list-header">
-    <h2>Інше / без класифікації</h2>
-    <span class="case-list-count">489 прикладів</span>
-  </header>
-  <div class="case-grid">
-<a class="case-card" href="/cases/diagnostic-lymphoma-suspect.html"
-   data-default-order="5"
-   data-name="Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-diag">Diagnostic Brief</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)</h3>
-  <p>Pre-biopsy режим — engine генерує Workup Brief, не Treatment Plan (CHARTER §15.2 C7 — без histology немає лікування).</p>
-  <div class="case-foot">patient_diagnostic_lymphoma_suspect.json</div>
-</a>
-<a class="case-card" href="/cases/nmzl-low-burden.html"
-   data-default-order="18"
-   data-name="Nodal MZL · Low Burden (W&amp;W)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Nodal MZL · Low Burden (W&amp;W)</h3>
-  <p>Нодальна MZL без GELF-критеріїв — engine обирає surveillance трек (повторює FL-парадигму).</p>
-  <div class="case-foot">patient_nmzl_low_burden.json</div>
-</a>
-<a class="case-card" href="/cases/hgbl-double-hit.html"
-   data-default-order="23"
-   data-name="HGBL · Double-Hit (DA-EPOCH-R)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>HGBL · Double-Hit (DA-EPOCH-R)</h3>
-  <p>High-Grade B-Cell Lymphoma з MYC + BCL2 break-apart — engine обирає DA-EPOCH-R (substantial OS improvement vs R-CHOP); reuse схеми з Burkitt.</p>
-  <div class="case-foot">patient_hgbl_double_hit.json</div>
-</a>
-<a class="case-card" href="/cases/mds-lr-rs-luspatercept.html"
-   data-default-order="82"
-   data-name="MDS-LR · RS+ EPO-failure (Luspatercept)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>MDS-LR · RS+ EPO-failure (Luspatercept)</h3>
-  <p>MDS-LR з ring sideroblasts + EPO-high (&gt;500) → ESA-failure — engine обирає luspatercept (COMMANDS).</p>
-  <div class="case-foot">patient_mds_lr_rs_luspatercept.json</div>
-</a>
 <a class="case-card" href="/cases/b-all-ph-pos-adult.html"
    data-default-order="91"
    data-name="B-ALL · Ph+ Adult (TKI + Chemo)">
@@ -1466,6 +132,17 @@
   <h3>B-ALL · Ph+ Adult (TKI + Chemo)</h3>
   <p>Adult B-ALL Ph+ (BCR-ABL1+) — engine обирає dasatinib + chemo (hyper-CVAD або pediatric-inspired); alloHCT для CR1 high-risk.</p>
   <div class="case-foot">patient_b_all_ph_pos_adult.json</div>
+</a>
+<a class="case-card" href="/cases/b-all-mrd-positive.html"
+   data-default-order="92"
+   data-name="B-ALL · MRD-positive (Blinatumomab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>B-ALL · MRD-positive (Blinatumomab)</h3>
+  <p>B-ALL MRD-positive після induction — engine обирає blinatumomab (BLAST: MRD eradication у &gt;75%).</p>
+  <div class="case-foot">patient_b_all_mrd_positive.json</div>
 </a>
 <a class="case-card" href="/cases/b-all-t315i-post-tki.html"
    data-default-order="93"
@@ -1478,94 +155,6 @@
   <p>Ph+ B-ALL relapsed з T315I gatekeeper — engine обирає ponatinib + chemo bridge → alloHCT.</p>
   <div class="case-foot">patient_b_all_t315i_post_tki.json</div>
 </a>
-<a class="case-card" href="/cases/cervical-locally-advanced.html"
-   data-default-order="96"
-   data-name="Cervical · Locally Advanced (CCRT + Pembrolizumab)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Cervical · Locally Advanced (CCRT + Pembrolizumab)</h3>
-  <p>Locally advanced cervical cancer (FIGO IIB-IVA) — engine обирає cisplatin-based CCRT + brachytherapy; pembrolizumab maintenance (KEYNOTE-A18).</p>
-  <div class="case-foot">patient_cervical_locally_advanced.json</div>
-</a>
-<a class="case-card" href="/cases/gbm-stupp.html"
-   data-default-order="97"
-   data-name="Glioblastoma · Newly Diagnosed (Stupp Protocol)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Glioblastoma · Newly Diagnosed (Stupp Protocol)</h3>
-  <p>GBM IDH-WT WHO grade 4 — engine обирає Stupp: maximal safe resection → RT + concurrent TMZ → adjuvant TMZ × 6; TTFields для MGMT-methylated.</p>
-  <div class="case-foot">patient_gbm_newly_diagnosed_stupp.json</div>
-</a>
-<a class="case-card" href="/cases/ovarian-advanced-hrd.html"
-   data-default-order="98"
-   data-name="Ovarian · Advanced HRD+ (PARPi maintenance)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Ovarian · Advanced HRD+ (PARPi maintenance)</h3>
-  <p>Advanced high-grade serous ovarian, HRD+ — engine обирає platinum-doublet → PARPi maintenance (olaparib/niraparib; SOLO-1, PRIMA).</p>
-  <div class="case-foot">patient_ovarian_advanced_hrd.json</div>
-</a>
-<a class="case-card" href="/cases/auto-aitl.html"
-   data-default-order="99"
-   data-name="DIS-AITL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Angioimmunoblastic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_aitl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-alcl.html"
-   data-default-order="100"
-   data-name="DIS-ALCL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Anaplastic Large Cell Lymphoma, Systemic. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_alcl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-aml.html"
-   data-default-order="101"
-   data-name="DIS-AML — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Acute Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_aml.json</div>
-</a>
-<a class="case-card" href="/cases/auto-apl.html"
-   data-default-order="102"
-   data-name="DIS-APL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Acute Promyelocytic Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_apl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-atll.html"
-   data-default-order="103"
-   data-name="DIS-ATLL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Adult T-Cell Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_atll.json</div>
-</a>
 <a class="case-card" href="/cases/auto-b_all.html"
    data-default-order="104"
    data-name="DIS-B-ALL — Auto-stub (88% наповненість)">
@@ -1576,985 +165,6 @@
   <h3>DIS-B-ALL — Auto-stub (88% наповненість)</h3>
   <p>Автогенерований мінімальний профіль для B-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
   <div class="case-foot">auto_b_all.json</div>
-</a>
-<a class="case-card" href="/cases/auto-breast.html"
-   data-default-order="105"
-   data-name="DIS-BREAST — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Invasive breast cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_breast.json</div>
-</a>
-<a class="case-card" href="/cases/auto-burkitt.html"
-   data-default-order="106"
-   data-name="DIS-BURKITT — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Burkitt Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_burkitt.json</div>
-</a>
-<a class="case-card" href="/cases/auto-cervical.html"
-   data-default-order="107"
-   data-name="DIS-CERVICAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Cervical carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cervical.json</div>
-</a>
-<a class="case-card" href="/cases/auto-chl.html"
-   data-default-order="108"
-   data-name="DIS-CHL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Classical Hodgkin Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_chl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-cholangiocarcinoma.html"
-   data-default-order="109"
-   data-name="DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Cholangiocarcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cholangiocarcinoma.json</div>
-</a>
-<a class="case-card" href="/cases/auto-chondrosarcoma.html"
-   data-default-order="110"
-   data-name="DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Chondrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_chondrosarcoma.json</div>
-</a>
-<a class="case-card" href="/cases/auto-cll.html"
-   data-default-order="111"
-   data-name="DIS-CLL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cll.json</div>
-</a>
-<a class="case-card" href="/cases/auto-cml.html"
-   data-default-order="112"
-   data-name="DIS-CML — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Chronic Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_cml.json</div>
-</a>
-<a class="case-card" href="/cases/auto-crc.html"
-   data-default-order="113"
-   data-name="DIS-CRC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Colorectal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_crc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-dlbcl_nos.html"
-   data-default-order="114"
-   data-name="DIS-DLBCL-NOS — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Diffuse Large B-Cell Lymphoma, Not Otherwise Specified. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_dlbcl_nos.json</div>
-</a>
-<a class="case-card" href="/cases/auto-eatl.html"
-   data-default-order="115"
-   data-name="DIS-EATL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-EATL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Enteropathy-Associated T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_eatl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-endometrial.html"
-   data-default-order="116"
-   data-name="DIS-ENDOMETRIAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Endometrial carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_endometrial.json</div>
-</a>
-<a class="case-card" href="/cases/auto-esophageal.html"
-   data-default-order="117"
-   data-name="DIS-ESOPHAGEAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Esophageal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_esophageal.json</div>
-</a>
-<a class="case-card" href="/cases/auto-et.html"
-   data-default-order="118"
-   data-name="DIS-ET — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Essential Thrombocythemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_et.json</div>
-</a>
-<a class="case-card" href="/cases/auto-fl.html"
-   data-default-order="119"
-   data-name="DIS-FL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-FL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Follicular Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_fl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-gastric.html"
-   data-default-order="120"
-   data-name="DIS-GASTRIC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Gastric and gastroesophageal junction adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_gastric.json</div>
-</a>
-<a class="case-card" href="/cases/auto-gbm.html"
-   data-default-order="121"
-   data-name="DIS-GBM — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GBM — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Glioblastoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_gbm.json</div>
-</a>
-<a class="case-card" href="/cases/auto-gist.html"
-   data-default-order="122"
-   data-name="DIS-GIST — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GIST — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Gastrointestinal stromal tumor. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_gist.json</div>
-</a>
-<a class="case-card" href="/cases/auto-glioma_low_grade.html"
-   data-default-order="123"
-   data-name="DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Low-grade glioma. Фактична наповненість бази для цієї хвороби — 50%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_glioma_low_grade.json</div>
-</a>
-<a class="case-card" href="/cases/auto-hcc.html"
-   data-default-order="124"
-   data-name="DIS-HCC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Hepatocellular carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hcc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-hcl.html"
-   data-default-order="125"
-   data-name="DIS-HCL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Hairy Cell Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hcl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-hcv_mzl.html"
-   data-default-order="126"
-   data-name="DIS-HCV-MZL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для HCV-associated Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hcv_mzl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-hgbl_dh.html"
-   data-default-order="127"
-   data-name="DIS-HGBL-DH — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для High-Grade B-Cell Lymphoma, Double-Hit / Triple-Hit. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hgbl_dh.json</div>
-</a>
-<a class="case-card" href="/cases/auto-hnscc.html"
-   data-default-order="128"
-   data-name="DIS-HNSCC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Head and neck squamous cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hnscc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-hstcl.html"
-   data-default-order="129"
-   data-name="DIS-HSTCL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Hepatosplenic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_hstcl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-ifs.html"
-   data-default-order="130"
-   data-name="DIS-IFS — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IFS — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Infantile fibrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ifs.json</div>
-</a>
-<a class="case-card" href="/cases/auto-imt.html"
-   data-default-order="131"
-   data-name="DIS-IMT — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IMT — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Inflammatory myofibroblastic tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_imt.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mastocytosis.html"
-   data-default-order="132"
-   data-name="DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Advanced systemic mastocytosis. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mastocytosis.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mcl.html"
-   data-default-order="133"
-   data-name="DIS-MCL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Mantle Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mcl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mds_hr.html"
-   data-default-order="134"
-   data-name="DIS-MDS-HR — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Higher Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mds_hr.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mds_lr.html"
-   data-default-order="135"
-   data-name="DIS-MDS-LR — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Lower Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mds_lr.json</div>
-</a>
-<a class="case-card" href="/cases/auto-melanoma.html"
-   data-default-order="136"
-   data-name="DIS-MELANOMA — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Cutaneous melanoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_melanoma.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mf_sezary.html"
-   data-default-order="137"
-   data-name="DIS-MF-SEZARY — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Mycosis Fungoides / Sézary Syndrome. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mf_sezary.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mm.html"
-   data-default-order="138"
-   data-name="DIS-MM — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Multiple Myeloma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mm.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mpnst.html"
-   data-default-order="139"
-   data-name="DIS-MPNST — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Malignant peripheral nerve sheath tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mpnst.json</div>
-</a>
-<a class="case-card" href="/cases/auto-mtc.html"
-   data-default-order="140"
-   data-name="DIS-MTC — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MTC — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Medullary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_mtc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-nk_t_nasal.html"
-   data-default-order="141"
-   data-name="DIS-NK-T-NASAL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Extranodal NK/T-Cell Lymphoma, Nasal Type. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nk_t_nasal.json</div>
-</a>
-<a class="case-card" href="/cases/auto-nlpbl.html"
-   data-default-order="142"
-   data-name="DIS-NLPBL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Nodular Lymphocyte-Predominant B-cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nlpbl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-nodal_mzl.html"
-   data-default-order="143"
-   data-name="DIS-NODAL-MZL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Nodal Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nodal_mzl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-nsclc.html"
-   data-default-order="144"
-   data-name="DIS-NSCLC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Non-small cell lung cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_nsclc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-ovarian.html"
-   data-default-order="145"
-   data-name="DIS-OVARIAN — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Ovarian carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ovarian.json</div>
-</a>
-<a class="case-card" href="/cases/auto-pcnsl.html"
-   data-default-order="146"
-   data-name="DIS-PCNSL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Primary CNS Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pcnsl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-pdac.html"
-   data-default-order="147"
-   data-name="DIS-PDAC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Pancreatic ductal adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pdac.json</div>
-</a>
-<a class="case-card" href="/cases/auto-pmbcl.html"
-   data-default-order="148"
-   data-name="DIS-PMBCL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Primary Mediastinal Large B-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pmbcl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-pmf.html"
-   data-default-order="149"
-   data-name="DIS-PMF — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Primary Myelofibrosis. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pmf.json</div>
-</a>
-<a class="case-card" href="/cases/auto-prostate.html"
-   data-default-order="150"
-   data-name="DIS-PROSTATE — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Prostate adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_prostate.json</div>
-</a>
-<a class="case-card" href="/cases/auto-ptcl_nos.html"
-   data-default-order="151"
-   data-name="DIS-PTCL-NOS — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Peripheral T-Cell Lymphoma, NOS. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ptcl_nos.json</div>
-</a>
-<a class="case-card" href="/cases/auto-ptld.html"
-   data-default-order="152"
-   data-name="DIS-PTLD — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Post-Transplant Lymphoproliferative Disorder. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_ptld.json</div>
-</a>
-<a class="case-card" href="/cases/auto-pv.html"
-   data-default-order="153"
-   data-name="DIS-PV — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Polycythemia Vera. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_pv.json</div>
-</a>
-<a class="case-card" href="/cases/auto-rcc.html"
-   data-default-order="154"
-   data-name="DIS-RCC — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Renal cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_rcc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-salivary.html"
-   data-default-order="155"
-   data-name="DIS-SALIVARY — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Salivary gland carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_salivary.json</div>
-</a>
-<a class="case-card" href="/cases/auto-sclc.html"
-   data-default-order="156"
-   data-name="DIS-SCLC — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Small cell lung cancer. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_sclc.json</div>
-</a>
-<a class="case-card" href="/cases/auto-splenic_mzl.html"
-   data-default-order="157"
-   data-name="DIS-SPLENIC-MZL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Splenic Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_splenic_mzl.json</div>
-</a>
-<a class="case-card" href="/cases/auto-t_all.html"
-   data-default-order="158"
-   data-name="DIS-T-ALL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для T-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_t_all.json</div>
-</a>
-<a class="case-card" href="/cases/auto-t_pll.html"
-   data-default-order="159"
-   data-name="DIS-T-PLL — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-T-PLL — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для T-Cell Prolymphocytic Leukemia. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_t_pll.json</div>
-</a>
-<a class="case-card" href="/cases/auto-thyroid_anaplastic.html"
-   data-default-order="160"
-   data-name="DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Anaplastic thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_thyroid_anaplastic.json</div>
-</a>
-<a class="case-card" href="/cases/auto-thyroid_papillary.html"
-   data-default-order="161"
-   data-name="DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Papillary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 62%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_thyroid_papillary.json</div>
-</a>
-<a class="case-card" href="/cases/auto-urothelial.html"
-   data-default-order="162"
-   data-name="DIS-UROTHELIAL — Auto-stub (75% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL — Auto-stub (75% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Urothelial carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_urothelial.json</div>
-</a>
-<a class="case-card" href="/cases/auto-wm.html"
-   data-default-order="163"
-   data-name="DIS-WM — Auto-stub (88% наповненість)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Auto-stub</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-WM — Auto-stub (88% наповненість)</h3>
-  <p>Автогенерований мінімальний профіль для Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
-  <div class="case-foot">auto_wm.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aitl-frail.html"
-   data-default-order="164"
-   data-name="DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aitl-organ-dysf.html"
-   data-default-order="165"
-   data-name="DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aitl-infection-hbv.html"
-   data-default-order="166"
-   data-name="DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aitl-relapsed-2l.html"
-   data-default-order="167"
-   data-name="DIS-AITL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aitl-biomarker-act.html"
-   data-default-order="168"
-   data-name="DIS-AITL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aitl-high-risk.html"
-   data-default-order="169"
-   data-name="DIS-AITL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AITL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aitl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-alcl-frail.html"
-   data-default-order="170"
-   data-name="DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-alcl-organ-dysf.html"
-   data-default-order="171"
-   data-name="DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-alcl-infection-hbv.html"
-   data-default-order="172"
-   data-name="DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-alcl-relapsed-2l.html"
-   data-default-order="173"
-   data-name="DIS-ALCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-alcl-biomarker-act.html"
-   data-default-order="174"
-   data-name="DIS-ALCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-alcl-high-risk.html"
-   data-default-order="175"
-   data-name="DIS-ALCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ALCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_alcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aml-frail.html"
-   data-default-order="176"
-   data-name="DIS-AML · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aml_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aml-organ-dysf.html"
-   data-default-order="177"
-   data-name="DIS-AML · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aml_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aml-infection-hbv.html"
-   data-default-order="178"
-   data-name="DIS-AML · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aml_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aml-relapsed-2l.html"
-   data-default-order="179"
-   data-name="DIS-AML · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aml_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aml-biomarker-act.html"
-   data-default-order="180"
-   data-name="DIS-AML · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aml_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-aml-high-risk.html"
-   data-default-order="181"
-   data-name="DIS-AML · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-AML · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_aml_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-apl-frail.html"
-   data-default-order="182"
-   data-name="DIS-APL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_apl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-apl-organ-dysf.html"
-   data-default-order="183"
-   data-name="DIS-APL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_apl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-apl-infection-hbv.html"
-   data-default-order="184"
-   data-name="DIS-APL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_apl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-apl-relapsed-2l.html"
-   data-default-order="185"
-   data-name="DIS-APL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_apl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-apl-biomarker-act.html"
-   data-default-order="186"
-   data-name="DIS-APL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_apl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-apl-high-risk.html"
-   data-default-order="187"
-   data-name="DIS-APL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-APL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_apl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-atll-frail.html"
-   data-default-order="188"
-   data-name="DIS-ATLL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_atll_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-atll-organ-dysf.html"
-   data-default-order="189"
-   data-name="DIS-ATLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_atll_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-atll-infection-hbv.html"
-   data-default-order="190"
-   data-name="DIS-ATLL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_atll_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-atll-relapsed-2l.html"
-   data-default-order="191"
-   data-name="DIS-ATLL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_atll_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-atll-biomarker-act.html"
-   data-default-order="192"
-   data-name="DIS-ATLL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_atll_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-atll-high-risk.html"
-   data-default-order="193"
-   data-name="DIS-ATLL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ATLL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_atll_high_risk.json</div>
 </a>
 <a class="case-card" href="/cases/variant-b_all-frail.html"
    data-default-order="194"
@@ -2622,3294 +232,46 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_b_all_high_risk.json</div>
 </a>
-<a class="case-card" href="/cases/variant-breast-frail.html"
-   data-default-order="200"
-   data-name="DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-breast-organ-dysf.html"
-   data-default-order="201"
-   data-name="DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-breast-infection-hbv.html"
-   data-default-order="202"
-   data-name="DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-breast-relapsed-2l.html"
-   data-default-order="203"
-   data-name="DIS-BREAST · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-breast-biomarker-act.html"
-   data-default-order="204"
-   data-name="DIS-BREAST · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-breast-high-risk.html"
-   data-default-order="205"
-   data-name="DIS-BREAST · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BREAST · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_breast_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-burkitt-frail.html"
-   data-default-order="206"
-   data-name="DIS-BURKITT · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_burkitt_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-burkitt-organ-dysf.html"
-   data-default-order="207"
-   data-name="DIS-BURKITT · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_burkitt_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-burkitt-infection-hbv.html"
-   data-default-order="208"
-   data-name="DIS-BURKITT · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_burkitt_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-burkitt-relapsed-2l.html"
-   data-default-order="209"
-   data-name="DIS-BURKITT · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_burkitt_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-burkitt-biomarker-act.html"
-   data-default-order="210"
-   data-name="DIS-BURKITT · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_burkitt_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-burkitt-high-risk.html"
-   data-default-order="211"
-   data-name="DIS-BURKITT · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-BURKITT · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_burkitt_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cervical-frail.html"
-   data-default-order="212"
-   data-name="DIS-CERVICAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cervical_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cervical-organ-dysf.html"
-   data-default-order="213"
-   data-name="DIS-CERVICAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cervical_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cervical-infection-hbv.html"
-   data-default-order="214"
-   data-name="DIS-CERVICAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cervical_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cervical-biomarker-act.html"
-   data-default-order="215"
-   data-name="DIS-CERVICAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cervical_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cervical-high-risk.html"
-   data-default-order="216"
-   data-name="DIS-CERVICAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CERVICAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cervical_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chl-frail.html"
-   data-default-order="217"
-   data-name="DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chl-organ-dysf.html"
-   data-default-order="218"
-   data-name="DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chl-infection-hbv.html"
-   data-default-order="219"
-   data-name="DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chl-relapsed-2l.html"
-   data-default-order="220"
-   data-name="DIS-CHL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chl-biomarker-act.html"
-   data-default-order="221"
-   data-name="DIS-CHL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chl-high-risk.html"
-   data-default-order="222"
-   data-name="DIS-CHL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cholangiocarcinoma-frail.html"
-   data-default-order="223"
-   data-name="DIS-CHOLANGIOCARCINOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cholangiocarcinoma_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cholangiocarcinoma-organ-dysf.html"
-   data-default-order="224"
-   data-name="DIS-CHOLANGIOCARCINOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cholangiocarcinoma_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cholangiocarcinoma-infection-hbv.html"
-   data-default-order="225"
-   data-name="DIS-CHOLANGIOCARCINOMA · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cholangiocarcinoma_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cholangiocarcinoma-biomarker-act.html"
-   data-default-order="226"
-   data-name="DIS-CHOLANGIOCARCINOMA · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cholangiocarcinoma_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cholangiocarcinoma-high-risk.html"
-   data-default-order="227"
-   data-name="DIS-CHOLANGIOCARCINOMA · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHOLANGIOCARCINOMA · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cholangiocarcinoma_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chondrosarcoma-frail.html"
-   data-default-order="228"
-   data-name="DIS-CHONDROSARCOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chondrosarcoma_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chondrosarcoma-organ-dysf.html"
-   data-default-order="229"
-   data-name="DIS-CHONDROSARCOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chondrosarcoma_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chondrosarcoma-infection-hbv.html"
-   data-default-order="230"
-   data-name="DIS-CHONDROSARCOMA · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chondrosarcoma_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chondrosarcoma-biomarker-act.html"
-   data-default-order="231"
-   data-name="DIS-CHONDROSARCOMA · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chondrosarcoma_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-chondrosarcoma-high-risk.html"
-   data-default-order="232"
-   data-name="DIS-CHONDROSARCOMA · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CHONDROSARCOMA · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_chondrosarcoma_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cll-frail.html"
-   data-default-order="233"
-   data-name="DIS-CLL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cll_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cll-organ-dysf.html"
-   data-default-order="234"
-   data-name="DIS-CLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cll_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cll-infection-hbv.html"
-   data-default-order="235"
-   data-name="DIS-CLL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cll_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cll-relapsed-2l.html"
-   data-default-order="236"
-   data-name="DIS-CLL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cll_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cll-biomarker-act.html"
-   data-default-order="237"
-   data-name="DIS-CLL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cll_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cll-high-risk.html"
-   data-default-order="238"
-   data-name="DIS-CLL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CLL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cll_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cml-frail.html"
-   data-default-order="239"
-   data-name="DIS-CML · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cml_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cml-organ-dysf.html"
-   data-default-order="240"
-   data-name="DIS-CML · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cml_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cml-infection-hbv.html"
-   data-default-order="241"
-   data-name="DIS-CML · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cml_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cml-relapsed-2l.html"
-   data-default-order="242"
-   data-name="DIS-CML · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cml_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cml-biomarker-act.html"
-   data-default-order="243"
-   data-name="DIS-CML · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cml_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-cml-high-risk.html"
-   data-default-order="244"
-   data-name="DIS-CML · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CML · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_cml_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-crc-frail.html"
-   data-default-order="245"
-   data-name="DIS-CRC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_crc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-crc-organ-dysf.html"
-   data-default-order="246"
-   data-name="DIS-CRC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_crc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-crc-infection-hbv.html"
-   data-default-order="247"
-   data-name="DIS-CRC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_crc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-crc-relapsed-2l.html"
-   data-default-order="248"
-   data-name="DIS-CRC · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_crc_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-crc-biomarker-act.html"
-   data-default-order="249"
-   data-name="DIS-CRC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_crc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-crc-high-risk.html"
-   data-default-order="250"
-   data-name="DIS-CRC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-CRC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_crc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-dlbcl_nos-frail.html"
-   data-default-order="251"
-   data-name="DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-dlbcl_nos-organ-dysf.html"
-   data-default-order="252"
-   data-name="DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-dlbcl_nos-infection-hbv.html"
-   data-default-order="253"
-   data-name="DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-dlbcl_nos-relapsed-2l.html"
-   data-default-order="254"
-   data-name="DIS-DLBCL-NOS · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-dlbcl_nos-biomarker-act.html"
-   data-default-order="255"
-   data-name="DIS-DLBCL-NOS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-dlbcl_nos-high-risk.html"
-   data-default-order="256"
-   data-name="DIS-DLBCL-NOS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-DLBCL-NOS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_dlbcl_nos_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-eatl-frail.html"
-   data-default-order="257"
-   data-name="DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-eatl-organ-dysf.html"
-   data-default-order="258"
-   data-name="DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-eatl-infection-hbv.html"
-   data-default-order="259"
-   data-name="DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-eatl-biomarker-act.html"
-   data-default-order="260"
-   data-name="DIS-EATL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-eatl-high-risk.html"
-   data-default-order="261"
-   data-name="DIS-EATL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-EATL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_eatl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-endometrial-frail.html"
-   data-default-order="262"
-   data-name="DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-endometrial-organ-dysf.html"
-   data-default-order="263"
-   data-name="DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-endometrial-infection-hbv.html"
-   data-default-order="264"
-   data-name="DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-endometrial-relapsed-2l.html"
-   data-default-order="265"
-   data-name="DIS-ENDOMETRIAL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-endometrial-biomarker-act.html"
-   data-default-order="266"
-   data-name="DIS-ENDOMETRIAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-endometrial-high-risk.html"
-   data-default-order="267"
-   data-name="DIS-ENDOMETRIAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ENDOMETRIAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_endometrial_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-esophageal-frail.html"
-   data-default-order="268"
-   data-name="DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-esophageal-organ-dysf.html"
-   data-default-order="269"
-   data-name="DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-esophageal-infection-hbv.html"
-   data-default-order="270"
-   data-name="DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-esophageal-relapsed-2l.html"
-   data-default-order="271"
-   data-name="DIS-ESOPHAGEAL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-esophageal-biomarker-act.html"
-   data-default-order="272"
-   data-name="DIS-ESOPHAGEAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-esophageal-high-risk.html"
-   data-default-order="273"
-   data-name="DIS-ESOPHAGEAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ESOPHAGEAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_esophageal_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-et-frail.html"
-   data-default-order="274"
-   data-name="DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-et-organ-dysf.html"
-   data-default-order="275"
-   data-name="DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-et-infection-hbv.html"
-   data-default-order="276"
-   data-name="DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-et-relapsed-2l.html"
-   data-default-order="277"
-   data-name="DIS-ET · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-et-biomarker-act.html"
-   data-default-order="278"
-   data-name="DIS-ET · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-et-high-risk.html"
-   data-default-order="279"
-   data-name="DIS-ET · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-ET · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_et_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-fl-frail.html"
-   data-default-order="280"
-   data-name="DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-fl-organ-dysf.html"
-   data-default-order="281"
-   data-name="DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-fl-infection-hbv.html"
-   data-default-order="282"
-   data-name="DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-fl-biomarker-act.html"
-   data-default-order="283"
-   data-name="DIS-FL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-FL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-fl-high-risk.html"
-   data-default-order="284"
-   data-name="DIS-FL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-FL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_fl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gastric-frail.html"
-   data-default-order="285"
-   data-name="DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gastric-organ-dysf.html"
-   data-default-order="286"
-   data-name="DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gastric-infection-hbv.html"
-   data-default-order="287"
-   data-name="DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gastric-relapsed-2l.html"
-   data-default-order="288"
-   data-name="DIS-GASTRIC · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gastric-biomarker-act.html"
-   data-default-order="289"
-   data-name="DIS-GASTRIC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gastric-high-risk.html"
-   data-default-order="290"
-   data-name="DIS-GASTRIC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GASTRIC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gastric_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gbm-frail.html"
-   data-default-order="291"
-   data-name="DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gbm-organ-dysf.html"
-   data-default-order="292"
-   data-name="DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gbm-infection-hbv.html"
-   data-default-order="293"
-   data-name="DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gbm-biomarker-act.html"
-   data-default-order="294"
-   data-name="DIS-GBM · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gbm-high-risk.html"
-   data-default-order="295"
-   data-name="DIS-GBM · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GBM · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gbm_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gist-frail.html"
-   data-default-order="296"
-   data-name="DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gist-organ-dysf.html"
-   data-default-order="297"
-   data-name="DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gist-infection-hbv.html"
-   data-default-order="298"
-   data-name="DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gist-biomarker-act.html"
-   data-default-order="299"
-   data-name="DIS-GIST · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-gist-high-risk.html"
-   data-default-order="300"
-   data-name="DIS-GIST · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-GIST · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_gist_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcc-frail.html"
-   data-default-order="301"
-   data-name="DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcc-organ-dysf.html"
-   data-default-order="302"
-   data-name="DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcc-infection-hbv.html"
-   data-default-order="303"
-   data-name="DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcc-biomarker-act.html"
-   data-default-order="304"
-   data-name="DIS-HCC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcc-high-risk.html"
-   data-default-order="305"
-   data-name="DIS-HCC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcl-frail.html"
-   data-default-order="306"
-   data-name="DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcl-organ-dysf.html"
-   data-default-order="307"
-   data-name="DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcl-infection-hbv.html"
-   data-default-order="308"
-   data-name="DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcl-relapsed-2l.html"
-   data-default-order="309"
-   data-name="DIS-HCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcl-biomarker-act.html"
-   data-default-order="310"
-   data-name="DIS-HCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcl-high-risk.html"
-   data-default-order="311"
-   data-name="DIS-HCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcv_mzl-frail.html"
-   data-default-order="312"
-   data-name="DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcv_mzl-organ-dysf.html"
-   data-default-order="313"
-   data-name="DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcv_mzl-infection-hbv.html"
-   data-default-order="314"
-   data-name="DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcv_mzl-relapsed-2l.html"
-   data-default-order="315"
-   data-name="DIS-HCV-MZL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcv_mzl-biomarker-act.html"
-   data-default-order="316"
-   data-name="DIS-HCV-MZL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hcv_mzl-high-risk.html"
-   data-default-order="317"
-   data-name="DIS-HCV-MZL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HCV-MZL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hcv_mzl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hgbl_dh-frail.html"
-   data-default-order="318"
-   data-name="DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hgbl_dh-organ-dysf.html"
-   data-default-order="319"
-   data-name="DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hgbl_dh-infection-hbv.html"
-   data-default-order="320"
-   data-name="DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hgbl_dh-relapsed-2l.html"
-   data-default-order="321"
-   data-name="DIS-HGBL-DH · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hgbl_dh-biomarker-act.html"
-   data-default-order="322"
-   data-name="DIS-HGBL-DH · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hgbl_dh-high-risk.html"
-   data-default-order="323"
-   data-name="DIS-HGBL-DH · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HGBL-DH · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hgbl_dh_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hnscc-frail.html"
-   data-default-order="324"
-   data-name="DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hnscc-organ-dysf.html"
-   data-default-order="325"
-   data-name="DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hnscc-infection-hbv.html"
-   data-default-order="326"
-   data-name="DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hnscc-biomarker-act.html"
-   data-default-order="327"
-   data-name="DIS-HNSCC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hnscc-high-risk.html"
-   data-default-order="328"
-   data-name="DIS-HNSCC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HNSCC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hnscc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hstcl-frail.html"
-   data-default-order="329"
-   data-name="DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hstcl-organ-dysf.html"
-   data-default-order="330"
-   data-name="DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hstcl-infection-hbv.html"
-   data-default-order="331"
-   data-name="DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hstcl-biomarker-act.html"
-   data-default-order="332"
-   data-name="DIS-HSTCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-hstcl-high-risk.html"
-   data-default-order="333"
-   data-name="DIS-HSTCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-HSTCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_hstcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ifs-frail.html"
-   data-default-order="334"
-   data-name="DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ifs-organ-dysf.html"
-   data-default-order="335"
-   data-name="DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ifs-infection-hbv.html"
-   data-default-order="336"
-   data-name="DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ifs-biomarker-act.html"
-   data-default-order="337"
-   data-name="DIS-IFS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ifs-high-risk.html"
-   data-default-order="338"
-   data-name="DIS-IFS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IFS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ifs_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-imt-frail.html"
-   data-default-order="339"
-   data-name="DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-imt-organ-dysf.html"
-   data-default-order="340"
-   data-name="DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-imt-infection-hbv.html"
-   data-default-order="341"
-   data-name="DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-imt-biomarker-act.html"
-   data-default-order="342"
-   data-name="DIS-IMT · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-imt-high-risk.html"
-   data-default-order="343"
-   data-name="DIS-IMT · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-IMT · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_imt_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mastocytosis-frail.html"
-   data-default-order="344"
-   data-name="DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mastocytosis-organ-dysf.html"
-   data-default-order="345"
-   data-name="DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mastocytosis-infection-hbv.html"
-   data-default-order="346"
-   data-name="DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mastocytosis-biomarker-act.html"
-   data-default-order="347"
-   data-name="DIS-MASTOCYTOSIS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mastocytosis-high-risk.html"
-   data-default-order="348"
-   data-name="DIS-MASTOCYTOSIS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MASTOCYTOSIS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mastocytosis_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mcl-frail.html"
-   data-default-order="349"
-   data-name="DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mcl-organ-dysf.html"
-   data-default-order="350"
-   data-name="DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mcl-infection-hbv.html"
-   data-default-order="351"
-   data-name="DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mcl-relapsed-2l.html"
-   data-default-order="352"
-   data-name="DIS-MCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mcl-biomarker-act.html"
-   data-default-order="353"
-   data-name="DIS-MCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mcl-high-risk.html"
-   data-default-order="354"
-   data-name="DIS-MCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_hr-frail.html"
-   data-default-order="355"
-   data-name="DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_hr-organ-dysf.html"
-   data-default-order="356"
-   data-name="DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_hr-infection-hbv.html"
-   data-default-order="357"
-   data-name="DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_hr-relapsed-2l.html"
-   data-default-order="358"
-   data-name="DIS-MDS-HR · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_hr-biomarker-act.html"
-   data-default-order="359"
-   data-name="DIS-MDS-HR · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_hr-high-risk.html"
-   data-default-order="360"
-   data-name="DIS-MDS-HR · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-HR · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_hr_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_lr-frail.html"
-   data-default-order="361"
-   data-name="DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_lr-organ-dysf.html"
-   data-default-order="362"
-   data-name="DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_lr-infection-hbv.html"
-   data-default-order="363"
-   data-name="DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_lr-relapsed-2l.html"
-   data-default-order="364"
-   data-name="DIS-MDS-LR · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_lr-biomarker-act.html"
-   data-default-order="365"
-   data-name="DIS-MDS-LR · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mds_lr-high-risk.html"
-   data-default-order="366"
-   data-name="DIS-MDS-LR · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MDS-LR · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mds_lr_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-melanoma-frail.html"
-   data-default-order="367"
-   data-name="DIS-MELANOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_melanoma_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-melanoma-organ-dysf.html"
-   data-default-order="368"
-   data-name="DIS-MELANOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_melanoma_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-melanoma-infection-hbv.html"
-   data-default-order="369"
-   data-name="DIS-MELANOMA · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_melanoma_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-melanoma-relapsed-2l.html"
-   data-default-order="370"
-   data-name="DIS-MELANOMA · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_melanoma_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-melanoma-biomarker-act.html"
-   data-default-order="371"
-   data-name="DIS-MELANOMA · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_melanoma_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-melanoma-high-risk.html"
-   data-default-order="372"
-   data-name="DIS-MELANOMA · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MELANOMA · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_melanoma_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mf_sezary-frail.html"
-   data-default-order="373"
-   data-name="DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mf_sezary-organ-dysf.html"
-   data-default-order="374"
-   data-name="DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mf_sezary-infection-hbv.html"
-   data-default-order="375"
-   data-name="DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mf_sezary-relapsed-2l.html"
-   data-default-order="376"
-   data-name="DIS-MF-SEZARY · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mf_sezary-biomarker-act.html"
-   data-default-order="377"
-   data-name="DIS-MF-SEZARY · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mf_sezary-high-risk.html"
-   data-default-order="378"
-   data-name="DIS-MF-SEZARY · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MF-SEZARY · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mf_sezary_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mm-frail.html"
-   data-default-order="379"
-   data-name="DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mm-organ-dysf.html"
-   data-default-order="380"
-   data-name="DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mm-infection-hbv.html"
-   data-default-order="381"
-   data-name="DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mm-relapsed-2l.html"
-   data-default-order="382"
-   data-name="DIS-MM · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mm-biomarker-act.html"
-   data-default-order="383"
-   data-name="DIS-MM · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mm-high-risk.html"
-   data-default-order="384"
-   data-name="DIS-MM · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MM · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mm_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mpnst-frail.html"
-   data-default-order="385"
-   data-name="DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mpnst-organ-dysf.html"
-   data-default-order="386"
-   data-name="DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mpnst-infection-hbv.html"
-   data-default-order="387"
-   data-name="DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mpnst-biomarker-act.html"
-   data-default-order="388"
-   data-name="DIS-MPNST · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mpnst-high-risk.html"
-   data-default-order="389"
-   data-name="DIS-MPNST · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MPNST · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mpnst_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mtc-frail.html"
-   data-default-order="390"
-   data-name="DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mtc-organ-dysf.html"
-   data-default-order="391"
-   data-name="DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mtc-infection-hbv.html"
-   data-default-order="392"
-   data-name="DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mtc-biomarker-act.html"
-   data-default-order="393"
-   data-name="DIS-MTC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MTC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-mtc-high-risk.html"
-   data-default-order="394"
-   data-name="DIS-MTC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-MTC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_mtc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nk_t_nasal-frail.html"
-   data-default-order="395"
-   data-name="DIS-NK-T-NASAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nk_t_nasal_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nk_t_nasal-organ-dysf.html"
-   data-default-order="396"
-   data-name="DIS-NK-T-NASAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nk_t_nasal_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nk_t_nasal-infection-hbv.html"
-   data-default-order="397"
-   data-name="DIS-NK-T-NASAL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nk_t_nasal_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nk_t_nasal-relapsed-2l.html"
-   data-default-order="398"
-   data-name="DIS-NK-T-NASAL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nk_t_nasal_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nk_t_nasal-biomarker-act.html"
-   data-default-order="399"
-   data-name="DIS-NK-T-NASAL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nk_t_nasal_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nk_t_nasal-high-risk.html"
-   data-default-order="400"
-   data-name="DIS-NK-T-NASAL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NK-T-NASAL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nk_t_nasal_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nlpbl-frail.html"
-   data-default-order="401"
-   data-name="DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nlpbl-organ-dysf.html"
-   data-default-order="402"
-   data-name="DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nlpbl-infection-hbv.html"
-   data-default-order="403"
-   data-name="DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nlpbl-relapsed-2l.html"
-   data-default-order="404"
-   data-name="DIS-NLPBL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nlpbl-biomarker-act.html"
-   data-default-order="405"
-   data-name="DIS-NLPBL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nlpbl-high-risk.html"
-   data-default-order="406"
-   data-name="DIS-NLPBL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NLPBL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nlpbl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nodal_mzl-frail.html"
-   data-default-order="407"
-   data-name="DIS-NODAL-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nodal_mzl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nodal_mzl-organ-dysf.html"
-   data-default-order="408"
-   data-name="DIS-NODAL-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nodal_mzl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nodal_mzl-infection-hbv.html"
-   data-default-order="409"
-   data-name="DIS-NODAL-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nodal_mzl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nodal_mzl-relapsed-2l.html"
-   data-default-order="410"
-   data-name="DIS-NODAL-MZL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nodal_mzl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nodal_mzl-biomarker-act.html"
-   data-default-order="411"
-   data-name="DIS-NODAL-MZL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nodal_mzl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nodal_mzl-high-risk.html"
-   data-default-order="412"
-   data-name="DIS-NODAL-MZL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NODAL-MZL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nodal_mzl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nsclc-frail.html"
-   data-default-order="413"
-   data-name="DIS-NSCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nsclc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nsclc-organ-dysf.html"
-   data-default-order="414"
-   data-name="DIS-NSCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nsclc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nsclc-infection-hbv.html"
-   data-default-order="415"
-   data-name="DIS-NSCLC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nsclc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nsclc-relapsed-2l.html"
-   data-default-order="416"
-   data-name="DIS-NSCLC · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 13 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nsclc_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nsclc-biomarker-act.html"
-   data-default-order="417"
-   data-name="DIS-NSCLC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nsclc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-nsclc-high-risk.html"
-   data-default-order="418"
-   data-name="DIS-NSCLC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-NSCLC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_nsclc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ovarian-frail.html"
-   data-default-order="419"
-   data-name="DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ovarian-organ-dysf.html"
-   data-default-order="420"
-   data-name="DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ovarian-infection-hbv.html"
-   data-default-order="421"
-   data-name="DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ovarian-relapsed-2l.html"
-   data-default-order="422"
-   data-name="DIS-OVARIAN · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 9 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ovarian-biomarker-act.html"
-   data-default-order="423"
-   data-name="DIS-OVARIAN · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ovarian-high-risk.html"
-   data-default-order="424"
-   data-name="DIS-OVARIAN · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-OVARIAN · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ovarian_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pcnsl-frail.html"
-   data-default-order="425"
-   data-name="DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pcnsl-organ-dysf.html"
-   data-default-order="426"
-   data-name="DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pcnsl-infection-hbv.html"
-   data-default-order="427"
-   data-name="DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pcnsl-relapsed-2l.html"
-   data-default-order="428"
-   data-name="DIS-PCNSL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pcnsl-biomarker-act.html"
-   data-default-order="429"
-   data-name="DIS-PCNSL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pcnsl-high-risk.html"
-   data-default-order="430"
-   data-name="DIS-PCNSL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PCNSL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pcnsl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pdac-frail.html"
-   data-default-order="431"
-   data-name="DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pdac-organ-dysf.html"
-   data-default-order="432"
-   data-name="DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pdac-infection-hbv.html"
-   data-default-order="433"
-   data-name="DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pdac-biomarker-act.html"
-   data-default-order="434"
-   data-name="DIS-PDAC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pdac-high-risk.html"
-   data-default-order="435"
-   data-name="DIS-PDAC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PDAC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pdac_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmbcl-frail.html"
-   data-default-order="436"
-   data-name="DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmbcl-organ-dysf.html"
-   data-default-order="437"
-   data-name="DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmbcl-infection-hbv.html"
-   data-default-order="438"
-   data-name="DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmbcl-relapsed-2l.html"
-   data-default-order="439"
-   data-name="DIS-PMBCL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmbcl-biomarker-act.html"
-   data-default-order="440"
-   data-name="DIS-PMBCL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmbcl-high-risk.html"
-   data-default-order="441"
-   data-name="DIS-PMBCL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMBCL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmbcl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmf-frail.html"
-   data-default-order="442"
-   data-name="DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmf-organ-dysf.html"
-   data-default-order="443"
-   data-name="DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmf-infection-hbv.html"
-   data-default-order="444"
-   data-name="DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmf-relapsed-2l.html"
-   data-default-order="445"
-   data-name="DIS-PMF · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmf-biomarker-act.html"
-   data-default-order="446"
-   data-name="DIS-PMF · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pmf-high-risk.html"
-   data-default-order="447"
-   data-name="DIS-PMF · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PMF · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pmf_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-prostate-frail.html"
-   data-default-order="448"
-   data-name="DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-prostate-organ-dysf.html"
-   data-default-order="449"
-   data-name="DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-prostate-infection-hbv.html"
-   data-default-order="450"
-   data-name="DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-prostate-biomarker-act.html"
-   data-default-order="451"
-   data-name="DIS-PROSTATE · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-prostate-high-risk.html"
-   data-default-order="452"
-   data-name="DIS-PROSTATE · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PROSTATE · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_prostate_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptcl_nos-frail.html"
-   data-default-order="453"
-   data-name="DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptcl_nos-organ-dysf.html"
-   data-default-order="454"
-   data-name="DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptcl_nos-infection-hbv.html"
-   data-default-order="455"
-   data-name="DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptcl_nos-relapsed-2l.html"
-   data-default-order="456"
-   data-name="DIS-PTCL-NOS · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptcl_nos-biomarker-act.html"
-   data-default-order="457"
-   data-name="DIS-PTCL-NOS · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptcl_nos-high-risk.html"
-   data-default-order="458"
-   data-name="DIS-PTCL-NOS · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTCL-NOS · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptcl_nos_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptld-frail.html"
-   data-default-order="459"
-   data-name="DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptld-organ-dysf.html"
-   data-default-order="460"
-   data-name="DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptld-infection-hbv.html"
-   data-default-order="461"
-   data-name="DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptld-relapsed-2l.html"
-   data-default-order="462"
-   data-name="DIS-PTLD · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptld-biomarker-act.html"
-   data-default-order="463"
-   data-name="DIS-PTLD · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-ptld-high-risk.html"
-   data-default-order="464"
-   data-name="DIS-PTLD · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PTLD · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_ptld_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pv-frail.html"
-   data-default-order="465"
-   data-name="DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pv-organ-dysf.html"
-   data-default-order="466"
-   data-name="DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pv-infection-hbv.html"
-   data-default-order="467"
-   data-name="DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pv-relapsed-2l.html"
-   data-default-order="468"
-   data-name="DIS-PV · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pv-biomarker-act.html"
-   data-default-order="469"
-   data-name="DIS-PV · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-pv-high-risk.html"
-   data-default-order="470"
-   data-name="DIS-PV · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-PV · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_pv_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-rcc-frail.html"
-   data-default-order="471"
-   data-name="DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-rcc-organ-dysf.html"
-   data-default-order="472"
-   data-name="DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-rcc-infection-hbv.html"
-   data-default-order="473"
-   data-name="DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-rcc-relapsed-2l.html"
-   data-default-order="474"
-   data-name="DIS-RCC · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-rcc-biomarker-act.html"
-   data-default-order="475"
-   data-name="DIS-RCC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-rcc-high-risk.html"
-   data-default-order="476"
-   data-name="DIS-RCC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-RCC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_rcc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-salivary-frail.html"
-   data-default-order="477"
-   data-name="DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-salivary-organ-dysf.html"
-   data-default-order="478"
-   data-name="DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-salivary-infection-hbv.html"
-   data-default-order="479"
-   data-name="DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-salivary-biomarker-act.html"
-   data-default-order="480"
-   data-name="DIS-SALIVARY · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-salivary-high-risk.html"
-   data-default-order="481"
-   data-name="DIS-SALIVARY · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SALIVARY · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_salivary_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-sclc-frail.html"
-   data-default-order="482"
-   data-name="DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-sclc-organ-dysf.html"
-   data-default-order="483"
-   data-name="DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-sclc-infection-hbv.html"
-   data-default-order="484"
-   data-name="DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-sclc-biomarker-act.html"
-   data-default-order="485"
-   data-name="DIS-SCLC · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-sclc-high-risk.html"
-   data-default-order="486"
-   data-name="DIS-SCLC · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SCLC · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_sclc_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-splenic_mzl-frail.html"
-   data-default-order="487"
-   data-name="DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-splenic_mzl-organ-dysf.html"
-   data-default-order="488"
-   data-name="DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-splenic_mzl-infection-hbv.html"
-   data-default-order="489"
-   data-name="DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-splenic_mzl-relapsed-2l.html"
-   data-default-order="490"
-   data-name="DIS-SPLENIC-MZL · Релапс / 2-а лінія">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_relapsed_2l.json</div>
-</a>
-<a class="case-card" href="/cases/variant-splenic_mzl-biomarker-act.html"
-   data-default-order="491"
-   data-name="DIS-SPLENIC-MZL · Actionable біомаркер present">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_biomarker_act.json</div>
-</a>
-<a class="case-card" href="/cases/variant-splenic_mzl-high-risk.html"
-   data-default-order="492"
-   data-name="DIS-SPLENIC-MZL · High-risk biology / bulky disease">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-SPLENIC-MZL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_splenic_mzl_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-t_all-frail.html"
-   data-default-order="493"
-   data-name="DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_frail.json</div>
-</a>
-<a class="case-card" href="/cases/variant-t_all-organ-dysf.html"
-   data-default-order="494"
-   data-name="DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_organ_dysf.json</div>
-</a>
-<a class="case-card" href="/cases/variant-t_all-infection-hbv.html"
-   data-default-order="495"
-   data-name="DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_infection_hbv.json</div>
-</a>
-<a class="case-card" href="/cases/variant-t_all-relapsed-2l.html"
-   data-default-order="496"
-   data-name="DIS-T-ALL · Релапс / 2-а лінія">
+</section>
+<section class="case-list" data-disease-id="DIS-T-PLL" hidden>
+  <header class="case-list-header">
+    <h2>T-клітинна пролімфоцитарна лейкемія</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/t-pll-typical.html"
+   data-default-order="57"
+   data-name="T-PLL · Typical (Alemtuzumab IV)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
   </div>
-  <h3>DIS-T-ALL · Релапс / 2-а лінія</h3>
-  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_relapsed_2l.json</div>
+  <h3>T-PLL · Typical (Alemtuzumab IV)</h3>
+  <p>T-PLL з ATM mutation + TCL1A rearrangement — engine обирає alemtuzumab IV (~90% ORR) → alloHCT consolidation.</p>
+  <div class="case-foot">patient_t_pll_typical.json</div>
 </a>
-<a class="case-card" href="/cases/variant-t_all-biomarker-act.html"
-   data-default-order="497"
-   data-name="DIS-T-ALL · Actionable біомаркер present">
+<a class="case-card" href="/cases/t-pll-alem-refractory.html"
+   data-default-order="58"
+   data-name="T-PLL · Alemtuzumab-refractory (Venetoclax + Alem)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
   </div>
-  <h3>DIS-T-ALL · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_biomarker_act.json</div>
+  <h3>T-PLL · Alemtuzumab-refractory (Venetoclax + Alem)</h3>
+  <p>T-PLL refractory до alemtuzumab mono — engine обирає venetoclax + alemtuzumab combo (Boidol/Hampel).</p>
+  <div class="case-foot">patient_t_pll_alemtuzumab_refractory.json</div>
 </a>
-<a class="case-card" href="/cases/variant-t_all-high-risk.html"
-   data-default-order="498"
-   data-name="DIS-T-ALL · High-risk biology / bulky disease">
+<a class="case-card" href="/cases/auto-t_pll.html"
+   data-default-order="159"
+   data-name="DIS-T-PLL — Auto-stub (88% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-stub">Auto-stub</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-T-ALL · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_t_all_high_risk.json</div>
+  <h3>DIS-T-PLL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для T-Cell Prolymphocytic Leukemia. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_t_pll.json</div>
 </a>
 <a class="case-card" href="/cases/variant-t_pll-frail.html"
    data-default-order="499"
@@ -5977,6 +339,442 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_t_pll_high_risk.json</div>
 </a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-T-ALL" hidden>
+  <header class="case-list-header">
+    <h2>T-лімфобластна лейкемія/лімфома</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/t-all-relapsed.html"
+   data-default-order="94"
+   data-name="T-ALL · Relapsed post-hyper-CVAD (Nelarabine)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>T-ALL · Relapsed post-hyper-CVAD (Nelarabine)</h3>
+  <p>T-ALL relapsed після hyper-CVAD — engine обирає nelarabine (T-cell selective; alloHCT consolidation).</p>
+  <div class="case-foot">patient_t_all_relapsed_post_hyper_cvad.json</div>
+</a>
+<a class="case-card" href="/cases/t-lbl-mediastinal.html"
+   data-default-order="95"
+   data-name="T-LBL · Mediastinal Mass (Pediatric-inspired ALL)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>T-LBL · Mediastinal Mass (Pediatric-inspired ALL)</h3>
+  <p>T-lymphoblastic lymphoma з mediastinal mass — engine обирає pediatric-inspired ALL regimen (CALGB 10403 / GMALL); CNS prophylaxis обов&#x27;язкове.</p>
+  <div class="case-foot">patient_t_lbl_mediastinal.json</div>
+</a>
+<a class="case-card" href="/cases/auto-t_all.html"
+   data-default-order="158"
+   data-name="DIS-T-ALL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для T-Lymphoblastic Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_t_all.json</div>
+</a>
+<a class="case-card" href="/cases/variant-t_all-frail.html"
+   data-default-order="493"
+   data-name="DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-t_all-organ-dysf.html"
+   data-default-order="494"
+   data-name="DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-t_all-infection-hbv.html"
+   data-default-order="495"
+   data-name="DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-t_all-relapsed-2l.html"
+   data-default-order="496"
+   data-name="DIS-T-ALL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-t_all-biomarker-act.html"
+   data-default-order="497"
+   data-name="DIS-T-ALL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-t_all-high-risk.html"
+   data-default-order="498"
+   data-name="DIS-T-ALL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-T-ALL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_t_all_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PROSTATE" hidden>
+  <header class="case-list-header">
+    <h2>Аденокарцинома передміхурової залози</h2>
+    <span class="case-list-count">7 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-prostate.html"
+   data-default-order="150"
+   data-name="DIS-PROSTATE — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Prostate adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_prostate.json</div>
+</a>
+<a class="case-card" href="/cases/variant-prostate-frail.html"
+   data-default-order="448"
+   data-name="DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-prostate-organ-dysf.html"
+   data-default-order="449"
+   data-name="DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-prostate-infection-hbv.html"
+   data-default-order="450"
+   data-name="DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-prostate-biomarker-act.html"
+   data-default-order="451"
+   data-name="DIS-PROSTATE · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-prostate-high-risk.html"
+   data-default-order="452"
+   data-name="DIS-PROSTATE · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PROSTATE · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_prostate_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/prostate-mcrpc-brca-olaparib.html"
+   data-default-order="557"
+   data-name="Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)</h3>
+  <p>mCRPC з BRCA-pathogenic, PARPi мono. Engine: ALGO-PROSTATE-MCRPC-1L step 1 → IND-PROSTATE-MCRPC-1L-PARPI (PROfound mPFS 7.4 мо).</p>
+  <div class="case-foot">patient_prostate_mcrpc_brca_olaparib_profound.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GASTRIC" hidden>
+  <header class="case-list-header">
+    <h2>Аденокарцинома шлунка / GEJ</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-gastric.html"
+   data-default-order="120"
+   data-name="DIS-GASTRIC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Gastric and gastroesophageal junction adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_gastric.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gastric-frail.html"
+   data-default-order="285"
+   data-name="DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gastric-organ-dysf.html"
+   data-default-order="286"
+   data-name="DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gastric-infection-hbv.html"
+   data-default-order="287"
+   data-name="DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gastric-relapsed-2l.html"
+   data-default-order="288"
+   data-name="DIS-GASTRIC · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gastric-biomarker-act.html"
+   data-default-order="289"
+   data-name="DIS-GASTRIC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gastric-high-risk.html"
+   data-default-order="290"
+   data-name="DIS-GASTRIC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GASTRIC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gastric_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/gastric-her2-pos-toga.html"
+   data-default-order="566"
+   data-name="Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)</h3>
+  <p>Метастатична HER2+ gastric. Engine: RF-HIGH-RISK-BIOLOGY → IND-GASTRIC-METASTATIC-1L-HER2-TOGA (TOGA mOS 13.8 мо).</p>
+  <div class="case-foot">patient_gastric_her2_pos_toga.json</div>
+</a>
+<a class="case-card" href="/cases/gastric-pdl1-cps-chemo-nivo.html"
+   data-default-order="567"
+   data-name="Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)</h3>
+  <p>Метастатична HER2- CPS≥5 gastric. Engine: HER2- step 2 → IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI (CM-649 mOS 14.4 мо).</p>
+  <div class="case-foot">patient_gastric_pdl1_cps_high_chemo_nivo.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ALCL" hidden>
+  <header class="case-list-header">
+    <h2>Анапластична великоклітинна лімфома (системна)</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/alcl-alk-negative.html"
+   data-default-order="24"
+   data-name="ALCL · ALK-negative (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ALCL · ALK-negative (CHP-Bv)</h3>
+  <p>Системна анапластична великоклітинна лімфома, ALK-negative — universally CD30+. Engine обирає CHP-Bv (ECHELON-2: brentuximab замість vincristine).</p>
+  <div class="case-foot">patient_alcl_alk_negative.json</div>
+</a>
+<a class="case-card" href="/cases/alcl-alk-positive-typical.html"
+   data-default-order="48"
+   data-name="ALCL · ALK-positive Typical (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ALCL · ALK-positive Typical (CHP-Bv)</h3>
+  <p>Молода особа з ALK+ ALCL — engine обирає CHP-Bv (ECHELON-2). ALK+ має значно кращий прогноз vs ALK-.</p>
+  <div class="case-foot">patient_alcl_alk_positive_typical.json</div>
+</a>
+<a class="case-card" href="/cases/alcl-relapsed-bv-naive.html"
+   data-default-order="49"
+   data-name="ALCL · Relapsed BV-naive (Brentuximab → autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ALCL · Relapsed BV-naive (Brentuximab → autoSCT)</h3>
+  <p>Relapsed ALCL без попереднього brentuximab — engine обирає brentuximab mono → autoSCT consolidation; BV maintenance per ECHELON-2 update.</p>
+  <div class="case-foot">patient_alcl_relapsed_bv_naive.json</div>
+</a>
+<a class="case-card" href="/cases/auto-alcl.html"
+   data-default-order="100"
+   data-name="DIS-ALCL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Anaplastic Large Cell Lymphoma, Systemic. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_alcl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-alcl-frail.html"
+   data-default-order="170"
+   data-name="DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-alcl-organ-dysf.html"
+   data-default-order="171"
+   data-name="DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-alcl-infection-hbv.html"
+   data-default-order="172"
+   data-name="DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-alcl-relapsed-2l.html"
+   data-default-order="173"
+   data-name="DIS-ALCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-alcl-biomarker-act.html"
+   data-default-order="174"
+   data-name="DIS-ALCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-alcl-high-risk.html"
+   data-default-order="175"
+   data-name="DIS-ALCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ALCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_alcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-THYROID-ANAPLASTIC" hidden>
+  <header class="case-list-header">
+    <h2>Анапластична карцинома щитовидної залози</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-thyroid_anaplastic.html"
+   data-default-order="160"
+   data-name="DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-ANAPLASTIC — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Anaplastic thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_thyroid_anaplastic.json</div>
+</a>
 <a class="case-card" href="/cases/variant-thyroid_anaplastic-frail.html"
    data-default-order="505"
    data-name="DIS-THYROID-ANAPLASTIC · Літній / крихкий пацієнт (age 78, ECOG 3)">
@@ -6032,115 +830,2995 @@
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_thyroid_anaplastic_high_risk.json</div>
 </a>
-<a class="case-card" href="/cases/variant-thyroid_papillary-frail.html"
-   data-default-order="510"
-   data-name="DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
-  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_frail.json</div>
+</section>
+<section class="case-list" data-disease-id="DIS-AITL" hidden>
+  <header class="case-list-header">
+    <h2>Ангіоімунобластна T-клітинна лімфома / нодальна TFH-лімфома</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/aitl-cd30-positive.html"
+   data-default-order="26"
+   data-name="AITL · CD30-positive (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AITL · CD30-positive (CHP-Bv)</h3>
+  <p>Ангіоімунобластна T-клітинна лімфома, CD30+ — RF-TCELL-CD30-POSITIVE fired. Engine обирає CHP-Bv.</p>
+  <div class="case-foot">patient_aitl_cd30_positive.json</div>
 </a>
-<a class="case-card" href="/cases/variant-thyroid_papillary-organ-dysf.html"
-   data-default-order="511"
-   data-name="DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/cases/aitl-cd30-negative.html"
+   data-default-order="30"
+   data-name="AITL · CD30-negative (CHOEP + AITL-specific workup)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
   </div>
-  <h3>DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
-  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_organ_dysf.json</div>
+  <h3>AITL · CD30-negative (CHOEP + AITL-specific workup)</h3>
+  <p>AITL з CD30-negative біопсією — engine обирає AITL-specific CHOEP. Layered workup: EBER-ISH (EBV+ B-cell мікрооточення), IgG quant (paraneoplastic hypogamma), DAT (AIHA risk).</p>
+  <div class="case-foot">patient_aitl_cd30_negative.json</div>
 </a>
-<a class="case-card" href="/cases/variant-thyroid_papillary-infection-hbv.html"
-   data-default-order="512"
-   data-name="DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/cases/aitl-relapsed-2l.html"
+   data-default-order="52"
+   data-name="AITL · Relapsed 2L (Azacitidine)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
   </div>
-  <h3>DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
-  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_infection_hbv.json</div>
+  <h3>AITL · Relapsed 2L (Azacitidine)</h3>
+  <p>AITL relapsed з TET2/DNMT3A epigenetic profile — engine обирає azacitidine (epigenetic targeting; AITL — найбільш azacitidine-responsive TCL subtype).</p>
+  <div class="case-foot">patient_aitl_relapsed_2l.json</div>
 </a>
-<a class="case-card" href="/cases/variant-thyroid_papillary-biomarker-act.html"
-   data-default-order="513"
-   data-name="DIS-THYROID-PAPILLARY · Actionable біомаркер present">
+<a class="case-card" href="/cases/auto-aitl.html"
+   data-default-order="99"
+   data-name="DIS-AITL — Auto-stub (88% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
+    <div class="case-badge bdg-stub">Auto-stub</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-THYROID-PAPILLARY · Actionable біомаркер present</h3>
-  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_biomarker_act.json</div>
+  <h3>DIS-AITL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Angioimmunoblastic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_aitl.json</div>
 </a>
-<a class="case-card" href="/cases/variant-thyroid_papillary-high-risk.html"
-   data-default-order="514"
-   data-name="DIS-THYROID-PAPILLARY · High-risk biology / bulky disease">
+<a class="case-card" href="/cases/variant-aitl-frail.html"
+   data-default-order="164"
+   data-name="DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-THYROID-PAPILLARY · High-risk biology / bulky disease</h3>
-  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_thyroid_papillary_high_risk.json</div>
-</a>
-<a class="case-card" href="/cases/variant-urothelial-frail.html"
-   data-default-order="515"
-   data-name="DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-stub">Variant</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <h3>DIS-AITL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
   <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_frail.json</div>
+  <div class="case-foot">variant_aitl_frail.json</div>
 </a>
-<a class="case-card" href="/cases/variant-urothelial-organ-dysf.html"
-   data-default-order="516"
-   data-name="DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+<a class="case-card" href="/cases/variant-aitl-organ-dysf.html"
+   data-default-order="165"
+   data-name="DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <h3>DIS-AITL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
   <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_organ_dysf.json</div>
+  <div class="case-foot">variant_aitl_organ_dysf.json</div>
 </a>
-<a class="case-card" href="/cases/variant-urothelial-infection-hbv.html"
-   data-default-order="517"
-   data-name="DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+<a class="case-card" href="/cases/variant-aitl-infection-hbv.html"
+   data-default-order="166"
+   data-name="DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <h3>DIS-AITL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
   <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_infection_hbv.json</div>
+  <div class="case-foot">variant_aitl_infection_hbv.json</div>
 </a>
-<a class="case-card" href="/cases/variant-urothelial-biomarker-act.html"
-   data-default-order="518"
-   data-name="DIS-UROTHELIAL · Actionable біомаркер present">
+<a class="case-card" href="/cases/variant-aitl-relapsed-2l.html"
+   data-default-order="167"
+   data-name="DIS-AITL · Релапс / 2-а лінія">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-UROTHELIAL · Actionable біомаркер present</h3>
+  <h3>DIS-AITL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aitl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aitl-biomarker-act.html"
+   data-default-order="168"
+   data-name="DIS-AITL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AITL · Actionable біомаркер present</h3>
   <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_biomarker_act.json</div>
+  <div class="case-foot">variant_aitl_biomarker_act.json</div>
 </a>
-<a class="case-card" href="/cases/variant-urothelial-high-risk.html"
-   data-default-order="519"
-   data-name="DIS-UROTHELIAL · High-risk biology / bulky disease">
+<a class="case-card" href="/cases/variant-aitl-high-risk.html"
+   data-default-order="169"
+   data-name="DIS-AITL · High-risk biology / bulky disease">
   <div class="case-badge-row">
     <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>DIS-UROTHELIAL · High-risk biology / bulky disease</h3>
+  <h3>DIS-AITL · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
-  <div class="case-foot">variant_urothelial_high_risk.json</div>
+  <div class="case-foot">variant_aitl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HGBL-DH" hidden>
+  <header class="case-list-header">
+    <h2>Високозлоякісна B-клітинна лімфома з MYC + BCL2/BCL6 (double-hit / triple-hit)</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/hgbl-double-hit.html"
+   data-default-order="23"
+   data-name="HGBL · Double-Hit (DA-EPOCH-R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>HGBL · Double-Hit (DA-EPOCH-R)</h3>
+  <p>High-Grade B-Cell Lymphoma з MYC + BCL2 break-apart — engine обирає DA-EPOCH-R (substantial OS improvement vs R-CHOP); reuse схеми з Burkitt.</p>
+  <div class="case-foot">patient_hgbl_double_hit.json</div>
+</a>
+<a class="case-card" href="/cases/auto-hgbl_dh.html"
+   data-default-order="127"
+   data-name="DIS-HGBL-DH — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для High-Grade B-Cell Lymphoma, Double-Hit / Triple-Hit. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hgbl_dh.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hgbl_dh-frail.html"
+   data-default-order="318"
+   data-name="DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hgbl_dh-organ-dysf.html"
+   data-default-order="319"
+   data-name="DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hgbl_dh-infection-hbv.html"
+   data-default-order="320"
+   data-name="DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hgbl_dh-relapsed-2l.html"
+   data-default-order="321"
+   data-name="DIS-HGBL-DH · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hgbl_dh-biomarker-act.html"
+   data-default-order="322"
+   data-name="DIS-HGBL-DH · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hgbl_dh-high-risk.html"
+   data-default-order="323"
+   data-name="DIS-HGBL-DH · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HGBL-DH · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hgbl_dh_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HCL" hidden>
+  <header class="case-list-header">
+    <h2>Волосатоклітинний лейкоз</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/hcl-typical.html"
+   data-default-order="21"
+   data-name="Hairy Cell Leukemia (Cladribine 7-day)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Hairy Cell Leukemia (Cladribine 7-day)</h3>
+  <p>Волосатоклітинний лейкоз з cytopenia + splenomegaly — engine обирає 1 курс cladribine 7 днів. ~85% durable CR.</p>
+  <div class="case-foot">patient_hcl_typical.json</div>
+</a>
+<a class="case-card" href="/cases/hcl-relapsed-braf.html"
+   data-default-order="45"
+   data-name="HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCL · Relapsed BRAF-V600E+ (Vemurafenib + Rituximab)</h3>
+  <p>HCL relapsed з BRAF-V600E+ — engine обирає vemurafenib+rituximab (Tiacci); BRAF-WT route → cladribine retreatment.</p>
+  <div class="case-foot">patient_hcl_relapsed_braf.json</div>
+</a>
+<a class="case-card" href="/cases/auto-hcl.html"
+   data-default-order="125"
+   data-name="DIS-HCL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Hairy Cell Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hcl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcl-frail.html"
+   data-default-order="306"
+   data-name="DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcl-organ-dysf.html"
+   data-default-order="307"
+   data-name="DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcl-infection-hbv.html"
+   data-default-order="308"
+   data-name="DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcl-relapsed-2l.html"
+   data-default-order="309"
+   data-name="DIS-HCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcl-biomarker-act.html"
+   data-default-order="310"
+   data-name="DIS-HCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcl-high-risk.html"
+   data-default-order="311"
+   data-name="DIS-HCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GIST" hidden>
+  <header class="case-list-header">
+    <h2>Гастроінтестинальна стромальна пухлина (GIST)</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-gist.html"
+   data-default-order="122"
+   data-name="DIS-GIST — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GIST — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Gastrointestinal stromal tumor. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_gist.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gist-frail.html"
+   data-default-order="296"
+   data-name="DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gist-organ-dysf.html"
+   data-default-order="297"
+   data-name="DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gist-infection-hbv.html"
+   data-default-order="298"
+   data-name="DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gist-biomarker-act.html"
+   data-default-order="299"
+   data-name="DIS-GIST · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gist-high-risk.html"
+   data-default-order="300"
+   data-name="DIS-GIST · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GIST · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gist_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HSTCL" hidden>
+  <header class="case-list-header">
+    <h2>Гепатоспленічна T-клітинна лімфома</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/hstcl-fit-younger.html"
+   data-default-order="55"
+   data-name="HSTCL · Fit Younger (ICE/IVAC → alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HSTCL · Fit Younger (ICE/IVAC → alloHCT)</h3>
+  <p>Hepatosplenic T-cell Lymphoma у молодої особи, ECOG 0 — engine обирає intensive ICE/IVAC → upfront alloHCT (CHOP неадекватний).</p>
+  <div class="case-foot">patient_hstcl_fit_younger.json</div>
+</a>
+<a class="case-card" href="/cases/hstcl-iatrogenic-ibd.html"
+   data-default-order="56"
+   data-name="HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HSTCL · Iatrogenic IBD (CHOEP-unfit fallback)</h3>
+  <p>HSTCL у IBD-пацієнта на тривалій thiopurine+anti-TNF therapy — engine припиняє imunosuppression + CHOEP-unfit fallback з branching algorithm.</p>
+  <div class="case-foot">patient_hstcl_iatrogenic_ibd.json</div>
+</a>
+<a class="case-card" href="/cases/auto-hstcl.html"
+   data-default-order="129"
+   data-name="DIS-HSTCL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Hepatosplenic T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hstcl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hstcl-frail.html"
+   data-default-order="329"
+   data-name="DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hstcl-organ-dysf.html"
+   data-default-order="330"
+   data-name="DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hstcl-infection-hbv.html"
+   data-default-order="331"
+   data-name="DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hstcl-biomarker-act.html"
+   data-default-order="332"
+   data-name="DIS-HSTCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hstcl-high-risk.html"
+   data-default-order="333"
+   data-name="DIS-HSTCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HSTCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hstcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HCC" hidden>
+  <header class="case-list-header">
+    <h2>Гепатоцелюлярна карцинома</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-hcc.html"
+   data-default-order="124"
+   data-name="DIS-HCC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Hepatocellular carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hcc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcc-frail.html"
+   data-default-order="301"
+   data-name="DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcc-organ-dysf.html"
+   data-default-order="302"
+   data-name="DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcc-infection-hbv.html"
+   data-default-order="303"
+   data-name="DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcc-biomarker-act.html"
+   data-default-order="304"
+   data-name="DIS-HCC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcc-high-risk.html"
+   data-default-order="305"
+   data-name="DIS-HCC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcc_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/hcc-atezo-bev-imbrave150.html"
+   data-default-order="564"
+   data-name="HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)</h3>
+  <p>HCC Child-Pugh A, fit. Engine: → IND-HCC-SYSTEMIC-1L-ATEZO-BEV (IMbrave150 mOS 19.2 мо).</p>
+  <div class="case-foot">patient_hcc_atezo_bev_imbrave150.json</div>
+</a>
+<a class="case-card" href="/cases/hcc-durva-treme-stride.html"
+   data-default-order="565"
+   data-name="HCC · 1L · Durva+treme (HIMALAYA STRIDE)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>HCC · 1L · Durva+treme (HIMALAYA STRIDE)</h3>
+  <p>HCC з high-risk varices. Engine: RF-HCC-VARICEAL-BLEED step 1 → IND-HCC-SYSTEMIC-1L-DURVA-TREME (HIMALAYA mOS 16.4 мо).</p>
+  <div class="case-foot">patient_hcc_durva_treme_stride.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GBM" hidden>
+  <header class="case-list-header">
+    <h2>Гліобластома (IDH-WT, WHO grade 4)</h2>
+    <span class="case-list-count">7 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/gbm-stupp.html"
+   data-default-order="97"
+   data-name="Glioblastoma · Newly Diagnosed (Stupp Protocol)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Glioblastoma · Newly Diagnosed (Stupp Protocol)</h3>
+  <p>GBM IDH-WT WHO grade 4 — engine обирає Stupp: maximal safe resection → RT + concurrent TMZ → adjuvant TMZ × 6; TTFields для MGMT-methylated.</p>
+  <div class="case-foot">patient_gbm_newly_diagnosed_stupp.json</div>
+</a>
+<a class="case-card" href="/cases/auto-gbm.html"
+   data-default-order="121"
+   data-name="DIS-GBM — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GBM — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Glioblastoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_gbm.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gbm-frail.html"
+   data-default-order="291"
+   data-name="DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gbm-organ-dysf.html"
+   data-default-order="292"
+   data-name="DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gbm-infection-hbv.html"
+   data-default-order="293"
+   data-name="DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gbm-biomarker-act.html"
+   data-default-order="294"
+   data-name="DIS-GBM · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-gbm-high-risk.html"
+   data-default-order="295"
+   data-name="DIS-GBM · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GBM · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_gbm_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-GLIOMA-LOW-GRADE" hidden>
+  <header class="case-list-header">
+    <h2>Гліома низького ступеня (WHO grade 2 — IDH-мутантна)</h2>
+    <span class="case-list-count">1 приклад</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-glioma_low_grade.html"
+   data-default-order="123"
+   data-name="DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-GLIOMA-LOW-GRADE — Auto-stub (50% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Low-grade glioma. Фактична наповненість бази для цієї хвороби — 50%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_glioma_low_grade.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-AML" hidden>
+  <header class="case-list-header">
+    <h2>Гострий мієлоїдний лейкоз (не-APL)</h2>
+    <span class="case-list-count">14 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/aml-fit-1l-7-3.html"
+   data-default-order="70"
+   data-name="AML · Fit 1L (7+3 Induction)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · Fit 1L (7+3 Induction)</h3>
+  <p>Newly-diagnosed AML, fit, ELN intermediate — engine обирає 7+3 induction (cytarabine + daunorubicin) → consolidation HiDAC.</p>
+  <div class="case-foot">patient_aml_fit_1l_seven_three.json</div>
+</a>
+<a class="case-card" href="/cases/aml-unfit-ven-aza.html"
+   data-default-order="71"
+   data-name="AML · Unfit (Venetoclax + Azacitidine)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · Unfit (Venetoclax + Azacitidine)</h3>
+  <p>AML вік 78, ECOG 2 — engine обирає ven+aza (VIALE-A: ~65% CR/CRi, OS 14.7 mo, краще ніж aza alone).</p>
+  <div class="case-foot">patient_aml_unfit_ven_aza.json</div>
+</a>
+<a class="case-card" href="/cases/aml-flt3-relapse.html"
+   data-default-order="72"
+   data-name="AML · FLT3-mutant Relapse (Gilteritinib)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · FLT3-mutant Relapse (Gilteritinib)</h3>
+  <p>AML relapsed з FLT3-ITD/TKD — engine обирає gilteritinib mono (ADMIRAL: superior до salvage chemo); alloHCT для responders.</p>
+  <div class="case-foot">patient_aml_flt3_relapse.json</div>
+</a>
+<a class="case-card" href="/cases/auto-aml.html"
+   data-default-order="101"
+   data-name="DIS-AML — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Acute Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_aml.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aml-frail.html"
+   data-default-order="176"
+   data-name="DIS-AML · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aml_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aml-organ-dysf.html"
+   data-default-order="177"
+   data-name="DIS-AML · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aml_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aml-infection-hbv.html"
+   data-default-order="178"
+   data-name="DIS-AML · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aml_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aml-relapsed-2l.html"
+   data-default-order="179"
+   data-name="DIS-AML · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aml_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aml-biomarker-act.html"
+   data-default-order="180"
+   data-name="DIS-AML · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aml_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-aml-high-risk.html"
+   data-default-order="181"
+   data-name="DIS-AML · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-AML · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_aml_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/aml-flt3-itd-midostaurin.html"
+   data-default-order="574"
+   data-name="AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · FLT3-ITD fit · 7+3 + Midostaurin (RATIFY)</h3>
+  <p>Fit AML FLT3-ITD. Engine: ALGO-1L → IND-AML-1L-7-3 (default); midostaurin/RATIFY як regimen-layer note у comment.</p>
+  <div class="case-foot">patient_aml_flt3_itd_midostaurin_7_3.json</div>
+</a>
+<a class="case-card" href="/cases/aml-cbf-inv16-7-3-go.html"
+   data-default-order="575"
+   data-name="AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)</h3>
+  <p>Fit CBF AML. Drift: 7+3+GO indication відсутня; engine default = 7+3 plain; ALFA-0701 анкер у comment.</p>
+  <div class="case-foot">patient_aml_cbf_inv16_7_3_go.json</div>
+</a>
+<a class="case-card" href="/cases/aml-secondary-cpx351.html"
+   data-default-order="576"
+   data-name="AML · secondary/t-AML · CPX-351 (Vyxeos)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>AML · secondary/t-AML · CPX-351 (Vyxeos)</h3>
+  <p>Secondary AML post-MDS. Drift: CPX-351 indication відсутня у ALGO-1L; engine default = 7+3; Vyxeos анкер у comment.</p>
+  <div class="case-foot">patient_aml_secondary_cpx351.json</div>
+</a>
+<a class="case-card" href="/cases/aml-rr-gilteritinib.html"
+   data-default-order="577"
+   data-name="AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>AML · R/R FLT3-mut · Gilteritinib (ADMIRAL)</h3>
+  <p>Primary-refractory FLT3-TKD AML. Engine: ALGO-2L → IND-AML-2L-GILTERITINIB-FLT3 (ADMIRAL mOS 9.3 мо vs salvage chemo).</p>
+  <div class="case-foot">patient_aml_rr_gilteritinib.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-APL" hidden>
+  <header class="case-list-header">
+    <h2>Гострий промієлоцитарний лейкоз (PML-RARA)</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/apl-low-risk.html"
+   data-default-order="73"
+   data-name="APL · Low Risk (ATRA + ATO chemo-free)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>APL · Low Risk (ATRA + ATO chemo-free)</h3>
+  <p>APL з WBC &lt;10K (low-risk Sanz) — engine обирає ATRA+ATO chemo-free (APL0406: ~98% CR, без anthracycline).</p>
+  <div class="case-foot">patient_apl_low_risk.json</div>
+</a>
+<a class="case-card" href="/cases/apl-high-risk.html"
+   data-default-order="74"
+   data-name="APL · High Risk + DIC (ATRA + ATO + Idarubicin)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>APL · High Risk + DIC (ATRA + ATO + Idarubicin)</h3>
+  <p>APL з WBC &gt;10K + active DIC — RF-APL-DIC + RF-APL-HIGH-RISK fired. Engine додає idarubicin до ATRA+ATO; emergency cryoprecipitate/platelets.</p>
+  <div class="case-foot">patient_apl_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/auto-apl.html"
+   data-default-order="102"
+   data-name="DIS-APL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Acute Promyelocytic Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_apl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-apl-frail.html"
+   data-default-order="182"
+   data-name="DIS-APL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_apl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-apl-organ-dysf.html"
+   data-default-order="183"
+   data-name="DIS-APL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_apl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-apl-infection-hbv.html"
+   data-default-order="184"
+   data-name="DIS-APL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_apl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-apl-relapsed-2l.html"
+   data-default-order="185"
+   data-name="DIS-APL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_apl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-apl-biomarker-act.html"
+   data-default-order="186"
+   data-name="DIS-APL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_apl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-apl-high-risk.html"
+   data-default-order="187"
+   data-name="DIS-APL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-APL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_apl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MF-SEZARY" hidden>
+  <header class="case-list-header">
+    <h2>Грибоподібний мікоз / Синдром Сезарі</h2>
+    <span class="case-list-count">11 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/mf-early-stage.html"
+   data-default-order="31"
+   data-name="Mycosis Fungoides · Early Stage (Skin-Directed)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Mycosis Fungoides · Early Stage (Skin-Directed)</h3>
+  <p>MF stage IB без B2/LCT — engine обирає skin-directed (NBUVB / topicals / TSEBT). Жодного системного режиму — preserves chemo для прогресу. Workup rules out occult Sézary (B2 count) + LCT.</p>
+  <div class="case-foot">patient_mf_early_stage.json</div>
+</a>
+<a class="case-card" href="/cases/sezary-advanced.html"
+   data-default-order="32"
+   data-name="Sézary Syndrome · Advanced (Mogamulizumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Sézary Syndrome · Advanced (Mogamulizumab)</h3>
+  <p>Sézary syndrome (B2 leukemic, generalized erythroderma) — RF-MF-SEZARY-LEUKEMIC fired. Engine обирає mogamulizumab (MAVORIC: anti-CCR4 ADCC, найкраща blood-compartment відповідь).</p>
+  <div class="case-foot">patient_sezary_advanced.json</div>
+</a>
+<a class="case-card" href="/cases/mf-advanced-cd30.html"
+   data-default-order="33"
+   data-name="MF · Advanced + CD30+ LCT (Brentuximab mono)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MF · Advanced + CD30+ LCT (Brentuximab mono)</h3>
+  <p>Advanced MF stage IIB з large-cell transformation, CD30+ — RF-MF-LARGE-CELL-TRANSFORMATION + RF-TCELL-CD30-POSITIVE fired. Engine обирає brentuximab vedotin monotherapy (ALCANZA).</p>
+  <div class="case-foot">patient_mf_advanced_cd30.json</div>
+</a>
+<a class="case-card" href="/cases/mf-relapsed-post-moga.html"
+   data-default-order="63"
+   data-name="MF · Relapsed post-Mogamulizumab (Bexarotene)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MF · Relapsed post-Mogamulizumab (Bexarotene)</h3>
+  <p>MF/Sézary relapsed після mogamulizumab — engine обирає bexarotene 2L з low-dose maintenance (RXR-targeted oral retinoid).</p>
+  <div class="case-foot">patient_mf_relapsed_post_moga.json</div>
+</a>
+<a class="case-card" href="/cases/auto-mf_sezary.html"
+   data-default-order="137"
+   data-name="DIS-MF-SEZARY — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Mycosis Fungoides / Sézary Syndrome. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mf_sezary.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mf_sezary-frail.html"
+   data-default-order="373"
+   data-name="DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mf_sezary-organ-dysf.html"
+   data-default-order="374"
+   data-name="DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mf_sezary-infection-hbv.html"
+   data-default-order="375"
+   data-name="DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mf_sezary-relapsed-2l.html"
+   data-default-order="376"
+   data-name="DIS-MF-SEZARY · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mf_sezary-biomarker-act.html"
+   data-default-order="377"
+   data-name="DIS-MF-SEZARY · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mf_sezary-high-risk.html"
+   data-default-order="378"
+   data-name="DIS-MF-SEZARY · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MF-SEZARY · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mf_sezary_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-DLBCL-NOS" hidden>
+  <header class="case-list-header">
+    <h2>Дифузна B-великоклітинна лімфома, неуточнена (DLBCL NOS)</h2>
+    <span class="case-list-count">12 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/dlbcl-chemorefractory-cart.html"
+   data-default-order="35"
+   data-name="DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL NOS · Primary Chemorefractory (CAR-T axi-cel)</h3>
+  <p>DLBCL з primary refractory disease (PD на R-CHOP) — engine обирає axi-cel CAR-T (ZUMA-7: 2L CAR-T &gt; salvage+autoSCT для early-failure).</p>
+  <div class="case-foot">patient_dlbcl_chemorefractory_for_cart.json</div>
+</a>
+<a class="case-card" href="/cases/dlbcl-relapsed-te-ineligible.html"
+   data-default-order="36"
+   data-name="DLBCL NOS · Relapsed (Transplant-Ineligible)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL NOS · Relapsed (Transplant-Ineligible)</h3>
+  <p>DLBCL relapsed, transplant-ineligible через age + comorbidity — engine обирає Pola-BR (POLARGO) або loncastuximab tesirine.</p>
+  <div class="case-foot">patient_dlbcl_relapsed_transplant_ineligible.json</div>
+</a>
+<a class="case-card" href="/cases/auto-dlbcl_nos.html"
+   data-default-order="114"
+   data-name="DIS-DLBCL-NOS — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Diffuse Large B-Cell Lymphoma, Not Otherwise Specified. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_dlbcl_nos.json</div>
+</a>
+<a class="case-card" href="/cases/variant-dlbcl_nos-frail.html"
+   data-default-order="251"
+   data-name="DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-dlbcl_nos-organ-dysf.html"
+   data-default-order="252"
+   data-name="DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-dlbcl_nos-infection-hbv.html"
+   data-default-order="253"
+   data-name="DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-dlbcl_nos-relapsed-2l.html"
+   data-default-order="254"
+   data-name="DIS-DLBCL-NOS · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-dlbcl_nos-biomarker-act.html"
+   data-default-order="255"
+   data-name="DIS-DLBCL-NOS · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-dlbcl_nos-high-risk.html"
+   data-default-order="256"
+   data-name="DIS-DLBCL-NOS · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-DLBCL-NOS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_dlbcl_nos_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/dlbcl-2l-pola-r-b.html"
+   data-default-order="578"
+   data-name="DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL · 2L · Pola-R-B transplant-ineligible (POLARIX 2L)</h3>
+  <p>ASCT-ineligible cardiac-comorbidity, late relapse. Engine: ALGO-2L → IND-DLBCL-2L-POLA-R-BENDAMUSTINE (distinct від існуючого relapsed_transplant_ineligible).</p>
+  <div class="case-foot">patient_dlbcl_2l_pola_r_b.json</div>
+</a>
+<a class="case-card" href="/cases/dlbcl-3l-axi-cel.html"
+   data-default-order="579"
+   data-name="DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL · 3L+ · Axi-cel post-2L (ZUMA-1)</h3>
+  <p>Прогрес після RCHOP→Pola-BR. Engine: ALGO-2L default = Pola-BR; axi-cel surfaces як aggressive alternative track. Distinct від chemorefractory_for_cart.</p>
+  <div class="case-foot">patient_dlbcl_3l_axi_cel.json</div>
+</a>
+<a class="case-card" href="/cases/dlbcl-primary-refractory-loncast.html"
+   data-default-order="580"
+   data-name="DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL · primary-refractory · Loncastuximab post-pola (LOTIS-2)</h3>
+  <p>Primary-refractory frail non-CAR-T-eligible. Drift: REG-LONCASTUXIMAB-TESIRINE відсутній; engine default = Pola-BR (re-MMAE inappropriate); LOTIS-2 анкер у comment.</p>
+  <div class="case-foot">patient_dlbcl_primary_refractory_loncast_post_pola.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ATLL" hidden>
+  <header class="case-list-header">
+    <h2>Дорослий T-клітинний лейкоз/лімфома</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/atll-acute.html"
+   data-default-order="59"
+   data-name="ATLL · Acute (mLSG15 / EPOCH)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ATLL · Acute (mLSG15 / EPOCH)</h3>
+  <p>Adult T-cell Leukemia/Lymphoma, acute subtype, HTLV-1+ — engine обирає intensive mLSG15 або EPOCH; alloHCT consolidation для responders.</p>
+  <div class="case-foot">patient_atll_acute.json</div>
+</a>
+<a class="case-card" href="/cases/atll-indolent-smoldering.html"
+   data-default-order="60"
+   data-name="ATLL · Indolent / Smoldering (Watchful Waiting)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>ATLL · Indolent / Smoldering (Watchful Waiting)</h3>
+  <p>ATLL indolent/smoldering — engine обирає observation; system trigger для transformation.</p>
+  <div class="case-foot">patient_atll_indolent_smoldering.json</div>
+</a>
+<a class="case-card" href="/cases/auto-atll.html"
+   data-default-order="103"
+   data-name="DIS-ATLL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Adult T-Cell Leukemia/Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_atll.json</div>
+</a>
+<a class="case-card" href="/cases/variant-atll-frail.html"
+   data-default-order="188"
+   data-name="DIS-ATLL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_atll_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-atll-organ-dysf.html"
+   data-default-order="189"
+   data-name="DIS-ATLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_atll_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-atll-infection-hbv.html"
+   data-default-order="190"
+   data-name="DIS-ATLL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_atll_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-atll-relapsed-2l.html"
+   data-default-order="191"
+   data-name="DIS-ATLL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_atll_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-atll-biomarker-act.html"
+   data-default-order="192"
+   data-name="DIS-ATLL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_atll_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-atll-high-risk.html"
+   data-default-order="193"
+   data-name="DIS-ATLL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ATLL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_atll_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-SCLC" hidden>
+  <header class="case-list-header">
+    <h2>Дрібноклітинний рак легені</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-sclc.html"
+   data-default-order="156"
+   data-name="DIS-SCLC — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Small cell lung cancer. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_sclc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-sclc-frail.html"
+   data-default-order="482"
+   data-name="DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-sclc-organ-dysf.html"
+   data-default-order="483"
+   data-name="DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-sclc-infection-hbv.html"
+   data-default-order="484"
+   data-name="DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-sclc-biomarker-act.html"
+   data-default-order="485"
+   data-name="DIS-SCLC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-sclc-high-risk.html"
+   data-default-order="486"
+   data-name="DIS-SCLC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SCLC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_sclc_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/sclc-ls-chemo-rt.html"
+   data-default-order="570"
+   data-name="SCLC · LS · Chemo + concurrent RT">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>SCLC · LS · Chemo + concurrent RT</h3>
+  <p>Limited-stage SCLC. RT не modellable per CHARTER §17 — engine emit chemo backbone EP, RT як free-text. Drift: engine default = ES-1L.</p>
+  <div class="case-foot">patient_sclc_ls_chemo_rt.json</div>
+</a>
+<a class="case-card" href="/cases/sclc-es-atezo-impower133.html"
+   data-default-order="571"
+   data-name="SCLC · ES · Atezo+carbo+etoposide (IMpower133)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>SCLC · ES · Atezo+carbo+etoposide (IMpower133)</h3>
+  <p>Extensive-stage SCLC. Engine: → IND-SCLC-EXTENSIVE-1L. Drift: дефолт REG-EP-DURVA не IMpower133 атезо; атезо regimen не wired.</p>
+  <div class="case-foot">patient_sclc_es_atezo_chemo_impower133.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NK-T-NASAL" hidden>
+  <header class="case-list-header">
+    <h2>Екстранодальна NK/T-клітинна лімфома, назального типу</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/nk-t-nasal-localized.html"
+   data-default-order="61"
+   data-name="NK/T-Nasal · Localized (P-GEMOX + RT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NK/T-Nasal · Localized (P-GEMOX + RT)</h3>
+  <p>Localized extranodal NK/T-cell lymphoma, nasal type — engine обирає concurrent P-GEMOX + RT (anthracycline-resistant biology).</p>
+  <div class="case-foot">patient_nk_t_nasal_localized.json</div>
+</a>
+<a class="case-card" href="/cases/nk-t-nasal-relapsed.html"
+   data-default-order="62"
+   data-name="NK/T-Nasal · Relapsed (Avelumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NK/T-Nasal · Relapsed (Avelumab)</h3>
+  <p>NK/T-nasal relapsed — engine обирає avelumab (NCCN-listed PD-L1 inhibitor; promoted from stub).</p>
+  <div class="case-foot">patient_nk_t_nasal_relapsed.json</div>
+</a>
+<a class="case-card" href="/cases/auto-nk_t_nasal.html"
+   data-default-order="141"
+   data-name="DIS-NK-T-NASAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Extranodal NK/T-Cell Lymphoma, Nasal Type. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nk_t_nasal.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nk_t_nasal-frail.html"
+   data-default-order="395"
+   data-name="DIS-NK-T-NASAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nk_t_nasal_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nk_t_nasal-organ-dysf.html"
+   data-default-order="396"
+   data-name="DIS-NK-T-NASAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nk_t_nasal_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nk_t_nasal-infection-hbv.html"
+   data-default-order="397"
+   data-name="DIS-NK-T-NASAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nk_t_nasal_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nk_t_nasal-relapsed-2l.html"
+   data-default-order="398"
+   data-name="DIS-NK-T-NASAL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nk_t_nasal_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nk_t_nasal-biomarker-act.html"
+   data-default-order="399"
+   data-name="DIS-NK-T-NASAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nk_t_nasal_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nk_t_nasal-high-risk.html"
+   data-default-order="400"
+   data-name="DIS-NK-T-NASAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NK-T-NASAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nk_t_nasal_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-EATL" hidden>
+  <header class="case-list-header">
+    <h2>Ентеропатія-асоційована T-клітинна лімфома</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/eatl-typical.html"
+   data-default-order="53"
+   data-name="EATL · Typical (Celiac, CHOEP → autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>EATL · Typical (Celiac, CHOEP → autoSCT)</h3>
+  <p>EATL у пацієнта з celiac disease — engine обирає CHOEP induction → autoSCT consolidation (NLG-T-01).</p>
+  <div class="case-foot">patient_eatl_typical.json</div>
+</a>
+<a class="case-card" href="/cases/eatl-relapsed-post-choep.html"
+   data-default-order="54"
+   data-name="EATL · Relapsed post-CHOEP (ICE Salvage)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>EATL · Relapsed post-CHOEP (ICE Salvage)</h3>
+  <p>EATL relapsed після CHOEP — engine обирає ICE salvage; alloHCT для chemosensitive.</p>
+  <div class="case-foot">patient_eatl_relapsed_post_choep.json</div>
+</a>
+<a class="case-card" href="/cases/auto-eatl.html"
+   data-default-order="115"
+   data-name="DIS-EATL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-EATL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Enteropathy-Associated T-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_eatl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-eatl-frail.html"
+   data-default-order="257"
+   data-name="DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-EATL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_eatl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-eatl-organ-dysf.html"
+   data-default-order="258"
+   data-name="DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-EATL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_eatl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-eatl-infection-hbv.html"
+   data-default-order="259"
+   data-name="DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-EATL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_eatl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-eatl-biomarker-act.html"
+   data-default-order="260"
+   data-name="DIS-EATL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-EATL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_eatl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-eatl-high-risk.html"
+   data-default-order="261"
+   data-name="DIS-EATL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-EATL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_eatl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ET" hidden>
+  <header class="case-list-header">
+    <h2>Есенціальна тромбоцитемія</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/et-high-risk-hu.html"
+   data-default-order="87"
+   data-name="Essential Thrombocythemia · High Risk (HU)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Essential Thrombocythemia · High Risk (HU)</h3>
+  <p>ET high-risk (age &gt;60 + JAK2+ + thrombosis) — engine обирає hydroxyurea + ASA; anagrelide як 2L (PT-1).</p>
+  <div class="case-foot">patient_et_high_risk_hu.json</div>
+</a>
+<a class="case-card" href="/cases/auto-et.html"
+   data-default-order="118"
+   data-name="DIS-ET — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Essential Thrombocythemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_et.json</div>
+</a>
+<a class="case-card" href="/cases/variant-et-frail.html"
+   data-default-order="274"
+   data-name="DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-et-organ-dysf.html"
+   data-default-order="275"
+   data-name="DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-et-infection-hbv.html"
+   data-default-order="276"
+   data-name="DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-et-relapsed-2l.html"
+   data-default-order="277"
+   data-name="DIS-ET · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-et-biomarker-act.html"
+   data-default-order="278"
+   data-name="DIS-ET · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-et-high-risk.html"
+   data-default-order="279"
+   data-name="DIS-ET · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ET · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_et_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-IMT" hidden>
+  <header class="case-list-header">
+    <h2>Запальна міофібробластична пухлина</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-imt.html"
+   data-default-order="131"
+   data-name="DIS-IMT — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-IMT — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Inflammatory myofibroblastic tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_imt.json</div>
+</a>
+<a class="case-card" href="/cases/variant-imt-frail.html"
+   data-default-order="339"
+   data-name="DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-imt-organ-dysf.html"
+   data-default-order="340"
+   data-name="DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-imt-infection-hbv.html"
+   data-default-order="341"
+   data-name="DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-imt-biomarker-act.html"
+   data-default-order="342"
+   data-name="DIS-IMT · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-imt-high-risk.html"
+   data-default-order="343"
+   data-name="DIS-IMT · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-IMT · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_imt_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MPNST" hidden>
+  <header class="case-list-header">
+    <h2>Злоякісна пухлина оболонки периферичного нерва</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-mpnst.html"
+   data-default-order="139"
+   data-name="DIS-MPNST — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Malignant peripheral nerve sheath tumor. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mpnst.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mpnst-frail.html"
+   data-default-order="385"
+   data-name="DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mpnst-organ-dysf.html"
+   data-default-order="386"
+   data-name="DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mpnst-infection-hbv.html"
+   data-default-order="387"
+   data-name="DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mpnst-biomarker-act.html"
+   data-default-order="388"
+   data-name="DIS-MPNST · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mpnst-high-risk.html"
+   data-default-order="389"
+   data-name="DIS-MPNST · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MPNST · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mpnst_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ENDOMETRIAL" hidden>
+  <header class="case-list-header">
+    <h2>Карцинома ендометрія</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-endometrial.html"
+   data-default-order="116"
+   data-name="DIS-ENDOMETRIAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Endometrial carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_endometrial.json</div>
+</a>
+<a class="case-card" href="/cases/variant-endometrial-frail.html"
+   data-default-order="262"
+   data-name="DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-endometrial-organ-dysf.html"
+   data-default-order="263"
+   data-name="DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-endometrial-infection-hbv.html"
+   data-default-order="264"
+   data-name="DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-endometrial-relapsed-2l.html"
+   data-default-order="265"
+   data-name="DIS-ENDOMETRIAL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-endometrial-biomarker-act.html"
+   data-default-order="266"
+   data-name="DIS-ENDOMETRIAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-endometrial-high-risk.html"
+   data-default-order="267"
+   data-name="DIS-ENDOMETRIAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ENDOMETRIAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_endometrial_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/endometrial-dmmr-pembro-kn775.html"
+   data-default-order="561"
+   data-name="Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)</h3>
+  <p>Advanced/recurrent dMMR endometrial. Engine: → IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO (NRG-GY018 mPFS NR vs 7.6).</p>
+  <div class="case-foot">patient_endometrial_dmmr_pembro_kn775.json</div>
+</a>
+<a class="case-card" href="/cases/endometrial-p53-abn-dosta-ruby.html"
+   data-default-order="562"
+   data-name="Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)</h3>
+  <p>Advanced p53-abnormal endometrial. Drift: engine default = pembro+chemo; RUBY dostarlimab анкер у comment.</p>
+  <div class="case-foot">patient_endometrial_p53_abn_dosta_kn775.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-SALIVARY" hidden>
+  <header class="case-list-header">
+    <h2>Карцинома слинних залоз</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-salivary.html"
+   data-default-order="155"
+   data-name="DIS-SALIVARY — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Salivary gland carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_salivary.json</div>
+</a>
+<a class="case-card" href="/cases/variant-salivary-frail.html"
+   data-default-order="477"
+   data-name="DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-salivary-organ-dysf.html"
+   data-default-order="478"
+   data-name="DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-salivary-infection-hbv.html"
+   data-default-order="479"
+   data-name="DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-salivary-biomarker-act.html"
+   data-default-order="480"
+   data-name="DIS-SALIVARY · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-salivary-high-risk.html"
+   data-default-order="481"
+   data-name="DIS-SALIVARY · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SALIVARY · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_salivary_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-ESOPHAGEAL" hidden>
+  <header class="case-list-header">
+    <h2>Карцинома стравоходу (плоскоклітинна + аденокарцинома)</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-esophageal.html"
+   data-default-order="117"
+   data-name="DIS-ESOPHAGEAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Esophageal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_esophageal.json</div>
+</a>
+<a class="case-card" href="/cases/variant-esophageal-frail.html"
+   data-default-order="268"
+   data-name="DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-esophageal-organ-dysf.html"
+   data-default-order="269"
+   data-name="DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-esophageal-infection-hbv.html"
+   data-default-order="270"
+   data-name="DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-esophageal-relapsed-2l.html"
+   data-default-order="271"
+   data-name="DIS-ESOPHAGEAL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-esophageal-biomarker-act.html"
+   data-default-order="272"
+   data-name="DIS-ESOPHAGEAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-esophageal-high-risk.html"
+   data-default-order="273"
+   data-name="DIS-ESOPHAGEAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-ESOPHAGEAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_esophageal_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/esophageal-cross-then-nivo.html"
+   data-default-order="568"
+   data-name="Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)</h3>
+  <p>Resectable adeno з ypT+/ypN+ residual. Drift: ALGO-1L emit only CROSS-NEOADJUVANT; CheckMate-577 adjuvant nivo неreachable (PROPOSAL §17 territory).</p>
+  <div class="case-foot">patient_esophageal_adeno_neoadj_cross_then_nivo.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CERVICAL" hidden>
+  <header class="case-list-header">
+    <h2>Карцинома шийки матки</h2>
+    <span class="case-list-count">7 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/cervical-locally-advanced.html"
+   data-default-order="96"
+   data-name="Cervical · Locally Advanced (CCRT + Pembrolizumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Cervical · Locally Advanced (CCRT + Pembrolizumab)</h3>
+  <p>Locally advanced cervical cancer (FIGO IIB-IVA) — engine обирає cisplatin-based CCRT + brachytherapy; pembrolizumab maintenance (KEYNOTE-A18).</p>
+  <div class="case-foot">patient_cervical_locally_advanced.json</div>
+</a>
+<a class="case-card" href="/cases/auto-cervical.html"
+   data-default-order="107"
+   data-name="DIS-CERVICAL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Cervical carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cervical.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cervical-frail.html"
+   data-default-order="212"
+   data-name="DIS-CERVICAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cervical_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cervical-organ-dysf.html"
+   data-default-order="213"
+   data-name="DIS-CERVICAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cervical_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cervical-infection-hbv.html"
+   data-default-order="214"
+   data-name="DIS-CERVICAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cervical_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cervical-biomarker-act.html"
+   data-default-order="215"
+   data-name="DIS-CERVICAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cervical_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cervical-high-risk.html"
+   data-default-order="216"
+   data-name="DIS-CERVICAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CERVICAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cervical_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-OVARIAN" hidden>
+  <header class="case-list-header">
+    <h2>Карцинома яєчників (переважно high-grade серозна)</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/ovarian-advanced-hrd.html"
+   data-default-order="98"
+   data-name="Ovarian · Advanced HRD+ (PARPi maintenance)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Ovarian · Advanced HRD+ (PARPi maintenance)</h3>
+  <p>Advanced high-grade serous ovarian, HRD+ — engine обирає platinum-doublet → PARPi maintenance (olaparib/niraparib; SOLO-1, PRIMA).</p>
+  <div class="case-foot">patient_ovarian_advanced_hrd.json</div>
+</a>
+<a class="case-card" href="/cases/auto-ovarian.html"
+   data-default-order="145"
+   data-name="DIS-OVARIAN — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Ovarian carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ovarian.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ovarian-frail.html"
+   data-default-order="419"
+   data-name="DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ovarian-organ-dysf.html"
+   data-default-order="420"
+   data-name="DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ovarian-infection-hbv.html"
+   data-default-order="421"
+   data-name="DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ovarian-relapsed-2l.html"
+   data-default-order="422"
+   data-name="DIS-OVARIAN · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 9 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ovarian-biomarker-act.html"
+   data-default-order="423"
+   data-name="DIS-OVARIAN · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ovarian-high-risk.html"
+   data-default-order="424"
+   data-name="DIS-OVARIAN · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-OVARIAN · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ovarian_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/ovarian-hrd-neg-no-parpi.html"
+   data-default-order="563"
+   data-name="Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance</h3>
+  <p>HRD-negative ovarian (контраст до patient_ovarian_advanced_hrd). Engine: → IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-NEG.</p>
+  <div class="case-foot">patient_ovarian_hrd_neg_carbo_pacli_no_parpi.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CHL" hidden>
+  <header class="case-list-header">
+    <h2>Класична лімфома Ходжкіна</h2>
+    <span class="case-list-count">11 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/chl-advanced.html"
+   data-default-order="27"
+   data-name="Classical Hodgkin · Advanced (A+AVD)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Classical Hodgkin · Advanced (A+AVD)</h3>
+  <p>Стадія IV cHL — RF-CHL-ADVANCED-STAGE fired. Engine обирає A+AVD (ECHELON-1: brentuximab замість bleomycin, superior OS).</p>
+  <div class="case-foot">patient_chl_advanced.json</div>
+</a>
+<a class="case-card" href="/cases/chl-early.html"
+   data-default-order="28"
+   data-name="Classical Hodgkin · Early Stage (ABVD)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Classical Hodgkin · Early Stage (ABVD)</h3>
+  <p>Стадія IIA cHL, без advanced criteria — engine обирає ABVD × 2-4 + ISRT (response-adapted).</p>
+  <div class="case-foot">patient_chl_early.json</div>
+</a>
+<a class="case-card" href="/cases/chl-pediatric-bulky.html"
+   data-default-order="66"
+   data-name="cHL · AYA Stage IIB Bulky Mediastinal">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>cHL · AYA Stage IIB Bulky Mediastinal</h3>
+  <p>AYA пацієнт з cHL stage IIB + bulky mediastinal mass + B-symptoms — RF-CHL-BULKY-MEDIASTINAL fired. Response-adapted intensification.</p>
+  <div class="case-foot">patient_chl_pediatric_bulky_mediastinal.json</div>
+</a>
+<a class="case-card" href="/cases/chl-relapsed-salvage.html"
+   data-default-order="67"
+   data-name="cHL · Relapsed (Salvage → autoSCT + BV maint.)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>cHL · Relapsed (Salvage → autoSCT + BV maint.)</h3>
+  <p>cHL relapsed після ABVD/A+AVD — engine обирає salvage chemo (ICE/DHAP) → autoSCT → brentuximab maintenance (AETHERA).</p>
+  <div class="case-foot">patient_chl_relapsed_for_salvage.json</div>
+</a>
+<a class="case-card" href="/cases/auto-chl.html"
+   data-default-order="108"
+   data-name="DIS-CHL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Classical Hodgkin Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_chl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chl-frail.html"
+   data-default-order="217"
+   data-name="DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chl-organ-dysf.html"
+   data-default-order="218"
+   data-name="DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chl-infection-hbv.html"
+   data-default-order="219"
+   data-name="DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chl-relapsed-2l.html"
+   data-default-order="220"
+   data-name="DIS-CHL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chl-biomarker-act.html"
+   data-default-order="221"
+   data-name="DIS-CHL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chl-high-risk.html"
+   data-default-order="222"
+   data-name="DIS-CHL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CRC" hidden>
+  <header class="case-list-header">
+    <h2>Колоректальний рак</h2>
+    <span class="case-list-count">13 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-crc.html"
+   data-default-order="113"
+   data-name="DIS-CRC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Colorectal carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_crc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-crc-frail.html"
+   data-default-order="245"
+   data-name="DIS-CRC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_crc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-crc-organ-dysf.html"
+   data-default-order="246"
+   data-name="DIS-CRC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_crc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-crc-infection-hbv.html"
+   data-default-order="247"
+   data-name="DIS-CRC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_crc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-crc-relapsed-2l.html"
+   data-default-order="248"
+   data-name="DIS-CRC · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_crc_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-crc-biomarker-act.html"
+   data-default-order="249"
+   data-name="DIS-CRC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_crc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-crc-high-risk.html"
+   data-default-order="250"
+   data-name="DIS-CRC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CRC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_crc_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/crc-stage-iii-adjuvant-folfox.html"
+   data-default-order="546"
+   data-name="CRC · stage III adjuvant FOLFOX (MOSAIC)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>CRC · stage III adjuvant FOLFOX (MOSAIC)</h3>
+  <p>Stage III після резекції. Drift: KB не має adjuvant CRC algo; engine default = mCRC FOLFOX+bev (анкер MOSAIC у comment).</p>
+  <div class="case-foot">patient_crc_stage_iii_adjuvant_folfox.json</div>
+</a>
+<a class="case-card" href="/cases/crc-mcrc-ras-wt-left-folfox-cetux.html"
+   data-default-order="547"
+   data-name="mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)</h3>
+  <p>RAS-WT левобічна mCRC. Engine: ALGO step 2 → IND-CRC-METASTATIC-1L-RAS-WT-LEFT (CRYSTAL/FIRE-3).</p>
+  <div class="case-foot">patient_crc_metastatic_ras_wt_left_folfox_cetux.json</div>
+</a>
+<a class="case-card" href="/cases/crc-mcrc-ras-mut-folfox-bev.html"
+   data-default-order="548"
+   data-name="mCRC · RAS-mutated 1L · FOLFOX+bevacizumab">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>mCRC · RAS-mutated 1L · FOLFOX+bevacizumab</h3>
+  <p>KRAS-мутована mCRC, 1L FOLFOX+bevacizumab. Engine: ALGO default → IND-CRC-METASTATIC-1L-FOLFOX-BEV.</p>
+  <div class="case-foot">patient_crc_metastatic_ras_mut_folfox_bev.json</div>
+</a>
+<a class="case-card" href="/cases/crc-mcrc-msi-h-pembro.html"
+   data-default-order="549"
+   data-name="mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)</h3>
+  <p>MSI-high mCRC. Engine: ALGO step 1 (MSI-H fires) → IND-CRC-METASTATIC-1L-MSI-H-PEMBRO (KEYNOTE-177 mPFS 16.5 мо).</p>
+  <div class="case-foot">patient_crc_metastatic_msi_h_pembro_mono.json</div>
+</a>
+<a class="case-card" href="/cases/crc-mcrc-2l-folfiri-bev.html"
+   data-default-order="550"
+   data-name="mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)</h3>
+  <p>Прогрес на FOLFOX+bev 1L. Engine: ALGO-2L → IND-CRC-METASTATIC-2L-FOLFIRI-BEV (continuum-of-care).</p>
+  <div class="case-foot">patient_crc_metastatic_2l_folfiri_bev.json</div>
+</a>
+<a class="case-card" href="/cases/crc-mcrc-3l-regorafenib.html"
+   data-default-order="551"
+   data-name="mCRC · 3L+ Regorafenib (CORRECT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>mCRC · 3L+ Regorafenib (CORRECT)</h3>
+  <p>Хеморефрактерна mCRC. Drift: engine default = TAS-102+bev (SUNLIGHT); regorafenib як alternative track.</p>
+  <div class="case-foot">patient_crc_metastatic_3l_regorafenib.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-BURKITT" hidden>
+  <header class="case-list-header">
+    <h2>Лімфома Беркітта</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/burkitt-low-risk.html"
+   data-default-order="19"
+   data-name="Burkitt · Low/Intermediate Risk (DA-EPOCH-R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Burkitt · Low/Intermediate Risk (DA-EPOCH-R)</h3>
+  <p>Burkitt без CNS+, LDH в нормі — engine обирає DA-EPOCH-R (CALGB 10002, ~90% CR including HIV+).</p>
+  <div class="case-foot">patient_burkitt_low_risk.json</div>
+</a>
+<a class="case-card" href="/cases/burkitt-high-risk.html"
+   data-default-order="20"
+   data-name="Burkitt · High Risk (CODOX-M / IVAC)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Burkitt · High Risk (CODOX-M / IVAC)</h3>
+  <p>Burkitt з CNS involvement + LDH &gt;3× ULN + bulky abdomen — RF-BURKITT-HIGH-RISK fired. Engine обирає Magrath protocol з HD-MTX + IT MTX/cytarabine.</p>
+  <div class="case-foot">patient_burkitt_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/auto-burkitt.html"
+   data-default-order="106"
+   data-name="DIS-BURKITT — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Burkitt Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_burkitt.json</div>
+</a>
+<a class="case-card" href="/cases/variant-burkitt-frail.html"
+   data-default-order="206"
+   data-name="DIS-BURKITT · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_burkitt_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-burkitt-organ-dysf.html"
+   data-default-order="207"
+   data-name="DIS-BURKITT · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_burkitt_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-burkitt-infection-hbv.html"
+   data-default-order="208"
+   data-name="DIS-BURKITT · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_burkitt_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-burkitt-relapsed-2l.html"
+   data-default-order="209"
+   data-name="DIS-BURKITT · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_burkitt_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-burkitt-biomarker-act.html"
+   data-default-order="210"
+   data-name="DIS-BURKITT · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_burkitt_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-burkitt-high-risk.html"
+   data-default-order="211"
+   data-name="DIS-BURKITT · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BURKITT · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_burkitt_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MCL" hidden>
+  <header class="case-list-header">
+    <h2>Лімфома з клітин зони мантії</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/mcl-fit-younger.html"
+   data-default-order="14"
+   data-name="Mantle Cell · Fit Younger (Intensive + autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Mantle Cell · Fit Younger (Intensive + autoSCT)</h3>
+  <p>MCL вік 58, ECOG 0, TP53-wt — engine обирає intensive R-CHOP/R-DHAP × 6 + autoSCT + R-maintenance × 3 years (Nordic protocol).</p>
+  <div class="case-foot">patient_mcl_fit_younger.json</div>
+</a>
+<a class="case-card" href="/cases/mcl-unfit-tp53.html"
+   data-default-order="15"
+   data-name="Mantle Cell · Unfit / TP53-mutant (BTKi+R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Mantle Cell · Unfit / TP53-mutant (BTKi+R)</h3>
+  <p>MCL вік 71, ECOG 2, TP53 mutation — RF-MCL-BLASTOID-OR-TP53 fired. Engine обирає acalabrutinib + rituximab (BTKi-based).</p>
+  <div class="case-foot">patient_mcl_unfit_or_tp53.json</div>
+</a>
+<a class="case-card" href="/cases/auto-mcl.html"
+   data-default-order="133"
+   data-name="DIS-MCL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Mantle Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mcl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mcl-frail.html"
+   data-default-order="349"
+   data-name="DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mcl-organ-dysf.html"
+   data-default-order="350"
+   data-name="DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mcl-infection-hbv.html"
+   data-default-order="351"
+   data-name="DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mcl-relapsed-2l.html"
+   data-default-order="352"
+   data-name="DIS-MCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mcl-biomarker-act.html"
+   data-default-order="353"
+   data-name="DIS-MCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mcl-high-risk.html"
+   data-default-order="354"
+   data-name="DIS-MCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mcl_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/mcl-pirtobrutinib-3l.html"
+   data-default-order="582"
+   data-name="MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)</h3>
+  <p>Post-covalent-BTKi прогрес з LVEF 38% (CAR-T ineligible). Drift: ALGO-MCL-2L step 3 free-text; engine default = acalabrutinib; BRUIN анкер у comment.</p>
+  <div class="case-foot">patient_mcl_pirtobrutinib_3l_post_btki.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HCV-MZL" hidden>
+  <header class="case-list-header">
+    <h2>Лімфома маргінальної зони, асоційована з HCV</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/diagnostic-lymphoma-confirmed.html"
+   data-default-order="6"
+   data-name="Lymphoma Confirmed · Post-Biopsy (Treatment Plan)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Lymphoma Confirmed · Post-Biopsy (Treatment Plan)</h3>
+  <p>Той самий пацієнт після підтвердження гістології — diagnostic→treatment promotion через revise_plan.</p>
+  <div class="case-foot">patient_diagnostic_lymphoma_confirmed.json</div>
+</a>
+<a class="case-card" href="/cases/auto-hcv_mzl.html"
+   data-default-order="126"
+   data-name="DIS-HCV-MZL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для HCV-associated Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hcv_mzl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcv_mzl-frail.html"
+   data-default-order="312"
+   data-name="DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcv_mzl-organ-dysf.html"
+   data-default-order="313"
+   data-name="DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcv_mzl-infection-hbv.html"
+   data-default-order="314"
+   data-name="DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcv_mzl-relapsed-2l.html"
+   data-default-order="315"
+   data-name="DIS-HCV-MZL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcv_mzl-biomarker-act.html"
+   data-default-order="316"
+   data-name="DIS-HCV-MZL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hcv_mzl-high-risk.html"
+   data-default-order="317"
+   data-name="DIS-HCV-MZL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HCV-MZL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hcv_mzl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-WM" hidden>
+  <header class="case-list-header">
+    <h2>Макроглобулінемія Вальденстрема / Лімфоплазмоцитарна лімфома</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/wm-myd88-positive.html"
+   data-default-order="22"
+   data-name="Waldenström · MYD88-positive (Zanubrutinib)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Waldenström · MYD88-positive (Zanubrutinib)</h3>
+  <p>WM з MYD88 L265P + iwWM treatment indication — engine обирає zanubrutinib (ASPEN — superior до ibrutinib).</p>
+  <div class="case-foot">patient_wm_myd88_positive.json</div>
+</a>
+<a class="case-card" href="/cases/wm-cxcr4-mut.html"
+   data-default-order="46"
+   data-name="Waldenström · CXCR4-mutant (BR fixed-duration)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Waldenström · CXCR4-mutant (BR fixed-duration)</h3>
+  <p>WM з MYD88+ AND CXCR4-mutant — RF-WM-CXCR4-MUT fired (CXCR4 знижує BTKi response). Engine обирає BR fixed-duration або zanubrutinib з extended observation.</p>
+  <div class="case-foot">patient_wm_cxcr4_mut.json</div>
+</a>
+<a class="case-card" href="/cases/auto-wm.html"
+   data-default-order="163"
+   data-name="DIS-WM — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-WM — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Waldenström Macroglobulinemia / Lymphoplasmacytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_wm.json</div>
 </a>
 <a class="case-card" href="/cases/variant-wm-frail.html"
    data-default-order="520"
@@ -6207,6 +3885,530 @@
   <h3>DIS-WM · High-risk biology / bulky disease</h3>
   <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
   <div class="case-foot">variant_wm_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MTC" hidden>
+  <header class="case-list-header">
+    <h2>Медулярна карцинома щитовидної залози</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-mtc.html"
+   data-default-order="140"
+   data-name="DIS-MTC — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MTC — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Medullary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mtc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mtc-frail.html"
+   data-default-order="390"
+   data-name="DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mtc-organ-dysf.html"
+   data-default-order="391"
+   data-name="DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mtc-infection-hbv.html"
+   data-default-order="392"
+   data-name="DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mtc-biomarker-act.html"
+   data-default-order="393"
+   data-name="DIS-MTC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mtc-high-risk.html"
+   data-default-order="394"
+   data-name="DIS-MTC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MTC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mtc_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MM" hidden>
+  <header class="case-list-header">
+    <h2>Множинна мієлома</h2>
+    <span class="case-list-count">11 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/mm-standard-risk.html"
+   data-default-order="3"
+   data-name="Multiple Myeloma · Standard-Risk">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · Standard-Risk</h3>
+  <p>Newly-diagnosed MM, t(11;14) + hyperdiploid, R-ISS II — engine обирає триплет VRd як default.</p>
+  <div class="case-foot">patient_mm_standard_risk.json</div>
+</a>
+<a class="case-card" href="/cases/mm-high-risk.html"
+   data-default-order="4"
+   data-name="Multiple Myeloma · High-Risk">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · High-Risk</h3>
+  <p>Newly-diagnosed MM, t(4;14) + gain 1q21, R2-ISS III — RF-MM-HIGH-RISK-CYTOGENETICS, engine обирає квадруплет D-VRd.</p>
+  <div class="case-foot">patient_mm_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/mm-post-vrd-progression.html"
+   data-default-order="68"
+   data-name="Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · Post-VRd Progression (DPd / IsaPd)</h3>
+  <p>MM relapsed після VRd induction — engine обирає daratumumab+pomalidomide+dex (APOLLO) або isatuximab+Pd (ICARIA).</p>
+  <div class="case-foot">patient_mm_post_vrd_progression.json</div>
+</a>
+<a class="case-card" href="/cases/mm-triple-class-refractory.html"
+   data-default-order="69"
+   data-name="Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Multiple Myeloma · Triple-Class Refractory (CAR-T / Teclistamab)</h3>
+  <p>MM triple-class refractory (PI + IMiD + anti-CD38) — engine обирає cilta-cel/ide-cel CAR-T або teclistamab BCMA-T-cell engager.</p>
+  <div class="case-foot">patient_mm_triple_class_refractory.json</div>
+</a>
+<a class="case-card" href="/cases/auto-mm.html"
+   data-default-order="138"
+   data-name="DIS-MM — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Multiple Myeloma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mm.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mm-frail.html"
+   data-default-order="379"
+   data-name="DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mm-organ-dysf.html"
+   data-default-order="380"
+   data-name="DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mm-infection-hbv.html"
+   data-default-order="381"
+   data-name="DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mm-relapsed-2l.html"
+   data-default-order="382"
+   data-name="DIS-MM · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mm-biomarker-act.html"
+   data-default-order="383"
+   data-name="DIS-MM · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mm-high-risk.html"
+   data-default-order="384"
+   data-name="DIS-MM · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MM · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mm_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MDS-HR" hidden>
+  <header class="case-list-header">
+    <h2>Мієлодиспластичні синдроми, високий ризик (IPSS-R високий / дуже високий; включає MDS-EB)</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/mds-hr-transplant-eligible.html"
+   data-default-order="78"
+   data-name="MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-HR · Transplant-Eligible (Aza Bridge → alloHCT)</h3>
+  <p>MDS IPSS-R high, fit, donor available — engine обирає azacitidine bridge → upfront alloHCT (curative).</p>
+  <div class="case-foot">patient_mds_hr_transplant_eligible.json</div>
+</a>
+<a class="case-card" href="/cases/mds-hr-unfit-aza.html"
+   data-default-order="79"
+   data-name="MDS-HR · Unfit (Azacitidine Maintenance)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-HR · Unfit (Azacitidine Maintenance)</h3>
+  <p>MDS-HR transplant-ineligible — engine обирає azacitidine indefinite (AZA-001: median OS 24 mo vs 15 mo для conventional care).</p>
+  <div class="case-foot">patient_mds_hr_unfit_aza.json</div>
+</a>
+<a class="case-card" href="/cases/mds-hr-progression-aml.html"
+   data-default-order="80"
+   data-name="MDS-HR · Progression to Secondary AML">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-HR · Progression to Secondary AML</h3>
+  <p>MDS на azacitidine з progression до sAML — engine реагує AML-reroute: ven+aza або 7+3 induction (за fitness).</p>
+  <div class="case-foot">patient_mds_hr_progression_to_aml.json</div>
+</a>
+<a class="case-card" href="/cases/auto-mds_hr.html"
+   data-default-order="134"
+   data-name="DIS-MDS-HR — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Higher Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mds_hr.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_hr-frail.html"
+   data-default-order="355"
+   data-name="DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_hr-organ-dysf.html"
+   data-default-order="356"
+   data-name="DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_hr-infection-hbv.html"
+   data-default-order="357"
+   data-name="DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_hr-relapsed-2l.html"
+   data-default-order="358"
+   data-name="DIS-MDS-HR · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_hr-biomarker-act.html"
+   data-default-order="359"
+   data-name="DIS-MDS-HR · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_hr-high-risk.html"
+   data-default-order="360"
+   data-name="DIS-MDS-HR · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-HR · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_hr_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MDS-LR" hidden>
+  <header class="case-list-header">
+    <h2>Мієлодиспластичні синдроми, низький ризик (IPSS-R дуже низький / низький / проміжний)</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/mds-lr-del5q.html"
+   data-default-order="81"
+   data-name="MDS-LR · del(5q) (Lenalidomide)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-LR · del(5q) (Lenalidomide)</h3>
+  <p>MDS-LR з isolated del(5q) syndrome — engine обирає lenalidomide (MDS-004: ~67% transfusion-independence).</p>
+  <div class="case-foot">patient_mds_lr_del5q.json</div>
+</a>
+<a class="case-card" href="/cases/mds-lr-rs-luspatercept.html"
+   data-default-order="82"
+   data-name="MDS-LR · RS+ EPO-failure (Luspatercept)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>MDS-LR · RS+ EPO-failure (Luspatercept)</h3>
+  <p>MDS-LR з ring sideroblasts + EPO-high (&gt;500) → ESA-failure — engine обирає luspatercept (COMMANDS).</p>
+  <div class="case-foot">patient_mds_lr_rs_luspatercept.json</div>
+</a>
+<a class="case-card" href="/cases/mds-lr-hypoplastic-ist.html"
+   data-default-order="83"
+   data-name="MDS-LR · Hypoplastic / IST candidate">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>MDS-LR · Hypoplastic / IST candidate</h3>
+  <p>Hypoplastic MDS, mimics aplastic anemia — engine обирає immunosuppressive therapy (ATG+CsA) як alternative до transfusion-only.</p>
+  <div class="case-foot">patient_mds_lr_hypoplastic_ist.json</div>
+</a>
+<a class="case-card" href="/cases/auto-mds_lr.html"
+   data-default-order="135"
+   data-name="DIS-MDS-LR — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Myelodysplastic Syndromes — Lower Risk. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mds_lr.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_lr-frail.html"
+   data-default-order="361"
+   data-name="DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_lr-organ-dysf.html"
+   data-default-order="362"
+   data-name="DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_lr-infection-hbv.html"
+   data-default-order="363"
+   data-name="DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_lr-relapsed-2l.html"
+   data-default-order="364"
+   data-name="DIS-MDS-LR · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_lr-biomarker-act.html"
+   data-default-order="365"
+   data-name="DIS-MDS-LR · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mds_lr-high-risk.html"
+   data-default-order="366"
+   data-name="DIS-MDS-LR · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MDS-LR · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mds_lr_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NSCLC" hidden>
+  <header class="case-list-header">
+    <h2>Недрібноклітинний рак легені</h2>
+    <span class="case-list-count">19 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-nsclc.html"
+   data-default-order="144"
+   data-name="DIS-NSCLC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Non-small cell lung cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nsclc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nsclc-frail.html"
+   data-default-order="413"
+   data-name="DIS-NSCLC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nsclc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nsclc-organ-dysf.html"
+   data-default-order="414"
+   data-name="DIS-NSCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nsclc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nsclc-infection-hbv.html"
+   data-default-order="415"
+   data-name="DIS-NSCLC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nsclc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nsclc-relapsed-2l.html"
+   data-default-order="416"
+   data-name="DIS-NSCLC · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 13 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nsclc_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nsclc-biomarker-act.html"
+   data-default-order="417"
+   data-name="DIS-NSCLC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nsclc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nsclc-high-risk.html"
+   data-default-order="418"
+   data-name="DIS-NSCLC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NSCLC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nsclc_high_risk.json</div>
 </a>
 <a class="case-card" href="/cases/nsclc-egfr-ex19del-1l.html"
    data-default-order="526"
@@ -6340,6 +4542,2338 @@
   <p>KIF5B-RET виявлено на RNA-NGS rebiopsy. Engine: step 13 → IND-NSCLC-2L-RET-FUSION-SELPERCATINIB (intracranial ORR 91%).</p>
   <div class="case-foot">patient_nsclc_ret_fusion_2l_selpercatinib.json</div>
 </a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-RCC" hidden>
+  <header class="case-list-header">
+    <h2>Нирково-клітинна карцинома</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-rcc.html"
+   data-default-order="154"
+   data-name="DIS-RCC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Renal cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_rcc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-rcc-frail.html"
+   data-default-order="471"
+   data-name="DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-rcc-organ-dysf.html"
+   data-default-order="472"
+   data-name="DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-rcc-infection-hbv.html"
+   data-default-order="473"
+   data-name="DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-rcc-relapsed-2l.html"
+   data-default-order="474"
+   data-name="DIS-RCC · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-rcc-biomarker-act.html"
+   data-default-order="475"
+   data-name="DIS-RCC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-rcc-high-risk.html"
+   data-default-order="476"
+   data-name="DIS-RCC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-RCC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_rcc_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/rcc-imdc-int-nivo-ipi.html"
+   data-default-order="558"
+   data-name="RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)</h3>
+  <p>Clear-cell RCC IMDC intermediate-poor. Drift: engine default = pembro+axi; nivo+ipi анкер CM-214 у comment.</p>
+  <div class="case-foot">patient_rcc_imdc_int_nivo_ipi.json</div>
+</a>
+<a class="case-card" href="/cases/rcc-imdc-fav-axi-pembro.html"
+   data-default-order="559"
+   data-name="RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)</h3>
+  <p>Clear-cell RCC IMDC favorable. Engine: → IND-RCC-METASTATIC-1L-PEMBRO-AXI (KEYNOTE-426 5-yr OS).</p>
+  <div class="case-foot">patient_rcc_imdc_fav_axi_pembro.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NODAL-MZL" hidden>
+  <header class="case-list-header">
+    <h2>Нодальна лімфома маргінальної зони</h2>
+    <span class="case-list-count">12 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/hcv-mzl-reference.html"
+   data-default-order="0"
+   data-name="HCV-MZL · Reference Case (Patient Zero)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCV-MZL · Reference Case (Patient Zero)</h3>
+  <p>Чоловік 49, ECOG 1, 5.3 см ураження кореня язика, HCV генотип 1b, indolent presentation. Acceptance test для P0.</p>
+  <div class="case-foot">patient_zero_reference_case.json</div>
+</a>
+<a class="case-card" href="/cases/hcv-mzl-bulky.html"
+   data-default-order="1"
+   data-name="HCV-MZL · Aggressive Burden (BR + concurrent DAA)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCV-MZL · Aggressive Burden (BR + concurrent DAA)</h3>
+  <p>HCV-MZL із bulky disease (&gt;7 см) — RF-BULKY-DISEASE fired. Engine обирає BR (бендамустин+ритуксимаб) + concurrent DAA. Поєднує колишні patient_zero_bulky та новий fixture aggressive_burden.</p>
+  <div class="case-foot">patient_hcv_mzl_aggressive_burden.json</div>
+</a>
+<a class="case-card" href="/cases/hcv-mzl-post-daa.html"
+   data-default-order="2"
+   data-name="HCV-MZL · Post-DAA Responder (Surveillance)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HCV-MZL · Post-DAA Responder (Surveillance)</h3>
+  <p>Пацієнт post-DAA з SVR12 + lymphoma response — engine обирає surveillance only; план для re-treatment trigger при relapse.</p>
+  <div class="case-foot">patient_hcv_mzl_post_daa_responder.json</div>
+</a>
+<a class="case-card" href="/cases/nmzl-low-burden.html"
+   data-default-order="18"
+   data-name="Nodal MZL · Low Burden (W&amp;W)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Nodal MZL · Low Burden (W&amp;W)</h3>
+  <p>Нодальна MZL без GELF-критеріїв — engine обирає surveillance трек (повторює FL-парадигму).</p>
+  <div class="case-foot">patient_nmzl_low_burden.json</div>
+</a>
+<a class="case-card" href="/cases/nmzl-high-burden.html"
+   data-default-order="47"
+   data-name="Nodal MZL · High Burden (BR)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Nodal MZL · High Burden (BR)</h3>
+  <p>Нодальна MZL з GELF+ — engine обирає BR (1L); 2L після rituximab/W&amp;W failure теж BR.</p>
+  <div class="case-foot">patient_nmzl_high_burden.json</div>
+</a>
+<a class="case-card" href="/cases/auto-nodal_mzl.html"
+   data-default-order="143"
+   data-name="DIS-NODAL-MZL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Nodal Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nodal_mzl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nodal_mzl-frail.html"
+   data-default-order="407"
+   data-name="DIS-NODAL-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nodal_mzl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nodal_mzl-organ-dysf.html"
+   data-default-order="408"
+   data-name="DIS-NODAL-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nodal_mzl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nodal_mzl-infection-hbv.html"
+   data-default-order="409"
+   data-name="DIS-NODAL-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nodal_mzl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nodal_mzl-relapsed-2l.html"
+   data-default-order="410"
+   data-name="DIS-NODAL-MZL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nodal_mzl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nodal_mzl-biomarker-act.html"
+   data-default-order="411"
+   data-name="DIS-NODAL-MZL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nodal_mzl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nodal_mzl-high-risk.html"
+   data-default-order="412"
+   data-name="DIS-NODAL-MZL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NODAL-MZL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 4 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nodal_mzl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-NLPBL" hidden>
+  <header class="case-list-header">
+    <h2>Нодулярна лімфоцит-домінантна B-клітинна лімфома (раніше NLPHL)</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/nlpbl-early.html"
+   data-default-order="29"
+   data-name="NLPBL · Early Stage (Observation / RT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NLPBL · Early Stage (Observation / RT)</h3>
+  <p>Нодулярна лімфоцит-домінантна B-клітинна лімфома (перекласифіковано WHO 5th-ed з NLPHL у B-cell) — early stage. Engine обирає observation / ISRT alone.</p>
+  <div class="case-foot">patient_nlpbl_early.json</div>
+</a>
+<a class="case-card" href="/cases/nlpbl-ia-rituximab.html"
+   data-default-order="34"
+   data-name="NLPBL · IA + RT-contraindicated (Rituximab mono)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>NLPBL · IA + RT-contraindicated (Rituximab mono)</h3>
+  <p>NLPBL stage IA у молодої жінки з cervical adenopathy — RT-contraindicated через breast/thyroid field overlap. Engine обирає rituximab monotherapy alternative (CD20+ B-cell biology, НЕ ABVD).</p>
+  <div class="case-foot">patient_nlpbl_ia_rituximab.json</div>
+</a>
+<a class="case-card" href="/cases/auto-nlpbl.html"
+   data-default-order="142"
+   data-name="DIS-NLPBL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Nodular Lymphocyte-Predominant B-cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_nlpbl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nlpbl-frail.html"
+   data-default-order="401"
+   data-name="DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nlpbl-organ-dysf.html"
+   data-default-order="402"
+   data-name="DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nlpbl-infection-hbv.html"
+   data-default-order="403"
+   data-name="DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nlpbl-relapsed-2l.html"
+   data-default-order="404"
+   data-name="DIS-NLPBL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nlpbl-biomarker-act.html"
+   data-default-order="405"
+   data-name="DIS-NLPBL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-nlpbl-high-risk.html"
+   data-default-order="406"
+   data-name="DIS-NLPBL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-NLPBL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_nlpbl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-THYROID-PAPILLARY" hidden>
+  <header class="case-list-header">
+    <h2>Папілярна карцинома щитовидної залози</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-thyroid_papillary.html"
+   data-default-order="161"
+   data-name="DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY — Auto-stub (62% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Papillary thyroid carcinoma. Фактична наповненість бази для цієї хвороби — 62%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_thyroid_papillary.json</div>
+</a>
+<a class="case-card" href="/cases/variant-thyroid_papillary-frail.html"
+   data-default-order="510"
+   data-name="DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-thyroid_papillary-organ-dysf.html"
+   data-default-order="511"
+   data-name="DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-thyroid_papillary-infection-hbv.html"
+   data-default-order="512"
+   data-name="DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-thyroid_papillary-biomarker-act.html"
+   data-default-order="513"
+   data-name="DIS-THYROID-PAPILLARY · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-thyroid_papillary-high-risk.html"
+   data-default-order="514"
+   data-name="DIS-THYROID-PAPILLARY · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-THYROID-PAPILLARY · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_thyroid_papillary_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PCNSL" hidden>
+  <header class="case-list-header">
+    <h2>Первинна дифузна великоклітинна B-клітинна лімфома центральної нервової системи</h2>
+    <span class="case-list-count">13 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/dlbcl-low-ipi.html"
+   data-default-order="7"
+   data-name="DLBCL NOS · Low-IPI (R-CHOP standard)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL NOS · Low-IPI (R-CHOP standard)</h3>
+  <p>Чоловік 54, ECOG 1, IPI 1, GCB cell-of-origin — engine обирає R-CHOP × 6 циклів як default. Найпоширеніша агресивна лімфома (~30% NHL).</p>
+  <div class="case-foot">patient_dlbcl_low_ipi.json</div>
+</a>
+<a class="case-card" href="/cases/dlbcl-high-ipi.html"
+   data-default-order="8"
+   data-name="DLBCL NOS · High-IPI (Pola-R-CHP)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>DLBCL NOS · High-IPI (Pola-R-CHP)</h3>
+  <p>Жінка 67, IPI 4, multiple extranodal — RF-DLBCL-HIGH-IPI fired. Engine ескалує до Pola-R-CHP (POLARIX trial); Ukraine-funding caveat.</p>
+  <div class="case-foot">patient_dlbcl_high_ipi.json</div>
+</a>
+<a class="case-card" href="/cases/hgbl-primary-refractory.html"
+   data-default-order="37"
+   data-name="HGBL · Primary Refractory (Early CAR-T)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>HGBL · Primary Refractory (Early CAR-T)</h3>
+  <p>HGBL-DH що не відповів на DA-EPOCH-R — engine обирає axi-cel CAR-T (ZUMA-7); chemosensitivity-test позитивний для late-relapse → salvage+autoSCT.</p>
+  <div class="case-foot">patient_hgbl_primary_refractory.json</div>
+</a>
+<a class="case-card" href="/cases/pcnsl-typical.html"
+   data-default-order="41"
+   data-name="PCNSL · Typical (R-MPV → autoSCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PCNSL · Typical (R-MPV → autoSCT)</h3>
+  <p>Імунокомпетентний пацієнт з biopsy-confirmed PCNSL — engine обирає R-MPV induction → thiotepa-based autoSCT consolidation (MATRix/IELSG 32).</p>
+  <div class="case-foot">patient_pcnsl_typical.json</div>
+</a>
+<a class="case-card" href="/cases/pcnsl-elderly-frail.html"
+   data-default-order="42"
+   data-name="PCNSL · Elderly Frail (R-MTX-attenuated)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PCNSL · Elderly Frail (R-MTX-attenuated)</h3>
+  <p>PCNSL вік 75, ECOG 2 — engine обирає attenuated MTX-based induction без autoSCT consolidation; lenalidomide maintenance як альтернатива.</p>
+  <div class="case-foot">patient_pcnsl_elderly_frail.json</div>
+</a>
+<a class="case-card" href="/cases/pcnsl-immunocompromised-ebv.html"
+   data-default-order="43"
+   data-name="PCNSL · Immunocompromised + EBV+ (Restore Immunity)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PCNSL · Immunocompromised + EBV+ (Restore Immunity)</h3>
+  <p>PCNSL у HIV+/post-transplant пацієнта, EBER+ — engine додає immune-restoration (HAART / RIS) перед HD-MTX; rituximab якщо CD20+.</p>
+  <div class="case-foot">patient_pcnsl_immunocompromised_ebv.json</div>
+</a>
+<a class="case-card" href="/cases/auto-pcnsl.html"
+   data-default-order="146"
+   data-name="DIS-PCNSL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Primary CNS Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pcnsl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pcnsl-frail.html"
+   data-default-order="425"
+   data-name="DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pcnsl-organ-dysf.html"
+   data-default-order="426"
+   data-name="DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pcnsl-infection-hbv.html"
+   data-default-order="427"
+   data-name="DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pcnsl-relapsed-2l.html"
+   data-default-order="428"
+   data-name="DIS-PCNSL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pcnsl-biomarker-act.html"
+   data-default-order="429"
+   data-name="DIS-PCNSL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pcnsl-high-risk.html"
+   data-default-order="430"
+   data-name="DIS-PCNSL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PCNSL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pcnsl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PMBCL" hidden>
+  <header class="case-list-header">
+    <h2>Первинна медіастинальна (тимічна) B-великоклітинна лімфома</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/pmbcl-typical.html"
+   data-default-order="38"
+   data-name="PMBCL · Typical (DA-EPOCH-R)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PMBCL · Typical (DA-EPOCH-R)</h3>
+  <p>Молода жінка з anterior mediastinal mass — engine обирає DA-EPOCH-R без RT (NCI 2013: ~93% EFS, обхід RT-токсичності для AYA).</p>
+  <div class="case-foot">patient_pmbcl_typical.json</div>
+</a>
+<a class="case-card" href="/cases/pmbcl-bulky-svc.html"
+   data-default-order="39"
+   data-name="PMBCL · Bulky + SVC Syndrome">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PMBCL · Bulky + SVC Syndrome</h3>
+  <p>PMBCL з bulky mediastinal mass + SVC compression — engine додає upfront pre-phase steroids + airway management до DA-EPOCH-R.</p>
+  <div class="case-foot">patient_pmbcl_bulky_svc.json</div>
+</a>
+<a class="case-card" href="/cases/pmbcl-relapsed-post-rchop.html"
+   data-default-order="40"
+   data-name="PMBCL · Relapsed post-R-CHOP (Pembrolizumab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PMBCL · Relapsed post-R-CHOP (Pembrolizumab)</h3>
+  <p>PMBCL relapsed/refractory після R-CHOP — engine обирає R-ICE+autoSCT (eligible) або pembrolizumab (KEYNOTE-170, ineligible/refractory).</p>
+  <div class="case-foot">patient_pmbcl_relapsed_post_rchop.json</div>
+</a>
+<a class="case-card" href="/cases/auto-pmbcl.html"
+   data-default-order="148"
+   data-name="DIS-PMBCL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Primary Mediastinal Large B-Cell Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pmbcl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmbcl-frail.html"
+   data-default-order="436"
+   data-name="DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmbcl-organ-dysf.html"
+   data-default-order="437"
+   data-name="DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmbcl-infection-hbv.html"
+   data-default-order="438"
+   data-name="DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmbcl-relapsed-2l.html"
+   data-default-order="439"
+   data-name="DIS-PMBCL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmbcl-biomarker-act.html"
+   data-default-order="440"
+   data-name="DIS-PMBCL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmbcl-high-risk.html"
+   data-default-order="441"
+   data-name="DIS-PMBCL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMBCL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmbcl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PMF" hidden>
+  <header class="case-list-header">
+    <h2>Первинний мієлофіброз</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/pmf-anemia-dominant.html"
+   data-default-order="88"
+   data-name="PMF · Anemia-Dominant (Momelotinib)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PMF · Anemia-Dominant (Momelotinib)</h3>
+  <p>PMF DIPSS-Plus int-1, anemia-dominant — engine обирає momelotinib (MOMENTUM: anemia-friendly JAKi).</p>
+  <div class="case-foot">patient_pmf_anemia_dominant.json</div>
+</a>
+<a class="case-card" href="/cases/pmf-int2-symptomatic-rux.html"
+   data-default-order="89"
+   data-name="PMF · Int-2 Symptomatic (Ruxolitinib)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PMF · Int-2 Symptomatic (Ruxolitinib)</h3>
+  <p>PMF DIPSS-Plus int-2 з splenomegaly + constitutional symptoms — engine обирає ruxolitinib (COMFORT-I/II).</p>
+  <div class="case-foot">patient_pmf_int2_symptomatic_ruxolitinib.json</div>
+</a>
+<a class="case-card" href="/cases/pmf-post-rux-allohct.html"
+   data-default-order="90"
+   data-name="PMF · Post-Rux alloHCT Bridge (Urgent)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PMF · Post-Rux alloHCT Bridge (Urgent)</h3>
+  <p>PMF post-ruxolitinib failure з massive splenomegaly + transfusion-dependence — engine обирає alloHCT bridge (curative-intent, urgent).</p>
+  <div class="case-foot">patient_pmf_post_rux_allohct_bridge.json</div>
+</a>
+<a class="case-card" href="/cases/auto-pmf.html"
+   data-default-order="149"
+   data-name="DIS-PMF — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Primary Myelofibrosis. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pmf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmf-frail.html"
+   data-default-order="442"
+   data-name="DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmf-organ-dysf.html"
+   data-default-order="443"
+   data-name="DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmf-infection-hbv.html"
+   data-default-order="444"
+   data-name="DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmf-relapsed-2l.html"
+   data-default-order="445"
+   data-name="DIS-PMF · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmf-biomarker-act.html"
+   data-default-order="446"
+   data-name="DIS-PMF · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pmf-high-risk.html"
+   data-default-order="447"
+   data-name="DIS-PMF · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PMF · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pmf_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PTCL-NOS" hidden>
+  <header class="case-list-header">
+    <h2>Периферична T-клітинна лімфома, неуточнена</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/ptcl-cd30-negative.html"
+   data-default-order="25"
+   data-name="PTCL NOS · CD30-negative (CHOEP)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PTCL NOS · CD30-negative (CHOEP)</h3>
+  <p>Периферична T-клітинна лімфома, CD30-negative — engine обирає CHOEP (CHOP + etoposide). CD30+ варіант ескалював би до CHP-Bv.</p>
+  <div class="case-foot">patient_ptcl_cd30_negative.json</div>
+</a>
+<a class="case-card" href="/cases/ptcl-cd30-positive.html"
+   data-default-order="50"
+   data-name="PTCL NOS · CD30-positive (CHP-Bv)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PTCL NOS · CD30-positive (CHP-Bv)</h3>
+  <p>PTCL NOS, CD30≥10% — RF-TCELL-CD30-POSITIVE fired. Engine обирає CHP-Bv (ECHELON-2 inclusion threshold).</p>
+  <div class="case-foot">patient_ptcl_cd30_positive.json</div>
+</a>
+<a class="case-card" href="/cases/ptcl-relapsed.html"
+   data-default-order="51"
+   data-name="PTCL NOS · Relapsed post-autoSCT (Romidepsin / Pralatrexate)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PTCL NOS · Relapsed post-autoSCT (Romidepsin / Pralatrexate)</h3>
+  <p>PTCL NOS relapsed після autoSCT — engine обирає romidepsin або pralatrexate; alloHCT як curative-intent для chemosensitive.</p>
+  <div class="case-foot">patient_ptcl_relapsed.json</div>
+</a>
+<a class="case-card" href="/cases/auto-ptcl_nos.html"
+   data-default-order="151"
+   data-name="DIS-PTCL-NOS — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Peripheral T-Cell Lymphoma, NOS. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ptcl_nos.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptcl_nos-frail.html"
+   data-default-order="453"
+   data-name="DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptcl_nos-organ-dysf.html"
+   data-default-order="454"
+   data-name="DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptcl_nos-infection-hbv.html"
+   data-default-order="455"
+   data-name="DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptcl_nos-relapsed-2l.html"
+   data-default-order="456"
+   data-name="DIS-PTCL-NOS · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptcl_nos-biomarker-act.html"
+   data-default-order="457"
+   data-name="DIS-PTCL-NOS · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptcl_nos-high-risk.html"
+   data-default-order="458"
+   data-name="DIS-PTCL-NOS · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTCL-NOS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptcl_nos_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-HNSCC" hidden>
+  <header class="case-list-header">
+    <h2>Плоскоклітинна карцинома голови та шиї</h2>
+    <span class="case-list-count">8 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-hnscc.html"
+   data-default-order="128"
+   data-name="DIS-HNSCC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Head and neck squamous cell carcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_hnscc.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hnscc-frail.html"
+   data-default-order="324"
+   data-name="DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hnscc-organ-dysf.html"
+   data-default-order="325"
+   data-name="DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hnscc-infection-hbv.html"
+   data-default-order="326"
+   data-name="DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hnscc-biomarker-act.html"
+   data-default-order="327"
+   data-name="DIS-HNSCC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-hnscc-high-risk.html"
+   data-default-order="328"
+   data-name="DIS-HNSCC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-HNSCC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_hnscc_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/hnscc-cps-high-pembro-mono.html"
+   data-default-order="572"
+   data-name="HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)</h3>
+  <p>R/M HNSCC CPS≥20. Engine: → IND-HNSCC-RM-1L-PEMBRO-MONO-CPS-HIGH (KEYNOTE-048 mOS 14.9 мо).</p>
+  <div class="case-foot">patient_hnscc_cps_high_pembro_mono.json</div>
+</a>
+<a class="case-card" href="/cases/hnscc-extreme-cetux-platin.html"
+   data-default-order="573"
+   data-name="HNSCC · R/M EXTREME · Cetux+platin+5FU">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>HNSCC · R/M EXTREME · Cetux+platin+5FU</h3>
+  <p>Drift: IND-HNSCC-RM-1L-EXTREME не authored у KB; engine fallback = pembro+chemo. EXTREME анкер у comment, highest content gap.</p>
+  <div class="case-foot">patient_hnscc_extreme_cetux_platin_5fu.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PTLD" hidden>
+  <header class="case-list-header">
+    <h2>Посттрансплантаційні лімфопроліферативні захворювання</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/ptld-polymorphic-ebv.html"
+   data-default-order="64"
+   data-name="PTLD · Polymorphic EBV+ (RIS + Rituximab)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PTLD · Polymorphic EBV+ (RIS + Rituximab)</h3>
+  <p>Post-transplant LPD, polymorphic EBV+ — engine обирає RIS (reduce immunosuppression) + sequential PTLD-1 rituximab maintenance.</p>
+  <div class="case-foot">patient_ptld_polymorphic_ebv.json</div>
+</a>
+<a class="case-card" href="/cases/ptld-monomorphic-dlbcl-like.html"
+   data-default-order="65"
+   data-name="PTLD · Monomorphic DLBCL-like (R-CHOP)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PTLD · Monomorphic DLBCL-like (R-CHOP)</h3>
+  <p>Monomorphic PTLD з DLBCL morphology — engine обирає R-CHOP після RIS-failure; sequential treatment per PTLD-1.</p>
+  <div class="case-foot">patient_ptld_monomorphic_dlbcl_like.json</div>
+</a>
+<a class="case-card" href="/cases/auto-ptld.html"
+   data-default-order="152"
+   data-name="DIS-PTLD — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Post-Transplant Lymphoproliferative Disorder. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ptld.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptld-frail.html"
+   data-default-order="459"
+   data-name="DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptld-organ-dysf.html"
+   data-default-order="460"
+   data-name="DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptld-infection-hbv.html"
+   data-default-order="461"
+   data-name="DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptld-relapsed-2l.html"
+   data-default-order="462"
+   data-name="DIS-PTLD · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptld-biomarker-act.html"
+   data-default-order="463"
+   data-name="DIS-PTLD · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-ptld-high-risk.html"
+   data-default-order="464"
+   data-name="DIS-PTLD · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PTLD · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ptld_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MASTOCYTOSIS" hidden>
+  <header class="case-list-header">
+    <h2>Поширений системний мастоцитоз</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-mastocytosis.html"
+   data-default-order="132"
+   data-name="DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Advanced systemic mastocytosis. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_mastocytosis.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mastocytosis-frail.html"
+   data-default-order="344"
+   data-name="DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mastocytosis-organ-dysf.html"
+   data-default-order="345"
+   data-name="DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mastocytosis-infection-hbv.html"
+   data-default-order="346"
+   data-name="DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mastocytosis-biomarker-act.html"
+   data-default-order="347"
+   data-name="DIS-MASTOCYTOSIS · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-mastocytosis-high-risk.html"
+   data-default-order="348"
+   data-name="DIS-MASTOCYTOSIS · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MASTOCYTOSIS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_mastocytosis_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PDAC" hidden>
+  <header class="case-list-header">
+    <h2>Протокова аденокарцинома підшлункової залози</h2>
+    <span class="case-list-count">7 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-pdac.html"
+   data-default-order="147"
+   data-name="DIS-PDAC — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Pancreatic ductal adenocarcinoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pdac.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pdac-frail.html"
+   data-default-order="431"
+   data-name="DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pdac-organ-dysf.html"
+   data-default-order="432"
+   data-name="DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pdac-infection-hbv.html"
+   data-default-order="433"
+   data-name="DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pdac-biomarker-act.html"
+   data-default-order="434"
+   data-name="DIS-PDAC · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pdac-high-risk.html"
+   data-default-order="435"
+   data-name="DIS-PDAC · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PDAC · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pdac_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/pdac-folfirinox-fit.html"
+   data-default-order="569"
+   data-name="PDAC · met fit · FOLFIRINOX (PRODIGE-4)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>PDAC · met fit · FOLFIRINOX (PRODIGE-4)</h3>
+  <p>Fit метастатична PDAC. Drift: ALGO step 3 condition free-text; engine default = gem-nab-pac; FOLFIRINOX як alternative track.</p>
+  <div class="case-foot">patient_pdac_metastatic_folfirinox_fit.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-SPLENIC-MZL" hidden>
+  <header class="case-list-header">
+    <h2>Селезінкова лімфома маргінальної зони</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/smzl-hcv-positive.html"
+   data-default-order="16"
+   data-name="Splenic MZL · HCV-positive (DAA antiviral)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Splenic MZL · HCV-positive (DAA antiviral)</h3>
+  <p>Селезінкова MZL із HCV-позитивним статусом — engine обирає DAA antiviral (sofosbuvir/velpatasvir 12 тижнів) як 1L; reuse REG-DAA-SOF-VEL з HCV-MZL extranodal.</p>
+  <div class="case-foot">patient_smzl_hcv_positive.json</div>
+</a>
+<a class="case-card" href="/cases/smzl-hcv-negative.html"
+   data-default-order="17"
+   data-name="Splenic MZL · HCV-negative (Rituximab mono)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Splenic MZL · HCV-negative (Rituximab mono)</h3>
+  <p>Селезінкова MZL HCV-negative — engine обирає rituximab monotherapy (4 weekly + 2-year maintenance).</p>
+  <div class="case-foot">patient_smzl_hcv_negative.json</div>
+</a>
+<a class="case-card" href="/cases/auto-splenic_mzl.html"
+   data-default-order="157"
+   data-name="DIS-SPLENIC-MZL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Splenic Marginal Zone Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_splenic_mzl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-splenic_mzl-frail.html"
+   data-default-order="487"
+   data-name="DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-splenic_mzl-organ-dysf.html"
+   data-default-order="488"
+   data-name="DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-splenic_mzl-infection-hbv.html"
+   data-default-order="489"
+   data-name="DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-splenic_mzl-relapsed-2l.html"
+   data-default-order="490"
+   data-name="DIS-SPLENIC-MZL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-splenic_mzl-biomarker-act.html"
+   data-default-order="491"
+   data-name="DIS-SPLENIC-MZL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-splenic_mzl-high-risk.html"
+   data-default-order="492"
+   data-name="DIS-SPLENIC-MZL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-SPLENIC-MZL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_splenic_mzl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-PV" hidden>
+  <header class="case-list-header">
+    <h2>Справжня поліцитемія</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/pv-high-risk-hu.html"
+   data-default-order="84"
+   data-name="Polycythemia Vera · High Risk (HU 1L)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Polycythemia Vera · High Risk (HU 1L)</h3>
+  <p>PV вік &gt;60 + thrombosis history — engine обирає phlebotomy + low-dose ASA + cytoreduction hydroxyurea.</p>
+  <div class="case-foot">patient_pv_high_risk_hu.json</div>
+</a>
+<a class="case-card" href="/cases/pv-hu-resistant-rux.html"
+   data-default-order="85"
+   data-name="PV · HU-resistant (Ruxolitinib 2L)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PV · HU-resistant (Ruxolitinib 2L)</h3>
+  <p>PV з HU-intolerance/resistance per ELN — engine обирає ruxolitinib (RESPONSE-2: hematocrit control + symptom relief).</p>
+  <div class="case-foot">patient_pv_hu_resistant_ruxolitinib.json</div>
+</a>
+<a class="case-card" href="/cases/pv-pregnancy-planning.html"
+   data-default-order="86"
+   data-name="PV · Pregnancy Planning (Peg-IFN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>PV · Pregnancy Planning (Peg-IFN)</h3>
+  <p>Reproductive-age жінка з PV, planning pregnancy — engine обирає peg-IFN α-2a (non-teratogenic, fetus-safe).</p>
+  <div class="case-foot">patient_pv_pregnancy_planning.json</div>
+</a>
+<a class="case-card" href="/cases/auto-pv.html"
+   data-default-order="153"
+   data-name="DIS-PV — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Polycythemia Vera. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_pv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pv-frail.html"
+   data-default-order="465"
+   data-name="DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pv-organ-dysf.html"
+   data-default-order="466"
+   data-name="DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pv-infection-hbv.html"
+   data-default-order="467"
+   data-name="DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pv-relapsed-2l.html"
+   data-default-order="468"
+   data-name="DIS-PV · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pv-biomarker-act.html"
+   data-default-order="469"
+   data-name="DIS-PV · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-pv-high-risk.html"
+   data-default-order="470"
+   data-name="DIS-PV · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-PV · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_pv_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-UROTHELIAL" hidden>
+  <header class="case-list-header">
+    <h2>Уротеліальна карцинома</h2>
+    <span class="case-list-count">7 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-urothelial.html"
+   data-default-order="162"
+   data-name="DIS-UROTHELIAL — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Urothelial carcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_urothelial.json</div>
+</a>
+<a class="case-card" href="/cases/variant-urothelial-frail.html"
+   data-default-order="515"
+   data-name="DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-urothelial-organ-dysf.html"
+   data-default-order="516"
+   data-name="DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-urothelial-infection-hbv.html"
+   data-default-order="517"
+   data-name="DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-urothelial-biomarker-act.html"
+   data-default-order="518"
+   data-name="DIS-UROTHELIAL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-urothelial-high-risk.html"
+   data-default-order="519"
+   data-name="DIS-UROTHELIAL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-UROTHELIAL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_urothelial_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/urothelial-muc-ev-pembro.html"
+   data-default-order="560"
+   data-name="Urothelial · mUC 1L · EV+pembro (EV-302)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Urothelial · mUC 1L · EV+pembro (EV-302)</h3>
+  <p>Метастатична мUC. Drift: free-text condition unevaluable; engine default = platinum+avelumab; EV-302 анкер у comment.</p>
+  <div class="case-foot">patient_urothelial_muc_ev_pembro.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-FL" hidden>
+  <header class="case-list-header">
+    <h2>Фолікулярна лімфома</h2>
+    <span class="case-list-count">9 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/fl-low-burden.html"
+   data-default-order="9"
+   data-name="Follicular · Low Burden (Watch-and-Wait)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Follicular · Low Burden (Watch-and-Wait)</h3>
+  <p>FL grade 1-2, asymptomatic, no GELF criteria — engine обирає surveillance трек (3 plans usable side-by-side, default = W&amp;W).</p>
+  <div class="case-foot">patient_fl_low_burden.json</div>
+</a>
+<a class="case-card" href="/cases/fl-high-burden.html"
+   data-default-order="10"
+   data-name="Follicular · High Burden (BR)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Follicular · High Burden (BR)</h3>
+  <p>FL з 8 cm масою + B-symptoms + LDH↑ — RF-FL-HIGH-TUMOR-BURDEN-GELF fired. Engine обирає BR (бендамустин + ритуксимаб); reuse REG-BR-STANDARD з HCV-MZL.</p>
+  <div class="case-foot">patient_fl_high_burden.json</div>
+</a>
+<a class="case-card" href="/cases/fl-transformation.html"
+   data-default-order="11"
+   data-name="Follicular · Transformation Suspect (R-CHOP)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>Follicular · Transformation Suspect (R-CHOP)</h3>
+  <p>FL з rapid progression + LDH doubling — RF-FL-TRANSFORMATION-SUSPECT fired. Engine обирає R-CHOP (трактує як DLBCL pathway).</p>
+  <div class="case-foot">patient_fl_transformation.json</div>
+</a>
+<a class="case-card" href="/cases/auto-fl.html"
+   data-default-order="119"
+   data-name="DIS-FL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-FL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Follicular Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_fl.json</div>
+</a>
+<a class="case-card" href="/cases/variant-fl-frail.html"
+   data-default-order="280"
+   data-name="DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-FL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_fl_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-fl-organ-dysf.html"
+   data-default-order="281"
+   data-name="DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-FL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_fl_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-fl-infection-hbv.html"
+   data-default-order="282"
+   data-name="DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-FL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_fl_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-fl-biomarker-act.html"
+   data-default-order="283"
+   data-name="DIS-FL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-FL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_fl_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-fl-high-risk.html"
+   data-default-order="284"
+   data-name="DIS-FL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-FL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_fl_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CHOLANGIOCARCINOMA" hidden>
+  <header class="case-list-header">
+    <h2>Холангіокарцинома (рак жовчних проток)</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-cholangiocarcinoma.html"
+   data-default-order="109"
+   data-name="DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHOLANGIOCARCINOMA — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Cholangiocarcinoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cholangiocarcinoma.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cholangiocarcinoma-frail.html"
+   data-default-order="223"
+   data-name="DIS-CHOLANGIOCARCINOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHOLANGIOCARCINOMA · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cholangiocarcinoma_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cholangiocarcinoma-organ-dysf.html"
+   data-default-order="224"
+   data-name="DIS-CHOLANGIOCARCINOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHOLANGIOCARCINOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cholangiocarcinoma_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cholangiocarcinoma-infection-hbv.html"
+   data-default-order="225"
+   data-name="DIS-CHOLANGIOCARCINOMA · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHOLANGIOCARCINOMA · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cholangiocarcinoma_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cholangiocarcinoma-biomarker-act.html"
+   data-default-order="226"
+   data-name="DIS-CHOLANGIOCARCINOMA · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHOLANGIOCARCINOMA · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cholangiocarcinoma_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cholangiocarcinoma-high-risk.html"
+   data-default-order="227"
+   data-name="DIS-CHOLANGIOCARCINOMA · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHOLANGIOCARCINOMA · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cholangiocarcinoma_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CHONDROSARCOMA" hidden>
+  <header class="case-list-header">
+    <h2>Хондросаркома</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-chondrosarcoma.html"
+   data-default-order="110"
+   data-name="DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Chondrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_chondrosarcoma.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chondrosarcoma-frail.html"
+   data-default-order="228"
+   data-name="DIS-CHONDROSARCOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chondrosarcoma_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chondrosarcoma-organ-dysf.html"
+   data-default-order="229"
+   data-name="DIS-CHONDROSARCOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chondrosarcoma_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chondrosarcoma-infection-hbv.html"
+   data-default-order="230"
+   data-name="DIS-CHONDROSARCOMA · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chondrosarcoma_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chondrosarcoma-biomarker-act.html"
+   data-default-order="231"
+   data-name="DIS-CHONDROSARCOMA · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chondrosarcoma_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-chondrosarcoma-high-risk.html"
+   data-default-order="232"
+   data-name="DIS-CHONDROSARCOMA · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CHONDROSARCOMA · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_chondrosarcoma_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CLL" hidden>
+  <header class="case-list-header">
+    <h2>Хронічна лімфоцитарна лейкемія / Дрібноклітинна лімфоцитарна лімфома</h2>
+    <span class="case-list-count">11 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/cll-low-risk.html"
+   data-default-order="12"
+   data-name="CLL/SLL · Low-Risk (BTKi continuous)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL/SLL · Low-Risk (BTKi continuous)</h3>
+  <p>ХЛЛ зі стандартним ризиком (no TP53/del 17p/IGHV-unmut) — engine обирає acalabrutinib continuous; modern era замість FCR/BR.</p>
+  <div class="case-foot">patient_cll_low_risk.json</div>
+</a>
+<a class="case-card" href="/cases/cll-high-risk.html"
+   data-default-order="13"
+   data-name="CLL/SLL · High-Risk (VenO time-limited)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL/SLL · High-Risk (VenO time-limited)</h3>
+  <p>ХЛЛ з TP53 mutation + IGHV-unmut + complex karyotype — RF-CLL-HIGH-RISK fired. Engine ескалує до venetoclax+obinutuzumab (CLL14).</p>
+  <div class="case-foot">patient_cll_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/cll-post-btki.html"
+   data-default-order="44"
+   data-name="CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL/SLL · Post-BTKi Progression (Pirtobrutinib / VenR)</h3>
+  <p>CLL з прогресією на covalent BTKi — engine обирає pirtobrutinib (BRUIN, non-covalent) або venetoclax+rituximab (MURANO).</p>
+  <div class="case-foot">patient_cll_post_btki_progression.json</div>
+</a>
+<a class="case-card" href="/cases/auto-cll.html"
+   data-default-order="111"
+   data-name="DIS-CLL — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Chronic Lymphocytic Leukemia / Small Lymphocytic Lymphoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cll.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cll-frail.html"
+   data-default-order="233"
+   data-name="DIS-CLL · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cll_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cll-organ-dysf.html"
+   data-default-order="234"
+   data-name="DIS-CLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cll_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cll-infection-hbv.html"
+   data-default-order="235"
+   data-name="DIS-CLL · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cll_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cll-relapsed-2l.html"
+   data-default-order="236"
+   data-name="DIS-CLL · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cll_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cll-biomarker-act.html"
+   data-default-order="237"
+   data-name="DIS-CLL · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cll_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cll-high-risk.html"
+   data-default-order="238"
+   data-name="DIS-CLL · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CLL · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cll_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/cll-venr-2l-murano.html"
+   data-default-order="581"
+   data-name="CLL · 2L post-BTKi · VenR fixed-duration (MURANO)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CLL · 2L post-BTKi · VenR fixed-duration (MURANO)</h3>
+  <p>Post-acalabrutinib PD без C481/BCL2-resistance. Engine: ALGO-CLL-2L step 2 (RF-PRIOR-BTKI-PROGRESSION) → IND-CLL-2L-VENR-MURANO (24-mo, mPFS 53.6 мо).</p>
+  <div class="case-foot">patient_cll_venr_2l_murano.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-CML" hidden>
+  <header class="case-list-header">
+    <h2>Хронічна мієлоїдна лейкемія (BCR-ABL1)</h2>
+    <span class="case-list-count">10 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/cml-chronic-newdx.html"
+   data-default-order="75"
+   data-name="CML · Chronic Phase Newly Diagnosed (TKI 1L)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CML · Chronic Phase Newly Diagnosed (TKI 1L)</h3>
+  <p>Newly-diagnosed CML chronic phase, BCR-ABL1+ — engine обирає imatinib (low-risk Sokal) або 2G TKI (intermediate/high).</p>
+  <div class="case-foot">patient_cml_chronic_phase_newdx.json</div>
+</a>
+<a class="case-card" href="/cases/cml-t315i.html"
+   data-default-order="76"
+   data-name="CML · T315I-mutated (Ponatinib / Asciminib)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CML · T315I-mutated (Ponatinib / Asciminib)</h3>
+  <p>CML з T315I gatekeeper mutation post-2G TKI — engine обирає ponatinib (PACE) або asciminib (allosteric STAMP-inhibitor).</p>
+  <div class="case-foot">patient_cml_t315i.json</div>
+</a>
+<a class="case-card" href="/cases/cml-blast-crisis.html"
+   data-default-order="77"
+   data-name="CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    
+  </div>
+  <h3>CML · Blast Crisis at Presentation (TKI + Chemo + alloHCT)</h3>
+  <p>CML що дебютує як blast crisis — engine обирає TKI + intensive chemo bridge → urgent alloHCT (без alloHCT медіана OS &lt;12 mo).</p>
+  <div class="case-foot">patient_cml_blast_crisis_at_presentation.json</div>
+</a>
+<a class="case-card" href="/cases/auto-cml.html"
+   data-default-order="112"
+   data-name="DIS-CML — Auto-stub (75% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Chronic Myeloid Leukemia. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_cml.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cml-frail.html"
+   data-default-order="239"
+   data-name="DIS-CML · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cml_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cml-organ-dysf.html"
+   data-default-order="240"
+   data-name="DIS-CML · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cml_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cml-infection-hbv.html"
+   data-default-order="241"
+   data-name="DIS-CML · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cml_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cml-relapsed-2l.html"
+   data-default-order="242"
+   data-name="DIS-CML · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 3 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cml_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cml-biomarker-act.html"
+   data-default-order="243"
+   data-name="DIS-CML · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cml_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-cml-high-risk.html"
+   data-default-order="244"
+   data-name="DIS-CML · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-CML · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_cml_high_risk.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-MELANOMA" hidden>
+  <header class="case-list-header">
+    <h2>Шкірна меланома</h2>
+    <span class="case-list-count">12 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-melanoma.html"
+   data-default-order="136"
+   data-name="DIS-MELANOMA — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Cutaneous melanoma. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_melanoma.json</div>
+</a>
+<a class="case-card" href="/cases/variant-melanoma-frail.html"
+   data-default-order="367"
+   data-name="DIS-MELANOMA · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_melanoma_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-melanoma-organ-dysf.html"
+   data-default-order="368"
+   data-name="DIS-MELANOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_melanoma_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-melanoma-infection-hbv.html"
+   data-default-order="369"
+   data-name="DIS-MELANOMA · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_melanoma_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-melanoma-relapsed-2l.html"
+   data-default-order="370"
+   data-name="DIS-MELANOMA · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 5 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_melanoma_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-melanoma-biomarker-act.html"
+   data-default-order="371"
+   data-name="DIS-MELANOMA · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_melanoma_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-melanoma-high-risk.html"
+   data-default-order="372"
+   data-name="DIS-MELANOMA · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-MELANOMA · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_melanoma_high_risk.json</div>
+</a>
+<a class="case-card" href="/cases/melanoma-braf-v600-dab-tram.html"
+   data-default-order="552"
+   data-name="Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)</h3>
+  <p>BRAF V600 метастатична. Engine: → IND-MELANOMA-BRAF-METASTATIC-1L-DABRA-TRAME (COMBI-d/v).</p>
+  <div class="case-foot">patient_melanoma_braf_v600_dab_tram.json</div>
+</a>
+<a class="case-card" href="/cases/melanoma-braf-v600-nivo-ipi.html"
+   data-default-order="553"
+   data-name="Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)</h3>
+  <p>BRAF V600 метастатична, IO doublet. Engine: → IND-MELANOMA-METASTATIC-1L-NIVO-IPI (CM-067 5-yr OS 52%).</p>
+  <div class="case-foot">patient_melanoma_braf_v600_nivo_ipi.json</div>
+</a>
+<a class="case-card" href="/cases/melanoma-braf-wt-pembro-mono.html"
+   data-default-order="554"
+   data-name="Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)</h3>
+  <p>BRAF-WT метастатична. Drift: KEYNOTE-006 не wired у KB; engine fallback до nivo+ipi; анкер у comment.</p>
+  <div class="case-foot">patient_melanoma_braf_wt_pembro_mono.json</div>
+</a>
+<a class="case-card" href="/cases/melanoma-nivo-relatlimab.html"
+   data-default-order="555"
+   data-name="Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)</h3>
+  <p>Drift: KB scopeє nivo+rela до 2L post-BRAFi; модельовано як 2L з frailty. RELATIVITY-047 анкер 1L FDA.</p>
+  <div class="case-foot">patient_melanoma_nivo_relatlimab.json</div>
+</a>
+<a class="case-card" href="/cases/melanoma-adjuvant-pembro-stage-iii.html"
+   data-default-order="556"
+   data-name="Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)</h3>
+  <p>Drift: adjuvant melanoma algo не існує в KB; engine output = met-1L IO doublet. KEYNOTE-054 анкер у comment, motivation для майбутнього ALGO-MELANOMA-ADJUVANT.</p>
+  <div class="case-foot">patient_melanoma_adjuvant_pembro_stage_iii.json</div>
+</a>
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-BREAST" hidden>
+  <header class="case-list-header">
+    <h2>Інвазивний рак молочної залози</h2>
+    <span class="case-list-count">15 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-breast.html"
+   data-default-order="105"
+   data-name="DIS-BREAST — Auto-stub (88% наповненість)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Auto-stub</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST — Auto-stub (88% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Invasive breast cancer. Фактична наповненість бази для цієї хвороби — 88%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_breast.json</div>
+</a>
+<a class="case-card" href="/cases/variant-breast-frail.html"
+   data-default-order="200"
+   data-name="DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_frail.json</div>
+</a>
+<a class="case-card" href="/cases/variant-breast-organ-dysf.html"
+   data-default-order="201"
+   data-name="DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_organ_dysf.json</div>
+</a>
+<a class="case-card" href="/cases/variant-breast-infection-hbv.html"
+   data-default-order="202"
+   data-name="DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_infection_hbv.json</div>
+</a>
+<a class="case-card" href="/cases/variant-breast-relapsed-2l.html"
+   data-default-order="203"
+   data-name="DIS-BREAST · Релапс / 2-а лінія">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Релапс / 2-а лінія</h3>
+  <p>Автогенерований variant &#x27;relapsed_2l&#x27;. Engine: 2 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_relapsed_2l.json</div>
+</a>
+<a class="case-card" href="/cases/variant-breast-biomarker-act.html"
+   data-default-order="204"
+   data-name="DIS-BREAST · Actionable біомаркер present">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_biomarker_act.json</div>
+</a>
+<a class="case-card" href="/cases/variant-breast-high-risk.html"
+   data-default-order="205"
+   data-name="DIS-BREAST · High-risk biology / bulky disease">
+  <div class="case-badge-row">
+    <div class="case-badge bdg-stub">Variant</div>
+    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
+  </div>
+  <h3>DIS-BREAST · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 6 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_breast_high_risk.json</div>
+</a>
 <a class="case-card" href="/cases/breast-hr-pos-met-1l-cdk46i.html"
    data-default-order="538"
    data-name="Breast · HR+/HER2- met 1L · AI+palbociclib (PALOMA-2)">
@@ -6428,335 +6962,98 @@
   <p>TNBC метастатична 2L+. Drift: engine routes до HER2-2L default; sacituzumab анкер у comment.</p>
   <div class="case-foot">patient_breast_tnbc_met_sacituzumab_2l.json</div>
 </a>
-<a class="case-card" href="/cases/crc-stage-iii-adjuvant-folfox.html"
-   data-default-order="546"
-   data-name="CRC · stage III adjuvant FOLFOX (MOSAIC)">
+  </div>
+</section>
+<section class="case-list" data-disease-id="DIS-IFS" hidden>
+  <header class="case-list-header">
+    <h2>Інфантильна фібросаркома</h2>
+    <span class="case-list-count">6 прикладів</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/auto-ifs.html"
+   data-default-order="130"
+   data-name="DIS-IFS — Auto-stub (75% наповненість)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-stub">Auto-stub</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>CRC · stage III adjuvant FOLFOX (MOSAIC)</h3>
-  <p>Stage III після резекції. Drift: KB не має adjuvant CRC algo; engine default = mCRC FOLFOX+bev (анкер MOSAIC у comment).</p>
-  <div class="case-foot">patient_crc_stage_iii_adjuvant_folfox.json</div>
+  <h3>DIS-IFS — Auto-stub (75% наповненість)</h3>
+  <p>Автогенерований мінімальний профіль для Infantile fibrosarcoma. Фактична наповненість бази для цієї хвороби — 75%. Використовується для перевірки end-to-end engine + render — не для клінічних рішень.</p>
+  <div class="case-foot">auto_ifs.json</div>
 </a>
-<a class="case-card" href="/cases/crc-mcrc-ras-wt-left-folfox-cetux.html"
-   data-default-order="547"
-   data-name="mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)">
+<a class="case-card" href="/cases/variant-ifs-frail.html"
+   data-default-order="334"
+   data-name="DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>mCRC · RAS-WT left-sided 1L · FOLFOX+cetuximab (CRYSTAL)</h3>
-  <p>RAS-WT левобічна mCRC. Engine: ALGO step 2 → IND-CRC-METASTATIC-1L-RAS-WT-LEFT (CRYSTAL/FIRE-3).</p>
-  <div class="case-foot">patient_crc_metastatic_ras_wt_left_folfox_cetux.json</div>
+  <h3>DIS-IFS · Літній / крихкий пацієнт (age 78, ECOG 3)</h3>
+  <p>Автогенерований variant &#x27;frail&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_frail.json</div>
 </a>
-<a class="case-card" href="/cases/crc-mcrc-ras-mut-folfox-bev.html"
-   data-default-order="548"
-   data-name="mCRC · RAS-mutated 1L · FOLFOX+bevacizumab">
+<a class="case-card" href="/cases/variant-ifs-organ-dysf.html"
+   data-default-order="335"
+   data-name="DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>mCRC · RAS-mutated 1L · FOLFOX+bevacizumab</h3>
-  <p>KRAS-мутована mCRC, 1L FOLFOX+bevacizumab. Engine: ALGO default → IND-CRC-METASTATIC-1L-FOLFOX-BEV.</p>
-  <div class="case-foot">patient_crc_metastatic_ras_mut_folfox_bev.json</div>
+  <h3>DIS-IFS · Дисфункція органів (CrCl 25, bili 3.5×ULN)</h3>
+  <p>Автогенерований variant &#x27;organ_dysf&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_organ_dysf.json</div>
 </a>
-<a class="case-card" href="/cases/crc-mcrc-msi-h-pembro.html"
-   data-default-order="549"
-   data-name="mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)">
+<a class="case-card" href="/cases/variant-ifs-infection-hbv.html"
+   data-default-order="336"
+   data-name="DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>mCRC · MSI-H 1L · Pembrolizumab mono (KEYNOTE-177)</h3>
-  <p>MSI-high mCRC. Engine: ALGO step 1 (MSI-H fires) → IND-CRC-METASTATIC-1L-MSI-H-PEMBRO (KEYNOTE-177 mPFS 16.5 мо).</p>
-  <div class="case-foot">patient_crc_metastatic_msi_h_pembro_mono.json</div>
+  <h3>DIS-IFS · HBV-позитивний (HBsAg+, anti-HBc+)</h3>
+  <p>Автогенерований variant &#x27;infection_hbv&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_infection_hbv.json</div>
 </a>
-<a class="case-card" href="/cases/crc-mcrc-2l-folfiri-bev.html"
-   data-default-order="550"
-   data-name="mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)">
+<a class="case-card" href="/cases/variant-ifs-biomarker-act.html"
+   data-default-order="337"
+   data-name="DIS-IFS · Actionable біомаркер present">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>mCRC · 2L FOLFIRI+bev post-FOLFOX (E3200/ML18147)</h3>
-  <p>Прогрес на FOLFOX+bev 1L. Engine: ALGO-2L → IND-CRC-METASTATIC-2L-FOLFIRI-BEV (continuum-of-care).</p>
-  <div class="case-foot">patient_crc_metastatic_2l_folfiri_bev.json</div>
+  <h3>DIS-IFS · Actionable біомаркер present</h3>
+  <p>Автогенерований variant &#x27;biomarker_act&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_biomarker_act.json</div>
 </a>
-<a class="case-card" href="/cases/crc-mcrc-3l-regorafenib.html"
-   data-default-order="551"
-   data-name="mCRC · 3L+ Regorafenib (CORRECT)">
+<a class="case-card" href="/cases/variant-ifs-high-risk.html"
+   data-default-order="338"
+   data-name="DIS-IFS · High-risk biology / bulky disease">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-stub">Variant</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>mCRC · 3L+ Regorafenib (CORRECT)</h3>
-  <p>Хеморефрактерна mCRC. Drift: engine default = TAS-102+bev (SUNLIGHT); regorafenib як alternative track.</p>
-  <div class="case-foot">patient_crc_metastatic_3l_regorafenib.json</div>
+  <h3>DIS-IFS · High-risk biology / bulky disease</h3>
+  <p>Автогенерований variant &#x27;high_risk&#x27;. Engine: 1 tracks. Синтетичний профіль — не для клінічних рішень.</p>
+  <div class="case-foot">variant_ifs_high_risk.json</div>
 </a>
-<a class="case-card" href="/cases/melanoma-braf-v600-dab-tram.html"
-   data-default-order="552"
-   data-name="Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)">
+  </div>
+</section>
+<section class="case-list" data-disease-id="OTHER" hidden>
+  <header class="case-list-header">
+    <h2>Інше / без класифікації</h2>
+    <span class="case-list-count">4 приклади</span>
+  </header>
+  <div class="case-grid">
+<a class="case-card" href="/cases/diagnostic-lymphoma-suspect.html"
+   data-default-order="5"
+   data-name="Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)">
   <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
+    <div class="case-badge bdg-diag">Diagnostic Brief</div>
     <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
   </div>
-  <h3>Melanoma · BRAF V600 · 1L Dab+tram (COMBI-d/v)</h3>
-  <p>BRAF V600 метастатична. Engine: → IND-MELANOMA-BRAF-METASTATIC-1L-DABRA-TRAME (COMBI-d/v).</p>
-  <div class="case-foot">patient_melanoma_braf_v600_dab_tram.json</div>
-</a>
-<a class="case-card" href="/cases/melanoma-braf-v600-nivo-ipi.html"
-   data-default-order="553"
-   data-name="Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Melanoma · BRAF V600 · 1L Nivo+ipi (CheckMate-067)</h3>
-  <p>BRAF V600 метастатична, IO doublet. Engine: → IND-MELANOMA-METASTATIC-1L-NIVO-IPI (CM-067 5-yr OS 52%).</p>
-  <div class="case-foot">patient_melanoma_braf_v600_nivo_ipi.json</div>
-</a>
-<a class="case-card" href="/cases/melanoma-braf-wt-pembro-mono.html"
-   data-default-order="554"
-   data-name="Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Melanoma · BRAF-WT · 1L Pembro mono (KEYNOTE-006)</h3>
-  <p>BRAF-WT метастатична. Drift: KEYNOTE-006 не wired у KB; engine fallback до nivo+ipi; анкер у comment.</p>
-  <div class="case-foot">patient_melanoma_braf_wt_pembro_mono.json</div>
-</a>
-<a class="case-card" href="/cases/melanoma-nivo-relatlimab.html"
-   data-default-order="555"
-   data-name="Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Melanoma · 1L Nivolumab+relatlimab (RELATIVITY-047)</h3>
-  <p>Drift: KB scopeє nivo+rela до 2L post-BRAFi; модельовано як 2L з frailty. RELATIVITY-047 анкер 1L FDA.</p>
-  <div class="case-foot">patient_melanoma_nivo_relatlimab.json</div>
-</a>
-<a class="case-card" href="/cases/melanoma-adjuvant-pembro-stage-iii.html"
-   data-default-order="556"
-   data-name="Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Melanoma · Stage III resected · Adjuvant pembro (KEYNOTE-054)</h3>
-  <p>Drift: adjuvant melanoma algo не існує в KB; engine output = met-1L IO doublet. KEYNOTE-054 анкер у comment, motivation для майбутнього ALGO-MELANOMA-ADJUVANT.</p>
-  <div class="case-foot">patient_melanoma_adjuvant_pembro_stage_iii.json</div>
-</a>
-<a class="case-card" href="/cases/prostate-mcrpc-brca-olaparib.html"
-   data-default-order="557"
-   data-name="Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Prostate · mCRPC · BRCA-mut · Olaparib (PROfound)</h3>
-  <p>mCRPC з BRCA-pathogenic, PARPi мono. Engine: ALGO-PROSTATE-MCRPC-1L step 1 → IND-PROSTATE-MCRPC-1L-PARPI (PROfound mPFS 7.4 мо).</p>
-  <div class="case-foot">patient_prostate_mcrpc_brca_olaparib_profound.json</div>
-</a>
-<a class="case-card" href="/cases/rcc-imdc-int-nivo-ipi.html"
-   data-default-order="558"
-   data-name="RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>RCC · IMDC int/poor 1L · Nivo+ipi (CheckMate-214)</h3>
-  <p>Clear-cell RCC IMDC intermediate-poor. Drift: engine default = pembro+axi; nivo+ipi анкер CM-214 у comment.</p>
-  <div class="case-foot">patient_rcc_imdc_int_nivo_ipi.json</div>
-</a>
-<a class="case-card" href="/cases/rcc-imdc-fav-axi-pembro.html"
-   data-default-order="559"
-   data-name="RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>RCC · IMDC favorable 1L · Axi+pembro (KEYNOTE-426)</h3>
-  <p>Clear-cell RCC IMDC favorable. Engine: → IND-RCC-METASTATIC-1L-PEMBRO-AXI (KEYNOTE-426 5-yr OS).</p>
-  <div class="case-foot">patient_rcc_imdc_fav_axi_pembro.json</div>
-</a>
-<a class="case-card" href="/cases/urothelial-muc-ev-pembro.html"
-   data-default-order="560"
-   data-name="Urothelial · mUC 1L · EV+pembro (EV-302)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Urothelial · mUC 1L · EV+pembro (EV-302)</h3>
-  <p>Метастатична мUC. Drift: free-text condition unevaluable; engine default = platinum+avelumab; EV-302 анкер у comment.</p>
-  <div class="case-foot">patient_urothelial_muc_ev_pembro.json</div>
-</a>
-<a class="case-card" href="/cases/endometrial-dmmr-pembro-kn775.html"
-   data-default-order="561"
-   data-name="Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Endometrial · advanced dMMR · Pembro+chemo (NRG-GY018)</h3>
-  <p>Advanced/recurrent dMMR endometrial. Engine: → IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO (NRG-GY018 mPFS NR vs 7.6).</p>
-  <div class="case-foot">patient_endometrial_dmmr_pembro_kn775.json</div>
-</a>
-<a class="case-card" href="/cases/endometrial-p53-abn-dosta-ruby.html"
-   data-default-order="562"
-   data-name="Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Endometrial · p53-abnormal · Carbo+pacli+dostarlimab (RUBY)</h3>
-  <p>Advanced p53-abnormal endometrial. Drift: engine default = pembro+chemo; RUBY dostarlimab анкер у comment.</p>
-  <div class="case-foot">patient_endometrial_p53_abn_dosta_kn775.json</div>
-</a>
-<a class="case-card" href="/cases/ovarian-hrd-neg-no-parpi.html"
-   data-default-order="563"
-   data-name="Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Ovarian · HRD-neg · Carbo+pacli, no PARPi maintenance</h3>
-  <p>HRD-negative ovarian (контраст до patient_ovarian_advanced_hrd). Engine: → IND-OVARIAN-ADVANCED-1L-CARBO-PACLI-HRD-NEG.</p>
-  <div class="case-foot">patient_ovarian_hrd_neg_carbo_pacli_no_parpi.json</div>
-</a>
-<a class="case-card" href="/cases/hcc-atezo-bev-imbrave150.html"
-   data-default-order="564"
-   data-name="HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>HCC · Child-Pugh A 1L · Atezo+bev (IMbrave150)</h3>
-  <p>HCC Child-Pugh A, fit. Engine: → IND-HCC-SYSTEMIC-1L-ATEZO-BEV (IMbrave150 mOS 19.2 мо).</p>
-  <div class="case-foot">patient_hcc_atezo_bev_imbrave150.json</div>
-</a>
-<a class="case-card" href="/cases/hcc-durva-treme-stride.html"
-   data-default-order="565"
-   data-name="HCC · 1L · Durva+treme (HIMALAYA STRIDE)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>HCC · 1L · Durva+treme (HIMALAYA STRIDE)</h3>
-  <p>HCC з high-risk varices. Engine: RF-HCC-VARICEAL-BLEED step 1 → IND-HCC-SYSTEMIC-1L-DURVA-TREME (HIMALAYA mOS 16.4 мо).</p>
-  <div class="case-foot">patient_hcc_durva_treme_stride.json</div>
-</a>
-<a class="case-card" href="/cases/gastric-her2-pos-toga.html"
-   data-default-order="566"
-   data-name="Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Gastric · met HER2+ 1L · Trastuzumab+chemo (TOGA)</h3>
-  <p>Метастатична HER2+ gastric. Engine: RF-HIGH-RISK-BIOLOGY → IND-GASTRIC-METASTATIC-1L-HER2-TOGA (TOGA mOS 13.8 мо).</p>
-  <div class="case-foot">patient_gastric_her2_pos_toga.json</div>
-</a>
-<a class="case-card" href="/cases/gastric-pdl1-cps-chemo-nivo.html"
-   data-default-order="567"
-   data-name="Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Gastric · met CPS≥5 1L · Chemo+nivolumab (CheckMate-649)</h3>
-  <p>Метастатична HER2- CPS≥5 gastric. Engine: HER2- step 2 → IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI (CM-649 mOS 14.4 мо).</p>
-  <div class="case-foot">patient_gastric_pdl1_cps_high_chemo_nivo.json</div>
-</a>
-<a class="case-card" href="/cases/esophageal-cross-then-nivo.html"
-   data-default-order="568"
-   data-name="Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>Esophageal · adeno · Neoadj CROSS → adjuvant nivolumab (CheckMate-577)</h3>
-  <p>Resectable adeno з ypT+/ypN+ residual. Drift: ALGO-1L emit only CROSS-NEOADJUVANT; CheckMate-577 adjuvant nivo неreachable (PROPOSAL §17 territory).</p>
-  <div class="case-foot">patient_esophageal_adeno_neoadj_cross_then_nivo.json</div>
-</a>
-<a class="case-card" href="/cases/pdac-folfirinox-fit.html"
-   data-default-order="569"
-   data-name="PDAC · met fit · FOLFIRINOX (PRODIGE-4)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>PDAC · met fit · FOLFIRINOX (PRODIGE-4)</h3>
-  <p>Fit метастатична PDAC. Drift: ALGO step 3 condition free-text; engine default = gem-nab-pac; FOLFIRINOX як alternative track.</p>
-  <div class="case-foot">patient_pdac_metastatic_folfirinox_fit.json</div>
-</a>
-<a class="case-card" href="/cases/sclc-ls-chemo-rt.html"
-   data-default-order="570"
-   data-name="SCLC · LS · Chemo + concurrent RT">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>SCLC · LS · Chemo + concurrent RT</h3>
-  <p>Limited-stage SCLC. RT не modellable per CHARTER §17 — engine emit chemo backbone EP, RT як free-text. Drift: engine default = ES-1L.</p>
-  <div class="case-foot">patient_sclc_ls_chemo_rt.json</div>
-</a>
-<a class="case-card" href="/cases/sclc-es-atezo-impower133.html"
-   data-default-order="571"
-   data-name="SCLC · ES · Atezo+carbo+etoposide (IMpower133)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>SCLC · ES · Atezo+carbo+etoposide (IMpower133)</h3>
-  <p>Extensive-stage SCLC. Engine: → IND-SCLC-EXTENSIVE-1L. Drift: дефолт REG-EP-DURVA не IMpower133 атезо; атезо regimen не wired.</p>
-  <div class="case-foot">patient_sclc_es_atezo_chemo_impower133.json</div>
-</a>
-<a class="case-card" href="/cases/hnscc-cps-high-pembro-mono.html"
-   data-default-order="572"
-   data-name="HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>HNSCC · R/M CPS≥1 1L · Pembro mono (KEYNOTE-048)</h3>
-  <p>R/M HNSCC CPS≥20. Engine: → IND-HNSCC-RM-1L-PEMBRO-MONO-CPS-HIGH (KEYNOTE-048 mOS 14.9 мо).</p>
-  <div class="case-foot">patient_hnscc_cps_high_pembro_mono.json</div>
-</a>
-<a class="case-card" href="/cases/hnscc-extreme-cetux-platin.html"
-   data-default-order="573"
-   data-name="HNSCC · R/M EXTREME · Cetux+platin+5FU">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>HNSCC · R/M EXTREME · Cetux+platin+5FU</h3>
-  <p>Drift: IND-HNSCC-RM-1L-EXTREME не authored у KB; engine fallback = pembro+chemo. EXTREME анкер у comment, highest content gap.</p>
-  <div class="case-foot">patient_hnscc_extreme_cetux_platin_5fu.json</div>
-</a>
-<a class="case-card" href="/cases/aml-cbf-inv16-7-3-go.html"
-   data-default-order="575"
-   data-name="AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>AML · CBF inv(16) · 7+3 + Gemtuzumab (ALFA-0701)</h3>
-  <p>Fit CBF AML. Drift: 7+3+GO indication відсутня; engine default = 7+3 plain; ALFA-0701 анкер у comment.</p>
-  <div class="case-foot">patient_aml_cbf_inv16_7_3_go.json</div>
-</a>
-<a class="case-card" href="/cases/aml-secondary-cpx351.html"
-   data-default-order="576"
-   data-name="AML · secondary/t-AML · CPX-351 (Vyxeos)">
-  <div class="case-badge-row">
-    <div class="case-badge bdg-plan">Treatment Plan</div>
-    <span class="case-json-only" title="Опитувальник для цієї хвороби ще не готовий — на Try-it відкриється як JSON">JSON-only</span>
-  </div>
-  <h3>AML · secondary/t-AML · CPX-351 (Vyxeos)</h3>
-  <p>Secondary AML post-MDS. Drift: CPX-351 indication відсутня у ALGO-1L; engine default = 7+3; Vyxeos анкер у comment.</p>
-  <div class="case-foot">patient_aml_secondary_cpx351.json</div>
+  <h3>Suspect Lymphoma · Pre-Biopsy (Diagnostic Brief)</h3>
+  <p>Pre-biopsy режим — engine генерує Workup Brief, не Treatment Plan (CHARTER §15.2 C7 — без histology немає лікування).</p>
+  <div class="case-foot">patient_diagnostic_lymphoma_suspect.json</div>
 </a>
 <a class="case-card" href="/cases/diagnostic-breast-lump-prebiopsy.html"
    data-default-order="583"
@@ -6864,7 +7161,7 @@
 </style>
 <div class="oo-widget" data-component="openonco-stats">
 <h2>OpenOnco — стан бази знань</h2>
-<div class="oo-sub">Зріз станом на 2026-04-30 17:20 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
+<div class="oo-sub">Зріз станом на 2026-04-30 19:26 UTC · видно і обсяг, і обмеження — поки покриваємо лише декілька хвороб.</div>
 <div class="oo-grid">
 <div class="oo-card"><div class="oo-num">65</div><div class="oo-lbl">Хвороби</div></div>
 <div class="oo-card"><div class="oo-num">312</div><div class="oo-lbl">Показання</div></div>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1288,20 +1288,41 @@ def _gallery_case_disease_meta() -> list[dict]:
     """For each CaseEntry, derive (disease_id, disease label UA/EN, ICD)
     by loading its example JSON. Cases whose JSON is missing or carries
     no recognised disease land in a synthetic 'OTHER' bucket so the UI
-    still surfaces them."""
+    still surfaces them.
+
+    Resolution order:
+      1. `disease.id` — direct DIS-* lookup against KB name map. Catches
+         all `auto_*.json` and `variant_*.json` stubs that carry only
+         `disease: {id: "DIS-X"}` without ICD-O-3 morphology. Without
+         this fallback, ~half of all KB diseases collapse into OTHER
+         because their auto-generated examples don't set ICD codes.
+      2. `disease.icd_o_3_morphology` via the ICD→DIS map (kept for
+         curated cases whose JSON sometimes carries only ICD).
+      3. OTHER bucket if neither resolves.
+    """
     icd_map = _icd_to_disease_id_map()
     name_map = _load_disease_name_map()
     out: list[dict] = []
     for c in CASES:
         p = EXAMPLES / c.file
+        did: str | None = None
         icd = None
         if p.exists():
             try:
                 ex = json.loads(p.read_text(encoding="utf-8"))
-                icd = ((ex or {}).get("disease") or {}).get("icd_o_3_morphology")
+                disease_block = (ex or {}).get("disease") or {}
+                # Step 1: direct disease.id lookup
+                raw_id = disease_block.get("id")
+                if isinstance(raw_id, str) and raw_id.upper().startswith("DIS-"):
+                    candidate = raw_id.upper()
+                    if candidate in name_map:
+                        did = candidate
+                # Step 2: ICD fallback
+                icd = disease_block.get("icd_o_3_morphology")
+                if did is None and icd:
+                    did = icd_map.get(str(icd))
             except Exception:
-                icd = None
-        did = icd_map.get(str(icd)) if icd else None
+                pass
         if did:
             names = name_map.get(did, {"ua": did, "en": did})
             out.append({


### PR DESCRIPTION
## Problem

Gallery search at \`/gallery.html\` showed only **33 disease tiles** despite the KB having **65 diseases** and 586 example cases. User noticed this mismatch.

## Root cause

\`scripts/build_site.py::_gallery_case_disease_meta\` grouped CaseEntries by \`disease.icd_o_3_morphology\` (ICD-O-3 code) only:

\`\`\`python
icd = ((ex or {}).get("disease") or {}).get("icd_o_3_morphology")
did = icd_map.get(str(icd)) if icd else None
\`\`\`

But all 65 \`auto_*.json\` stubs (one per disease — the very files that ensure every KB disease shows up) carry only \`disease: {id: "DIS-X"}\` with NO \`icd_o_3_morphology\`. Same for most of PR #143's 362 \`variant_*.json\` files.

Result: ~half of the KB diseases collapsed into the synthetic "OTHER" bucket because their auto-generated examples don't set ICD codes. Only 32 diseases whose curated patient JSONs happened to set ICD made it onto the tile grid.

## Fix

In \`_gallery_case_disease_meta\`, look up \`disease.id\` directly against the KB disease-name-map FIRST, then fall back to ICD lookup:

\`\`\`python
# Step 1: direct disease.id lookup
raw_id = disease_block.get("id")
if isinstance(raw_id, str) and raw_id.upper().startswith("DIS-"):
    candidate = raw_id.upper()
    if candidate in name_map:
        did = candidate
# Step 2: ICD fallback
icd = disease_block.get("icd_o_3_morphology")
if did is None and icd:
    did = icd_map.get(str(icd))
\`\`\`

Resolution order documented in docstring.

## Verified

- **Tile count: 33 → 66** (65 KB diseases + 1 OTHER bucket)
- OTHER bucket shrunk from ~half of cases to **4 cases** with neither \`disease.id\` nor recognized ICD (genuine edge cases — possibly old patient_zero_* fixtures)
- \`scripts.build_site\` runs cleanly
- Regenerated \`docs/gallery.html\` (UA) + \`docs/en/gallery.html\` (EN) committed in PR; other regenerated \`docs/cases/*.html\` files (which only differ by timestamp) intentionally NOT committed to keep PR focused

## No KB / engine / schema changes

Pure build-site grouping bug fix.

## Test plan

- [x] \`python -m scripts.build_site\` runs cleanly
- [x] \`grep -c 'class="disease-tile"' docs/gallery.html\` → 66 (was 33)
- [x] All 65 KB DIS-* IDs appear as data-disease-id values
- [ ] Reviewer eyeballs gallery UI to confirm all diseases now searchable

🤖 Generated with [Claude Code](https://claude.com/claude-code)