### PR TITLE
docs(plans): Tier-2 dispatch (PR #179 squash-bug recovery)

### DIFF
--- a/docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md
+++ b/docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md
@@ -1,0 +1,385 @@
+# Tier-2 expansion roadmap (W7–W13) — 2026-05-01-1100
+
+**Status:** active planning track. Sequel to `docs/plans/biomarker_expansion_roadmap_2026-04-30-1500.md` (Tier-1 W1–W6, landed via PR #166 commit `b5810f4b` and W5b/W5c via PR #171).
+**Driver:** Tier-1 closed the immediate-impact biomarker gaps. Tier-2 covers the second wave — emerging-targeted-therapy biomarkers, bispecific/CAR-T expansion, drug-class line additions, and the long tail of Q-axis quality work (CIViC backfill wave-2, source recency wave-2). Drug UA-NSZU axis is **complete** (220/220) and SKIPPED here.
+**Excluded scope:** LymphGen DLBCL classifier (`docs/plans/lymphgen_dlbcl_proposal_2026-04-30-1500.md` still deferred — trigger conditions unchanged); Tier-3 niche entities (W13 — enumerated but post-v1.0); engine refactors (none required).
+**Related docs:** `docs/plans/kb_data_quality_plan_2026-04-29.md` (Q1–Q5 quality gates each chunk must satisfy), `docs/plans/curated_examples_expansion_2026-04-29-0313.md` (chunk-fleet pattern reference), `docs/kb-coverage-matrix.md` (matrix the chunks move).
+
+## Why this exists
+
+Tier-1 (12 biomarkers) routed FDA-approved targeted therapies that the engine could not previously reach. Tier-2 (28 biomarkers + 21 drugs + ~50 regimens + ~50 indications + ~25 RFs) is **second-wave coverage**: drugs approved in 2023–2025 that the v0.1 KB does not yet wire (heme bispecifics, CAR-T expansion across diseases, breast/NSCLC ADC second-wave, gyn ADC, gastric/CRC/cholangio targeted-therapy expansion). It also closes two Q-axes that did not finish in the first 100-chunk batch:
+
+- **Q1 BMA-CIViC:** 295/399 BMAs have an `evidence_sources[SRC-CIVIC]` block or `no_civic_match_reason`. **104 outstanding** — wave-2 targets these.
+- **Q2 source recency:** 269/271 sources are stale by `current_as_of` (older than 2026-04-01) or are missing the field entirely. The orchestrator's "131 stale" prioritization is honored: this roadmap selects the 131 oldest (missing-field first, then ascending date) for wave-2.
+- **Q3 drug UA-NSZU access:** **complete (220/220)** — no Tier-2 chunks needed.
+
+Tier-2 turns these gaps into concrete chunks with allowlists, validation gates, and explicit stop conditions, mirroring the Tier-1 pattern that landed cleanly.
+
+## Workstream summary
+
+| ID | Workstream | Cadence | KB-edits? | Chunks |
+|---|---|---|---|---|
+| W7 | Tier-2 biomarkers (28 entities) | this month | yes | 7 |
+| W8 | Tier-2 drugs (21 not-yet-in-KB entities) | this month | yes | 5 |
+| W9 | Tier-2 regimens (~50 across W8 drugs × line × disease) | this month | yes | 8 |
+| W10 | Tier-2 indications (~50, wiring W7 + W8 + W9) | this month | yes | 7 |
+| W11 | Tier-2 RFs (~25, gating W10 indications) | this month | yes | 4 |
+| W12a | BMA-CIViC backfill wave-2 (104 BMAs / 5 per chunk) | parallel | yes (sidecar) | 21 |
+| W12b | Source recency refresh wave-2 (131 sources / 5 per chunk) | parallel | yes (sidecar) | 27 |
+| W13 | Tier-3 niche entities (deferred, stubs only) | post-v1.0 | yes | 3 |
+| — | Dispatch tracker | — | no | 1 |
+
+**Total dispatchable issues:** ~83 (7 W7 + 5 W8 + 8 W9 + 7 W10 + 4 W11 + 21 W12a + 27 W12b + 3 W13 + 1 tracker = 83).
+
+## W7 — Tier-2 biomarkers (28 entities, 7 chunks)
+
+**Goal:** add 28 second-wave biomarkers grouped by therapeutic area. These are research-grade or recently-FDA-approved markers that the v0.1 KB can route to once Tier-2 drugs + indications land in W8/W10. Each chunk authors `bio_*.yaml` files with provenance + UA fields per Q1/Q3 quality gates.
+
+### W7a — Heme expression markers (6 bio)
+
+Chunk key: `tier2-bio-heme-2026-05-01`.
+
+- `bio_cd79b_mutation` (LymphGen MCD-relevant, distinct from existing `bio_cd79b_ihc`)
+- `bio_notch2_mutation` (LymphGen BN2-relevant)
+- `bio_cd22_expression` (quantitative — for inotuzumab eligibility)
+- `bio_cd33_expression` (quantitative — for gemtuzumab/CD33 ADC eligibility)
+- `bio_bcma_expression` (for teclistamab/elranatamab/CAR-T eligibility)
+- `bio_cd38_expression` (quantitative — for daratumumab/isatuximab line stratification)
+
+KB delta: 6 bio. No regimen/indication wiring in this chunk (W10 wires).
+
+### W7b — Hereditary panel split (5 bio)
+
+Chunk key: `tier2-bio-hereditary-2026-05-01`.
+
+- `bio_brca_somatic` (distinct from existing `bio_brca_germline`/`bio_brca1_brca2_germline` — affects PARPi tier per disease)
+- `bio_palb2_germline`
+- `bio_atm_chek2_cdk12_germline` (composite hereditary panel; or 3 separate entries — verify schema preference at chunk time)
+- `bio_cdh1_germline` (lobular breast / hereditary diffuse gastric)
+- `bio_lynch_panel_split` (MLH1 / MSH2 / MSH6 / PMS2 — author either as one composite biomarker entity with 4 alleles or 4 separate entries; chunk picks the cleaner option after reading existing Lynch coverage in `bio_msi_*` and `bio_dmmr_*`)
+
+KB delta: 5 bio entities (or up to 8 if Lynch authored allele-by-allele).
+
+### W7c — Prostate (3 bio)
+
+Chunk key: `tier2-bio-prostate-2026-05-01`.
+
+- `bio_ar_amplification` (distinct from existing AR-V7 splice variant; mCRPC ARSI-resistance complement)
+- `bio_tmprss2_erg_fusion` (prostate prognostic, not Tx-modifying)
+- `bio_dmmr_prostate` (small-population pembro eligibility — verify if existing `bio_dmmr_solid` already covers prostate; if so, this is an indication-wiring chunk only)
+
+KB delta: 3 bio (or 2 + indication delta).
+
+### W7d — Emerging targeted (6 bio)
+
+Chunk key: `tier2-bio-emerging-targeted-2026-05-01`.
+
+- `bio_nrg1_fusion` (zenocutuzumab pan-tumor, FDA Dec 2024)
+- `bio_braf_class_ii_iii` (non-V600, distinct drug strategy)
+- `bio_her2_ultralow` (DESTINY-Breast06; distinct from existing `bio_her2_low`)
+- `bio_esr1_y537s_d538g` (extension to existing `bio_esr1`; hot-spot allele granularity for elacestrant)
+- `bio_akt1_e17k` (extension to existing `bio_akt1`; capivasertib eligibility hot-spot)
+- `bio_cdkn2a_loss` (extension to existing `bio_cdkn2a`; co-deletion vs LOH variants)
+
+KB delta: 6 bio (or extensions to existing — chunk decides based on schema flexibility).
+
+### W7e — Melanoma + rare (4 bio)
+
+Chunk key: `tier2-bio-melanoma-rare-2026-05-01`.
+
+- `bio_nf1_mutation` (melanoma sub-classification)
+- `bio_bap1_mutation` (uveal melanoma + mesothelioma)
+- `bio_ctdna_mrd` (generic ctDNA-MRD; lineage-agnostic)
+- `bio_hrd_assay_distinction` (Myriad MyChoice CDx vs F1CDx — extend existing `bio_hrd_status` or new entity)
+
+KB delta: 4 bio.
+
+### W7f — PD-L1 IHC clones (4 bio)
+
+Chunk key: `tier2-bio-pdl1-clones-2026-05-01`.
+
+Currently `bio_pdl1_cps`, `bio_pdl1_tps`, `bio_pdl1_expression` exist. Add clone-specific entries because clinical literature ties specific drugs to specific clones (KEYNOTE used 22C3, IMpower used SP142, IMmotion used SP142, CheckMate used 28-8).
+
+- `bio_pdl1_22c3_clone` (Dako 22C3 — pembrolizumab indications)
+- `bio_pdl1_sp142_clone` (Ventana SP142 — atezolizumab TNBC, urothelial)
+- `bio_pdl1_sp263_clone` (Ventana SP263 — durvalumab)
+- `bio_pdl1_28_8_clone` (Dako 28-8 — nivolumab)
+
+KB delta: 4 bio. Wiring lives in W10.
+
+### W7 sequencing
+
+All seven chunks parallel. Worktree-isolated. Branch off `origin/master`. Integration agent **not** required: W10 indication chunks reference these IDs and will surface any naming-clash via validator failure.
+
+### W7 validation gates (each chunk)
+
+1. KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK — all entities valid". Entity counts ≥ baseline.
+2. pytest fixture: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed" (no regression).
+3. Per-chunk allowlist strictly enforced: `git diff --name-only origin/master | grep -v "^knowledge_base/hosted/content/biomarkers/"` should be empty.
+4. Each new biomarker has `actionability_lookup` if a single-variant target gene/variant; otherwise `oncokb_skip_reason`. Mutually exclusive — model_validator enforces.
+5. Each new biomarker has UA fields (`names.ukrainian`, `ukrainian_review_status: pending_clinical_signoff`, `ukrainian_drafted_by: claude_extraction`).
+6. Trial Source IDs cited in commit body if any new ones referenced; flag missing trial Sources as "to be authored" — do not invent.
+
+## W8 — Tier-2 drugs (21 not-yet-in-KB entities, 5 chunks)
+
+**Existence-check pre-flight (verified 2026-05-01):** of the 35 drugs in the original Tier-2 brief, 13 already exist in `knowledge_base/hosted/content/drugs/`:
+
+> avapritinib, blinatumomab, capivasertib, fruquintinib, inotuzumab_ozogamicin, mirvetuximab_soravtansine, mosunetuzumab, niraparib, quizartinib, repotrectinib, talazoparib, teclistamab, tisagenlecleucel.
+
+Tier-2 W8 therefore covers the **21 remaining**.
+
+### W8a — Heme bispecifics + CAR-T (6 drugs)
+
+Chunk key: `tier2-drug-heme-bispecific-cart-2026-05-01`.
+
+- `drug_elranatamab` (BCMA bispecific — MagnetisMM-3, FDA Aug 2023)
+- `drug_talquetamab` (GPRC5D bispecific — MonumenTAL-1, FDA Aug 2023)
+- `drug_idecabtagene_vicleucel` (ide-cel BCMA CAR-T — KarMMa, FDA Mar 2021)
+- `drug_ciltacabtagene_autoleucel` (cilta-cel BCMA CAR-T — CARTITUDE-1, FDA Feb 2022)
+- `drug_epcoritamab` (CD3xCD20 bispecific — EPCORE NHL-1, FDA May 2023)
+- `drug_glofitamab` (CD3xCD20 bispecific — NP30179, FDA Jun 2023)
+
+### W8b — Heme CAR-T continued (1 drug)
+
+Chunk key: `tier2-drug-heme-liso-cel-2026-05-01`.
+
+- `drug_lisocabtagene_maraleucel` (liso-cel CD19 CAR-T — TRANSCEND, FDA Feb 2021; CLL TRANSCEND-CLL Mar 2024)
+
+(Authored as separate small chunk because it's CD19-target across DLBCL+CLL+MCL; W11 RFs differ per disease.)
+
+### W8c — Breast + NSCLC emerging (5 drugs)
+
+Chunk key: `tier2-drug-breast-nsclc-emerging-2026-05-01`.
+
+- `drug_inavolisib` (PIK3CA-mut HR+ breast — INAVO120, FDA Oct 2024)
+- `drug_datopotamab_deruxtecan` (TROP2 ADC — TROPION-Breast01 / TROPION-Lung01)
+- `drug_zenocutuzumab` (NRG1-fusion bispecific — eNRGy, FDA Dec 2024)
+- `drug_patritumab_deruxtecan` (HER3 ADC — HERTHENA-Lung01)
+- `drug_ensartinib` (ALK TKI — eXalt3, FDA Dec 2024)
+
+### W8d — GI + GYN emerging (5 drugs)
+
+Chunk key: `tier2-drug-gi-gyn-emerging-2026-05-01`.
+
+- `drug_futibatinib` (FGFR2 TKI for cholangio — FOENIX-CCA2, FDA Sep 2022)
+- `drug_infigratinib` (FGFR2 TKI for cholangio — CBGJ398X2204, FDA May 2021; commercial status volatile — verify still marketed at chunk time)
+- `drug_magrolimab` (CD47 mAb — verify FDA approval status at chunk time; AML/MDS development was discontinued 2024 — chunk may drop and document)
+- `drug_tisotumab_vedotin` (TF ADC — innovaTV 204, FDA Sep 2021 cervical)
+- `drug_olutasidenib` (IDH1 R132 inhibitor — Study 2102-HEM-101, FDA Dec 2022 R/R AML)
+
+### W8e — Misc niche (4 drugs)
+
+Chunk key: `tier2-drug-misc-niche-2026-05-01`.
+
+- `drug_lurbinectedin` (RNAPII inhibitor — ATLANTIS, FDA Jun 2020 SCLC R/R)
+- `drug_ripretinib` (KIT/PDGFRA TKI — INVICTUS, FDA May 2020 GIST 4L+)
+- `drug_retifanlimab` (PD-1 mAb — POD1UM-202 anal SCC, FDA Mar 2023)
+- `drug_erdafitinib` (FGFR TKI — BLC2001/THOR, FDA Apr 2019; THOR Jan 2024 reaffirmation urothelial 2L)
+
+### W8 validation gates
+
+Same as W7 (validator + pytest + allowlist + UA fields). Plus drug-specific:
+
+- Each drug has `mechanism_of_action` UA-language field, `class`, `route`, `monitoring`, `nszu_status` (Q3 axis — defer to "unresolved" if not yet in NSZU registry rather than guessing).
+- Each drug cites at least one regulatory source (FDA label or EMA SmPC) and one pivotal-trial source.
+
+## W9 — Tier-2 regimens (~50, 8 chunks)
+
+**Goal:** every drug from W8 becomes 2–3 regimen YAMLs (per disease × line of therapy combination). Estimate 4–6 regimens per chunk.
+
+### W9 chunks
+
+| Chunk key | Drug class | Estimated regimens |
+|---|---|---|
+| `tier2-reg-mm-bispecific-2026-05-01` | teclistamab/elranatamab/talquetamab @ MM-RR (3L+, 4L+) | 6 |
+| `tier2-reg-mm-cart-2026-05-01` | ide-cel/cilta-cel @ MM-RR (3L+, 4L+) | 5 |
+| `tier2-reg-dlbcl-bispecific-cart-2026-05-01` | epcoritamab/glofitamab/liso-cel @ DLBCL (2L, 3L) | 6 |
+| `tier2-reg-breast-emerging-2026-05-01` | capivasertib/inavolisib/dato-DXd @ breast HR+ post-CDK4/6i; HER2+ post-T-DXd | 6 |
+| `tier2-reg-nsclc-emerging-2026-05-01` | dato-DXd-Lung/patritumab-DXd/repotrectinib/ensartinib | 6 |
+| `tier2-reg-gi-emerging-2026-05-01` | futibatinib/infigratinib (FGFR2 cholangio); fruquintinib (CRC-3L); erdafitinib (urothelial-2L) | 5 |
+| `tier2-reg-gyn-emerging-2026-05-01` | tisotumab-vedotin (cervical-2L); mirvetuximab (FRα ovarian-2L); retifanlimab (anal-1L) | 5 |
+| `tier2-reg-niche-2026-05-01` | lurbinectedin (SCLC-RR); ripretinib (GIST-4L); olutasidenib (AML-RR-IDH1); blinatumomab/inotuzumab (B-ALL adult) | 6 |
+
+KB delta per chunk: 4–6 `regimen_*.yaml` files. Each cites a pivotal-trial source.
+
+### W9 validation gates
+
+Same five quality gates plus:
+
+- Each regimen references existing drug IDs (W8 chunks must merge first or be on integration branch; orchestrator sequences W9 to start *after* W8 merges).
+- Each regimen has dosing (UA-language `description`), supportive-care notes (anti-emesis, GCSF), and CTCAE-toxicity profile.
+
+## W10 — Tier-2 indications (~50, 7 chunks)
+
+**Goal:** wire W7 biomarkers + W8 drugs + W9 regimens into the engine via `indication_*.yaml` files. Each indication = `(disease, line_of_therapy, biomarker_constraint, regimen_id)`.
+
+### W10 chunks
+
+| Chunk key | Disease area | Estimated indications |
+|---|---|---|
+| `tier2-ind-mm-2026-05-01` | MM 3L+/4L+ bispecifics + CAR-T | 6 |
+| `tier2-ind-dlbcl-mcl-cll-2026-05-01` | DLBCL 2L/3L+ bispecifics + CAR-T; MCL/CLL CAR-T | 8 |
+| `tier2-ind-breast-2026-05-01` | breast HR+ post-CDK4/6i (capivasertib/inavolisib); HER2+ post-T-DXd; TNBC/HR+ dato-DXd | 8 |
+| `tier2-ind-nsclc-2026-05-01` | NSCLC NRG1/HER3/TROP2/ALK-2L/ROS1/NTRK | 8 |
+| `tier2-ind-gi-2026-05-01` | cholangio FGFR2 (futibatinib/infigratinib); urothelial FGFR (erdafitinib); CRC-3L (fruquintinib) | 6 |
+| `tier2-ind-gyn-2026-05-01` | cervical 2L (tisotumab); ovarian 2L FRα (mirvetuximab); anal 1L (retifanlimab) | 5 |
+| `tier2-ind-aml-bal-misc-2026-05-01` | AML-RR-IDH1 (olutasidenib); B-ALL adult (blino/InO); SCLC-RR (lurbinectedin); GIST-4L (ripretinib) | 8 |
+
+### W10 validation gates
+
+Same plus:
+
+- Each indication's `biomarker_constraints` reference existing biomarker IDs.
+- Each indication's `regimen_ids` reference existing regimen IDs.
+- Each indication ships with at least 2 source citations (Q4 citation density).
+- Algorithm-file edits limited to additive steps; document if existing-step modification needed.
+
+## W11 — Tier-2 RFs (~25, 4 chunks)
+
+**Goal:** for each new biomarker that gates an indication, author the corresponding RF. Group by therapeutic area.
+
+### W11 chunks
+
+| Chunk key | Therapeutic area | Estimated RFs |
+|---|---|---|
+| `tier2-rf-heme-2026-05-01` | BCMA-pos / CD22-pos / CD33-pos / CD38-quant / CD79B-mut / NOTCH2-mut RFs | 7 |
+| `tier2-rf-breast-nsclc-2026-05-01` | HER2-ultralow, ESR1-Y537S/D538G, AKT1-E17K, NRG1, HER3-high, PIK3CA-coalt | 7 |
+| `tier2-rf-hereditary-prostate-2026-05-01` | BRCA-somatic, PALB2, ATM/CHEK2/CDK12, CDH1, AR-amp, TMPRSS2-ERG | 6 |
+| `tier2-rf-misc-2026-05-01` | NF1, BAP1, ctDNA-MRD, HRD-assay-distinction, PD-L1 clone-specific eligibility | 5 |
+
+### W11 validation gates
+
+Same as W7 plus:
+
+- Each RF references existing biomarker IDs (or W7 IDs landed earlier in the wave).
+- RF `evaluation` block uses structured `findings` keys, not free-text `condition:` strings (drift signal #4 from W5 already documented this; do not reintroduce).
+
+## W12 — Q-axis second waves
+
+### W12a — BMA-CIViC backfill wave-2 (104 BMAs / 5 per chunk = 21 chunks)
+
+**Goal:** advance Q1 BMA evidence integrity from 295/399 (74%) to 399/399 (100%). Each chunk owns a manifest of 5 BMAs and either adds an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or records a structured `no_civic_match_reason`.
+
+**Chunking pattern:** identical to closed `bma-civic-backfill-2026-04-29-007` (issue #49). Sidecar-only output under `contributions/<chunk-id>/`. Hosted YAML never edited directly in chunk.
+
+**Manifest distribution:** 104 BMAs distributed across 21 chunks via deterministic round-robin (5 per chunk, last chunk gets 4). Manifests are listed in each issue body.
+
+**Chunk keys:** `bma-civic-backfill-wave2-001` … `bma-civic-backfill-wave2-021`.
+
+### W12b — Source recency refresh wave-2 (131 sources / 5 per chunk = 27 chunks)
+
+**Goal:** advance Q2 source recency. The brief specifies "131 sources stale by `last_verified` older than 2026-04-01"; this roadmap reproduced that count via a different proxy (most sources had identical `last_verified` post the Q2 wave-1 batch; ordering was done by `current_as_of` ascending, missing-field first). Chunk picks 5 sources, verifies the URL, bumps `current_as_of` to the chunk's run date, and adds a sidecar `source_recency_audit.yaml`.
+
+**Chunk keys:** `source-recency-refresh-wave2-001` … `source-recency-refresh-wave2-027`.
+
+### W12 validation gates
+
+- `py -3.12 -m scripts.tasktorrent.validate_contributions <chunk-id>` passes.
+- `git diff --name-only master..HEAD` shows no paths outside `contributions/<chunk-id>/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+## W13 — Tier-3 niche (deferred, 3 stub issues)
+
+Specialist-noted gaps that don't have immediate FDA-approved-drug routing or require multi-entity stratification. Authored here as stubs with deferral rationale.
+
+| Chunk key | Scope | Trigger to revisit |
+|---|---|---|
+| `tier3-bio-sarcoma-fusions-deferred` | EWSR1, SS18, DDIT3, MDM2 amp; sarcoma fusions | rare-disease coverage initiative or specialist request |
+| `tier3-bio-pediatric-cns-deferred` | H3K27M, BRAF-fusion KIAA1549, DICER1 thyroid | pediatric oncology track activation |
+| `tier3-bio-hereditary-panel-deferred` | Lynch genes individually, TP53 germline, APC, MUTYH (if not absorbed by W7b Lynch decision) | hereditary cancer counseling integration |
+
+Each W13 issue is a short stub: trigger condition + contact-on-revisit + estimated scope.
+
+## Cross-cutting concerns
+
+### Tier-2 chunk validation gates (uniform per chunk)
+
+1. KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK — all entities valid".
+2. pytest fixture: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed" (no regression).
+3. Per-chunk allowlist strictly enforced.
+4. Sources cited (no invented IDs); flag missing trial Sources in commit body — do not invent.
+5. Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+### Quality gates (per `kb_data_quality_plan_2026-04-29.md` Q1–Q5)
+
+- **Q1 BMA evidence integrity:** W7 biomarkers ship with `actionability_lookup` (single-variant) XOR `oncokb_skip_reason` (composite/IHC/CN). W12a closes the BMA-CIViC backfill axis.
+- **Q2 Source metadata:** W8/W9/W10 cite existing `SRC-*` IDs only. W12b closes the recency axis.
+- **Q3 UA applicability:** every new biomarker/drug carries `names.ukrainian`, `ukrainian_review_status: pending_clinical_signoff`, `ukrainian_drafted_by: claude_extraction`. NSZU status declared explicitly (or `unresolved`).
+- **Q4 Citation density:** each indication ≥ 2 source citations.
+- **Q5 Regression prevention:** existing 62-case curated fixture is the gate. Tier-2 must not regress it without documented routing-change rationale.
+
+### Multi-session reality
+
+Master moves daily. Tier-2 chunks branch off `origin/master` at the moment they start, not from a frozen baseline. Where W9/W10 depend on W8 drug IDs, the orchestrator sequences (W7+W8+W12 parallel; W9 after W8 merges; W10 after W7+W8+W9; W11 last).
+
+### Self-push authorization
+
+Per CLAUDE.md commit `3a60901b`: chunks self-push when all gates pass. Branch names follow `chunk/<chunk-key>-<NNN>` per memory `feedback_chunk_naming`.
+
+### Stop conditions (any chunk)
+
+- HEAD on a different branch than expected.
+- Working tree unexpectedly modified outside the chunk allowlist.
+- KB validator regresses (was clean, now isn't).
+- pytest 62-case fixture regresses without routing-rationale documentation.
+- Trial / source ID missing from KB and required by indication — drop case, document, do not invent IDs.
+- Two chunks editing the same file (coordination bug — surfaces as worktree merge conflict).
+- Existing YAML modification beyond additive sections (escalate to user).
+
+## Sequencing summary
+
+```
+Wave A (parallel, ~Day 1-2):
+  W7a heme bio
+  W7b hereditary bio
+  W7c prostate bio
+  W7d emerging targeted bio
+  W7e melanoma+rare bio
+  W7f PD-L1 clones bio
+  W8a heme bispecific+CAR-T drugs
+  W8b liso-cel drug
+  W8c breast+NSCLC emerging drugs
+  W8d GI+GYN emerging drugs
+  W8e niche drugs
+  W12a × 21 BMA-CIViC backfill (sidecar — fully parallel)
+  W12b × 27 source-recency (sidecar — fully parallel)
+
+Wave B (after W8 merges, ~Day 2-3):
+  W9 × 8 regimens
+
+Wave C (after W7+W9 merges, ~Day 3-4):
+  W10 × 7 indications
+
+Wave D (after W7 merges, ~Day 3-4):
+  W11 × 4 RFs
+
+W13: deferred stubs (open as parking issues only).
+```
+
+## Acceptance criteria for this roadmap
+
+- All 28 Tier-2 biomarkers shipped end-to-end (biomarker + RF + indication + regimen + drug wiring) per W7+W8+W9+W10+W11.
+- 104 outstanding BMAs closed via W12a (CIViC link or `no_civic_match_reason`).
+- 131 oldest sources refreshed via W12b.
+- W13 stubs filed, deferral rationale + revisit triggers documented.
+- KB validator stays clean throughout.
+- pytest 62-case fixture never regresses without documented justification.
+- All chunks self-pushed per CLAUDE.md `3a60901b`.
+
+## Appendix A — counts at roadmap-author time (2026-05-01)
+
+- biomarkers: 125
+- biomarker_actionability: 399 (104 outstanding for CIViC)
+- sources: 271 (131 selected for wave-2 refresh)
+- drugs: 220 (220 with NSZU axis complete; 13 of 35 Tier-2 drugs already in KB)
+- pytest fixture: `tests/test_curated_chunk_e2e.py` = 62 passed
+
+## Appendix B — drugs already in KB (W8 scope reduction)
+
+Confirmed present at `origin/master` HEAD `5df14cc8`: avapritinib, blinatumomab, capivasertib, fruquintinib, inotuzumab_ozogamicin, mirvetuximab_soravtansine, mosunetuzumab, niraparib, quizartinib, repotrectinib, talazoparib, teclistamab, tisagenlecleucel.
+
+These are referenced by W9 regimens and W10 indications but are NOT re-authored in W8. The original Tier-2 brief listed 35 drugs; W8 scope reduced to **21**.
+
+## Appendix C — recency-stat reconciliation note
+
+Orchestrator brief specified "131 sources with `last_verified` older than 2026-04-01". Actual filesystem state at `5df14cc8` shows 270/271 sources with `last_verified` in 2026-04 (post wave-1 batch refresh). Roadmap therefore selected 131 oldest sources by `current_as_of` (missing-field first, then ascending date) as the wave-2 priority queue. Manifests reflect that selection. Final report flags this discrepancy.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/00-tier2-dispatch-tracker-2026-05-01-1100.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/00-tier2-dispatch-tracker-2026-05-01-1100.md
@@ -1,0 +1,118 @@
+# [Tracker] Tier-2 dispatch 2026-05-01-1100
+
+## Mission
+
+Master tracker for the Tier-2 expansion wave. 82 chunks total.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md`.
+
+## Sub-issues checklist
+
+Check off each as it lands on master.
+
+- [ ] [W7] tier2-bio-heme-2026-05-01-001
+- [ ] [W7] tier2-bio-hereditary-2026-05-01-002
+- [ ] [W7] tier2-bio-prostate-2026-05-01-003
+- [ ] [W7] tier2-bio-emerging-targeted-2026-05-01-004
+- [ ] [W7] tier2-bio-melanoma-rare-2026-05-01-005
+- [ ] [W7] tier2-bio-pdl1-clones-2026-05-01-006
+- [ ] [W7] tier2-bio-followup-2026-05-01-007
+- [ ] [W8] tier2-drug-heme-bispecific-cart-2026-05-01-008
+- [ ] [W8] tier2-drug-heme-liso-cel-2026-05-01-009
+- [ ] [W8] tier2-drug-breast-nsclc-emerging-2026-05-01-010
+- [ ] [W8] tier2-drug-gi-gyn-emerging-2026-05-01-011
+- [ ] [W8] tier2-drug-misc-niche-2026-05-01-012
+- [ ] [W9] tier2-reg-mm-bispecific-2026-05-01-013
+- [ ] [W9] tier2-reg-mm-cart-2026-05-01-014
+- [ ] [W9] tier2-reg-dlbcl-bispecific-cart-2026-05-01-015
+- [ ] [W9] tier2-reg-breast-emerging-2026-05-01-016
+- [ ] [W9] tier2-reg-nsclc-emerging-2026-05-01-017
+- [ ] [W9] tier2-reg-gi-emerging-2026-05-01-018
+- [ ] [W9] tier2-reg-gyn-emerging-2026-05-01-019
+- [ ] [W9] tier2-reg-niche-2026-05-01-020
+- [ ] [W10] tier2-ind-mm-2026-05-01-021
+- [ ] [W10] tier2-ind-dlbcl-mcl-cll-2026-05-01-022
+- [ ] [W10] tier2-ind-breast-2026-05-01-023
+- [ ] [W10] tier2-ind-nsclc-2026-05-01-024
+- [ ] [W10] tier2-ind-gi-2026-05-01-025
+- [ ] [W10] tier2-ind-gyn-2026-05-01-026
+- [ ] [W10] tier2-ind-aml-bal-misc-2026-05-01-027
+- [ ] [W11] tier2-rf-heme-2026-05-01-028
+- [ ] [W11] tier2-rf-breast-nsclc-2026-05-01-029
+- [ ] [W11] tier2-rf-hereditary-prostate-2026-05-01-030
+- [ ] [W11] tier2-rf-misc-2026-05-01-031
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-001
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-002
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-003
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-004
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-005
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-006
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-007
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-008
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-009
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-010
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-011
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-012
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-013
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-014
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-015
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-016
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-017
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-018
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-019
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-020
+- [ ] [W12a] bma-civic-backfill-wave2-2026-05-01-021
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-001
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-002
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-003
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-004
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-005
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-006
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-007
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-008
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-009
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-010
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-011
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-012
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-013
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-014
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-015
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-016
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-017
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-018
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-019
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-020
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-021
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-022
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-023
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-024
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-025
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-026
+- [ ] [W12b] source-recency-refresh-wave2-2026-05-01-027
+- [ ] [W13 deferred] tier3-bio-sarcoma-fusions-deferred-2026-05-01-060
+- [ ] [W13 deferred] tier3-bio-pediatric-cns-deferred-2026-05-01-061
+- [ ] [W13 deferred] tier3-bio-hereditary-panel-deferred-2026-05-01-062
+
+## Sequencing
+
+- **Wave A (parallel, Day 1-2):** all W7 (7) + all W8 (5) + all W12a (21) + all W12b (27).
+- **Wave B (after W8 merges):** W9 (8).
+- **Wave C (after W7+W9 merge):** W10 (7).
+- **Wave D (after W7 merges):** W11 (4).
+- **W13 (3):** parking stubs only -- do NOT dispatch.
+
+## Quality gates (uniform per chunk)
+
+1. KB validator clean.
+2. pytest fixture `tests/test_curated_chunk_e2e.py` returns 62 passed.
+3. Per-chunk allowlist strictly enforced.
+4. Sources cited (no invented IDs).
+5. Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Acceptance for the wave
+
+- All non-deferred sub-issues closed.
+- KB validator clean throughout.
+- pytest 62/62 throughout.
+- Coverage matrix entries moved per roadmap acceptance criteria.
+- Final integration pass merges any remaining feature branches; orchestrator declares wave complete.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-001.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-001.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-001
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-001`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-001`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-001/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-ATM-LOSS-CLL
+BMA-CHEK2-SOMATIC-PROSTATE
+BMA-MLH1-GERMLINE-CRC
+BMA-MSH2-SOMATIC-OVARIAN
+BMA-NTRK-FUSION-SALIVARY
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-ATM-LOSS-CLL
+- BMA-CHEK2-SOMATIC-PROSTATE
+- BMA-MLH1-GERMLINE-CRC
+- BMA-MSH2-SOMATIC-OVARIAN
+- BMA-NTRK-FUSION-SALIVARY
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-001` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-001/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-001 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-001/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-001
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-001
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-002.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-002.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-002
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-002`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-002`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-002/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-ATM-LOSS-MCL
+BMA-CXCR4-WHIM-WM
+BMA-MLH1-GERMLINE-ENDOMETRIAL
+BMA-MSH2-SOMATIC-PROSTATE
+BMA-NTRK-FUSION-THYROID-PAPILLARY
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-ATM-LOSS-MCL
+- BMA-CXCR4-WHIM-WM
+- BMA-MLH1-GERMLINE-ENDOMETRIAL
+- BMA-MSH2-SOMATIC-PROSTATE
+- BMA-NTRK-FUSION-THYROID-PAPILLARY
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-002` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-002/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-002 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-002/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-002
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-002
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-003.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-003.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-003
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-003`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-003`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-003/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-EXPRESSION-CLL
+BMA-EPCAM-GERMLINE-CRC
+BMA-MLH1-GERMLINE-GASTRIC
+BMA-MSH2-SOMATIC-UROTHELIAL
+BMA-PDGFRA-EXON12-GIST
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-EXPRESSION-CLL
+- BMA-EPCAM-GERMLINE-CRC
+- BMA-MLH1-GERMLINE-GASTRIC
+- BMA-MSH2-SOMATIC-UROTHELIAL
+- BMA-PDGFRA-EXON12-GIST
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-003` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-003/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-003 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-003/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-003
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-003
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-004.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-004.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-004
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-004`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-004`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-004/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-EXPRESSION-DLBCL-NOS
+BMA-EPCAM-GERMLINE-ENDOMETRIAL
+BMA-MLH1-GERMLINE-OVARIAN
+BMA-MSH6-GERMLINE-CRC
+BMA-PDGFRA-EXON14-GIST
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-EXPRESSION-DLBCL-NOS
+- BMA-EPCAM-GERMLINE-ENDOMETRIAL
+- BMA-MLH1-GERMLINE-OVARIAN
+- BMA-MSH6-GERMLINE-CRC
+- BMA-PDGFRA-EXON14-GIST
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-004` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-004/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-004 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-004/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-004
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-004
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-005.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-005.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-005
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-005`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-005`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-005/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-EXPRESSION-FL
+BMA-EZH2-Y641-FL
+BMA-MLH1-GERMLINE-PROSTATE
+BMA-MSH6-GERMLINE-ENDOMETRIAL
+BMA-PMS2-GERMLINE-CRC
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-EXPRESSION-FL
+- BMA-EZH2-Y641-FL
+- BMA-MLH1-GERMLINE-PROSTATE
+- BMA-MSH6-GERMLINE-ENDOMETRIAL
+- BMA-PMS2-GERMLINE-CRC
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-005` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-005/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-005 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-005/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-005
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-005
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-006.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-006.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-006
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-006`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-006`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-006/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-EXPRESSION-MCL
+BMA-FANCA-GERMLINE-OVARIAN
+BMA-MLH1-GERMLINE-UROTHELIAL
+BMA-MSH6-GERMLINE-GASTRIC
+BMA-PMS2-GERMLINE-ENDOMETRIAL
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-EXPRESSION-MCL
+- BMA-FANCA-GERMLINE-OVARIAN
+- BMA-MLH1-GERMLINE-UROTHELIAL
+- BMA-MSH6-GERMLINE-GASTRIC
+- BMA-PMS2-GERMLINE-ENDOMETRIAL
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-006` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-006/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-006 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-006/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-006
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-006
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-007.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-007.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-007
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-007`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-007`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-007/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-REARRANGEMENT-DLBCL-NOS
+BMA-FANCL-GERMLINE-OVARIAN
+BMA-MLH1-SOMATIC-CRC
+BMA-MSH6-GERMLINE-OVARIAN
+BMA-PMS2-GERMLINE-GASTRIC
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-REARRANGEMENT-DLBCL-NOS
+- BMA-FANCL-GERMLINE-OVARIAN
+- BMA-MLH1-SOMATIC-CRC
+- BMA-MSH6-GERMLINE-OVARIAN
+- BMA-PMS2-GERMLINE-GASTRIC
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-007` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-007/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-007 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-007/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-007
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-007
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-008.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-008.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-008
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-008`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-008`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-008/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-REARRANGEMENT-FL
+BMA-HER2-AMP-CRC
+BMA-MLH1-SOMATIC-ENDOMETRIAL
+BMA-MSH6-GERMLINE-PROSTATE
+BMA-PMS2-GERMLINE-OVARIAN
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-REARRANGEMENT-FL
+- BMA-HER2-AMP-CRC
+- BMA-MLH1-SOMATIC-ENDOMETRIAL
+- BMA-MSH6-GERMLINE-PROSTATE
+- BMA-PMS2-GERMLINE-OVARIAN
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-008` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-008/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-008 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-008/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-008
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-008
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-009.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-009.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-009
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-009`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-009`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-009/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-REARRANGEMENT-HGBL-DH
+BMA-HER2-AMP-ESOPHAGEAL
+BMA-MLH1-SOMATIC-GASTRIC
+BMA-MSH6-GERMLINE-UROTHELIAL
+BMA-PMS2-GERMLINE-PROSTATE
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-REARRANGEMENT-HGBL-DH
+- BMA-HER2-AMP-ESOPHAGEAL
+- BMA-MLH1-SOMATIC-GASTRIC
+- BMA-MSH6-GERMLINE-UROTHELIAL
+- BMA-PMS2-GERMLINE-PROSTATE
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-009` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-009/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-009 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-009/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-009
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-009
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-010.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-010.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-010
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-010`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-010`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-010/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-BCL2-REARRANGEMENT-MCL
+BMA-HER2-AMP-GASTRIC
+BMA-MLH1-SOMATIC-OVARIAN
+BMA-MSH6-SOMATIC-CRC
+BMA-PMS2-GERMLINE-UROTHELIAL
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-BCL2-REARRANGEMENT-MCL
+- BMA-HER2-AMP-GASTRIC
+- BMA-MLH1-SOMATIC-OVARIAN
+- BMA-MSH6-SOMATIC-CRC
+- BMA-PMS2-GERMLINE-UROTHELIAL
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-010` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-010/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-010 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-010/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-010
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-010
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-011.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-011.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-011
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-011`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-011`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-011/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CALR-ET
+BMA-HRD-STATUS-BREAST
+BMA-MLH1-SOMATIC-PROSTATE
+BMA-MSH6-SOMATIC-ENDOMETRIAL
+BMA-PMS2-SOMATIC-CRC
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CALR-ET
+- BMA-HRD-STATUS-BREAST
+- BMA-MLH1-SOMATIC-PROSTATE
+- BMA-MSH6-SOMATIC-ENDOMETRIAL
+- BMA-PMS2-SOMATIC-CRC
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-011` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-011/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-011 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-011/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-011
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-011
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-012.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-012.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-012
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-012`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-012`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-012/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CALR-PMF
+BMA-HRD-STATUS-OVARIAN
+BMA-MLH1-SOMATIC-UROTHELIAL
+BMA-MSH6-SOMATIC-GASTRIC
+BMA-PMS2-SOMATIC-ENDOMETRIAL
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CALR-PMF
+- BMA-HRD-STATUS-OVARIAN
+- BMA-MLH1-SOMATIC-UROTHELIAL
+- BMA-MSH6-SOMATIC-GASTRIC
+- BMA-PMS2-SOMATIC-ENDOMETRIAL
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-012` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-012/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-012 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-012/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-012
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-012
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-013.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-013.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-013
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-013`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-013`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-013/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CCND1-IHC-MCL
+BMA-HRD-STATUS-PDAC
+BMA-MSH2-GERMLINE-CRC
+BMA-MSH6-SOMATIC-OVARIAN
+BMA-PMS2-SOMATIC-GASTRIC
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CCND1-IHC-MCL
+- BMA-HRD-STATUS-PDAC
+- BMA-MSH2-GERMLINE-CRC
+- BMA-MSH6-SOMATIC-OVARIAN
+- BMA-PMS2-SOMATIC-GASTRIC
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-013` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-013/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-013 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-013/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-013
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-013
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-014.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-014.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-014
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-014`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-014`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-014/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CCND1-IHC-MM
+BMA-HRD-STATUS-PROSTATE
+BMA-MSH2-GERMLINE-ENDOMETRIAL
+BMA-MSH6-SOMATIC-PROSTATE
+BMA-PMS2-SOMATIC-OVARIAN
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CCND1-IHC-MM
+- BMA-HRD-STATUS-PROSTATE
+- BMA-MSH2-GERMLINE-ENDOMETRIAL
+- BMA-MSH6-SOMATIC-PROSTATE
+- BMA-PMS2-SOMATIC-OVARIAN
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-014` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-014/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-014 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-014/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-014
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-014
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-015.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-015.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-015
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-015`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-015`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-015/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CCND1-T1114-MCL
+BMA-IGHV-UNMUTATED-CLL
+BMA-MSH2-GERMLINE-GASTRIC
+BMA-MSH6-SOMATIC-UROTHELIAL
+BMA-PMS2-SOMATIC-PROSTATE
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CCND1-T1114-MCL
+- BMA-IGHV-UNMUTATED-CLL
+- BMA-MSH2-GERMLINE-GASTRIC
+- BMA-MSH6-SOMATIC-UROTHELIAL
+- BMA-PMS2-SOMATIC-PROSTATE
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-015` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-015/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-015 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-015/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-015
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-015
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-016.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-016.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-016
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-016`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-016`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-016/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CCND1-T1114-MM
+BMA-KIT-EXON11-GIST
+BMA-MSH2-GERMLINE-OVARIAN
+BMA-NPM1-AML
+BMA-PMS2-SOMATIC-UROTHELIAL
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CCND1-T1114-MM
+- BMA-KIT-EXON11-GIST
+- BMA-MSH2-GERMLINE-OVARIAN
+- BMA-NPM1-AML
+- BMA-PMS2-SOMATIC-UROTHELIAL
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-016` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-016/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-016 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-016/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-016
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-016
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-017.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-017.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-017
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-017`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-017`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-017/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CD30-ALCL
+BMA-KIT-EXON13-17-GIST
+BMA-MSH2-GERMLINE-PROSTATE
+BMA-NTRK-ETV6-SALIVARY
+BMA-RAD51C-GERMLINE-BREAST
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CD30-ALCL
+- BMA-KIT-EXON13-17-GIST
+- BMA-MSH2-GERMLINE-PROSTATE
+- BMA-NTRK-ETV6-SALIVARY
+- BMA-RAD51C-GERMLINE-BREAST
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-017` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-017/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-017 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-017/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-017
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-017
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-018.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-018.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-018
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-018`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-018`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-018/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CD30-CHL
+BMA-KIT-EXON9-GIST
+BMA-MSH2-GERMLINE-UROTHELIAL
+BMA-NTRK-FUSION-CRC
+BMA-RAD51C-GERMLINE-OVARIAN
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CD30-CHL
+- BMA-KIT-EXON9-GIST
+- BMA-MSH2-GERMLINE-UROTHELIAL
+- BMA-NTRK-FUSION-CRC
+- BMA-RAD51C-GERMLINE-OVARIAN
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-018` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-018/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-018 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-018/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-018
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-018
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-019.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-019.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-019
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-019`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-019`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-019/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CHEK2-GERMLINE-BREAST
+BMA-MET-AMP-RCC-PAPILLARY
+BMA-MSH2-SOMATIC-CRC
+BMA-NTRK-FUSION-GIST
+BMA-RAD51C-SOMATIC-BREAST
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CHEK2-GERMLINE-BREAST
+- BMA-MET-AMP-RCC-PAPILLARY
+- BMA-MSH2-SOMATIC-CRC
+- BMA-NTRK-FUSION-GIST
+- BMA-RAD51C-SOMATIC-BREAST
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-019` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-019/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-019 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-019/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-019
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-019
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-020.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-020.md
@@ -1,0 +1,122 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-020
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-020`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-020`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-020/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CHEK2-GERMLINE-PROSTATE
+BMA-MET-EX14-NSCLC
+BMA-MSH2-SOMATIC-ENDOMETRIAL
+BMA-NTRK-FUSION-IFS
+BMA-RAD51C-SOMATIC-OVARIAN
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CHEK2-GERMLINE-PROSTATE
+- BMA-MET-EX14-NSCLC
+- BMA-MSH2-SOMATIC-ENDOMETRIAL
+- BMA-NTRK-FUSION-IFS
+- BMA-RAD51C-SOMATIC-OVARIAN
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-020` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-020/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-020 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-020/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-020
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-020
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-021.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/bma-civic-backfill-wave2-2026-05-01-021.md
@@ -1,0 +1,120 @@
+# [Chunk] bma-civic-backfill-wave2-2026-05-01-021
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q1 BMA-CIViC backfill wave-2` from 295/399 BMAs (74%) toward 399/399 (100%) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12a -- BMA-CIViC backfill wave-2`. Pattern mirrors closed `bma-civic-backfill-2026-04-29-007` (issue #43).
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`bma-civic-backfill-wave2-2026-05-01-021`
+
+## Branch Naming Convention
+
+`tasktorrent/bma-civic-backfill-wave2-2026-05-01-021`
+
+## Sidecar Output Path
+
+```
+contributions/bma-civic-backfill-wave2-2026-05-01-021/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+BMA-CHEK2-SOMATIC-BREAST
+BMA-MGMT-METHYLATION-GBM
+BMA-MSH2-SOMATIC-GASTRIC
+BMA-NTRK-FUSION-NSCLC
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- BMA-CHEK2-SOMATIC-BREAST
+- BMA-MGMT-METHYLATION-GBM
+- BMA-MSH2-SOMATIC-GASTRIC
+- BMA-NTRK-FUSION-NSCLC
+
+## Task
+
+Review each hosted BMA in the manifest for possible CIViC evidence linkage. Add sidecar updates that propose either an `evidence_sources[SRC-CIVIC]` entry (with CIViC evidence ID + PMID) or an explicit `no_civic_match_reason`. Do not invent treatment claims when CIViC has no suitable evidence item.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include a YAML report that records one outcome per manifest ID and cites all evidence used.
+- Each proposed CIViC link is checked against disease context, biomarker alteration, therapy, and evidence direction.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions bma-civic-backfill-wave2-2026-05-01-021` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/bma-civic-backfill-wave2-2026-05-01-021/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/bma-civic-backfill-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/bma-civic-backfill-wave2-2026-05-01-021 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/bma-civic-backfill-wave2-2026-05-01-021/
+git commit -m "$(cat <<'EOF'
+chore(contributions): bma-civic-backfill-wave2-2026-05-01-021
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/bma-civic-backfill-wave2-2026-05-01-021
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-001.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-001.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-001
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-001`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-001`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-001/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ARROW
+SRC-HODI-2013
+SRC-EXTREME-VERMORKEN-2008
+SRC-LEE-2015-BELINOSTAT-PTCL
+SRC-CTCAE-V5
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ARROW
+- SRC-HODI-2013
+- SRC-EXTREME-VERMORKEN-2008
+- SRC-LEE-2015-BELINOSTAT-PTCL
+- SRC-CTCAE-V5
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-001` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-001/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-001 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-001/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-001
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-001
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-002.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-002.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-002
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-002`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-002`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-002/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ASCO-BTC-2023
+SRC-INVICTUS
+SRC-OVA-301-MONK-2010
+SRC-ESMO-MPN-2015
+SRC-ZUMA-1-NEELAPU-2017
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ASCO-BTC-2023
+- SRC-INVICTUS
+- SRC-OVA-301-MONK-2010
+- SRC-ESMO-MPN-2015
+- SRC-ZUMA-1-NEELAPU-2017
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-002` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-002/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-002 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-002/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-002
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-002
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-003.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-003.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-003
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-003`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-003`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-003/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ATA-ATC-2021
+SRC-LIBRETTO-431
+SRC-DIPSS-PLUS-GANGAT-2011
+SRC-TOURMALINE-MM1-MOREAU-2016
+SRC-FLAURA-SORIA-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ATA-ATC-2021
+- SRC-LIBRETTO-431
+- SRC-DIPSS-PLUS-GANGAT-2011
+- SRC-TOURMALINE-MM1-MOREAU-2016
+- SRC-FLAURA-SORIA-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-003` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-003/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-003 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-003/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-003
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-003
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-004.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-004.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-004
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-004`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-004`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-004/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ATA-THYROID-2015
+SRC-MOZ-UA-LYMPH-2013
+SRC-CARVAJAL-KIT-MELANOMA-2013
+SRC-INOVATE-KANTARJIAN-2016
+SRC-ECHELON-1-CONNORS-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ATA-THYROID-2015
+- SRC-MOZ-UA-LYMPH-2013
+- SRC-CARVAJAL-KIT-MELANOMA-2013
+- SRC-INOVATE-KANTARJIAN-2016
+- SRC-ECHELON-1-CONNORS-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-004` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-004/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-004 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-004/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-004
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-004
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-005.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-005.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-005
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-005`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-005`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-005/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-B2222-DEMETRI
+SRC-NAVIGATOR
+SRC-BRIM-3-CHAPMAN-2011
+SRC-BRF113928-PLANCHARD-2016
+SRC-ELIANA-MAUDE-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-B2222-DEMETRI
+- SRC-NAVIGATOR
+- SRC-BRIM-3-CHAPMAN-2011
+- SRC-BRF113928-PLANCHARD-2016
+- SRC-ELIANA-MAUDE-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-005` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-005/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-005 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-005/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-005
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-005
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-006.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-006.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-006
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-006`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-006`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-006/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-BSH-MZL-2024
+SRC-NCCN-ALL-2025
+SRC-MDS-004-FENAUX-2011
+SRC-CASTOR-PALUMBO-2016
+SRC-ALCYONE-MATEOS-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-BSH-MZL-2024
+- SRC-NCCN-ALL-2025
+- SRC-MDS-004-FENAUX-2011
+- SRC-CASTOR-PALUMBO-2016
+- SRC-ALCYONE-MATEOS-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-006` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-006/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-006 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-006/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-006
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-006
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-007.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-007.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-007
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-007`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-007`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-007/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-CALGB-10801
+SRC-NCCN-AML-2025
+SRC-BOLERO2-BASELGA-2012
+SRC-POLLUX-DIMOPOULOS-2016
+SRC-NAVIGATE-DRILON-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-CALGB-10801
+- SRC-NCCN-AML-2025
+- SRC-BOLERO2-BASELGA-2012
+- SRC-POLLUX-DIMOPOULOS-2016
+- SRC-NAVIGATE-DRILON-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-007` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-007/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-007 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-007/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-007
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-007
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-008.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-008.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-008
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-008`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-008`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-008/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-COG
+SRC-NCCN-BCELL-2025
+SRC-COIFFIER-2012-ROMIDEPSIN-PTCL
+SRC-MONALEESA-2-HORTOBAGYI-2016
+SRC-MURANO-SEYMOUR-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-COG
+- SRC-NCCN-BCELL-2025
+- SRC-COIFFIER-2012-ROMIDEPSIN-PTCL
+- SRC-MONALEESA-2-HORTOBAGYI-2016
+- SRC-MURANO-SEYMOUR-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-008` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-008/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-008 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-008/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-008
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-008
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-009.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-009.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-009
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-009`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-009`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-009/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-EANO-LGG-2024
+SRC-NCCN-BONE-SARCOMA
+SRC-COMFORT-I-VERSTOVSEK-2012
+SRC-KEYNOTE-024-RECK-2016
+SRC-BLAST-GOKBUGET-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-EANO-LGG-2024
+- SRC-NCCN-BONE-SARCOMA
+- SRC-COMFORT-I-VERSTOVSEK-2012
+- SRC-KEYNOTE-024-RECK-2016
+- SRC-BLAST-GOKBUGET-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-009` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-009/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-009 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-009/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-009
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-009
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-010.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-010.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-010
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-010`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-010`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-010/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-EASL-HBV-2025
+SRC-NCCN-HEAD-AND-NECK
+SRC-ALFA-0701-CASTAIGNE-2012
+SRC-PALOMA-2-FINN-2016
+SRC-KEYNOTE-189-GANDHI-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-EASL-HBV-2025
+- SRC-NCCN-HEAD-AND-NECK
+- SRC-ALFA-0701-CASTAIGNE-2012
+- SRC-PALOMA-2-FINN-2016
+- SRC-KEYNOTE-189-GANDHI-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-010` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-010/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-010 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-010/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-010
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-010
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-011.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-011.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-011
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-011`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-011`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-011/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-EASL-HCV-2023
+SRC-NCCN-HEPATOBILIARY
+SRC-OCEANS-AGHAJANIAN-2012
+SRC-NOVA-MIRZA-2016
+SRC-KEYNOTE-054-EGGERMONT-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-EASL-HCV-2023
+- SRC-NCCN-HEPATOBILIARY
+- SRC-OCEANS-AGHAJANIAN-2012
+- SRC-NOVA-MIRZA-2016
+- SRC-KEYNOTE-054-EGGERMONT-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-011` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-011/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-011 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-011/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-011
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-011
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-012.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-012.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-012
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-012`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-012`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-012/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-EHA-WORKUP-2024
+SRC-NCCN-MM-2025
+SRC-BREAK-3-HAUSCHILD-2012
+SRC-ARCAINI-2014
+SRC-INNOVATE-DIMOPOULOS-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-EHA-WORKUP-2024
+- SRC-NCCN-MM-2025
+- SRC-BREAK-3-HAUSCHILD-2012
+- SRC-ARCAINI-2014
+- SRC-INNOVATE-DIMOPOULOS-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-012` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-012/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-012 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-012/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-012
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-012
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-013.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-013.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-013
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-013`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-013`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-013/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-EORTC-62005
+SRC-NCCN-MPN-2025
+SRC-EMILIA-VERMA-2012
+SRC-AURA3-MOK-2017
+SRC-MONALEESA-7-TRIPATHY-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-EORTC-62005
+- SRC-NCCN-MPN-2025
+- SRC-EMILIA-VERMA-2012
+- SRC-AURA3-MOK-2017
+- SRC-MONALEESA-7-TRIPATHY-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-013` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-013/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-013 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-013/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-013
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-013
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-014.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-014.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-014
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-014`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-014`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-014/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-BONE-SARCOMA
+SRC-NCCN-PEDIATRIC-SARCOMA
+SRC-APL0406-LOCOCO-2013
+SRC-APL-RELAPSE-LENGFELDER-2017
+SRC-EMBRACA-LITTON-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-BONE-SARCOMA
+- SRC-NCCN-PEDIATRIC-SARCOMA
+- SRC-APL0406-LOCOCO-2013
+- SRC-APL-RELAPSE-LENGFELDER-2017
+- SRC-EMBRACA-LITTON-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-014` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-014/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-014 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-014/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-014
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-014
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-015.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-015.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-015
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-015`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-015`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-015/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-BTC-2023
+SRC-NCCN-SARCOMA
+SRC-PACE-CORTES-2013
+SRC-GOG0213-COLEMAN-2017
+SRC-MONALEESA-3-SLAMON-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-BTC-2023
+- SRC-NCCN-SARCOMA
+- SRC-PACE-CORTES-2013
+- SRC-GOG0213-COLEMAN-2017
+- SRC-MONALEESA-3-SLAMON-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-015` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-015/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-015 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-015/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-015
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-015
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-016.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-016.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-016
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-016`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-016`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-016/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-CRC-2024
+SRC-NF1-CONSORTIUM
+SRC-LUMELUNG1-RECK-2014
+SRC-ESMO-CML-2017
+SRC-COLUMBUS-DUMMETT-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-CRC-2024
+- SRC-NF1-CONSORTIUM
+- SRC-LUMELUNG1-RECK-2014
+- SRC-ESMO-CML-2017
+- SRC-COLUMBUS-DUMMETT-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-016` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-016/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-016 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-016/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-016
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-016
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-017.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-017.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-017
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-017`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-017`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-017/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-HNSCC-2020
+SRC-PAPMET
+SRC-AURELIA-PUJADE-LAURAINE-2014
+SRC-JAKARTA2-HARRISON-2017
+SRC-ESCAT-MATEO-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-HNSCC-2020
+- SRC-PAPMET
+- SRC-AURELIA-PUJADE-LAURAINE-2014
+- SRC-JAKARTA2-HARRISON-2017
+- SRC-ESCAT-MATEO-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-017` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-017/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-017 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-017/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-017
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-017
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-018.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-018.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-018
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-018`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-018`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-018/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-SALIVARY
+SRC-PATHFINDER
+SRC-REVEL-GARON-2014
+SRC-APHINITY-VONMINCKWITZ-2017
+SRC-LANCET-CPX351-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-SALIVARY
+- SRC-PATHFINDER
+- SRC-REVEL-GARON-2014
+- SRC-APHINITY-VONMINCKWITZ-2017
+- SRC-LANCET-CPX351-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-018` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-018/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-018 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-018/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-018
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-018
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-019.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-019.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-019
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-019`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-019`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-019/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-SARCOMA
+SRC-SAVOIR
+SRC-COBRIM-LARKIN-2014
+SRC-RATIFY-STONE-2017
+SRC-ELOQUENT-3-DIMOPOULOS-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-SARCOMA
+- SRC-SAVOIR
+- SRC-COBRIM-LARKIN-2014
+- SRC-RATIFY-STONE-2017
+- SRC-ELOQUENT-3-DIMOPOULOS-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-019` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-019/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-019 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-019/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-019
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-019
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-020.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-020.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-020
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-020`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-020`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-020/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-ESMO-SARCOMA-2024
+SRC-SCOUT
+SRC-COMBI-D-LONG-2014
+SRC-OLYMPIAD-ROBSON-2017
+SRC-KEYNOTE-407-PAZ-ARES-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-ESMO-SARCOMA-2024
+- SRC-SCOUT
+- SRC-COMBI-D-LONG-2014
+- SRC-OLYMPIAD-ROBSON-2017
+- SRC-KEYNOTE-407-PAZ-ARES-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-020` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-020/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-020 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-020/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-020
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-020
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-021.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-021.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-021
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-021`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-021`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-021/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-EXPLORER
+SRC-SSG-XVIII
+SRC-COMBI-V-ROBERT-2015
+SRC-ALEX-PETERS-2017
+SRC-SOLO1-MOORE-2018
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-EXPLORER
+- SRC-SSG-XVIII
+- SRC-COMBI-V-ROBERT-2015
+- SRC-ALEX-PETERS-2017
+- SRC-SOLO1-MOORE-2018
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-021` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-021/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-021 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-021/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-021
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-021
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-022.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-022.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-022
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-022`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-022`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-022/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-FIGHT
+SRC-VOYAGER
+SRC-RESPONSE-VANNUCCHI-2015
+SRC-MONARCH-2-SLEDGE-2017
+SRC-IMC-HTLV-2017
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-FIGHT
+- SRC-VOYAGER
+- SRC-RESPONSE-VANNUCCHI-2015
+- SRC-MONARCH-2-SLEDGE-2017
+- SRC-IMC-HTLV-2017
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-022` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-022/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-022 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-022/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-022
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-022
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-023.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-023.md
@@ -1,0 +1,121 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-023
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-023`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-023`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-023/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-FIGHT-202
+SRC-WHO-LNSC-2023
+SRC-CLEOPATRA-SWAIN-2015
+SRC-SOLO2-PUJADE-LAURAINE-2017
+SRC-ECHELON-2-HORWITZ-2019
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-FIGHT-202
+- SRC-WHO-LNSC-2023
+- SRC-CLEOPATRA-SWAIN-2015
+- SRC-SOLO2-PUJADE-LAURAINE-2017
+- SRC-ECHELON-2-HORWITZ-2019
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-023` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-023/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-023 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-023/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-023
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-023
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-024.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-024.md
@@ -1,0 +1,119 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-024
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-024`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-024`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-024/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-FIGHT-207
+SRC-IRIS-OBRIEN-2003
+SRC-AETHERA-MOSKOWITZ-2015
+SRC-ARIEL3-COLEMAN-2017
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-FIGHT-207
+- SRC-IRIS-OBRIEN-2003
+- SRC-AETHERA-MOSKOWITZ-2015
+- SRC-ARIEL3-COLEMAN-2017
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-024` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-024/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-024 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-024/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-024
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-024
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-025.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-025.md
@@ -1,0 +1,119 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-025
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-025`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-025`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-025/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-FOENIX-CCA2
+SRC-PT1-HARRISON-2005
+SRC-RECOURSE-MAYER-2015
+SRC-CHECKMATE-238-WEBER-2017
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-FOENIX-CCA2
+- SRC-PT1-HARRISON-2005
+- SRC-RECOURSE-MAYER-2015
+- SRC-CHECKMATE-238-WEBER-2017
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-025` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-025/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-025 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-025/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-025
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-025
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-026.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-026.md
@@ -1,0 +1,119 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-026
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-026`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-026`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-026/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-FORTITUDE-101
+SRC-BR21-SHEPHERD-2005
+SRC-KEYNOTE-006-ROBERT-2015
+SRC-COMBI-AD-LONG-2017
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-FORTITUDE-101
+- SRC-BR21-SHEPHERD-2005
+- SRC-KEYNOTE-006-ROBERT-2015
+- SRC-COMBI-AD-LONG-2017
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-026` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-026/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-026 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-026/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-026
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-026
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-027.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/source-recency-refresh-wave2-2026-05-01-027.md
@@ -1,0 +1,119 @@
+# [Chunk] source-recency-refresh-wave2-2026-05-01-027
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Q2 Source recency wave-2` from 270/271 sources have last_verified field; 219/271 have stale current_as_of (older than 2026-04-01) or are missing the field toward 131 oldest-priority sources refreshed (URL verified, current_as_of bumped, license/terms confirmed) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W12b -- Source recency refresh wave-2`. Pattern mirrors original `source-recency-refresh-*` chunks (issues #92-#121). Recency-stat reconciliation: see roadmap Appendix C.
+
+## Chunk Spec
+
+https://github.com/romeo111/OpenOnco/blob/master/docs/kb-coverage-strategy.md
+
+## Chunk ID
+
+`source-recency-refresh-wave2-2026-05-01-027`
+
+## Branch Naming Convention
+
+`tasktorrent/source-recency-refresh-wave2-2026-05-01-027`
+
+## Sidecar Output Path
+
+```
+contributions/source-recency-refresh-wave2-2026-05-01-027/
+```
+
+## Claim Method
+
+`formal-issue`
+
+## Drop Estimate
+
+0.5 day
+
+## Task Manifest
+
+```
+SRC-GEOMETRY-MONO-1
+SRC-MYLOFRANCE-ARIBI-2007
+SRC-PALOMA-3-TURNER-2015
+SRC-MONARCH-3-GOETZ-2017
+```
+
+## Manifest IDs (this chunk's allowlist)
+
+- SRC-GEOMETRY-MONO-1
+- SRC-MYLOFRANCE-ARIBI-2007
+- SRC-PALOMA-3-TURNER-2015
+- SRC-MONARCH-3-GOETZ-2017
+
+## Task
+
+For each source in the manifest: (1) verify the publisher URL still resolves (or replace with DOI / PubMed canonical URL); (2) confirm clinical content has not been superseded -- if so, add `superseded_by: SRC-XXX`; (3) bump `current_as_of` to the chunk run date IF clinical content is current; (4) confirm license/terms field is populated. Output sidecar audit YAML per source.
+
+## Allowed Sources
+
+- Hosted OpenOnco YAML files already present in this repository.
+- Source records already present in `knowledge_base/hosted/content/sources/`.
+- Public CC0/open-access metadata and publisher landing pages for IDs in the manifest.
+- CIViC evidence pages and linked PubMed records where relevant.
+
+## Disallowed Sources
+
+- `SRC-ONCOKB`
+- `SRC-SNOMED`
+- `SRC-MEDDRA`
+- Private, paywalled, or copied guideline text.
+
+## Output Requirements
+
+- All edits must be sidecar files under `contributions/<chunk-id>/` only.
+- Include `_contribution_meta.yaml` with `chunk_id: <chunk-id>` and `claim_method: formal-issue`.
+- Include `task_manifest.txt` containing exactly the manifest IDs above.
+- Include `source_recency_audit.yaml` with one entry per source: `id`, `url_verified` (yes/no/replaced-with), `content_current` (yes/no/superseded-by), `proposed_current_as_of`, `license_status`, `notes`.
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly.
+- `py -3.12 -m scripts.tasktorrent.validate_contributions source-recency-refresh-wave2-2026-05-01-027` passes locally.
+- `git diff --name-only origin/master..HEAD` shows no paths outside `contributions/source-recency-refresh-wave2-2026-05-01-027/`.
+- No disallowed source IDs (`SRC-ONCOKB`, `SRC-SNOMED`, `SRC-MEDDRA`) appear.
+
+
+## Reference pattern
+
+`git show origin/master:contributions/source-recency-refresh-2026-04-29-001/`
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b tasktorrent/source-recency-refresh-wave2-2026-05-01-027 origin/master
+# author sidecar files only -- never edit hosted KB
+git status --short
+git add contributions/source-recency-refresh-wave2-2026-05-01-027/
+git commit -m "$(cat <<'EOF'
+chore(contributions): source-recency-refresh-wave2-2026-05-01-027
+
+<one-line scope description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin tasktorrent/source-recency-refresh-wave2-2026-05-01-027
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Rejection Criteria
+
+- Hosted KB files are edited directly instead of using sidecars.
+- Any manifest ID is silently skipped.
+- Clinical claims lack source IDs, PMID/DOI links where available, or an explicit unresolved reason.
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-emerging-targeted-2026-05-01-004.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-emerging-targeted-2026-05-01-004.md
@@ -1,0 +1,83 @@
+# [Chunk] tier2-bio-emerging-targeted-2026-05-01-004
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7d -- Emerging targeted (6 bio)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- bio_nrg1_fusion (zenocutuzumab pan-tumor, FDA Dec 2024)
+- bio_braf_class_ii_iii (non-V600; distinct drug strategy)
+- bio_her2_ultralow (DESTINY-Breast06; distinct from bio_her2_low)
+- bio_esr1_y537s_d538g (extension to bio_esr1; elacestrant hot-spots)
+- bio_akt1_e17k (extension to bio_akt1; capivasertib hot-spot)
+- bio_cdkn2a_loss (extension to bio_cdkn2a; co-deletion vs LOH)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_braf_v600e.yaml`
+
+## Sources to cite
+
+- eNRGy (zenocutuzumab NRG1)
+- DESTINY-Breast06 (HER2-ultralow)
+- EMERALD (elacestrant ESR1)
+- CAPItello-291 (capivasertib AKT1/PIK3CA/PTEN)
+- INAVO120 (inavolisib PIK3CA)
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_nrg1_fusion.yaml
+knowledge_base/hosted/content/biomarkers/bio_braf_class_ii_iii.yaml
+knowledge_base/hosted/content/biomarkers/bio_her2_ultralow.yaml
+knowledge_base/hosted/content/biomarkers/bio_esr1_y537s_d538g.yaml
+knowledge_base/hosted/content/biomarkers/bio_akt1_e17k.yaml
+knowledge_base/hosted/content/biomarkers/bio_cdkn2a_loss.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-emerging-targeted-2026-05-01-004 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-emerging-targeted-2026-05-01-004
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-emerging-targeted-2026-05-01-004
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-followup-2026-05-01-007.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-followup-2026-05-01-007.md
@@ -1,0 +1,74 @@
+# [Chunk] tier2-bio-followup-2026-05-01-007
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7 followup -- placeholder for any biomarkers split out during chunk authoring`. Optional / overflow chunk -- only opens if W7b authoring decides to split Lynch into 4 entities. Otherwise close as duplicate.
+
+## Manifest IDs (this chunk's allowlist)
+
+- (Reserved -- if W7b Lynch is split into 4 individual entities, additional bio_msi_lynch_*.yaml files land here)
+- (Reserved for any W7 biomarker that requires separate authoring after schema review)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_brca_germline.yaml`
+
+## Sources to cite
+
+- NCCN Lynch Syndrome guidelines
+- PubMed consensus on Lynch gene-specific cancer risk
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_lynch_mlh1_germline.yaml
+knowledge_base/hosted/content/biomarkers/bio_lynch_msh2_germline.yaml
+knowledge_base/hosted/content/biomarkers/bio_lynch_msh6_germline.yaml
+knowledge_base/hosted/content/biomarkers/bio_lynch_pms2_germline.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-followup-2026-05-01-007 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-followup-2026-05-01-007
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-followup-2026-05-01-007
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-heme-2026-05-01-001.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-heme-2026-05-01-001.md
@@ -1,0 +1,81 @@
+# [Chunk] tier2-bio-heme-2026-05-01-001
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7a -- Heme expression markers (6 bio)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- bio_cd79b_mutation (LymphGen MCD-relevant; distinct from existing bio_cd79b_ihc)
+- bio_notch2_mutation (LymphGen BN2-relevant)
+- bio_cd22_expression (quantitative -- inotuzumab eligibility)
+- bio_cd33_expression (quantitative -- gemtuzumab/CD33 ADC eligibility)
+- bio_bcma_expression (teclistamab/elranatamab/CAR-T eligibility)
+- bio_cd38_expression (quantitative -- daratumumab/isatuximab line stratification)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_cd79b_ihc.yaml`
+
+## Sources to cite
+
+- CIViC entries for CD79B, NOTCH2 if available
+- PubMed pivotal trials -- MajesTEC-1 (teclistamab), MagnetisMM-3 (elranatamab) for BCMA
+- INO-VATE ALL (inotuzumab) for CD22 quant rationale
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_cd79b_mutation.yaml
+knowledge_base/hosted/content/biomarkers/bio_notch2_mutation.yaml
+knowledge_base/hosted/content/biomarkers/bio_cd22_expression.yaml
+knowledge_base/hosted/content/biomarkers/bio_cd33_expression.yaml
+knowledge_base/hosted/content/biomarkers/bio_bcma_expression.yaml
+knowledge_base/hosted/content/biomarkers/bio_cd38_expression.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-heme-2026-05-01-001 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-heme-2026-05-01-001
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-heme-2026-05-01-001
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-hereditary-2026-05-01-002.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-hereditary-2026-05-01-002.md
@@ -1,0 +1,80 @@
+# [Chunk] tier2-bio-hereditary-2026-05-01-002
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7b -- Hereditary panel split (5 bio)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- bio_brca_somatic (distinct from germline; PARPi tier varies by disease)
+- bio_palb2_germline
+- bio_atm_chek2_cdk12_germline (composite or 3 separate -- chunk picks based on schema)
+- bio_cdh1_germline (lobular breast / hereditary diffuse gastric)
+- bio_lynch_panel_split (MLH1 / MSH2 / MSH6 / PMS2 -- author as one composite OR 4 separate after reading existing Lynch coverage)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_brca_germline.yaml`
+
+## Sources to cite
+
+- PROfound (olaparib mCRPC PALB2/ATM/BRCA-somatic stratification)
+- EMBRACA (talazoparib germline BRCA)
+- NCCN hereditary cancer panel guidelines
+- CIViC entries per gene where available
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_brca_somatic.yaml
+knowledge_base/hosted/content/biomarkers/bio_palb2_germline.yaml
+knowledge_base/hosted/content/biomarkers/bio_atm_chek2_cdk12_germline.yaml
+knowledge_base/hosted/content/biomarkers/bio_cdh1_germline.yaml
+knowledge_base/hosted/content/biomarkers/bio_lynch_panel_split.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-hereditary-2026-05-01-002 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-hereditary-2026-05-01-002
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-hereditary-2026-05-01-002
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-melanoma-rare-2026-05-01-005.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-melanoma-rare-2026-05-01-005.md
@@ -1,0 +1,78 @@
+# [Chunk] tier2-bio-melanoma-rare-2026-05-01-005
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7e -- Melanoma + rare (4 bio)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- bio_nf1_mutation (melanoma sub-classification)
+- bio_bap1_mutation (uveal melanoma + mesothelioma)
+- bio_ctdna_mrd (generic ctDNA-MRD; lineage-agnostic)
+- bio_hrd_assay_distinction (Myriad MyChoice CDx vs F1CDx -- extend bio_hrd_status or new entity)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_hrd_status.yaml`
+
+## Sources to cite
+
+- TCGA melanoma classification (Cell 2015)
+- BAP1 uveal melanoma literature (PubMed)
+- GALAXY/CIRCULATE (ctDNA-MRD CRC)
+- Myriad MyChoice CDx vs F1CDx assay documentation
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_nf1_mutation.yaml
+knowledge_base/hosted/content/biomarkers/bio_bap1_mutation.yaml
+knowledge_base/hosted/content/biomarkers/bio_ctdna_mrd.yaml
+knowledge_base/hosted/content/biomarkers/bio_hrd_assay_distinction.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-melanoma-rare-2026-05-01-005 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-melanoma-rare-2026-05-01-005
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-melanoma-rare-2026-05-01-005
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-pdl1-clones-2026-05-01-006.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-pdl1-clones-2026-05-01-006.md
@@ -1,0 +1,79 @@
+# [Chunk] tier2-bio-pdl1-clones-2026-05-01-006
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7f -- PD-L1 IHC clones (4 bio)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- bio_pdl1_22c3_clone (Dako 22C3 -- pembrolizumab indications)
+- bio_pdl1_sp142_clone (Ventana SP142 -- atezolizumab TNBC, urothelial)
+- bio_pdl1_sp263_clone (Ventana SP263 -- durvalumab)
+- bio_pdl1_28_8_clone (Dako 28-8 -- nivolumab)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_pdl1_cps.yaml`
+
+## Sources to cite
+
+- KEYNOTE-024/189/407 (22C3)
+- IMpower150/IMpassion130 (SP142)
+- PACIFIC/CASPIAN (SP263)
+- CheckMate-067/214 (28-8)
+- Blueprint PD-L1 Assay Comparison Project (J Thorac Oncol 2017/2018)
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_pdl1_22c3_clone.yaml
+knowledge_base/hosted/content/biomarkers/bio_pdl1_sp142_clone.yaml
+knowledge_base/hosted/content/biomarkers/bio_pdl1_sp263_clone.yaml
+knowledge_base/hosted/content/biomarkers/bio_pdl1_28_8_clone.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-pdl1-clones-2026-05-01-006 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-pdl1-clones-2026-05-01-006
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-pdl1-clones-2026-05-01-006
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-prostate-2026-05-01-003.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-bio-prostate-2026-05-01-003.md
@@ -1,0 +1,75 @@
+# [Chunk] tier2-bio-prostate-2026-05-01-003
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 biomarker coverage` from current biomarker count 125 toward full second-wave coverage (28 new biomarkers across W7a-W7f) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W7c -- Prostate (3 bio)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- bio_ar_amplification (distinct from AR-V7 splice variant; ARSI-resistance complement)
+- bio_tmprss2_erg_fusion (prognostic, not Tx-modifying)
+- bio_dmmr_prostate (small-pop pembro eligibility -- verify if existing bio_dmmr_solid covers; if so, drop and document)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/biomarkers/bio_ar_v7.yaml`
+
+## Sources to cite
+
+- KEYNOTE-199 (pembro mCRPC)
+- PROPHECY trial (AR-V7)
+- TMPRSS2-ERG prognostic literature (PubMed)
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/biomarkers/bio_ar_amplification.yaml
+knowledge_base/hosted/content/biomarkers/bio_tmprss2_erg_fusion.yaml
+knowledge_base/hosted/content/biomarkers/bio_dmmr_prostate.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-bio-prostate-2026-05-01-003 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-bio-prostate-2026-05-01-003
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-bio-prostate-2026-05-01-003
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-breast-nsclc-emerging-2026-05-01-010.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-breast-nsclc-emerging-2026-05-01-010.md
@@ -1,0 +1,78 @@
+# [Chunk] tier2-drug-breast-nsclc-emerging-2026-05-01-010
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 drug coverage` from current drug count 220 (13 of 35 Tier-2 drugs already present) toward 220 + 21 = 241 (W8 scope: 21 not-yet-in-KB drugs) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W8c -- Breast + NSCLC emerging (5 drugs)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- drug_inavolisib (PIK3CA-mut HR+ breast; INAVO120, FDA Oct 2024)
+- drug_datopotamab_deruxtecan (TROP2 ADC; TROPION-Breast01, TROPION-Lung01)
+- drug_zenocutuzumab (NRG1-fusion bispecific; eNRGy, FDA Dec 2024)
+- drug_patritumab_deruxtecan (HER3 ADC; HERTHENA-Lung01)
+- drug_ensartinib (ALK TKI; eXalt3, FDA Dec 2024)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/drugs/alpelisib.yaml`
+
+## Sources to cite
+
+- FDA labels for inavolisib (Itovebi), zenocutuzumab (Bizengri), ensartinib (Ensacove)
+- INAVO120, TROPION-Breast01, TROPION-Lung01, eNRGy, HERTHENA-Lung01, eXalt3 trials
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/drugs/inavolisib.yaml
+knowledge_base/hosted/content/drugs/datopotamab_deruxtecan.yaml
+knowledge_base/hosted/content/drugs/zenocutuzumab.yaml
+knowledge_base/hosted/content/drugs/patritumab_deruxtecan.yaml
+knowledge_base/hosted/content/drugs/ensartinib.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-drug-breast-nsclc-emerging-2026-05-01-010 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-drug-breast-nsclc-emerging-2026-05-01-010
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-drug-breast-nsclc-emerging-2026-05-01-010
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-gi-gyn-emerging-2026-05-01-011.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-gi-gyn-emerging-2026-05-01-011.md
@@ -1,0 +1,79 @@
+# [Chunk] tier2-drug-gi-gyn-emerging-2026-05-01-011
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 drug coverage` from current drug count 220 (13 of 35 Tier-2 drugs already present) toward 220 + 21 = 241 (W8 scope: 21 not-yet-in-KB drugs) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W8d -- GI + GYN emerging (5 drugs)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- drug_futibatinib (FGFR2 TKI for cholangio; FOENIX-CCA2, FDA Sep 2022)
+- drug_infigratinib (FGFR2 TKI for cholangio; CBGJ398X2204, FDA May 2021 -- verify still marketed)
+- drug_magrolimab (CD47 mAb -- AML/MDS dev discontinued 2024; chunk may DROP and document)
+- drug_tisotumab_vedotin (TF ADC; innovaTV 204, FDA Sep 2021 cervical)
+- drug_olutasidenib (IDH1 R132 inhibitor; Study 2102-HEM-101, FDA Dec 2022 R/R AML)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/drugs/drug_pemigatinib.yaml`
+
+## Sources to cite
+
+- FDA labels for futibatinib (Lytgobi), tisotumab vedotin (Tivdak), olutasidenib (Rezlidhia)
+- FOENIX-CCA2, innovaTV 204, Study 2102-HEM-101
+- For magrolimab: Gilead announcement of MDS/AML program halt (Feb 2024) -- if dropped, document in commit body
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/drugs/futibatinib.yaml
+knowledge_base/hosted/content/drugs/infigratinib.yaml
+knowledge_base/hosted/content/drugs/magrolimab.yaml
+knowledge_base/hosted/content/drugs/tisotumab_vedotin.yaml
+knowledge_base/hosted/content/drugs/olutasidenib.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-drug-gi-gyn-emerging-2026-05-01-011 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-drug-gi-gyn-emerging-2026-05-01-011
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-drug-gi-gyn-emerging-2026-05-01-011
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-heme-bispecific-cart-2026-05-01-008.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-heme-bispecific-cart-2026-05-01-008.md
@@ -1,0 +1,81 @@
+# [Chunk] tier2-drug-heme-bispecific-cart-2026-05-01-008
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 drug coverage` from current drug count 220 (13 of 35 Tier-2 drugs already present) toward 220 + 21 = 241 (W8 scope: 21 not-yet-in-KB drugs) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W8a -- Heme bispecifics + CAR-T (6 drugs)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- drug_elranatamab (BCMA bispecific; MagnetisMM-3, FDA Aug 2023)
+- drug_talquetamab (GPRC5D bispecific; MonumenTAL-1, FDA Aug 2023)
+- drug_idecabtagene_vicleucel (ide-cel BCMA CAR-T; KarMMa, FDA Mar 2021)
+- drug_ciltacabtagene_autoleucel (cilta-cel BCMA CAR-T; CARTITUDE-1, FDA Feb 2022)
+- drug_epcoritamab (CD3xCD20 bispecific; EPCORE NHL-1, FDA May 2023)
+- drug_glofitamab (CD3xCD20 bispecific; NP30179, FDA Jun 2023)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/drugs/teclistamab.yaml`
+
+## Sources to cite
+
+- FDA labels for each drug
+- Pivotal trial sources (MagnetisMM-3, MonumenTAL-1, KarMMa, CARTITUDE-1, EPCORE NHL-1, NP30179)
+- EMA SmPCs where applicable
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/drugs/elranatamab.yaml
+knowledge_base/hosted/content/drugs/talquetamab.yaml
+knowledge_base/hosted/content/drugs/idecabtagene_vicleucel.yaml
+knowledge_base/hosted/content/drugs/ciltacabtagene_autoleucel.yaml
+knowledge_base/hosted/content/drugs/epcoritamab.yaml
+knowledge_base/hosted/content/drugs/glofitamab.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-drug-heme-bispecific-cart-2026-05-01-008 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-drug-heme-bispecific-cart-2026-05-01-008
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-drug-heme-bispecific-cart-2026-05-01-008
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-heme-liso-cel-2026-05-01-009.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-heme-liso-cel-2026-05-01-009.md
@@ -1,0 +1,71 @@
+# [Chunk] tier2-drug-heme-liso-cel-2026-05-01-009
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 drug coverage` from current drug count 220 (13 of 35 Tier-2 drugs already present) toward 220 + 21 = 241 (W8 scope: 21 not-yet-in-KB drugs) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W8b -- Heme CAR-T continued (1 drug)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- drug_lisocabtagene_maraleucel (liso-cel CD19 CAR-T; TRANSCEND DLBCL FDA Feb 2021; TRANSCEND-CLL Mar 2024; TRANSCEND-FL/MCL labels)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/drugs/axicabtagene_ciloleucel.yaml`
+
+## Sources to cite
+
+- FDA label liso-cel
+- TRANSCEND-NHL-001 (DLBCL)
+- TRANSCEND-CLL-004 (CLL)
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/drugs/lisocabtagene_maraleucel.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-drug-heme-liso-cel-2026-05-01-009 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-drug-heme-liso-cel-2026-05-01-009
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-drug-heme-liso-cel-2026-05-01-009
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-misc-niche-2026-05-01-012.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-drug-misc-niche-2026-05-01-012.md
@@ -1,0 +1,76 @@
+# [Chunk] tier2-drug-misc-niche-2026-05-01-012
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 drug coverage` from current drug count 220 (13 of 35 Tier-2 drugs already present) toward 220 + 21 = 241 (W8 scope: 21 not-yet-in-KB drugs) for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W8e -- Misc niche (4 drugs)`.
+
+## Manifest IDs (this chunk's allowlist)
+
+- drug_lurbinectedin (RNAPII inhibitor; ATLANTIS, FDA Jun 2020 SCLC R/R)
+- drug_ripretinib (KIT/PDGFRA TKI; INVICTUS, FDA May 2020 GIST 4L+)
+- drug_retifanlimab (PD-1 mAb; POD1UM-202 anal SCC, FDA Mar 2023)
+- drug_erdafitinib (FGFR TKI; BLC2001/THOR, FDA Apr 2019; THOR Jan 2024)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/drugs/avapritinib.yaml`
+
+## Sources to cite
+
+- FDA labels for Zepzelca, Qinlock, Zynyz, Balversa
+- ATLANTIS, INVICTUS, POD1UM-202, BLC2001, THOR
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/drugs/lurbinectedin.yaml
+knowledge_base/hosted/content/drugs/ripretinib.yaml
+knowledge_base/hosted/content/drugs/retifanlimab.yaml
+knowledge_base/hosted/content/drugs/erdafitinib.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-drug-misc-niche-2026-05-01-012 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-drug-misc-niche-2026-05-01-012
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-drug-misc-niche-2026-05-01-012
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-aml-bal-misc-2026-05-01-027.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-aml-bal-misc-2026-05-01-027.md
@@ -1,0 +1,81 @@
+# [Chunk] tier2-ind-aml-bal-misc-2026-05-01-027
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- AML / B-ALL / SCLC / GIST indications (~8)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-AML-RR-IDH1-OLUTASIDENIB (Study 2102-HEM-101)
+- IND-BALL-ADULT-RR-BLINATUMOMAB (TOWER)
+- IND-BALL-ADULT-RR-INOTUZUMAB (INO-VATE ALL)
+- IND-BALL-PED-CD19-TISACEL (existing -- verify)
+- IND-SCLC-RR-LURBINECTEDIN (ATLANTIS)
+- IND-GIST-4L-RIPRETINIB (INVICTUS)
+- IND-MELANOMA-ADJ-1L-PEMBRO-EXISTING (KEYNOTE-054; verify; if not present add)
+- IND-HNSCC-RM-1L-EXTREME-EXISTING (verify; if not present add)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_aml_2l_idh2_enasidenib.yaml`
+
+## Sources to cite
+
+- Study 2102-HEM-101
+- TOWER
+- INO-VATE ALL
+- ATLANTIS
+- INVICTUS
+- KEYNOTE-054
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_(aml|ball|sclc|gist|melanoma|hnscc)_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-aml-bal-misc-2026-05-01-027 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-aml-bal-misc-2026-05-01-027
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-aml-bal-misc-2026-05-01-027
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-breast-2026-05-01-023.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-breast-2026-05-01-023.md
@@ -1,0 +1,80 @@
+# [Chunk] tier2-ind-breast-2026-05-01-023
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- Breast indications (~8)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-BREAST-HR-POS-2L-CAPIVASERTIB (post-CDK4/6i, AKT1/PIK3CA/PTEN-altered)
+- IND-BREAST-HR-POS-1L-INAVOLISIB (PIK3CA-mut, post-CDK4/6i context per INAVO120)
+- IND-BREAST-HR-POS-2L-DATO-DXD (TROPION-Breast01)
+- IND-BREAST-TNBC-2L-DATO-DXD
+- IND-BREAST-HER2-LOW-2L-DATO-DXD
+- IND-BREAST-BRCA-MET-TALAZOPARIB (EMBRACA)
+- IND-BREAST-HRD-MET-NIRAPARIB (verify trial-source rationale)
+- IND-BREAST-HR-POS-ESR1-2L-ELACESTRANT (EMERALD)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_breast_hr_pos_2l_pik3ca_alpelisib.yaml`
+
+## Sources to cite
+
+- CAPItello-291
+- INAVO120
+- TROPION-Breast01
+- EMBRACA
+- EMERALD
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_breast_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-breast-2026-05-01-023 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-breast-2026-05-01-023
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-breast-2026-05-01-023
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-dlbcl-mcl-cll-2026-05-01-022.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-dlbcl-mcl-cll-2026-05-01-022.md
@@ -1,0 +1,80 @@
+# [Chunk] tier2-ind-dlbcl-mcl-cll-2026-05-01-022
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- DLBCL/MCL/CLL indications (~8)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-DLBCL-3L-EPCORITAMAB
+- IND-DLBCL-3L-GLOFITAMAB
+- IND-DLBCL-3L-LISOCEL
+- IND-DLBCL-2L-LISOCEL (TRANSFORM)
+- IND-MCL-3L-LISOCEL
+- IND-MCL-3L-PIRTOBRUTINIB-EXISTING (verify if present, else add)
+- IND-CLL-3L-LISOCEL (TRANSCEND-CLL-004)
+- IND-FL-3L-MOSUNETUZUMAB (verify existing; if so, drop and document)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_dlbcl_3l_axicel_cart.yaml`
+
+## Sources to cite
+
+- EPCORE NHL-1
+- NP30179
+- TRANSCEND-NHL-001
+- TRANSFORM
+- TRANSCEND-CLL-004
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_(dlbcl|mcl|cll|fl)_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-dlbcl-mcl-cll-2026-05-01-022 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-dlbcl-mcl-cll-2026-05-01-022
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-dlbcl-mcl-cll-2026-05-01-022
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-gi-2026-05-01-025.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-gi-2026-05-01-025.md
@@ -1,0 +1,76 @@
+# [Chunk] tier2-ind-gi-2026-05-01-025
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- GI indications (~6)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-CHOLANGIO-2L-FUTIBATINIB (FGFR2 fusion)
+- IND-CHOLANGIO-2L-INFIGRATINIB (FGFR2 fusion -- verify drug commercial status)
+- IND-CRC-3L-FRUQUINTINIB (FRESCO-2)
+- IND-UROTHELIAL-2L-ERDAFITINIB (THOR FGFR-altered)
+- IND-GASTRIC-METASTATIC-1L-CLDN18-2-ZOLBETUXIMAB-EXISTING (verify; if not present add)
+- IND-CRC-METASTATIC-2L-HER2-AMP-MOUNTAINEER-EXISTING (verify; if not present add)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_cholangio_2l_fgfr2_fusion_pemigatinib.yaml`
+
+## Sources to cite
+
+- FOENIX-CCA2
+- FRESCO-2
+- THOR
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_(cholangio|crc|urothelial|gastric)_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-gi-2026-05-01-025 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-gi-2026-05-01-025
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-gi-2026-05-01-025
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-gyn-2026-05-01-026.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-gyn-2026-05-01-026.md
@@ -1,0 +1,77 @@
+# [Chunk] tier2-ind-gyn-2026-05-01-026
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- GYN indications (~5)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-CERVICAL-2L-TISOTUMAB-VEDOTIN (innovaTV 204)
+- IND-OVARIAN-2L-FRA-MIRVETUXIMAB (MIRASOL)
+- IND-ANAL-1L-RETIFANLIMAB (POD1UM-303)
+- IND-CERVICAL-1L-PEMBRO-CHEMO-EXISTING (KEYNOTE-826 -- verify; if not, add)
+- IND-ENDOMETRIAL-1L-DOSTARLIMAB-EXISTING (RUBY -- verify; if not, add)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_cholangio_2l_fgfr2_fusion_pemigatinib.yaml`
+
+## Sources to cite
+
+- innovaTV 204
+- MIRASOL
+- POD1UM-303
+- KEYNOTE-826
+- RUBY
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_(cervical|ovarian|anal|endometrial)_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-gyn-2026-05-01-026 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-gyn-2026-05-01-026
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-gyn-2026-05-01-026
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-mm-2026-05-01-021.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-mm-2026-05-01-021.md
@@ -1,0 +1,79 @@
+# [Chunk] tier2-ind-mm-2026-05-01-021
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- MM indications (~6)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-MM-RR-3L-TECLISTAMAB (BCMA bispecific)
+- IND-MM-RR-3L-ELRANATAMAB (BCMA bispecific)
+- IND-MM-RR-3L-TALQUETAMAB (GPRC5D bispecific)
+- IND-MM-RR-3L-IDECEL (BCMA CAR-T)
+- IND-MM-RR-3L-CILTACEL (BCMA CAR-T)
+- IND-MM-RR-2L-CILTACEL (CARTITUDE-4 lifted to 2L)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_mm_4l_teclistamab.yaml`
+
+## Sources to cite
+
+- MajesTEC-1
+- MagnetisMM-3
+- MonumenTAL-1
+- KarMMa
+- CARTITUDE-1
+- CARTITUDE-4
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_mm_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-mm-2026-05-01-021 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-mm-2026-05-01-021
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-mm-2026-05-01-021
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-nsclc-2026-05-01-024.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-ind-nsclc-2026-05-01-024.md
@@ -1,0 +1,80 @@
+# [Chunk] tier2-ind-nsclc-2026-05-01-024
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 indication coverage` from Tier-1 indications landed via PR #166; Tier-2 drugs+regimens require indication wiring toward ~50 new indications routing W7 biomarkers + W8 drugs + W9 regimens for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W10 -- NSCLC indications (~8)`. Sequencing: starts after relevant W7+W8+W9 chunks merge; each indication >=2 source citations (Q4 axis).
+
+## Manifest IDs (this chunk's allowlist)
+
+- IND-NSCLC-2L-DATO-DXD (TROPION-Lung01)
+- IND-NSCLC-EGFR-POST-OSI-PATRITUMAB-DXD (HERTHENA-Lung01)
+- IND-NSCLC-NRG1-ZENOCUTUZUMAB
+- IND-NSCLC-ROS1-1L-REPOTRECTINIB
+- IND-NSCLC-ALK-1L-ENSARTINIB (alternative to alectinib)
+- IND-PAN-NTRK-2L-REPOTRECTINIB
+- IND-NSCLC-METAMP-CAPMATINIB-EXISTING (verify; if not present add)
+- IND-NSCLC-PDL1-22C3-PEMBRO-CLONE-SPECIFIC (per W7f)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/indications/ind_nsclc_alk_met_1l.yaml`
+
+## Sources to cite
+
+- TROPION-Lung01
+- HERTHENA-Lung01
+- eNRGy
+- TRIDENT-1
+- eXalt3
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/indications/indication_nsclc_*.yaml + indication_pan_ntrk_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-ind-nsclc-2026-05-01-024 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-ind-nsclc-2026-05-01-024
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-ind-nsclc-2026-05-01-024
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-breast-emerging-2026-05-01-016.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-breast-emerging-2026-05-01-016.md
@@ -1,0 +1,78 @@
+# [Chunk] tier2-reg-breast-emerging-2026-05-01-016
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- Breast emerging regimens (~6)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_capivasertib_fulvestrant_breast (CAPItello-291)
+- regimen_inavolisib_palbo_fulv_breast (INAVO120)
+- regimen_dato_dxd_breast_2l (TROPION-Breast01 HR+/HER2-low/TNBC)
+- regimen_talazoparib_mono_breast (EMBRACA)
+- regimen_niraparib_breast_germline (NCT trial citation)
+- regimen_elacestrant_mono_breast_esr1 (EMERALD)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_alpelisib_fulvestrant_breast.yaml`
+
+## Sources to cite
+
+- CAPItello-291
+- INAVO120
+- TROPION-Breast01
+- EMBRACA
+- EMERALD
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*breast*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-breast-emerging-2026-05-01-016 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-breast-emerging-2026-05-01-016
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-breast-emerging-2026-05-01-016
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-dlbcl-bispecific-cart-2026-05-01-015.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-dlbcl-bispecific-cart-2026-05-01-015.md
@@ -1,0 +1,77 @@
+# [Chunk] tier2-reg-dlbcl-bispecific-cart-2026-05-01-015
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- DLBCL bispecific + liso-cel regimens (~6)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_epcoritamab_mono_dlbcl_3l (EPCORE NHL-1)
+- regimen_glofitamab_mono_dlbcl_3l (NP30179 fixed-duration 12 cycles)
+- regimen_lisocel_dlbcl_3l (TRANSCEND-NHL-001)
+- regimen_lisocel_dlbcl_2l (TRANSFORM)
+- regimen_epcoritamab_step_up_dosing
+- regimen_glofitamab_obinutuzumab_pretreatment
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_tisagenlecleucel_b_all.yaml`
+
+## Sources to cite
+
+- EPCORE NHL-1
+- NP30179
+- TRANSCEND-NHL-001
+- TRANSFORM
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*dlbcl*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-dlbcl-bispecific-cart-2026-05-01-015 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-dlbcl-bispecific-cart-2026-05-01-015
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-dlbcl-bispecific-cart-2026-05-01-015
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-gi-emerging-2026-05-01-018.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-gi-emerging-2026-05-01-018.md
@@ -1,0 +1,76 @@
+# [Chunk] tier2-reg-gi-emerging-2026-05-01-018
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- GI emerging regimens (~5)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_futibatinib_cholangio_2l (FOENIX-CCA2)
+- regimen_infigratinib_cholangio_2l (CBGJ398X2204) -- verify drug still marketed
+- regimen_fruquintinib_crc_3l (FRESCO-2)
+- regimen_erdafitinib_urothelial_2l (THOR)
+- regimen_olutasidenib_aml_rr_idh1 (Study 2102-HEM-101)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_pemigatinib_cholangio.yaml`
+
+## Sources to cite
+
+- FOENIX-CCA2
+- FRESCO-2
+- THOR
+- Study 2102-HEM-101
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*cholangio*.yaml + regimen_fruquintinib_*.yaml + regimen_erdafitinib_*.yaml + regimen_olutasidenib_*.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-gi-emerging-2026-05-01-018 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-gi-emerging-2026-05-01-018
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-gi-emerging-2026-05-01-018
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-gyn-emerging-2026-05-01-019.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-gyn-emerging-2026-05-01-019.md
@@ -1,0 +1,76 @@
+# [Chunk] tier2-reg-gyn-emerging-2026-05-01-019
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- GYN emerging regimens (~5)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_tisotumab_vedotin_cervical_2l (innovaTV 204)
+- regimen_mirvetuximab_ovarian_2l_fra (MIRASOL)
+- regimen_retifanlimab_anal_1l (POD1UM-303 + POD1UM-202)
+- regimen_pembrolizumab_cervical_1l (KEYNOTE-826) -- if not already present, otherwise drop
+- regimen_dostarlimab_endometrial_1l (RUBY) -- if not already present, otherwise drop
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_pembrolizumab_maintenance.yaml`
+
+## Sources to cite
+
+- innovaTV 204
+- MIRASOL
+- POD1UM-202
+- POD1UM-303
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*cervical*.yaml + regimen_*ovarian*.yaml + regimen_*anal*.yaml + regimen_*endometrial*.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-gyn-emerging-2026-05-01-019 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-gyn-emerging-2026-05-01-019
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-gyn-emerging-2026-05-01-019
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-mm-bispecific-2026-05-01-013.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-mm-bispecific-2026-05-01-013.md
@@ -1,0 +1,77 @@
+# [Chunk] tier2-reg-mm-bispecific-2026-05-01-013
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- MM bispecific regimens (~6)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_teclistamab_mono_mm (MajesTEC-1)
+- regimen_elranatamab_mono_mm (MagnetisMM-3)
+- regimen_talquetamab_mono_mm (MonumenTAL-1)
+- regimen_teclistamab_step_up_dosing_mm
+- regimen_elranatamab_step_up_dosing_mm
+- regimen_talquetamab_qw_q2w_mm
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_teclistamab.yaml`
+
+## Sources to cite
+
+- MajesTEC-1
+- MagnetisMM-3
+- MonumenTAL-1
+- FDA labels
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*_mm*.yaml (only files in manifest)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-mm-bispecific-2026-05-01-013 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-mm-bispecific-2026-05-01-013
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-mm-bispecific-2026-05-01-013
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-mm-cart-2026-05-01-014.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-mm-cart-2026-05-01-014.md
@@ -1,0 +1,76 @@
+# [Chunk] tier2-reg-mm-cart-2026-05-01-014
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- MM CAR-T regimens (~5)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_idecel_mm_3l (KarMMa)
+- regimen_ciltacel_mm_3l (CARTITUDE-1)
+- regimen_ciltacel_mm_2l (CARTITUDE-4)
+- regimen_idecel_lymphodepletion_flu_cy
+- regimen_ciltacel_lymphodepletion_flu_cy
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_tisagenlecleucel_b_all.yaml`
+
+## Sources to cite
+
+- KarMMa
+- CARTITUDE-1
+- CARTITUDE-4
+- FDA labels
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*cel_mm*.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-mm-cart-2026-05-01-014 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-mm-cart-2026-05-01-014
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-mm-cart-2026-05-01-014
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-niche-2026-05-01-020.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-niche-2026-05-01-020.md
@@ -1,0 +1,78 @@
+# [Chunk] tier2-reg-niche-2026-05-01-020
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- Niche regimens (~6)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_lurbinectedin_sclc_rr (ATLANTIS)
+- regimen_ripretinib_gist_4l (INVICTUS)
+- regimen_blinatumomab_ball_adult_rr (TOWER)
+- regimen_inotuzumab_ball_adult_rr (INO-VATE ALL)
+- regimen_blina_inotuzumab_consolidation_ball
+- regimen_olutasidenib_aml_idh1_consolidation
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_tisagenlecleucel_b_all.yaml`
+
+## Sources to cite
+
+- ATLANTIS
+- INVICTUS
+- TOWER
+- INO-VATE ALL
+- Study 2102-HEM-101
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*sclc*.yaml + regimen_*gist*.yaml + regimen_*ball*.yaml + regimen_*aml*idh1*.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-niche-2026-05-01-020 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-niche-2026-05-01-020
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-niche-2026-05-01-020
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-nsclc-emerging-2026-05-01-017.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-reg-nsclc-emerging-2026-05-01-017.md
@@ -1,0 +1,78 @@
+# [Chunk] tier2-reg-nsclc-emerging-2026-05-01-017
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 regimen coverage` from Tier-1 regimens landed; Tier-2 drugs (W8) require regimen wiring toward ~50 new regimens covering W8 drugs across line/disease combinations for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W9 -- NSCLC emerging regimens (~6)`. Sequencing: starts after the relevant W8 drug chunk merges; verify drug IDs exist before authoring.
+
+## Manifest IDs (this chunk's allowlist)
+
+- regimen_dato_dxd_nsclc_2l (TROPION-Lung01)
+- regimen_patritumab_dxd_nsclc_post_egfr (HERTHENA-Lung01)
+- regimen_zenocutuzumab_nrg1_pan_tumor (eNRGy)
+- regimen_repotrectinib_ros1_1l (TRIDENT-1)
+- regimen_repotrectinib_ntrk_pan_tumor (TRIDENT-1)
+- regimen_ensartinib_alk_1l (eXalt3)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/regimens/reg_alectinib_nsclc.yaml`
+
+## Sources to cite
+
+- TROPION-Lung01
+- HERTHENA-Lung01
+- eNRGy
+- TRIDENT-1
+- eXalt3
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/regimens/regimen_*nsclc*.yaml + regimen_*ntrk*.yaml
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-reg-nsclc-emerging-2026-05-01-017 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-reg-nsclc-emerging-2026-05-01-017
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-reg-nsclc-emerging-2026-05-01-017
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-breast-nsclc-2026-05-01-029.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-breast-nsclc-2026-05-01-029.md
@@ -1,0 +1,81 @@
+# [Chunk] tier2-rf-breast-nsclc-2026-05-01-029
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 RedFlag coverage` from Tier-1 RFs landed; Tier-2 biomarkers require RF gating toward ~25 new RFs gating W10 indications for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W11 -- Breast/NSCLC RFs (~7)`. Each RF uses structured `findings` keys (no free-text condition strings -- drift signal #4 already documented).
+
+## Manifest IDs (this chunk's allowlist)
+
+- RF-BREAST-HER2-ULTRALOW-CANDIDATE (DESTINY-Breast06)
+- RF-BREAST-ESR1-Y537S-D538G-CANDIDATE (EMERALD)
+- RF-BREAST-AKT1-E17K-CAPIVASERTIB-CANDIDATE (CAPItello-291)
+- RF-BREAST-PIK3CA-COALT-INAVOLISIB-CANDIDATE (INAVO120)
+- RF-NSCLC-NRG1-FUSION-ZENO-CANDIDATE
+- RF-NSCLC-HER3-HIGH-PATRITUMAB-CANDIDATE
+- RF-NSCLC-TROP2-DATO-CANDIDATE
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/redflags/rf_breast_pik3ca_mut_actionable.yaml`
+
+## Sources to cite
+
+- DESTINY-Breast06
+- EMERALD
+- CAPItello-291
+- INAVO120
+- eNRGy
+- HERTHENA-Lung01
+- TROPION-Lung01
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/redflags/rf_(breast|nsclc)_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-rf-breast-nsclc-2026-05-01-029 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-rf-breast-nsclc-2026-05-01-029
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-rf-breast-nsclc-2026-05-01-029
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-heme-2026-05-01-028.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-heme-2026-05-01-028.md
@@ -1,0 +1,78 @@
+# [Chunk] tier2-rf-heme-2026-05-01-028
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 RedFlag coverage` from Tier-1 RFs landed; Tier-2 biomarkers require RF gating toward ~25 new RFs gating W10 indications for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W11 -- Heme RFs (~7)`. Each RF uses structured `findings` keys (no free-text condition strings -- drift signal #4 already documented).
+
+## Manifest IDs (this chunk's allowlist)
+
+- RF-MM-BCMA-EXPRESSION-POS (gates teclistamab/elranatamab/CAR-T)
+- RF-DLBCL-CD20-POS-EPCORITAMAB-CANDIDATE
+- RF-DLBCL-CD20-POS-GLOFITAMAB-CANDIDATE
+- RF-MM-CD38-EXPRESSION-DARA-CANDIDATE
+- RF-AML-CD33-POS-GO-CANDIDATE
+- RF-BALL-CD22-POS-INO-CANDIDATE
+- RF-DLBCL-CD79B-MUT-MCD-CANDIDATE (informational; LymphGen-relevant)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/redflags/rf_dlbcl_cart_ineligible_post_2l.yaml`
+
+## Sources to cite
+
+- MajesTEC-1
+- EPCORE NHL-1
+- INO-VATE ALL
+- ALFA-0701 (GO)
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/redflags/rf_*.yaml (subset; heme only)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-rf-heme-2026-05-01-028 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-rf-heme-2026-05-01-028
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-rf-heme-2026-05-01-028
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-hereditary-prostate-2026-05-01-030.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-hereditary-prostate-2026-05-01-030.md
@@ -1,0 +1,77 @@
+# [Chunk] tier2-rf-hereditary-prostate-2026-05-01-030
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 RedFlag coverage` from Tier-1 RFs landed; Tier-2 biomarkers require RF gating toward ~25 new RFs gating W10 indications for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W11 -- Hereditary + prostate RFs (~6)`. Each RF uses structured `findings` keys (no free-text condition strings -- drift signal #4 already documented).
+
+## Manifest IDs (this chunk's allowlist)
+
+- RF-PAN-BRCA-SOMATIC-PARPI-CANDIDATE
+- RF-PAN-PALB2-PARPI-CANDIDATE
+- RF-PAN-ATM-CHEK2-CDK12-PARPI-CANDIDATE (composite)
+- RF-BREAST-CDH1-LOBULAR-CANDIDATE (informational; lobular subtype)
+- RF-PROSTATE-AR-AMP-ARSI-RESISTANCE
+- RF-PROSTATE-TMPRSS2-ERG-PROGNOSTIC
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/redflags/rf_prostate_ar_v7_arsi_resistance.yaml`
+
+## Sources to cite
+
+- PROfound
+- EMBRACA
+- OlympiAD
+- NCCN hereditary cancer panel
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/redflags/rf_(pan|breast|prostate)_*.yaml (subset)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-rf-hereditary-prostate-2026-05-01-030 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-rf-hereditary-prostate-2026-05-01-030
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-rf-hereditary-prostate-2026-05-01-030
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-misc-2026-05-01-031.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier2-rf-misc-2026-05-01-031.md
@@ -1,0 +1,76 @@
+# [Chunk] tier2-rf-misc-2026-05-01-031
+
+## Mission
+
+This chunk advances `kb-coverage-matrix.md > Quality gaps > Tier-2 RedFlag coverage` from Tier-1 RFs landed; Tier-2 biomarkers require RF gating toward ~25 new RFs gating W10 indications for the manifest IDs below.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W11 -- Misc RFs (~5)`. Each RF uses structured `findings` keys (no free-text condition strings -- drift signal #4 already documented).
+
+## Manifest IDs (this chunk's allowlist)
+
+- RF-MELANOMA-NF1-MUT-CANDIDATE (informational)
+- RF-UVEAL-MELANOMA-BAP1-MUT-CANDIDATE (informational)
+- RF-PAN-CTDNA-MRD-POSITIVE
+- RF-BREAST-OVARIAN-HRD-ASSAY-DISTINCTION (Myriad MyChoice CDx vs F1CDx)
+- RF-PAN-PDL1-CLONE-22C3-PEMBRO-ELIGIBLE (per W7f)
+
+## Quality Gate
+
+- Each manifest ID has a source-backed outcome.
+- Each unresolved item has a structured reason.
+- No hosted KB file is edited directly outside the allowlist.
+- KB validator clean: `python -m knowledge_base.validation.loader knowledge_base/hosted/content` returns "OK -- all entities valid".
+- pytest fixture green: `pytest tests/test_curated_chunk_e2e.py -q` returns "62 passed".
+- Per-chunk allowlist strictly enforced: `git diff --name-only origin/master` should only list paths in the allowlist below.
+- Sources cited (no invented IDs); flag missing trial Sources in commit body.
+
+
+## Reference YAML pattern
+
+`git show origin/master:knowledge_base/hosted/content/redflags/rf_breast_brca_germline_actionable.yaml`
+
+## Sources to cite
+
+- TCGA melanoma
+- BAP1 uveal literature
+- GALAXY/CIRCULATE
+- Blueprint PD-L1 Comparison
+
+## Allowlist (file pathspecs this chunk may touch)
+
+```
+knowledge_base/hosted/content/redflags/rf_*.yaml (subset; melanoma+uveal+pan+breast+ovarian)
+```
+
+## Branch + commit + push
+
+```
+git fetch origin
+git checkout -b chunk/tier2-rf-misc-2026-05-01-031 origin/master
+# author files in allowlist
+git status --short
+git add <explicit pathspecs from allowlist>
+git commit -m "$(cat <<'EOF'
+feat(kb): tier2-rf-misc-2026-05-01-031
+
+<one-line scope description per roadmap section>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin chunk/tier2-rf-misc-2026-05-01-031
+```
+
+Self-push authorized per CLAUDE.md commit `3a60901b`.
+
+## Stop conditions
+
+- KB validator regresses.
+- pytest fixture drops below 62 passed.
+- Edits land outside the allowlist.
+- Required source ID does not exist in KB -- flag in commit body, do not invent.
+- Two chunks editing the same file (coordination bug, escalate).
+
+## Never
+
+`git add -A`, `--no-verify`, force-push, branch deletion, edits to existing YAML beyond the allowlist.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier3-bio-hereditary-panel-deferred-2026-05-01-062.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier3-bio-hereditary-panel-deferred-2026-05-01-062.md
@@ -1,0 +1,39 @@
+# [Chunk] tier3-bio-hereditary-panel-deferred-2026-05-01-062
+
+## Mission
+
+This issue is a **deferred parking stub** for Tier-3 niche biomarkers. It is NOT to be dispatched in the Tier-2 wave; it lives as a tracked parking lot until the trigger condition fires.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W13 -- Tier-3 niche (deferred, 3 stub issues)`.
+
+## Scope
+
+Lynch genes individually (if not absorbed by W7b), TP53 germline (Li-Fraumeni), APC (FAP), MUTYH biallelic
+
+## Deferral rationale
+
+- Rare-disease scope: low patient volume relative to v0.1 launch goals.
+- Engine architecture sufficient for current workflows; no immediate gap.
+- Clinical co-lead capacity reserved for v0.1/v0.2 high-impact work first.
+
+## Trigger condition (revisit when this fires)
+
+Hereditary cancer counseling integration; CHARTER §15 patient-data extension to include family history.
+
+## When triggered, expected scope
+
+- ~3-8 new biomarkers per chunk
+- ~1-3 new RFs per biomarker
+- ~0-2 new indications per biomarker (depends on FDA-approval landscape at trigger time)
+- 1-2 new regimens per indication
+
+## Action now
+
+- Keep this issue OPEN as a parking lot.
+- Re-read at every v0.x to v(0.x+1) milestone planning meeting.
+- If trigger fires, fork into an implementation plan (analog to `lymphgen_dlbcl_proposal_2026-04-30-1500.md` model).
+- If trigger does not fire after 6 months, update "as of YYYY-MM-DD" status and re-park.
+
+## Stop conditions / Never
+
+This issue is not for active work. Do NOT dispatch a contributor agent against it. If a contributor opens it by mistake, close it without action.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier3-bio-pediatric-cns-deferred-2026-05-01-061.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier3-bio-pediatric-cns-deferred-2026-05-01-061.md
@@ -1,0 +1,39 @@
+# [Chunk] tier3-bio-pediatric-cns-deferred-2026-05-01-061
+
+## Mission
+
+This issue is a **deferred parking stub** for Tier-3 niche biomarkers. It is NOT to be dispatched in the Tier-2 wave; it lives as a tracked parking lot until the trigger condition fires.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W13 -- Tier-3 niche (deferred, 3 stub issues)`.
+
+## Scope
+
+H3K27M (DIPG / midline glioma), BRAF-fusion KIAA1549 (pilocytic astrocytoma), DICER1 (thyroid + pleuropulmonary blastoma)
+
+## Deferral rationale
+
+- Rare-disease scope: low patient volume relative to v0.1 launch goals.
+- Engine architecture sufficient for current workflows; no immediate gap.
+- Clinical co-lead capacity reserved for v0.1/v0.2 high-impact work first.
+
+## Trigger condition (revisit when this fires)
+
+Pediatric oncology track activation in OpenOnco roadmap.
+
+## When triggered, expected scope
+
+- ~3-8 new biomarkers per chunk
+- ~1-3 new RFs per biomarker
+- ~0-2 new indications per biomarker (depends on FDA-approval landscape at trigger time)
+- 1-2 new regimens per indication
+
+## Action now
+
+- Keep this issue OPEN as a parking lot.
+- Re-read at every v0.x to v(0.x+1) milestone planning meeting.
+- If trigger fires, fork into an implementation plan (analog to `lymphgen_dlbcl_proposal_2026-04-30-1500.md` model).
+- If trigger does not fire after 6 months, update "as of YYYY-MM-DD" status and re-park.
+
+## Stop conditions / Never
+
+This issue is not for active work. Do NOT dispatch a contributor agent against it. If a contributor opens it by mistake, close it without action.

--- a/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier3-bio-sarcoma-fusions-deferred-2026-05-01-060.md
+++ b/docs/plans/tier2_dispatch_2026-05-01-1100/issues/tier3-bio-sarcoma-fusions-deferred-2026-05-01-060.md
@@ -1,0 +1,39 @@
+# [Chunk] tier3-bio-sarcoma-fusions-deferred-2026-05-01-060
+
+## Mission
+
+This issue is a **deferred parking stub** for Tier-3 niche biomarkers. It is NOT to be dispatched in the Tier-2 wave; it lives as a tracked parking lot until the trigger condition fires.
+
+Tier-2 roadmap reference: `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md > W13 -- Tier-3 niche (deferred, 3 stub issues)`.
+
+## Scope
+
+EWSR1, SS18, DDIT3, MDM2 amp; sarcoma fusions (Ewing, synovial, myxoid liposarcoma, dedifferentiated lipo)
+
+## Deferral rationale
+
+- Rare-disease scope: low patient volume relative to v0.1 launch goals.
+- Engine architecture sufficient for current workflows; no immediate gap.
+- Clinical co-lead capacity reserved for v0.1/v0.2 high-impact work first.
+
+## Trigger condition (revisit when this fires)
+
+Rare-disease coverage initiative or specialist request from sarcoma-focused clinical co-lead.
+
+## When triggered, expected scope
+
+- ~3-8 new biomarkers per chunk
+- ~1-3 new RFs per biomarker
+- ~0-2 new indications per biomarker (depends on FDA-approval landscape at trigger time)
+- 1-2 new regimens per indication
+
+## Action now
+
+- Keep this issue OPEN as a parking lot.
+- Re-read at every v0.x to v(0.x+1) milestone planning meeting.
+- If trigger fires, fork into an implementation plan (analog to `lymphgen_dlbcl_proposal_2026-04-30-1500.md` model).
+- If trigger does not fire after 6 months, update "as of YYYY-MM-DD" status and re-park.
+
+## Stop conditions / Never
+
+This issue is not for active work. Do NOT dispatch a contributor agent against it. If a contributor opens it by mistake, close it without action.


### PR DESCRIPTION
Recovery PR for #179 (squash bug repeated from #165 — empty merge commit `e1304126`). Brings the actual 84 docs-only files via single direct commit onto current master.

**Tree check post-merge MUST show:** master tree changes from `6a051fa0` to a new tree containing `docs/plans/biomarker_expansion_tier2_roadmap_2026-05-01-1100.md` + 83 issue-body files under `docs/plans/tier2_dispatch_2026-05-01-1100/issues/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)