### PR TITLE
fix(scripts): force utf-8 stdout in 5 scripts that print non-ASCII

### DIFF
--- a/scripts/_pkg3_normalize.py
+++ b/scripts/_pkg3_normalize.py
@@ -9,6 +9,7 @@ Run: py -3.12 scripts/_pkg3_normalize.py
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 KB = Path(__file__).resolve().parent.parent / "knowledge_base/hosted/content/drugs"
@@ -502,7 +503,18 @@ def process(path: Path, drug_id: str) -> dict:
     return {"path": str(path), "drug_id": drug_id, "changes": []}
 
 
+def _force_utf8_stdout() -> None:
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+
 def main():
+    _force_utf8_stdout()
     # Map filename stem → DRUG-ID for safety check
     pkg3 = {
         "adagrasib": "DRUG-ADAGRASIB",

--- a/scripts/audit_unresolved_sources.py
+++ b/scripts/audit_unresolved_sources.py
@@ -121,7 +121,18 @@ def _format_markdown(report: dict) -> str:
     return "\n".join(out)
 
 
+def _force_utf8_stdout() -> None:
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+
 def main() -> int:
+    _force_utf8_stdout()
     parser = argparse.ArgumentParser(
         description="List unresolved SRC-* citations grouped by category.",
     )

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -43,6 +43,7 @@ import argparse
 import html
 import json
 import shutil
+import sys
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -7000,7 +7001,18 @@ def build_site(output_dir: Path) -> dict:
     }
 
 
+def _force_utf8_stdout() -> None:
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+
 def main(argv: list[str] | None = None) -> int:
+    _force_utf8_stdout()
     parser = argparse.ArgumentParser(description="Build OpenOnco static site for GitHub Pages.")
     parser.add_argument("--output", default="docs", help="Output directory (default: docs/)")
     parser.add_argument("--clean", action="store_true", help="Wipe output directory before building.")

--- a/scripts/disease_coverage_matrix.py
+++ b/scripts/disease_coverage_matrix.py
@@ -441,7 +441,18 @@ def render_markdown_table(rows: list[dict]) -> str:
     return "\n".join(out)
 
 
+def _force_utf8_stdout() -> None:
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+
 def main() -> int:
+    _force_utf8_stdout()
     rows = per_disease_metrics(REPO_ROOT / "knowledge_base" / "hosted" / "content")
     print(render_markdown_table(rows))
     return 0

--- a/scripts/draft_ua_fields.py
+++ b/scripts/draft_ua_fields.py
@@ -1260,7 +1260,18 @@ def process_file(
     return True, "", str(eid) if eid else None, ua_text[:240]
 
 
+def _force_utf8_stdout() -> None:
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+
 def main() -> int:
+    _force_utf8_stdout()
     yaml_io = YAML()
     yaml_io.preserve_quotes = True
     yaml_io.width = 4096


### PR DESCRIPTION
## Summary

- Default Windows console encoding is `cp1252`, so running these scripts directly without `PYTHONIOENCODING=utf-8` raises `UnicodeEncodeError` whenever they print characters outside cp1252 (≥, ≤, →, ✓, Cyrillic).
- Adopts the existing repo helper from `audit_freshness.py` / `audit_validator.py` / `cron_kb_audit_runner.py` / `run_scheduled_audit.py`: defines `_force_utf8_stdout()` and calls it from `main()` so importing the module as a library has no side effects.
- Surfaced during Phase 2 schema migration work in [#177](https://github.com/romeo111/OpenOnco/pull/177) but kept out of scope there.

## Affected scripts

Each was confirmed to crash with `UnicodeEncodeError` under `PYTHONIOENCODING=cp1252` before the fix and runs cleanly after:

| Script | Failing char | Source |
|---|---|---|
| [scripts/disease_coverage_matrix.py](scripts/disease_coverage_matrix.py) | `≥` U+2265 | markdown legend |
| [scripts/audit_unresolved_sources.py](scripts/audit_unresolved_sources.py) | `≤` U+2264 | section header |
| [scripts/build_site.py](scripts/build_site.py) | `→` U+2192 | rendered site JSON |
| [scripts/_pkg3_normalize.py](scripts/_pkg3_normalize.py) | `✓` U+2713 | per-drug status line |
| [scripts/draft_ua_fields.py](scripts/draft_ua_fields.py) | Cyrillic | drafted UA snippets |

Empirical scoping was done by running every other Python script under `scripts/` (and `scripts/tasktorrent/`) under `PYTHONIOENCODING=cp1252`; the 60+ that did not crash are unaffected (they either write to UTF-8 files only, or their stdout is pure ASCII).

## Test plan

- [x] Each of the 5 scripts runs without `UnicodeEncodeError` under `PYTHONIOENCODING=cp1252` on Windows
- [x] `tests/test_translate_client.py` + `tests/test_source_ref_integrity.py` — 76/76 pass
- [x] `knowledge_base.validation.loader.load_content` — `ok=True`, 0 schema/contract/ref errors
- [x] Module imports for all 5 scripts succeed (no `import sys` regression in `build_site.py`, no helper-name collision)
- [ ] Note: `tests/test_build_site.py` and `tests/test_engine_lazy_load_js.py` have 14 pre-existing failures on master (missing `en/` mirror artifacts and the `try.html` link); those are unrelated to this PR and reproduce on `30ea2e0b` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)