### PR TITLE
fix(site): bilingual toolbar step-label on /try.html

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1667,7 +1667,7 @@ def render_try(
     <span class="status-top-text">{'Loading questionnaires…' if target_lang == 'en' else 'Завантажую опитувальники…'}</span>
   </div>
 
-  <div class="quest-toolbar">
+  <div class="quest-toolbar" data-step-label="{'1. Pick a disease and (optionally) an example' if target_lang == 'en' else '1. Оберіть хворобу та (опційно) приклад'}">
     <label class="qt-label">
       {'Disease' if target_lang == 'en' else 'Хвороба'}
       <select id="diseaseSelect">

--- a/scripts/site_styles.py
+++ b/scripts/site_styles.py
@@ -773,8 +773,8 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
   box-shadow: 0 4px 16px rgba(22, 101, 52, 0.08);
   position: relative;
 }
-.quest-toolbar::before {
-  content: "1. Оберіть хворобу та (опційно) приклад";
+.quest-toolbar[data-step-label]::before {
+  content: attr(data-step-label);
   position: absolute; top: -11px; left: 18px;
   background: var(--green-700); color: white;
   font-size: 11px; font-weight: 700; letter-spacing: 0.6px;


### PR DESCRIPTION
## Summary

The green-bordered step badge above the disease + example dropdowns on `/try.html` was hardcoded in Ukrainian via a CSS `::before` pseudo-element, so it leaked onto the EN page (root `/try.html`) the same way it appeared on the UA mirror. Fix routes the label through a `data-step-label` HTML attribute so each language renders its own copy.

User report (screenshot): EN `/try.html` showed `1. ОБЕРІТЬ ХВОРОБУ ТА (ОПЦІЙНО) ПРИКЛАД` even though every other UI string on the page was English.

## Root cause

[`scripts/site_styles.py:777`](scripts/site_styles.py):

```css
.quest-toolbar::before {
  content: \"1. Оберіть хворобу та (опційно) приклад\";
  ...
  text-transform: uppercase;
  ...
}
```

`scripts/site_styles.py` builds a single static `STYLESHEET` constant — no `target_lang` available at CSS-build time, so the literal UA string was embedded in `style.css` and applied to **every** page that used `.quest-toolbar`, EN included.

## Fix

Drive the label from a `data-step-label` attribute set by the HTML (which has `target_lang`):

- `scripts/site_styles.py`: `.quest-toolbar::before` → `.quest-toolbar[data-step-label]::before`; `content: \"…\"` → `content: attr(data-step-label)`
- `scripts/build_site.py` (in `render_try`): `<div class=\"quest-toolbar\">` → `<div class=\"quest-toolbar\" data-step-label=\"…\">`, with the EN/UA twin set inline by `target_lang`

EN renders `1. Pick a disease and (optionally) an example`; UA keeps `1. Оберіть хворобу та (опційно) приклад`. Styling (green badge, uppercase, monospace, absolute-positioned) unchanged.

## Verification

- [x] Built site locally: EN `/try.html` `data-step-label=\"1. Pick a disease and (optionally) an example\"`; UA `/ukr/try.html` `data-step-label=\"1. Оберіть хворобу та (опційно) приклад\"`
- [x] EN `/try.html` UA-token count went 0 → 0 (the leak was CSS, never in the DOM, but the rendered text via `::before` was UA)
- [x] `pytest tests/test_build_site.py tests/test_engine_lazy_load_js.py` → 33 passed
- [ ] Render check on deployed openonco.info after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)