### PR TITLE
perf(tests): cache RedFlag/Algorithm YAML loads — full suite 19:01 → 7:37 (60% faster)

### DIFF
--- a/tests/test_redflag_fixtures.py
+++ b/tests/test_redflag_fixtures.py
@@ -20,6 +20,7 @@ This module covers two layers:
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 
 import pytest
@@ -36,10 +37,19 @@ KB_ROOT = REPO_ROOT / "knowledge_base" / "hosted" / "content"
 FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "redflags"
 
 
+# NOTE: Caches below shave ~14 minutes off the full pytest suite.
+# `test_redflag_fixture` is parametrized over ~864 fixture YAMLs and was
+# rebuilding the entire RedFlag map (rglob + yaml.safe_load over ~500
+# files) on EVERY invocation. With lru_cache, the walk happens once per
+# pytest session. KB YAMLs are immutable during a test session, so the
+# cache is safe.
+
+@functools.lru_cache(maxsize=4096)
 def _load_yaml(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
+@functools.lru_cache(maxsize=1)
 def _load_redflags() -> dict[str, dict]:
     """All RedFlag YAMLs, keyed by id."""
     rfs: dict[str, dict] = {}
@@ -51,6 +61,7 @@ def _load_redflags() -> dict[str, dict]:
     return rfs
 
 
+@functools.lru_cache(maxsize=1)
 def _load_algorithms() -> dict[str, dict]:
     algs: dict[str, dict] = {}
     for p in sorted((KB_ROOT / "algorithms").glob("*.yaml")):


### PR DESCRIPTION
## Summary

Wraps three module-level helpers in \`tests/test_redflag_fixtures.py\` with \`functools.lru_cache\`:

- \`_load_yaml(path)\` — maxsize=4096
- \`_load_redflags()\` — maxsize=1
- \`_load_algorithms()\` — maxsize=1

## Root cause

\`test_redflag_fixture\` is parametrized over 864 RedFlag golden fixtures. Each invocation called \`_load_redflags()\` inside the test body, which rglobbed and \`yaml.safe_load\`'ed every RedFlag YAML in the KB (~500 files).

Profile per file:
- Before: 864 tests × ~500 YAMLs × ~1ms = ~432K file-reads = **900.53s**
- After: one walk + parse on first call, cache hit thereafter = **11.32s**
- File-level speedup: **80×**

KB YAMLs are immutable during a test session, so the cache is safe.

## Full-suite measured impact

| | Before | After | Δ |
|---|---|---|---|
| Wall time | 1141.21s (19:01) | 457.41s (7:37) | **−683.80s (−11:24, −60%)** |
| Tests passed | 2027 | 2027 | unchanged |
| Tests skipped | 8 | 8 | unchanged |
| Pre-existing failures | 2 | 2 | unchanged |

The 2 pre-existing failures (\`test_no_orphan_red_flag_decl\`, \`test_all_drugs_have_last_verified_2026_04_27\`) are unrelated to this change — they're stale-baseline issues flagged by W5b agents earlier in the day.

## Scope

\`tests/\` only. No production code touched. No KB edits. No engine changes. 11-line diff.

## Test plan

- [x] \`pytest tests/test_redflag_fixtures.py -q\` → 11.32s (was 900.53s)
- [x] \`pytest tests/ -q\` → 7:37 (was 19:01); same 2027 passed + 8 skipped + 2 pre-existing failures
- [ ] Reviewer eyeballs cache correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)