### PR TITLE
chore(sources): ESMO URL refresh batch (25 sources, post-restructure 2026-04-27)

### DIFF
--- a/knowledge_base/hosted/content/sources/src_esmo_breast_early_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_breast_early_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-BREAST
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Surgical + neoadjuvant + adjuvant strategy for stage I-III breast
   cancer. AJCC 8th prognostic stage, gene-expression-profile use

--- a/knowledge_base/hosted/content/sources/src_esmo_breast_metastatic_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_breast_metastatic_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-BREAST
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Subtype-specific metastatic strategies. HR+/HER2-: AI/SERD + CDK4/6i
   (PALOMA, MONALEESA, MONARCH); SERD second-line (EMERALD elacestrant

--- a/knowledge_base/hosted/content/sources/src_esmo_burkitt_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_burkitt_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-BURKITT
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for Burkitt lymphoma 1L and R/R.
   Codifies CALGB/CODOX-M-IVAC and DA-EPOCH-R intensity stratification,

--- a/knowledge_base/hosted/content/sources/src_esmo_cervical_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_cervical_2024.yaml
@@ -27,7 +27,7 @@ legal_review:
   status: pending
 relates_to_diseases:
 - DIS-CERVICAL
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: European cervical. CRT for IB3-IVA, KEYNOTE-826 for metastatic.
 pages_count: 22
 references_count: 160

--- a/knowledge_base/hosted/content/sources/src_esmo_cll_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_cll_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-CLL
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for CLL. Codifies high-risk genetics
   (TP53 mutation, del(17p), unmutated IGHV, complex karyotype) →

--- a/knowledge_base/hosted/content/sources/src_esmo_colon_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_colon_2024.yaml
@@ -19,7 +19,7 @@ modifications_allowed: false
 sharealike_required: false
 legal_review: {status: pending}
 relates_to_diseases: [DIS-CRC]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: 'European CRC primary guideline.'
 pages_count: 32
 references_count: 220

--- a/knowledge_base/hosted/content/sources/src_esmo_ctcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_ctcl_2024.yaml
@@ -6,7 +6,7 @@ authors:
   - ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
-url: https://www.esmo.org/guidelines/esmo-clinical-practice-guidelines-haematological-malignancies
+url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-primary-cutaneous-lymphomas
 access_level: open_access
 currency_status: current
 superseded_by: null
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-MF-SEZARY
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for cutaneous T-cell lymphomas (Mycosis
   Fungoides / Sézary Syndrome). Codifies ISCL/EORTC TNMB staging (B0/B1/B2
@@ -51,13 +51,13 @@ notes: >
   (>25% large cells in biopsy, often CD30+), skin-directed therapy for
   early stage IA/IB/IIA, systemic therapy escalation for stage IIB+ /
   Sézary B2 disease.
-  URL refresh 2026-04-27: ESMO retired the dedicated primary-cutaneous-
-  lymphomas page during the guidelines-by-topic → living-guidelines
-  restructure; the underlying source guideline (Willemze 2018, Ann Oncol
-  29(Suppl 4):iv30-iv40) has not yet been migrated to a living-guideline
-  node. URL temporarily points to the haematological-malignancies CPG
-  master index. Replace with dedicated CTCL/PCL living-guideline page
-  when ESMO authors one (escalated to next clinical-content review).
+  URL refresh 2026-04-30: re-pointed to the dedicated ESMO primary
+  cutaneous lymphomas CPG node
+  (esmo-clinical-practice-guideline-primary-cutaneous-lymphomas, HTTP 200
+  verified 2026-04-30) after the prior haematological-malignancies hub
+  fallback put in place at 2026-04-27 during the guidelines-by-topic →
+  living-guidelines restructure. Underlying guideline document is still
+  Willemze 2018, Ann Oncol 29(Suppl 4):iv30-iv40.
 pages_count: 22
 references_count: 175
 corpus_role: primary_guideline

--- a/knowledge_base/hosted/content/sources/src_esmo_dlbcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_dlbcl_2024.yaml
@@ -45,7 +45,7 @@ relates_to_diseases:
   - DIS-DLBCL-NOS
   - DIS-PMBCL
   - DIS-HGBL-DH
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for DLBCL NOS first-line and relapsed/refractory
   treatment. Codifies R-CHOP × 6 as standard 1L; Pola-R-CHP for IPI ≥3 (POLARIX);

--- a/knowledge_base/hosted/content/sources/src_esmo_endometrial_2022.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_endometrial_2022.yaml
@@ -27,7 +27,7 @@ sharealike_required: false
 known_restrictions: ['Quote-paraphrase model']
 legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
 relates_to_diseases: [DIS-ENDOMETRIAL]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary guideline (2022 ESMO-ESGO-ESTRO consensus).
   Freshness check 2026-04-27: superseded by ESGO-ESTRO-ESP 2025 update

--- a/knowledge_base/hosted/content/sources/src_esmo_esophageal_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_esophageal_2024.yaml
@@ -19,7 +19,7 @@ modifications_allowed: false
 sharealike_required: false
 legal_review: {status: pending}
 relates_to_diseases: [DIS-ESOPHAGEAL]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: 'Histology-tailored. FLOT for adeno, CROSS for both.'
 pages_count: 28
 references_count: 180

--- a/knowledge_base/hosted/content/sources/src_esmo_fl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_fl_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-FL
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for follicular lymphoma. Codifies
   watch-and-wait for asymptomatic low-tumor-burden disease, GELF-criteria

--- a/knowledge_base/hosted/content/sources/src_esmo_gastric_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_gastric_2024.yaml
@@ -19,7 +19,7 @@ modifications_allowed: false
 sharealike_required: false
 legal_review: {status: pending}
 relates_to_diseases: [DIS-GASTRIC, DIS-ESOPHAGEAL]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: 'FLOT periop emphasis.'
 pages_count: 30
 references_count: 195

--- a/knowledge_base/hosted/content/sources/src_esmo_hodgkin_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_hodgkin_2024.yaml
@@ -44,7 +44,7 @@ legal_review:
 relates_to_diseases:
   - DIS-CHL
   - DIS-NLPBL
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for classical and nodular-lymphocyte-
   predominant Hodgkin lymphoma. Codifies ABVD vs escBEACOPP / BV-AVD

--- a/knowledge_base/hosted/content/sources/src_esmo_mcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_mcl_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-MCL
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for MCL. Codifies high-risk biology
   flags (TP53 mutation, del(17p), Ki-67 >30%, blastoid/pleomorphic

--- a/knowledge_base/hosted/content/sources/src_esmo_melanoma_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_melanoma_2024.yaml
@@ -27,7 +27,7 @@ sharealike_required: false
 known_restrictions: ['Quote-paraphrase model']
 legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
 relates_to_diseases: [DIS-MELANOMA]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: "Primary guideline."
 pages_count: 200
 references_count: 500

--- a/knowledge_base/hosted/content/sources/src_esmo_mm_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_mm_2023.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-MZL-2024 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-MM
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for multiple myeloma. Codifies
   R-ISS / R2-ISS staging, FISH risk stratification (t(4;14), t(14;16),

--- a/knowledge_base/hosted/content/sources/src_esmo_mzl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_mzl_2024.yaml
@@ -44,7 +44,7 @@ legal_review:
   notes: Verify 'derivative work' interpretation for rule engine use
 relates_to_diseases:
 - DIS-HCV-MZL
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: 'Primary international guideline for MZL, including HCV-associated subset. References antiviral-first
   (DAA) strategy for HCV-positive patients; chemoimmunotherapy reserved for non-response / aggressive
   phenotype.

--- a/knowledge_base/hosted/content/sources/src_esmo_nsclc_early_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_nsclc_early_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-NCCN-PROSTATE-2025 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-NSCLC
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Resectable I-II + locally-advanced III. Adjuvant osimertinib (ADAURA) for EGFR-mut stage IB-IIIA resected. Atezolizumab adjuvant (IMpower010) for PD-L1≥1% stage II-IIIA resected. PACIFIC durvalumab consolidation post-CRT for stage III unresectable. Neoadjuvant chemo+ICI (CheckMate-816 nivolumab+chemo) for resectable stage II-IIIA.
 pages_count: 250

--- a/knowledge_base/hosted/content/sources/src_esmo_nsclc_metastatic_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_nsclc_metastatic_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-NCCN-PROSTATE-2025 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-NSCLC
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Driver-mutation hierarchy + 1L sequencing for metastatic NSCLC. Detailed osimertinib first-line (FLAURA + FLAURA2 osi+chemo combination), alectinib first-line ALK (ALEX), KRAS G12C 2L+ (CodeBreaK 100/200), BRAF V600E doublet (dabrafenib + trametinib), MET ex14 (capmatinib + tepotinib), RET (selpercatinib), NTRK (larotrectinib + entrectinib), HER2-mut T-DXd (DESTINY-Lung01/02). Driver-negative: pembrolizumab mono PD-L1≥50% (KEYNOTE-024), pembro+chemo PD-L1<50% (KEYNOTE-189/407), atezolizumab combinations.
 pages_count: 250

--- a/knowledge_base/hosted/content/sources/src_esmo_ovarian_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_ovarian_2024.yaml
@@ -19,7 +19,7 @@ modifications_allowed: false
 sharealike_required: false
 legal_review: {status: pending}
 relates_to_diseases: [DIS-OVARIAN]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: 'European primary ovarian. Cytoreductive surgery + carbo-pacli + bev + PARPi maintenance per HRD.'
 pages_count: 28
 references_count: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_pancreatic_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_pancreatic_2024.yaml
@@ -19,7 +19,7 @@ modifications_allowed: false
 sharealike_required: false
 legal_review: {status: pending}
 relates_to_diseases: [DIS-PDAC]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: 'PDAC; mFOLFIRINOX adjuvant + 1L metastatic.'
 pages_count: 26
 references_count: 175

--- a/knowledge_base/hosted/content/sources/src_esmo_prostate_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_prostate_2024.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-PROSTATE
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for prostate cancer. Detailed mHSPC
   stratification (CHAARTED + LATITUDE), mCRPC sequencing, biomarker-driven

--- a/knowledge_base/hosted/content/sources/src_esmo_ptcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_ptcl_2024.yaml
@@ -49,7 +49,7 @@ relates_to_diseases:
   - DIS-HSTCL
   - DIS-T-PLL
   - DIS-MF-SEZARY
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Primary international guideline for PTCL subtypes 1L and R/R. Codifies
   CHOP/CHOEP standards, ECHELON-2 brentuximab + CHP for CD30+ disease,

--- a/knowledge_base/hosted/content/sources/src_esmo_rcc_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_rcc_2024.yaml
@@ -27,7 +27,7 @@ sharealike_required: false
 known_restrictions: ['Quote-paraphrase model']
 legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
 relates_to_diseases: [DIS-RCC]
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: "Primary guideline."
 pages_count: 200
 references_count: 500

--- a/knowledge_base/hosted/content/sources/src_esmo_sclc_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_sclc_2021.yaml
@@ -43,7 +43,7 @@ legal_review:
   notes: Same posture as SRC-NCCN-PROSTATE-2025 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
   - DIS-SCLC
-last_verified: '2026-04-27'
+last_verified: '2026-04-30'
 notes: >
   Pre-IMpower133 / CASPIAN baseline. Updated supplementary recommendations integrate ICI combinations for extensive-stage.
   Freshness check 2026-04-27: ESMO has not published a SCLC guideline

--- a/knowledge_base/hosted/content/sources/src_esmo_wm_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_wm_2024.yaml
@@ -44,6 +44,7 @@ legal_review:
 relates_to_diseases:
   - DIS-WM
 last_verified: '2026-04-27'
+url_status: broken_publisher_restructured_2026-04-27
 notes: >
   Primary international guideline for Waldenström Macroglobulinaemia.
   Codifies hyperviscosity-syndrome management (urgent plasmapheresis +
@@ -57,6 +58,12 @@ notes: >
   temporarily points to the haematological-malignancies CPG master
   index. Replace with dedicated WM living-guideline page when ESMO
   authors one (escalated to next clinical-content review).
+  URL refresh check 2026-04-30: tried disease-specific candidates
+  (living-guidelines/.../waldenstrom-macroglobulinaemia-wm,
+  esmo-clinical-practice-guideline-waldenstrom-macroglobulinaemia, plus
+  spelling variants) — all returned HTTP 404. Hub-page fallback kept;
+  URL needs manual replacement after ESMO 2024 restructure (audit
+  2026-04-27).
 pages_count: 18
 references_count: 130
 corpus_role: primary_guideline


### PR DESCRIPTION
## Summary

Follow-up to `docs/plans/source_freshness_audit_2026-04-27.md` §3 + §6
recommendation #1 — *ESMO URL refresh batch*. The §3 audit flagged 25
ESMO sources whose URL pattern (`guidelines/guidelines-by-topic/<area>/<disease>`)
returned site-wide 404 after ESMO's namespace restructure.

HEAD-checked each source's *current* YAML URL (most had already migrated
to candidate replacements between the audit and this batch); bumped
`last_verified` only on the ones that resolve cleanly to a
disease-specific page. Cross-checked HTTP-200 vs HTTP-404 with bogus
slugs in the same prefix to control for ESMO's JS-rendered SPA.

## Outcomes

- **24 sources** with HTTP 200 on disease-specific URL → `last_verified`
  bumped 2026-04-27 → 2026-04-30. Includes Burkitt, whose URL points at
  the master Lymphomas CPG hub by prior intentional fallback (the YAML
  notes already document why).
- **1 source — CTCL** (SRC-ESMO-CTCL-2024): hub-fallback URL replaced
  with the dedicated
  `/esmo-clinical-practice-guideline-primary-cutaneous-lymphomas` page
  (HTTP 200 verified). Notes refreshed; `last_verified` bumped.
- **1 source — WM** (SRC-ESMO-WM-2024): no disease-specific URL found
  (tried `living-guidelines/.../waldenstrom-macroglobulinaemia-wm`,
  `esmo-clinical-practice-guideline-waldenstrom-macroglobulinaemia`,
  plus spelling variants — all HTTP 404). Hub-page fallback kept; added
  `url_status: broken_publisher_restructured_2026-04-27`; `last_verified`
  left at 2026-04-27. Awaits manual replacement when ESMO publishes a
  dedicated WM living-guideline node.

## Scope guardrails

No clinical content, citations, names, summaries, schemas, or any
non-URL-related fields touched. Only `url`, `last_verified`,
`url_status`, and (for CTCL/WM) the `notes` block — exactly what the
brief authorized.

## Test plan

- [x] KB validator green: `PYTHONIOENCODING=utf-8 C:/Python312/python.exe -m knowledge_base.validation.loader knowledge_base/hosted/content` → `OK — all entities valid, all references resolve.` (2471 entities, 0 errors)
- [x] Sources/loader pytest spot-check: `py -3.12 -m pytest tests/test_base_source_client.py tests/test_loader.py tests/test_loader_cache.py tests/test_source_ref_integrity.py -q` → 35 passed
- [x] Pre-commit hooks ran clean (no `--no-verify`)
- [ ] Reviewer: confirm WM hub-fallback handling acceptable until ESMO authors a dedicated page

🤖 Generated with [Claude Code](https://claude.com/claude-code)