### PR TITLE
docs(readme): bilingual knowledge_base/ + new specs/README.md

### DIFF
--- a/knowledge_base/README.md
+++ b/knowledge_base/README.md
@@ -1,172 +1,73 @@
 # knowledge_base/
 
-The OpenOnco rule-engine and knowledge base. Live at
-[**openonco.info**](https://openonco.info) (EN default, UA mirror at
-[`/ukr/`](https://openonco.info/ukr/)). Specifications under
-[`../specs/`](../specs/) — start with
-[`CHARTER.md`](../specs/CHARTER.md) for governance + scope and
-[`KNOWLEDGE_SCHEMA_SPECIFICATION.md`](../specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md)
-for the entity model.
+🇬🇧 English (below) · 🇺🇦 [Українська](#-українська)
 
-**Version:** v0.1.2 (released 2026-04-30, see
-[`__init__.py`](__init__.py)).
+The OpenOnco rule engine and knowledge base. Patient profile in
+(FHIR R4 / mCODE compatible) → **two alternative treatment plans**
+(standard + aggressive), side by side, every recommendation cited.
+LLMs do **not** make clinical decisions — clinical logic runs in a
+declarative rule engine reading versioned YAML
+([CHARTER §8.3](../specs/CHARTER.md)).
 
-## What it does
-
-Patient profile (FHIR R4 / mCODE compatible) → declarative rule engine
-→ two alternative treatment plans (standard + aggressive) with full
-source citations, MDT role activation, red flags, dose adjustments,
-and monitoring schedule. Plans refresh as new data arrives (new labs,
-doctor decisions, updated guidelines). LLMs do **not** make clinical
-decisions (CHARTER §8.3) — clinical logic runs in the rule engine
-reading versioned YAML.
+Live at **[openonco.info](https://openonco.info)** (EN default,
+UA mirror at [`/ukr/`](https://openonco.info/ukr/)).
+Live KB metrics, per-disease coverage matrix, sign-off ratio:
+**[openonco.info/capabilities](https://openonco.info/capabilities.html)**.
 
 ## Layout
 
 ```
 knowledge_base/
-├── schemas/                   # 23 Pydantic models (entities + KB facets)
-├── clients/                   # Live-API clients for referenced sources
-│   ├── base.py                # SourceClient protocol + TokenBucket + cache
-│   ├── ctgov_client.py        # ClinicalTrials.gov v2
-│   ├── pubmed_client.py
-│   ├── dailymed_client.py
-│   ├── openfda_client.py
-│   └── translate_client.py    # DeepL / LibreTranslate (UI + KB free-text)
-├── engine/                    # 34 modules — rule engine, MDT, render
-│   ├── plan.py                # generate_plan() / PlanResult
-│   ├── diagnostic.py          # generate_diagnostic_brief() — pre-biopsy mode
-│   ├── algorithm_eval.py      # algorithm step evaluator
-│   ├── redflag_eval.py        # red-flag firing
-│   ├── questionnaire_eval.py  # questionnaire impact + what-if
-│   ├── mdt_orchestrator.py    # role activation + Open Questions (Q1-Q6 / DQ1-DQ4)
-│   ├── mdt_protocol.py        # multidisciplinary team protocol
-│   ├── access_matrix.py       # per-Plan access (NHSU / MoH / commercial)
-│   ├── experimental_options.py # CT.gov match into Plan
-│   ├── lazy_loader.py         # per-disease bundle loading (Pyodide-friendly)
-│   ├── render.py              # Plan/Brief HTML renderer (UA + EN)
-│   ├── render_styles.py       # render-time CSS
-│   ├── _citation_guard.py     # render-time citation-presence guard (Layer 3)
-│   ├── _ask_doctor.py         # patient-mode "ask your doctor" prompt
-│   ├── _emergency_rf.py       # RF emergency triage
-│   ├── _patient_vocabulary.py # plain-language drug / ICD glossing
-│   ├── _track_filter.py       # per-track filter logic
-│   ├── _nszu.py               # NHSU coverage lookup
-│   ├── actionability_*.py     # CIViC actionability extractor + conflict
-│   ├── civic_variant_matcher.py # fusion-aware variant match
-│   ├── persistence.py         # event store on top of YAML
-│   └── …
-├── ingestion/                 # Loaders for hosted sources
-│   ├── civic_loader.py        # CIViC monthly snapshot import
-│   ├── ctcae_loader.py        # CTCAE v5.0
-│   ├── icd_loader.py          # ICD-O-3 morphology
-│   ├── loinc_loader.py
-│   ├── rxnorm_loader.py
-│   ├── atc_loader.py
-│   ├── moz_extractor.py       # МОЗ (Ukraine MoH) PDF extractor
-│   ├── nszu_loader.py         # НСЗУ formulary
-│   └── drlz_lookup.py         # Держреєстр лікарських засобів
-├── validation/                # YAML loader + schema + referential integrity
-├── hosted/                    # Everything we host locally
-│   ├── content/               # Our clinical content (see counts below)
-│   ├── code_systems/          # ICD-O-3, HGNC populated; LOINC/RxNorm pending
-│   ├── civic/<date>/          # CIViC nightly snapshot (CC0)
-│   ├── ctcae/v5.0/            # CTCAE v5.0 grading
-│   └── audit/                 # signoffs.jsonl — clinical sign-off log
-├── cache/                     # Live API query cache (gitignored)
-├── stats.py                   # Compute KB stats for /capabilities.html
-├── README.md                  # this file
-└── TODO.md
+├── schemas/         # Pydantic entity models (Disease, Drug, Indication, …)
+├── engine/          # rule engine, MDT orchestrator, render, persistence
+├── validation/      # YAML loader + schema + referential-integrity checker
+├── clients/         # live-API clients (CT.gov, PubMed, DailyMed, openFDA, …)
+├── ingestion/       # loaders for hosted sources (CIViC, CTCAE, ICD-O-3, МОЗ, НСЗУ, …)
+├── hosted/
+│   ├── content/     # YAML knowledge base — clinical content
+│   ├── code_systems/, civic/, ctcae/   # vendored snapshots
+│   └── audit/       # signoffs.jsonl — clinical sign-off log
+└── stats.py         # KB stats for the public capabilities page
 ```
 
-## Status
-
-**Working rule engine + 65-disease KB + bilingual rendering.** First
-real-patient plans validated by practising oncologists (see
-`CLAUDE.md`).
-
-### Content scale (as of v0.1.2)
-
-| Entity type             | Count |
-|-------------------------|-------|
-| Diseases                | 65    |
-| Indications             | 312   |
-| Regimens                | 253   |
-| Algorithms              | 113   |
-| Biomarkers              | 125   |
-| Biomarker actionability | 399   |
-| Drugs                   | 220   |
-| Tests                   | 95    |
-| Workups                 | 24    |
-| RedFlags                | 442   |
-| Contraindications       | 12    |
-| Supportive care         | 13    |
-| Monitoring schedules    | 8     |
-| Questionnaires          | 65    |
-| MDT skills              | 16    |
-| Sources                 | 272   |
-| Reviewers               | 4     |
-
-### What's implemented
+## What's implemented
 
 - **Rule engine** — `generate_plan()` and `generate_diagnostic_brief()`
   produce a versioned `PlanResult` from a patient profile.
-- **MDT orchestrator** — role activation (required / recommended /
-  optional), Open Questions Q1-Q6 (treatment) + DQ1-DQ4 (diagnostic),
-  decision-provenance graph for audit-grade explanation
-  (`MDT_ORCHESTRATOR_SPEC.md`, `DIAGNOSTIC_MDT_SPEC.md`).
+- **MDT orchestrator** — role activation, Open Questions, decision-
+  provenance graph for audit-grade explanation
+  ([`MDT_ORCHESTRATOR_SPEC.md`](../specs/MDT_ORCHESTRATOR_SPEC.md),
+  [`DIAGNOSTIC_MDT_SPEC.md`](../specs/DIAGNOSTIC_MDT_SPEC.md)).
 - **Two-track plans** — standard + aggressive side-by-side
-  (CHARTER §15.2 C6 anti-automation-bias).
+  ([CHARTER §15.2 C6](../specs/CHARTER.md) anti-automation-bias).
 - **CIViC actionability** (CC0) — fusion-aware variant matcher,
-  ESCAT-tier rendering, monthly snapshot CI refresh
-  (replaced OncoKB on 2026-04-27 — see
-  `docs/reviews/oncokb-public-civic-coverage-2026-04-27.md`).
+  ESCAT-tier rendering, monthly snapshot CI refresh.
 - **Three-layer citation guard** — loader-level SRC-* referential
-  integrity, background citation-verifier, render-time
-  `_citation_guard` strip-or-fail.
-- **Bilingual render** — Plan/Brief HTML in UA and EN. UI labels via
-  `_UI_STRINGS`; KB names via `_pick_name()` (english → preferred →
-  ukrainian or reverse depending on `target_lang`); free-text prose
-  via `_translate_kb_text()` (DeepL/LibreTranslate, env-configured —
-  graceful UA fallback when no client).
-- **Pre-biopsy mode** (CHARTER §15.2 C7 hard rule) — engine refuses
-  to emit a treatment Plan without `disease.id` / `icd_o_3_morphology`,
-  emits a `DiagnosticPlan` with workup brief instead.
-- **Live clients** — ClinicalTrials.gov (v2), PubMed, DailyMed,
-  openFDA. All inherit `BaseSourceClient` (per-source rate-limit +
-  TTL-cache).
+  integrity, background citation-verifier, render-time strip-or-fail.
+- **Bilingual render** — Plan / Brief HTML in UA and EN; UI labels
+  + KB names + free-text prose all locale-aware.
+- **Pre-biopsy mode** ([CHARTER §15.2 C7](../specs/CHARTER.md) hard rule)
+  — engine refuses to emit a treatment Plan without histology / disease
+  ID; emits a `DiagnosticPlan` with workup brief instead.
+- **Live API clients** — ClinicalTrials.gov v2, PubMed, DailyMed, openFDA.
+  Per-source rate-limit + TTL-cache.
 - **Patient mode** — separate render path with plain-language drug /
   ICD glossing, "ask your doctor" prompts, technical-ID stripping.
 - **Per-disease lazy loading** — engine bundle is a core zip + per-
-  disease zips (`lazy_loader.py`); `/try.html` Pyodide engine fetches
-  on demand.
+  disease zips; the `/try.html` Pyodide engine fetches on demand.
 
-### What's pending
-
-- Full EN translation of long-form prose fields (`do_not_do`, redflag
-  definitions, indication notes) — handled by `_translate_kb_text` at
-  render time when DeepL/LibreTranslate is configured; otherwise
-  falls back to UA inline. Adding `*_en` mirror fields to KB schemas
-  is one option; pre-translating via cached client is another.
-- Code-system populations: LOINC + RxNorm + ATC ingestion loaders
-  exist but data not yet fully populated.
-- PostgreSQL migration: the spec mentions transitioning from YAML
-  files + git history once entity count passes ~10K
-  (`SOURCE_INGESTION_SPEC.md` §12.1). Not urgent at current scale.
-
-## Running the validator
+## Run the validator
 
 ```bash
 pip install -e .
 python -m knowledge_base.validation.loader knowledge_base/hosted/content
 ```
 
-Lists all entities, validates each against its schema, checks that
-every referenced ID exists, runs contract validators (e.g. every
-clinical claim cites a Source, every Indication wires to an Algorithm
-when one exists for the disease).
+Lists all entities, validates each against its schema, checks every
+referenced ID, and runs contract validators (e.g. every clinical claim
+cites a Source).
 
-## Generating a Plan from a profile
+## Generate a Plan from a profile
 
 ```python
 from pathlib import Path
@@ -188,40 +89,34 @@ else:
     html = render_plan_html(result, mdt=mdt, target_lang="en")
 ```
 
-The same engine ships in-browser via Pyodide — see `/try.html` on
-[openonco.info](https://openonco.info/try.html) for the interactive
-demo.
-
-## Schema conventions
-
-- `model_config = ConfigDict(extra="allow")` on every entity so adding
-  fields in YAML doesn't break schema. Forces schema evolution to be
-  intentional (pin specific fields as required when stable).
-- IDs: prefix + upper-case, e.g. `DIS-HCV-MZL`, `DRUG-RITUXIMAB`,
-  `IND-HCV-MZL-1L-STANDARD`, `BMA-EGFR-L858R-OSIMERTINIB`.
-- Citations: every clinical claim references a Source via
-  `source_id`, never inline URL.
-- Names: `names: {ukrainian, english, preferred, synonyms: [...]}`.
-  Render picks based on `target_lang` (EN: english → preferred →
-  ukrainian; UA: ukrainian → preferred → english).
-- **Two-reviewer signoff** for clinical content (CHARTER §6.1) — any
-  Indication / Regimen / RedFlag merged on master needs 2 of 3
-  Clinical Co-Lead approvals; otherwise stays STUB.
+The same engine ships in-browser via Pyodide — see
+[openonco.info/try.html](https://openonco.info/try.html).
 
 ## Adding a new entity
 
-1. Check `specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md` for the canonical
-   entity definition.
+1. Read [`KNOWLEDGE_SCHEMA_SPECIFICATION.md`](../specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md)
+   for the canonical entity definition.
 2. Write YAML under the appropriate `hosted/content/<type>/` directory.
 3. Run the validator.
-4. If you add a new source, add a Source YAML under
-   `hosted/content/sources/` with full license/hosting metadata per
-   `specs/SOURCE_INGESTION_SPEC.md` §3 + §8 (referenced vs hosted vs
-   mixed; H1-H5 hosting justification).
-5. For clinical content (Indication / Regimen / RedFlag /
-   Contraindication / SupportiveCare): mark `reviewer_signoffs: 0`
-   STUB until two Clinical Co-Leads approve via the signoff log
-   (`hosted/audit/signoffs.jsonl`).
+4. New source → add a Source YAML with full license / hosting metadata
+   per [`SOURCE_INGESTION_SPEC.md`](../specs/SOURCE_INGESTION_SPEC.md).
+5. Clinical content (Indication / Regimen / RedFlag /
+   Contraindication / SupportiveCare) stays STUB until **two of three
+   Clinical Co-Leads** approve via the signoff log
+   ([CHARTER §6.1](../specs/CHARTER.md)) — never set
+   `reviewed: true` yourself.
+
+## Schema conventions
+
+- IDs: prefix + upper-case, e.g. `DIS-HCV-MZL`, `DRUG-RITUXIMAB`,
+  `BMA-EGFR-L858R-OSIMERTINIB`.
+- Citations: every clinical claim references a Source via
+  `source_id`, never inline URL.
+- Names: `names: {ukrainian, english, preferred, synonyms: [...]}`.
+  Render picks based on `target_lang`.
+- `model_config = ConfigDict(extra="allow")` on every entity so adding
+  fields in YAML doesn't break schema; pin specific fields as required
+  when stable.
 
 ## Contributing via TaskTorrent
 
@@ -230,3 +125,134 @@ structured chunk of work from the queue and open a PR — full guide at
 [`docs/contributing/CONTRIBUTOR_QUICKSTART.md`](../docs/contributing/CONTRIBUTOR_QUICKSTART.md)
 or the public landing page
 [openonco.info/contribute.html](https://openonco.info/contribute.html).
+
+---
+
+## 🇺🇦 Українська
+
+Рушій правил і база знань OpenOnco. Профіль пацієнта (сумісний з
+FHIR R4 / mCODE) → **два альтернативні плани лікування** (стандартний
+і інтенсивніший) поряд, з повним цитуванням джерел. LLM **не**
+приймають клінічних рішень — клінічна логіка працює в декларативному
+рушії правил над версіонованим YAML
+([CHARTER §8.3](../specs/CHARTER.md)).
+
+Живий сайт: **[openonco.info](https://openonco.info)** (EN за
+замовчуванням, UA-дзеркало на [`/ukr/`](https://openonco.info/ukr/)).
+Метрики KB у реальному часі, матриця покриття за хворобами, частка
+клінічних sign-off:
+**[openonco.info/ukr/capabilities](https://openonco.info/ukr/capabilities.html)**.
+
+### Структура каталогу
+
+```
+knowledge_base/
+├── schemas/         # Pydantic-моделі сутностей (Disease, Drug, Indication, …)
+├── engine/          # рушій правил, MDT-оркестратор, render, персистентність
+├── validation/      # YAML-loader + схема + перевірка референтної цілісності
+├── clients/         # клієнти живих API (CT.gov, PubMed, DailyMed, openFDA, …)
+├── ingestion/       # loader-и хостових джерел (CIViC, CTCAE, ICD-O-3, МОЗ, НСЗУ, …)
+├── hosted/
+│   ├── content/     # YAML-база знань — клінічний контент
+│   ├── code_systems/, civic/, ctcae/   # vendored-снепшоти
+│   └── audit/       # signoffs.jsonl — журнал клінічних sign-off
+└── stats.py         # KB-статистика для публічної /capabilities-сторінки
+```
+
+### Що реалізовано
+
+- **Рушій правил** — `generate_plan()` і `generate_diagnostic_brief()`
+  будують версіонований `PlanResult` з профілю пацієнта.
+- **MDT-оркестратор** — активація ролей, Open Questions, граф
+  decision-provenance для аудитного пояснення
+  ([`MDT_ORCHESTRATOR_SPEC.md`](../specs/MDT_ORCHESTRATOR_SPEC.md),
+  [`DIAGNOSTIC_MDT_SPEC.md`](../specs/DIAGNOSTIC_MDT_SPEC.md)).
+- **Двотрекові плани** — стандартний + інтенсивний поряд
+  ([CHARTER §15.2 C6](../specs/CHARTER.md) — захист від
+  automation-bias).
+- **CIViC actionability** (CC0) — fusion-aware variant matcher,
+  ESCAT-tier рендеринг, місячний CI-refresh снепшоту.
+- **Триланкова citation-guard** — referential-integrity SRC-* у
+  loader, фоновий citation-verifier, strip-or-fail при рендері.
+- **Білінгвальний рендер** — Plan / Brief HTML в UA та EN; мітки UI
+  + назви KB + free-text-проза локалізуються залежно від `target_lang`.
+- **Pre-biopsy режим** ([CHARTER §15.2 C7](../specs/CHARTER.md) —
+  жорстке правило) — рушій відмовляється видавати лікувальний Plan
+  без гістології / disease ID; видає `DiagnosticPlan` з workup-brief.
+- **Живі API-клієнти** — ClinicalTrials.gov v2, PubMed, DailyMed,
+  openFDA. Окремий rate-limit + TTL-кеш на джерело.
+- **Патієнт-режим** — окремий render path з glossing назв препаратів /
+  ICD простою мовою, prompt-и "запитайте лікаря", очищення
+  технічних ID.
+- **Lazy-loading per-disease** — engine bundle = core-zip + per-disease
+  zip-и; `/try.html` Pyodide завантажує по запиту.
+
+### Запустити валідатор
+
+```bash
+pip install -e .
+python -m knowledge_base.validation.loader knowledge_base/hosted/content
+```
+
+Виводить усі сутності, валідує кожну проти схеми, перевіряє всі
+референси, виконує contract-валідатори (наприклад: кожне клінічне
+твердження цитує Source).
+
+### Згенерувати Plan з профілю
+
+```python
+from pathlib import Path
+from knowledge_base.engine import (
+    generate_plan, generate_diagnostic_brief, is_diagnostic_profile,
+    orchestrate_mdt, render_plan_html, render_diagnostic_brief_html,
+)
+
+KB = Path("knowledge_base/hosted/content")
+patient = {...}  # dict у формі FHIR R4 / mCODE
+
+if is_diagnostic_profile(patient):
+    result = generate_diagnostic_brief(patient, kb_root=KB)
+    mdt = orchestrate_mdt(patient, result, kb_root=KB)
+    html = render_diagnostic_brief_html(result, mdt=mdt, target_lang="uk")
+else:
+    result = generate_plan(patient, kb_root=KB)
+    mdt = orchestrate_mdt(patient, result, kb_root=KB)
+    html = render_plan_html(result, mdt=mdt, target_lang="uk")
+```
+
+Той самий рушій працює в браузері через Pyodide — див.
+[openonco.info/try.html](https://openonco.info/try.html).
+
+### Додати нову сутність
+
+1. Прочитай [`KNOWLEDGE_SCHEMA_SPECIFICATION.md`](../specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md)
+   для канонічного визначення сутності.
+2. Напиши YAML під відповідним каталогом `hosted/content/<type>/`.
+3. Запусти валідатор.
+4. Нове джерело → додай YAML Source з повними license / hosting
+   метаданими за [`SOURCE_INGESTION_SPEC.md`](../specs/SOURCE_INGESTION_SPEC.md).
+5. Клінічний контент (Indication / Regimen / RedFlag /
+   Contraindication / SupportiveCare) лишається STUB, доки **двоє з
+   трьох Clinical Co-Leads** не підтвердять через signoff-журнал
+   ([CHARTER §6.1](../specs/CHARTER.md)) — ніколи не виставляй
+   `reviewed: true` самостійно.
+
+### Конвенції схеми
+
+- ID: префікс + upper-case, наприклад `DIS-HCV-MZL`, `DRUG-RITUXIMAB`,
+  `BMA-EGFR-L858R-OSIMERTINIB`.
+- Цитування: кожне клінічне твердження посилається на Source через
+  `source_id`, ніколи не inline-URL.
+- Назви: `names: {ukrainian, english, preferred, synonyms: [...]}`.
+  Render обирає на основі `target_lang`.
+- `model_config = ConfigDict(extra="allow")` на кожній сутності, щоб
+  додавання полів у YAML не ламало схему; pin-уй конкретні поля як
+  required, коли стабільні.
+
+### Внески через TaskTorrent
+
+Маєш вільну ємність у Claude Code, Codex, Cursor чи ChatGPT? Візьми
+структуровану задачу з черги і відкрий PR — повний гайд у
+[`docs/contributing/CONTRIBUTOR_QUICKSTART.md`](../docs/contributing/CONTRIBUTOR_QUICKSTART.md)
+або на публічній сторінці
+[openonco.info/ukr/contribute.html](https://openonco.info/ukr/contribute.html).

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,135 @@
+# specs/
+
+🇬🇧 English (below) · 🇺🇦 [Українська](#-українська)
+
+Active specifications for OpenOnco. **Specifications are the source of
+truth** — when this README, `CLAUDE.md`, `README.md` or any code
+disagrees with `specs/`, the spec wins.
+
+Documents are written in **Ukrainian** with English technical terms
+inline (entity names, license names, code conventions). Translation
+is intentional, not accidental — see [`CHARTER §1`](CHARTER.md) for
+language policy.
+
+## Read this first
+
+- **[`CHARTER.md`](CHARTER.md)** — governance, scope, FDA non-device
+  CDS positioning, dual clinical-lead review process, what the project
+  explicitly does **not** do. **Read before any other spec.**
+
+## Clinical content
+
+- **[`CLINICAL_CONTENT_STANDARDS.md`](CLINICAL_CONTENT_STANDARDS.md)** —
+  citation format, evidence levels, draft / proposed / reviewed
+  lifecycle, two-reviewer signoff rules.
+- **[`REDFLAG_AUTHORING_GUIDE.md`](REDFLAG_AUTHORING_GUIDE.md)** —
+  RedFlag schema (≥2 Source citations required), severity, action
+  triggers.
+- **[`WORKUP_METHODOLOGY_SPEC.md`](WORKUP_METHODOLOGY_SPEC.md)** —
+  pre-biopsy diagnostic-path methodology.
+
+## Schema and data
+
+- **[`KNOWLEDGE_SCHEMA_SPECIFICATION.md`](KNOWLEDGE_SCHEMA_SPECIFICATION.md)** —
+  entity model: Disease, Drug, Indication, Regimen, BiomarkerActionability,
+  RedFlag, Source, Reviewer, etc.
+- **[`DATA_STANDARDS.md`](DATA_STANDARDS.md)** — FHIR R4/R5, mCODE,
+  LOINC, ICD-10, ICD-O-3, RxNorm, ATC, CTCAE v5.0; explicit no-go list
+  (no SNOMED CT, no MedDRA in MVP — license gates).
+- **[`SOURCE_INGESTION_SPEC.md`](SOURCE_INGESTION_SPEC.md)** — license
+  classification, `referenced` vs `hosted` vs `mixed`, H1–H5 hosting
+  justification, monthly snapshot CI cadence.
+- **[`REFERENCE_CASE_SPECIFICATION.md`](REFERENCE_CASE_SPECIFICATION.md)** —
+  end-to-end reference case for testing the engine.
+
+## Engine and orchestration
+
+- **[`MDT_ORCHESTRATOR_SPEC.md`](MDT_ORCHESTRATOR_SPEC.md)** —
+  multidisciplinary tumor-board orchestration, role activation,
+  Open Questions.
+- **[`DIAGNOSTIC_MDT_SPEC.md`](DIAGNOSTIC_MDT_SPEC.md)** — pre-biopsy
+  mode (no histology → diagnostic Brief, never a treatment Plan).
+- **[`SKILL_ARCHITECTURE_SPEC.md`](SKILL_ARCHITECTURE_SPEC.md)** —
+  versioned skill registry, per-skill `last_reviewed`,
+  `clinical_lead`, `verified_by`.
+
+## Operations and integrations
+
+- **[`NSZU_FEED_PLAN.md`](NSZU_FEED_PLAN.md)** — НСЗУ formulary
+  ingestion + reimbursement signal.
+- Clinical-review queues: [`CLINICAL_REVIEW_QUEUE_MYELOID.md`](CLINICAL_REVIEW_QUEUE_MYELOID.md),
+  [`CLINICAL_REVIEW_QUEUE_REDFLAGS.md`](CLINICAL_REVIEW_QUEUE_REDFLAGS.md)
+  — work-in-flight items awaiting Clinical Co-Lead signoff.
+
+## External reference
+
+- `Guidance-Clinical-Decision-Software_5.pdf` — FDA Clinical Decision
+  Support guidance; CHARTER §15 cross-references its Criteria 1-4.
+
+---
+
+## 🇺🇦 Українська
+
+Активні специфікації OpenOnco. **Специфікації — джерело істини**:
+коли цей README, `CLAUDE.md`, `README.md` чи будь-який код суперечать
+вмісту `specs/`, перемагає специфікація.
+
+Документи написані **українською** з англомовними технічними термінами
+inline (назви сутностей, ліцензії, code conventions). Переклад
+навмисний, не випадковий — див. [`CHARTER §1`](CHARTER.md) щодо
+політики мови.
+
+### Прочитай це першим
+
+- **[`CHARTER.md`](CHARTER.md)** — governance, scope, FDA non-device
+  CDS positioning, процес dual clinical-lead review, чого проєкт
+  свідомо **не робить**. **Читай перед будь-якою іншою специфікацією.**
+
+### Клінічний контент
+
+- **[`CLINICAL_CONTENT_STANDARDS.md`](CLINICAL_CONTENT_STANDARDS.md)** —
+  формат цитування, рівні доказовості, lifecycle
+  draft / proposed / reviewed, правила двореферентного signoff.
+- **[`REDFLAG_AUTHORING_GUIDE.md`](REDFLAG_AUTHORING_GUIDE.md)** —
+  схема RedFlag (≥2 цитування Source), severity, тригери дій.
+- **[`WORKUP_METHODOLOGY_SPEC.md`](WORKUP_METHODOLOGY_SPEC.md)** —
+  методологія pre-biopsy діагностичного шляху.
+
+### Схема і дані
+
+- **[`KNOWLEDGE_SCHEMA_SPECIFICATION.md`](KNOWLEDGE_SCHEMA_SPECIFICATION.md)** —
+  модель сутностей: Disease, Drug, Indication, Regimen,
+  BiomarkerActionability, RedFlag, Source, Reviewer тощо.
+- **[`DATA_STANDARDS.md`](DATA_STANDARDS.md)** — FHIR R4/R5, mCODE,
+  LOINC, ICD-10, ICD-O-3, RxNorm, ATC, CTCAE v5.0; явний no-go-список
+  (без SNOMED CT, без MedDRA у MVP — license-обмеження).
+- **[`SOURCE_INGESTION_SPEC.md`](SOURCE_INGESTION_SPEC.md)** —
+  класифікація ліцензій, `referenced` vs `hosted` vs `mixed`,
+  обґрунтування H1–H5 hosting, місячна каденція CI-снепшоту.
+- **[`REFERENCE_CASE_SPECIFICATION.md`](REFERENCE_CASE_SPECIFICATION.md)** —
+  наскрізний reference-кейс для тестування рушія.
+
+### Рушій і оркестрація
+
+- **[`MDT_ORCHESTRATOR_SPEC.md`](MDT_ORCHESTRATOR_SPEC.md)** —
+  оркестрація мультидисциплінарного тумор-борду, активація ролей,
+  Open Questions.
+- **[`DIAGNOSTIC_MDT_SPEC.md`](DIAGNOSTIC_MDT_SPEC.md)** — pre-biopsy
+  режим (немає гістології → diagnostic Brief, ніколи не лікувальний
+  Plan).
+- **[`SKILL_ARCHITECTURE_SPEC.md`](SKILL_ARCHITECTURE_SPEC.md)** —
+  версіонований skill-реєстр, per-skill `last_reviewed`,
+  `clinical_lead`, `verified_by`.
+
+### Операційні і інтеграційні
+
+- **[`NSZU_FEED_PLAN.md`](NSZU_FEED_PLAN.md)** — інгест НСЗУ-формуляра +
+  сигнал відшкодування.
+- Черги клінічного review: [`CLINICAL_REVIEW_QUEUE_MYELOID.md`](CLINICAL_REVIEW_QUEUE_MYELOID.md),
+  [`CLINICAL_REVIEW_QUEUE_REDFLAGS.md`](CLINICAL_REVIEW_QUEUE_REDFLAGS.md)
+  — поточні елементи, що чекають signoff Clinical Co-Lead.
+
+### Зовнішній референс
+
+- `Guidance-Clinical-Decision-Software_5.pdf` — FDA Clinical Decision
+  Support guidance; CHARTER §15 посилається на його Criteria 1-4.


### PR DESCRIPTION
## Summary

Two directory-level READMEs now ship **EN + UA inline** so contributors landing on those GitHub tree views see project context in either language.

- **`knowledge_base/README.md`** — shortened (233 → 130 lines for EN portion) and bilingual
- **`specs/README.md`** — new file; previously the `/specs` tree had no rendered index

## What changed

### `knowledge_base/README.md`

**Removed (volatile / over-detailed):**
- Entity-counts table (Diseases / Indications / Regimens / Algorithms / Biomarkers / BMA / Drugs / Tests / Workups / RedFlags / Sources / …) — every count rotates each batch
- `**Version:** v0.1.2 (released 2026-04-30, …)` block
- `### Content scale (as of v0.1.2)` block
- `### What's pending` block (translation status, code-system population status, PostgreSQL migration timing — all change)
- Per-module annotated layout tree (50+ files listed individually; module names age fast)
- "Bilingual render" mechanism deep-dive (`_UI_STRINGS` / `_pick_name` / `_translate_kb_text` etc. — implementation detail belongs in code)

**Added:** mirror UA section under `## 🇺🇦 Українська` — translated layout, what's-implemented bullets, validator + plan-generation snippets, schema conventions, contributor entry points. Top-of-file language nav.

### `specs/README.md` (new)

GitHub renders this as the index when browsing `/specs/`. Was previously absent (visitors saw a flat alphabetical file list).

Thematic grouping of all 12 specs:
- **Governance** — `CHARTER.md` (read first)
- **Clinical content** — `CLINICAL_CONTENT_STANDARDS`, `REDFLAG_AUTHORING_GUIDE`, `WORKUP_METHODOLOGY_SPEC`
- **Schema + data** — `KNOWLEDGE_SCHEMA_SPECIFICATION`, `DATA_STANDARDS`, `SOURCE_INGESTION_SPEC`, `REFERENCE_CASE_SPECIFICATION`
- **Engine + orchestration** — `MDT_ORCHESTRATOR_SPEC`, `DIAGNOSTIC_MDT_SPEC`, `SKILL_ARCHITECTURE_SPEC`
- **Operations + integrations** — `NSZU_FEED_PLAN`, clinical-review queues

Bilingual EN + UA with the same anchor-link pattern as `knowledge_base/README.md`.

## Test plan

- [x] No code touched — READMEs only
- [x] All internal spec links verified to exist on disk
- [x] EN section shortens, UA section preserves the same content semantics for non-English readers
- [ ] Render check on GitHub after merge (anchor jumps, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)