### PR TITLE
feat(render): patient-mode v2.2 — between-visit watchpoints + Latin gate

### DIFF
--- a/docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md
+++ b/docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md
@@ -1,0 +1,89 @@
+# Patient watchpoints — authoring queue
+
+**Stamp:** 2026-05-01-0100 · **Status:** queue open · **Spec:** [`specs/PATIENT_MODE_SPEC.md`](../../specs/PATIENT_MODE_SPEC.md) §3.4 + §6 · **Schema landed in:** Phase 4 of the patient-mode v2.1 plan
+
+## What this queue is
+
+Phase 4 of the patient-mode iteration shipped the `Regimen.between_visit_watchpoints` schema + renderer + fallback. The remaining work — and what this doc tracks — is **authoring the actual content** for each of the 253 regimens currently in the KB.
+
+Each `BetweenVisitWatchpoint` is a clinically-loaded statement (it tells a patient at home when to log a symptom vs call the clinic vs go to ER). Per CHARTER §6.1 + PATIENT_MODE_SPEC §6, each regimen's watchpoint list needs **two Clinical Co-Lead sign-offs** before it is considered authored. Until then, the renderer surfaces the placeholder string:
+
+> Список того, на що звернути увагу між візитами, для цього курсу ще не узгоджено клінічною командою. Запитайте лікаря на наступному візиті, які симптоми треба занотовувати, а які — приводи дзвонити в клініку.
+
+This is honest by design: the patient is told the list isn't ready, not given fabricated content.
+
+## Estimated content volume
+
+| Tier | Watchpoints/regimen | Regimens × tier | Subtotal |
+|---|---:|---:|---:|
+| `log_at_next_visit` | 2-3 | 253 | ~625 |
+| `call_clinic_same_day` | 2-3 | 253 | ~625 |
+| `er_now` | 1-2 | 253 | ~380 |
+| **Total** | **5-8 / regimen** | | **~1,000–1,500** |
+
+`er_now` items often dedupe with the existing emergency-RedFlag layer (renderer auto-handles via `_emergency_trigger_keys`), so net new ER-tier content ≈ 50% of nominal.
+
+## Anchor regimens — Wave 1 priority
+
+These 12 regimens are used in many tracks across diseases and have well-known AE profiles. Authoring them first delivers the biggest patient-bundle coverage per session:
+
+| Priority | Regimen ID | Why first |
+|---|---|---|
+| 1 | `REG-CHOP` | DLBCL + several T-cell lymphomas; cytopenia / nadir watchpoint pattern |
+| 2 | `REG-RCHOP` | Same as CHOP + rituximab infusion-reaction watchpoint |
+| 3 | `REG-FOLFOX` | 1L mCRC + adjuvant CRC; oxaliplatin neuropathy + cold sensitivity |
+| 4 | `REG-FOLFOX-BEV` | Same + bevacizumab BP / proteinuria watchpoints |
+| 5 | `REG-DAA-SOF-VEL` | HCV-MZL standard; mostly mild watchpoints — good "easy first" template |
+| 6 | `REG-BR-STANDARD` | HCV-MZL aggressive + iNHL salvage; bendamustine cytopenia + opportunistic infections |
+| 7 | `REG-VRD` | MM 1L standard; bortezomib neuropathy + lenalidomide thrombosis |
+| 8 | `REG-DARA-VRD` | MM 1L aggressive; same + daratumumab infusion / immunosuppression |
+| 9 | `REG-A-AVD` | cHL 1L; brentuximab neuropathy |
+| 10 | `REG-ATRA-ATO-APL` | APL emergency archetype; differentiation-syndrome watchpoint critical |
+| 11 | `REG-VEN-AZA-AML` | AML unfit 1L; tumor-lysis-syndrome window |
+| 12 | `REG-PEMBROLIZUMAB-MONO` | pan-tumor checkpoint; immune-related AE watchpoints — pattern reusable for nivolumab, atezolizumab, durvalumab |
+
+**Wave 1 = ~80–100 watchpoints across 12 regimens.** Achievable in a single co-lead review session; covers ~30-40% of KB plan paths because anchor regimens repeat across diseases.
+
+## Wave 2 — disease-anchor regimens (~50 regimens)
+
+After Wave 1, broaden to one regimen per disease where Wave 1 doesn't already cover. Goal: every disease in the KB has ≥1 fully-authored regimen so every plan-track surfaces real watchpoints for at least one option.
+
+## Wave 3 — long tail (~190 regimens)
+
+Less common regimens (rare-tumor 2L+, salvage, etc.). Prioritize by curated-case usage from `scripts/site_cases.py` — regimens that appear in ≥1 published case go before regimens that don't.
+
+## Authoring workflow
+
+1. **Pick a regimen** from the priority list (Wave 1 first).
+2. **Draft watchpoints** — between-visit clinically meaningful events grouped by urgency. Reference: ESMO patient guides, NCI-PDQ patient versions, NCCN patient information, FDA Med Guides for the constituent drugs.
+3. **Review tier mapping:**
+   - `log_at_next_visit` — annoying but not dangerous; mention at next visit.
+   - `call_clinic_same_day` — call clinic, don't wait.
+   - `er_now` — go to ER. Often duplicates an existing RedFlag — that's OK, the renderer dedupes against emergency banner so the patient doesn't see the same thing twice.
+4. **Fill `cycle_day_window`** when the symptom is cycle-phase specific (cytopenia nadir, post-infusion reaction, etc.). Skip when not applicable.
+5. **Cite sources** — `SRC-*` entity IDs from existing KB Sources. New sources need `source_stub_<id>.yaml` per SOURCE_INGESTION_SPEC §8.
+6. **CHARTER §6.1 sign-off** — two Clinical Co-Leads append `reviewer_signoffs_v2` entries to the regimen YAML. Until both sign, the watchpoint list still loads (schema accepts it) but the patient bundle could optionally surface a "🟡 ще одна перевірка" badge on the regimen card. **(Render-side feature for follow-up — not in Phase 4.)**
+
+## Tracking
+
+Each authored regimen lands as a separate small PR (`feat(kb): patient watchpoints for REG-FOLFOX` etc.) or is bundled with other clinical-content updates. The queue is consumed top-down via the priority list above; status flips as PRs merge.
+
+| Wave | Status | Authored / target |
+|---|---|---|
+| Wave 1 (12 anchor regimens) | not started | 0 / 12 |
+| Wave 2 (~50 disease anchors) | not started | 0 / ~50 |
+| Wave 3 (~190 long tail) | not started | 0 / ~190 |
+
+Update this file when the first regimens land — flip Wave 1 to `in progress`, increment the counters as PRs merge.
+
+## Out of scope for this queue
+
+- **Translation to EN** — patient bundle is UA-only (PATIENT_MODE_SPEC §9).
+- **Re-authoring AE_PLAIN_UA vocabulary** — separate vocabulary contract (§5.1); changes flow through `knowledge_base/engine/_patient_vocabulary.py`, not regimen YAMLs.
+- **Regimen-specific monitoring schedules** — already lives in `MonitoringSchedule.phases` and renders via `_render_monitoring_phases` for the clinician bundle. The patient-mode "between-visits" section is complementary, not a duplicate: monitoring-schedule = labs and visits the clinic schedules; between-visits = patient-driven self-monitoring at home.
+
+## Open questions for Clinical Co-Leads
+
+1. **Tier consistency** — should the same trigger always map to the same urgency tier across regimens (e.g. "лихоманка >38°C" → always `call_clinic_same_day`)? Or can it shift based on regimen-specific risk (e.g. higher-risk regimens upgrade to `er_now`)? Plan currently allows per-regimen variation.
+2. **Source-anchor floor** — should every watchpoint require ≥1 `SRC-*` citation, or is the regimen-level source list (already required by Pydantic) sufficient?
+3. **Rare-event reporting** — should we surface watchpoints for events with <5% incidence, or keep the list focused on common events the patient is likely to encounter? Plan currently leans toward the latter (≥5% as a soft threshold).

--- a/knowledge_base/engine/_patient_rationale.py
+++ b/knowledge_base/engine/_patient_rationale.py
@@ -198,8 +198,8 @@ def build_track_rationale(plan_result: Any, track: Any) -> list[str]:
     )
     if is_default and not fired_rf_ids and len(bullets) < 4:
         bullets.append(
-            "Стандартний варіант рекомендовано, бо немає сигналів "
-            "(redflags), що вимагали б іншого підходу."
+            "Стандартний варіант рекомендовано, бо немає клінічних "
+            "сигналів-тривоги, що вимагали б іншого підходу."
         )
 
     # ── 3. Fired-RF lines ───────────────────────────────────────────

--- a/knowledge_base/engine/_patient_vocabulary.py
+++ b/knowledge_base/engine/_patient_vocabulary.py
@@ -50,7 +50,7 @@ from typing import Optional
 
 DRUG_CLASS_PLAIN_UA: dict[str, str] = {
     # Targeted small molecules — kinase inhibitors & co.
-    "BRAFi": "препарат, який блокує мутацію BRAF — ключовий 'driver' пухлини",
+    "BRAFi": "препарат, який блокує мутацію BRAF — ключову рушійну мутацію пухлини",
     "MEKi": "препарат, який блокує сигнал нижче за BRAF — у комбінації працює краще",
     "BRAF+MEK": "комбінація BRAFi + MEKi — стандартна для BRAF V600 меланоми та деяких NSCLC",
     "PARPi": "препарат, який блокує DNA-repair фермент — пухлина гине, бо не може лагодити свою ДНК",
@@ -164,7 +164,7 @@ DRUG_CLASS_PLAIN_UA: dict[str, str] = {
 
 VARIANT_TYPE_PLAIN_UA: dict[str, str] = {
     # BRAF
-    "V600E": "конкретна заміна валіну на глутамат у позиції 600 BRAF — найчастіша 'driver' мутація",
+    "V600E": "конкретна заміна валіну на глутамат у позиції 600 BRAF — найчастіша рушійна мутація",
     "V600K": "схожа на V600E, але lysine замість глутамату — поведінкою близько ідентична",
     "V600": "будь-яка заміна у позиції 600 BRAF — клас V600E/K/D/R разом",
     "BRAF non-V600": "інші BRAF-мутації (наприклад G469A, K601E) — потребують індивідуальної оцінки",
@@ -172,8 +172,8 @@ VARIANT_TYPE_PLAIN_UA: dict[str, str] = {
     # EGFR
     "T790M": "часто виникає як стійкість до 1-ї та 2-ї лінії EGFR-інгібіторів",
     "C797S": "стійкість до 3-ї лінії EGFR-інгібіторів (osimertinib)",
-    "Ex19del": "видалення в exon 19 EGFR — перший EGFR-driver мутація",
-    "L858R": "точкова заміна в exon 21 EGFR — другий EGFR-driver",
+    "Ex19del": "видалення в 19-му екзоні EGFR — перша значуща EGFR-рушійна мутація",
+    "L858R": "точкова заміна в 21-му екзоні EGFR — друга значуща EGFR-рушійна мутація",
     "Ex20ins": "вставка в exon 20 EGFR — гірше відповідає на стандартні EGFR-інгібітори",
     "G719X": "uncommon EGFR — частково чутливий до afatinib/osimertinib",
     "L861Q": "uncommon EGFR — частково чутливий до afatinib/osimertinib",
@@ -231,7 +231,7 @@ VARIANT_TYPE_PLAIN_UA: dict[str, str] = {
     "TPS": "Tumor Proportion Score — стандарт для PD-L1 у NSCLC",
 
     # Lymphoma-specific
-    "double-hit lymphoma": "лімфома з двома 'driver' translocations (MYC + BCL2) — агресивніша",
+    "double-hit lymphoma": "лімфома з двома рушійними транслокаціями (MYC + BCL2) — агресивніша",
     "triple-hit lymphoma": "MYC + BCL2 + BCL6 — найагресивніший підтип",
     "GCB": "germinal center B-cell — підтип DLBCL з кращим прогнозом",
     "ABC": "activated B-cell — підтип DLBCL з гіршим прогнозом",
@@ -401,19 +401,19 @@ AE_PLAIN_UA: dict[str, str] = {
     "infusion reaction": "реакція на введення препарату — лихоманка, озноб, задишка під час інфузії; повідомляйте медсестрі негайно",
     "anaphylaxis": "тяжка алергічна реакція — задишка, набряк, гіпотензія; невідкладна медична допомога",
     "CRS": "cytokine release syndrome — лихоманка, гіпотензія, гіпоксія після CAR-T або bispecifics; ургентний стан",
-    "ICANS": "immune effector cell-associated neurotoxicity — сплутаність свідомості, тремор після CAR-T",
+    "ICANS": "нейротоксичність, пов'язана з імунною клітинною терапією — сплутаність свідомості, тремор після CAR-T",
     "pneumonitis": "запалення легень — задишка, кашель; рідко але серйозно",
     "interstitial lung disease": "ускладнення деяких таргетних препаратів — задишка, кашель; терміново",
     "hepatotoxicity": "токсичність для печінки — слабість, жовте забарвлення шкіри/очей, темна сеча; терміново",
     "hepatitis": "запалення печінки — частіше від імунотерапії; стежать ALT/AST",
-    "cardiotoxicity": "токсичність для серця (anthracyclines, trastuzumab) — задишка, набряки, прискорене серцебиття",
+    "cardiotoxicity": "токсичність для серця (від антрациклінів, трастузумабу) — задишка, набряки, прискорене серцебиття",
     "QT prolongation": "подовження QT-інтервалу — ризик аритмії; контроль ЕКГ",
     "hypertension": "підвищений артеріальний тиск — частий ефект VEGFi та TKI",
     "thromboembolism": "тромбози — підвищений ризик при IMiD та деяких хіміотерапіях",
     "neuropathy": "поколювання, оніміння кистей/стіп (taxanes, vinca alkaloids, platinum); часто незворотна",
     "peripheral neuropathy": "те саме, що neuropathy — конкретно про периферичні нерви",
-    "ototoxicity": "втрата слуху або шум у вухах — ризик при cisplatin",
-    "nephrotoxicity": "ушкодження нирок — особливо при cisplatin, methotrexate; контроль креатиніну",
+    "ototoxicity": "втрата слуху або шум у вухах — ризик від цисплатину",
+    "nephrotoxicity": "ушкодження нирок — особливо від цисплатину чи метотрексату; контроль креатиніну",
     "hemorrhagic cystitis": "кров у сечі від cyclophosphamide/ifosfamide; запобігаємо MESNA та гідратацією",
     "tumor lysis syndrome": "TLS — масовий розпад пухлинних клітин → розлад електролітів; небезпечно у перший тиждень лікування",
     "differentiation syndrome": "ускладнення ATRA/IDHi у AML — задишка, набряки, лихоманка; терміново стероїди",
@@ -425,7 +425,7 @@ AE_PLAIN_UA: dict[str, str] = {
     "CMV reactivation": "цитомегаловірус — особливо важливий після алло-ТСК",
     "PJP": "Pneumocystis jirovecii pneumonia — рідкісна, але смертельна без TMP/SMX профілактики",
     "secondary malignancy": "ризик другої пухлини через роки після хіміотерапії — важливо знати",
-    "infertility": "тимчасова або постійна втрата фертильності — обговорити cryopreservation перед стартом",
+    "infertility": "тимчасова або постійна втрата фертильності — обговорити кріоконсервацію репродуктивних клітин перед стартом",
     "menopausal symptoms": "припливи, сухість слизових — ефект hormonal-терапії",
     "weight gain": "набирання ваги — частий ефект стероїдів та hormonal-блокаторів",
     "weight loss": "втрата ваги — типова при поширеній пухлині та хіміотерапії",
@@ -447,7 +447,7 @@ AE_PLAIN_UA: dict[str, str] = {
     "renal toxicity (ICI)": "імунно-опосередкований нефрит — підвищений креатинін; стероїди",
     "skin toxicity (EGFRi)": "акнеформний висип на тлі EGFRi — фактично свідчить про активність препарату",
     "paronychia": "запалення нігтьового валика на тлі EGFRi/MEKi",
-    "ocular toxicity (MEKi)": "тимчасові порушення зору на тлі trametinib/cobimetinib",
+    "ocular toxicity (MEKi)": "тимчасові порушення зору на тлі траметинібу/кобіметинібу",
     "GVHD": "graft-versus-host disease — імунна реакція донорських клітин проти ваших тканин після allo-HSCT",
     "VOD/SOS": "veno-occlusive disease / sinusoidal obstruction syndrome — ускладнення HSCT",
     "engraftment syndrome": "ранні дні після HSCT — лихоманка, висип, набряки",
@@ -569,6 +569,172 @@ NSZU_PATIENT_LABEL: dict[str, str] = {
 }
 
 
+# ── First-use abbreviation expansion (Phase 5) ───────────────────────
+#
+# Acronyms that the patient should see expanded the first time they
+# appear in renderer-controlled prose. Renderer applies via
+# `expand_first_use()` once per bundle. Subsequent occurrences stay
+# bare. Engine MUST NOT consult this table (CHARTER §8.3).
+
+ABBREVIATION_FIRST_USE_UA: dict[str, str] = {
+    "ESCAT": "ESCAT (рівень доказів — як міцно доведено, що препарат працює)",
+    "FDA": "FDA (Управління з продовольства й медикаментів США)",
+    "MDT": "MDT (мультидисциплінарна команда лікарів)",
+    "ECOG": "ECOG (шкала функціонального стану пацієнта)",
+    "MSI": "MSI (індекс мікросателітної нестабільності пухлини)",
+    "PD-L1": "PD-L1 (білок на пухлинних клітинах, що блокує імунну атаку)",
+    "PD-1": "PD-1 (білок-перемикач імунної системи)",
+    "HCV": "HCV (вірус гепатиту C)",
+    "HBV": "HBV (вірус гепатиту B)",
+    "CAR-T": "CAR-T (терапія модифікованими T-клітинами пацієнта)",
+}
+
+
+# ── Allowlist for the no-Latin / no-abbreviation render gate ─────────
+#
+# PATIENT_MODE_SPEC §5.3 + §5.4. Tokens here may appear in the rendered
+# patient body without triggering the test gate.
+
+# Uppercase abbreviations that may stay bare. Includes gene symbols,
+# regimen acronyms widely used in patient-facing material, drug brand
+# acronyms, lab abbreviations, and the keys of ABBREVIATION_FIRST_USE_UA
+# (the gate treats post-expansion bare occurrences as fine).
+PATIENT_ALLOWLIST_ACRONYMS: frozenset[str] = frozenset({
+    # Gene symbols + biomarkers (subset; full list grows per disease)
+    "BRAF", "EGFR", "KRAS", "NRAS", "BRCA", "BRCA1", "BRCA2", "ALK",
+    "ROS1", "RET", "MET", "HER2", "PD-1", "PD-L1", "KIT", "FGFR3",
+    "JAK2", "BCR-ABL1", "MGMT", "IDH1", "IDH2", "FLT3", "NPM1", "TP53",
+    "PIK3CA", "PTEN", "RB1", "MYC", "BCL2", "CDKN2A", "CD20", "CD30",
+    "CD38", "CD52", "CD79", "CCR4", "VEGF", "CTLA-4", "LAG3", "TIGIT",
+    "MMR", "HRD", "CPS", "AFP", "PSA",
+    # Disease abbreviations the patient may search
+    "AML", "ALL", "CLL", "DLBCL", "FL", "MM", "MZL", "MCL", "NHL", "WM",
+    "HL", "TNBC", "NSCLC", "SCLC", "RCC", "HCC", "MDS", "MPN", "CML",
+    "APL", "PMF", "PV", "ET", "AITL", "ALCL", "MGUS", "GIST", "GBM",
+    "HNSCC", "PDAC", "CRC", "PTCL", "PTLD", "ATLL", "T-ALL", "HCL",
+    "EATL", "HSTCL", "PMBCL", "PCNSL", "MF", "CTCL", "NLPBL", "NLPHL",
+    "iNHL", "T-PLL", "FLT3-ITD",
+    # Toxicities / outcomes
+    "TLS", "CRS", "GVHD", "VOD", "SOS", "DIC", "ICANS", "PFS", "OS",
+    "DFS", "EFS", "RFS", "CR", "PR", "SD", "PD", "ORR", "DCR", "MRD",
+    "ANC", "LVEF", "INR", "PFT", "DLCO", "ECG", "EKG", "ICU", "MRI",
+    "MUGA", "CTCAE", "QT", "QTc", "BMI", "LDH", "CRP", "BMD",
+    # Drug names that travel as acronyms (INN/brand)
+    "5-FU", "BCG", "ATRA", "ATO", "TKI", "ADC", "FU",
+    # Standard regimen acronyms (widely cited in patient guides)
+    "ABVD", "BEACOPP", "CHOP", "CHP", "CHOEP", "RCHOP", "RCHP", "RCVP",
+    "BR", "RB", "RFC", "FCR", "RDHA", "RICE", "ICE", "EPOCH", "DEPOC",
+    "FOLFOX", "FOLFIRI", "FOLFIRINOX", "CAPOX", "XELOX", "FOLFOXIRI",
+    "BV", "AVD", "VAD", "DA-EPOCH", "DRC", "BVD", "VRD", "VTD", "DVD",
+    "PVAG", "GEMOX", "GEMCIS", "MAGIC", "FLOT", "STRIDE", "DAA",
+    # First-use-expanded abbreviations
+    "ESCAT", "FDA", "MDT", "ECOG", "MSI", "HCV", "HBV", "HIV", "EBV",
+    "CMV", "TB",
+    # Allowed Latin biology fragments
+    "DNA", "RNA", "mRNA", "MoA", "AE",
+    # ESCAT tier labels
+    "IA", "IB", "IIA", "IIB", "IIIA", "IIIB", "IV", "X",
+    # Site / tooling
+    "OpenOnco", "GitHub", "MIT", "API", "URL",
+    # Routes / common short tokens
+    "IV", "PO", "SC", "IM", "IT", "CT", "UA", "EN", "PHI", "CD",
+    "NSZU",  # already Cyrillic in body but ASCII-only HTML attrs
+})
+
+
+# Lowercase Latin words that may stay bare. Loanwords, biology stems,
+# URL fragments, and unavoidable KB regimen-name vocabulary (CHARTER
+# §6.1 prevents unilateral KB rewrites — the gate accepts these
+# contextually rather than blocking the whole feature on translation).
+PATIENT_ALLOWLIST_LATIN_WORDS: frozenset[str] = frozenset({
+    # Biology / pharmacology stems
+    "anti", "post", "pre", "non", "neo", "auto", "allo", "alpha", "beta",
+    "gamma", "delta", "kappa", "lambda", "wild", "type",
+    # KB regimen-name vocabulary
+    "cycle", "cycles", "week", "weeks", "month", "months", "year",
+    "years", "day", "days", "course", "courses", "phase", "phases",
+    "cohort", "regimen", "regimens", "monotherapy", "continuous",
+    "until", "progression", "toxicity", "unacceptable", "induction",
+    "consolidation", "maintenance", "lymphodepletion", "bridging",
+    "salvage", "adjuvant", "neoadjuvant", "first", "second", "third",
+    "high", "low", "risk", "trial", "stage", "line", "grade",
+    # URL / tooling
+    "github", "issues", "info", "html", "https", "www", "openonco",
+    "claude", "code", "src", "noopener", "noreferrer",
+    # Tooling sentinel that may surface in <!-- comments --> stripped
+    # by _visible_text — defensive
+    "abbrev", "expanded",
+})
+
+
+# Trial-name prefixes — any acronym starting with these passes the
+# uppercase gate without an explicit listing.
+PATIENT_ALLOWLIST_TRIAL_PREFIXES: tuple[str, ...] = (
+    "KEYNOTE", "CHECKMATE", "JAVELIN", "MURANO", "VENICE", "CASTOR",
+    "POLLUX", "ALEX", "ALCANZA", "MAVORIC", "ECHELON", "ECHO", "ELOQUENT",
+    "FLAURA", "AURA", "OAK", "POPLAR", "IMPOWER", "PACIFIC", "STRIDE",
+    "EMERALD", "VIALE", "RATIFY", "APL0406", "IRIS", "RESPONSE", "COMFORT",
+    "COMMANDS", "BEACON", "TOGA", "MPACT", "POLO", "SUNLIGHT", "BCFI",
+    "STAMPEDE", "ATLAS", "OLYMPIA", "MIRROR", "PROFOUND", "EMBARK",
+    "GALACTIC", "ARASENS", "CHAARTED", "LATITUDE", "TITAN", "TROPICAL",
+    "DESTINY", "EMBRACA", "PALOMA", "MONALEESA", "MONARCH", "RUBY",
+    "ATTRACTION", "TROPiCS", "POSEIDON", "GEMINI", "MARS",
+)
+
+
+def is_allowlisted_acronym(token: str) -> bool:
+    """True if `token` is on the patient-mode acronym allowlist —
+    either explicitly listed or matches a clinical-trial prefix."""
+    if not token:
+        return False
+    if token in PATIENT_ALLOWLIST_ACRONYMS:
+        return True
+    upper_prefix = token.split("-", 1)[0].upper()
+    if upper_prefix in PATIENT_ALLOWLIST_TRIAL_PREFIXES:
+        return True
+    return False
+
+
+def is_allowlisted_latin_word(token: str) -> bool:
+    """True if `token` (lowercase Latin word ≥4 chars) is on the
+    allowlist of accepted loanwords, biology stems, or KB regimen
+    vocabulary."""
+    return bool(token) and token.lower() in PATIENT_ALLOWLIST_LATIN_WORDS
+
+
+def expand_first_use(html: str) -> str:
+    """Inject first-use expansions for `ABBREVIATION_FIRST_USE_UA` keys
+    into a rendered patient HTML.
+
+    Rule: the **first** unbracketed occurrence of each key in body
+    prose is replaced with the expansion; subsequent occurrences stay
+    bare. Idempotent — a sentinel HTML comment marks expanded bundles
+    so re-renders (mode toggle, language switch) don't double-expand."""
+    import re as _re
+
+    sentinel = "<!-- abbrev-expanded -->"
+    if sentinel in html:
+        return html
+
+    out = html
+    for key, expansion in ABBREVIATION_FIRST_USE_UA.items():
+        # `\b` plus a negative-lookbehind/ahead that excludes Latin
+        # letters, Cyrillic letters, dashes, and digits — so `PD-1`
+        # doesn't match inside `BCR-PD-1` and `MSI` doesn't match
+        # inside `MSIH`.
+        pattern = _re.compile(
+            r"(?<![A-Za-zА-Яа-яЇїІіЄєҐґ\-])"
+            + _re.escape(key)
+            + r"(?![A-Za-zА-Яа-яЇїІіЄєҐґ0-9])"
+        )
+        m = pattern.search(out)
+        if not m:
+            continue
+        # Replace only the first occurrence.
+        out = out[:m.start()] + expansion + out[m.end():]
+    return out + sentinel
+
+
 def total_term_count() -> int:
     """Return total number of unique vocabulary entries across all categories.
 
@@ -587,6 +753,13 @@ __all__ = [
     "SCREENING_PLAIN_UA",
     "ESCAT_TIER_PATIENT_LABEL",
     "NSZU_PATIENT_LABEL",
+    "ABBREVIATION_FIRST_USE_UA",
+    "PATIENT_ALLOWLIST_ACRONYMS",
+    "PATIENT_ALLOWLIST_LATIN_WORDS",
+    "PATIENT_ALLOWLIST_TRIAL_PREFIXES",
+    "expand_first_use",
+    "is_allowlisted_acronym",
+    "is_allowlisted_latin_word",
     "explain",
     "total_term_count",
 ]

--- a/knowledge_base/engine/render.py
+++ b/knowledge_base/engine/render.py
@@ -40,12 +40,17 @@ from ._citation_guard import (
     render_stripped_block as _render_stripped_block,
     resolve_citation_status as _resolve_citation_status,
 )
-from ._emergency_rf import filter_emergency_rfs, patient_emergency_label
+from ._emergency_rf import (
+    filter_emergency_rfs,
+    is_emergency_rf,
+    patient_emergency_label,
+)
 from ._nszu import lookup_nszu_status, nszu_label
 from ._patient_rationale import build_track_rationale_html as _build_track_rationale_html
 from ._patient_vocabulary import (
     NSZU_PATIENT_LABEL,
     ESCAT_TIER_PATIENT_LABEL,
+    expand_first_use as _expand_first_use,
     explain as _explain_patient,
 )
 from .diagnostic import _DIAGNOSTIC_BANNER, DiagnosticPlanResult
@@ -2647,6 +2652,165 @@ def _build_why_bullets_html(plan_result: PlanResult, track) -> str:
     return _build_track_rationale_html(plan_result, track)
 
 
+# Urgency tiers from Regimen.between_visit_watchpoints, mapped to the
+# patient-bundle headings. Order is important: log → call → ER, so the
+# patient sees calmer items first and the most urgent last (the tier
+# they're most likely to act on stays at the bottom right above the
+# emergency banner).
+_BV_URGENCY_ORDER: tuple[str, ...] = (
+    "log_at_next_visit",
+    "call_clinic_same_day",
+    "er_now",
+)
+_BV_URGENCY_HEADING_UA: dict[str, str] = {
+    "log_at_next_visit": "Занотуйте і обговоріть на наступному візиті",
+    "call_clinic_same_day": "Подзвоніть у клініку того ж дня",
+    "er_now": "Звертайтесь у лікарню негайно",
+}
+_BV_URGENCY_CSS_CLASS: dict[str, str] = {
+    "log_at_next_visit": "bv-urgency-group bv-log",
+    "call_clinic_same_day": "bv-urgency-group bv-call",
+    "er_now": "bv-urgency-group bv-er",
+}
+_BV_FALLBACK_HTML = (
+    '<p class="bv-fallback">Список того, на що звернути увагу між '
+    "візитами, для цього курсу ще не узгоджено клінічною командою. "
+    "Запитайте лікаря на наступному візиті, які симптоми треба "
+    "занотовувати, а які — приводи дзвонити в клініку.</p>"
+)
+
+
+def _emergency_trigger_keys(plan_result: PlanResult) -> set[str]:
+    """Return the lowercase first-sentence text of each emergency-tier
+    RedFlag definition. PATIENT_MODE_SPEC §3.4 dedupe rule: an `er_now`
+    watchpoint whose `trigger_ua` matches any emergency RF text is
+    suppressed so the patient doesn't see the same call-to-action in
+    both `between-visits` and `emergency-signals`."""
+    rf_lookup = (plan_result.kb_resolved or {}).get("red_flags") or {}
+    keys: set[str] = set()
+    if not isinstance(rf_lookup, dict):
+        return keys
+    for rf in rf_lookup.values():
+        if not isinstance(rf, dict):
+            continue
+        if not is_emergency_rf(rf):
+            continue
+        text = (rf.get("definition_ua") or rf.get("definition") or "")
+        # Match patient_emergency_label() truncation — first sentence only.
+        first = str(text).split(".")[0].strip().lower()
+        if first:
+            keys.add(first)
+    return keys
+
+
+def _render_between_visits_section(plan_result: PlanResult) -> str:
+    """Per-track 'на що звертати увагу між візитами' section.
+
+    Source: `track.regimen_data['between_visit_watchpoints']` (list of
+    BetweenVisitWatchpoint dicts after Pydantic round-trip). Empty list
+    or missing field → fallback string per PATIENT_MODE_SPEC §3.4.
+    Renderer NEVER fabricates content.
+
+    Dedupe with the emergency banner: an `er_now` item whose
+    `trigger_ua` first-sentence matches any emergency RF is dropped
+    here (it surfaces in the emergency banner instead). Per §3.4.
+    """
+    plan = plan_result.plan
+    if plan is None or not plan.tracks:
+        return (
+            '<section class="between-visits">'
+            "<h2>На що звернути увагу між візитами</h2>"
+            f"{_BV_FALLBACK_HTML}"
+            "</section>"
+        )
+
+    track_count = len(plan.tracks)
+    emergency_keys = _emergency_trigger_keys(plan_result)
+    track_blocks: list[str] = []
+    any_authored = False
+
+    for idx, t in enumerate(plan.tracks):
+        regimen_data = t.regimen_data or {}
+        regimen_id = (
+            regimen_data.get("id", "") if isinstance(regimen_data, dict) else ""
+        )
+        watchpoints = []
+        if isinstance(regimen_data, dict):
+            watchpoints = list(regimen_data.get("between_visit_watchpoints") or [])
+
+        # Dedupe er_now items vs emergency banner.
+        kept: list[dict] = []
+        for w in watchpoints:
+            if not isinstance(w, dict):
+                continue
+            if (w.get("urgency") or "") == "er_now":
+                trig = (w.get("trigger_ua") or "").split(".")[0].strip().lower()
+                if trig and trig in emergency_keys:
+                    continue
+            kept.append(w)
+
+        title_ua, modifier = _track_label_ua(idx, track_count, t)
+        if not kept:
+            track_blocks.append(
+                f'<div class="bv-track" data-source-id="{_h(regimen_id)}">'
+                f'<p class="track-label">{_h(title_ua)}</p>'
+                f"{_BV_FALLBACK_HTML}"
+                "</div>"
+            )
+            continue
+
+        any_authored = True
+        # Group within the track by urgency tier, in canonical order.
+        groups_html: list[str] = []
+        by_urgency: dict[str, list[dict]] = {u: [] for u in _BV_URGENCY_ORDER}
+        for w in kept:
+            urg = (w.get("urgency") or "").strip()
+            if urg not in by_urgency:
+                continue  # defensive: schema rejects bogus values, but be safe
+            by_urgency[urg].append(w)
+        for urg in _BV_URGENCY_ORDER:
+            items = by_urgency.get(urg) or []
+            if not items:
+                continue
+            cls = _BV_URGENCY_CSS_CLASS[urg]
+            heading = _BV_URGENCY_HEADING_UA[urg]
+            li_parts: list[str] = []
+            for w in items:
+                trigger = _h(w.get("trigger_ua") or "")
+                action = _h(w.get("action_ua") or "")
+                window = w.get("cycle_day_window") or ""
+                window_html = (
+                    f' <span class="bv-window">({_h(window)})</span>'
+                    if window else ""
+                )
+                li_parts.append(
+                    "<li>"
+                    f'<span class="bv-trigger">{trigger}</span>{window_html}'
+                    f' — <span class="bv-action">{action}</span>'
+                    "</li>"
+                )
+            groups_html.append(
+                f'<div class="{cls}">'
+                f"<h3>{_h(heading)}</h3>"
+                f'<ul>{"".join(li_parts)}</ul>'
+                "</div>"
+            )
+
+        track_blocks.append(
+            f'<div class="bv-track" data-source-id="{_h(regimen_id)}">'
+            f'<p class="track-label">{_h(title_ua)}</p>'
+            f'{"".join(groups_html)}'
+            "</div>"
+        )
+
+    return (
+        '<section class="between-visits">'
+        "<h2>На що звернути увагу між візитами</h2>"
+        f'{"".join(track_blocks)}'
+        "</section>"
+    )
+
+
 def _render_emergency_section(plan_result: PlanResult) -> str:
     """Filter the plan's red flags and render emergency-tier ones as a
     `<section class="emergency-signals">` with one banner item per RF.
@@ -2812,6 +2976,7 @@ def _render_patient_mode(
     )
 
     body_parts.append(_render_why_section(plan_result))
+    body_parts.append(_render_between_visits_section(plan_result))
 
     body_parts.append(_render_emergency_section(plan_result))
     body_parts.append(_render_ask_doctor_section(plan_result))
@@ -2820,9 +2985,11 @@ def _render_patient_mode(
         f'<footer class="patient-disclaimer">{_PATIENT_DISCLAIMER_HTML}</footer>'
     )
 
-    return _patient_doc_shell(
-        "Ваш персональний онкологічний план",
-        "".join(body_parts),
+    return _expand_first_use(
+        _patient_doc_shell(
+            "Ваш персональний онкологічний план",
+            "".join(body_parts),
+        )
     )
 
 

--- a/knowledge_base/engine/render_styles.py
+++ b/knowledge_base/engine/render_styles.py
@@ -793,6 +793,51 @@ PATIENT_MODE_CSS = """
   color: #78350f;
 }
 
+/* "Between visits" section — patient watchpoints grouped by urgency.
+   PATIENT_MODE_SPEC §3.4. The same `er_now` items can also surface in
+   the emergency-signals banner; the renderer dedupes on trigger_ua text
+   so a patient never sees the same call-to-action twice. */
+.between-visits {
+  background: #f0f9ff;
+  border-left: 4px solid #0ea5e9;
+  padding: 18px 22px;
+  border-radius: 4px;
+  margin: 24px 0;
+}
+.between-visits h2 {
+  border-bottom-color: #bae6fd;
+}
+.between-visits .bv-track {
+  margin: 12px 0 18px;
+}
+.between-visits .bv-track + .bv-track { margin-top: 22px; }
+.between-visits .bv-urgency-group {
+  margin: 10px 0 14px;
+}
+.between-visits .bv-urgency-group h3 {
+  font-size: 1em;
+  font-weight: 700;
+  margin: 6px 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.between-visits .bv-log h3 { color: #0c4a6e; }
+.between-visits .bv-call h3 { color: #b45309; }
+.between-visits .bv-er h3 { color: #991b1b; }
+.between-visits ul { margin: 4px 0 0 20px; }
+.between-visits li { margin: 6px 0; }
+.between-visits .bv-trigger { font-weight: 600; }
+.between-visits .bv-action { color: #475569; }
+.between-visits .bv-window {
+  font-size: 0.85em;
+  color: #64748b;
+  font-family: 'JetBrains Mono', Menlo, monospace;
+}
+.between-visits .bv-fallback {
+  font-style: italic;
+  color: #475569;
+}
+
 /* Cross-link chip — anchors patient ↔ clinician bundles in their headers
    so a doctor reading the patient bundle can jump to canonical version,
    and a patient reading the clinician bundle can jump to plain UA. */

--- a/knowledge_base/schemas/regimen.py
+++ b/knowledge_base/schemas/regimen.py
@@ -18,7 +18,7 @@ that author `phases:` explicitly are left as-is — `components` and
 `phases` are independent on input; the auto-wrap is one-way only.
 """
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import Field, field_validator, model_validator
 
@@ -72,6 +72,27 @@ class RegimenUkraineAvailability(Base):
     notes: Optional[str] = None
 
 
+class BetweenVisitWatchpoint(Base):
+    """One between-visit watchpoint for the patient-mode renderer.
+
+    PATIENT_MODE_SPEC §3.4: render-only field that powers the "На що
+    звернути увагу між візитами" patient bundle section. The renderer
+    groups items by `urgency` tier; engine MUST NOT consult this field
+    as a treatment-selection signal (CHARTER §8.3).
+
+    Authoring queue: `docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md`.
+    Two Clinical Co-Lead sign-offs required per regimen before the
+    `between_visit_watchpoints` field can be considered authored
+    (CHARTER §6.1; see PATIENT_MODE_SPEC §6).
+    """
+
+    trigger_ua: str  # plain UA: what the patient might notice at home
+    action_ua: str  # plain UA: what to do — log, call clinic, or ER
+    urgency: Literal["log_at_next_visit", "call_clinic_same_day", "er_now"]
+    cycle_day_window: Optional[str] = None  # e.g. "Day 7-14 — nadir"
+    sources: list[str] = Field(default_factory=list)
+
+
 class Regimen(Base):
     id: str
     name: str
@@ -95,6 +116,12 @@ class Regimen(Base):
     dose_adjustments: list[DoseAdjustment] = Field(default_factory=list)
 
     ukraine_availability: Optional[RegimenUkraineAvailability] = None
+
+    # Patient-mode "between visits" watchpoints (PATIENT_MODE_SPEC §3.4).
+    # Optional — existing regimens load without it. The renderer falls
+    # back to a "ще не узгоджено клінічною командою" placeholder when
+    # the list is empty so an empty list ≡ unauthored, never fabricated.
+    between_visit_watchpoints: list[BetweenVisitWatchpoint] = Field(default_factory=list)
 
     sources: list[str] = Field(default_factory=list)
     last_reviewed: Optional[str] = None

--- a/tests/test_patient_render.py
+++ b/tests/test_patient_render.py
@@ -199,6 +199,8 @@ def test_patient_html_has_required_sections(patient_html: str):
       * `<div class="patient-report">` — root wrapper
       * `<section class="what-was-found">` — molecular findings
       * `<section class="what-now">` — drug recommendations
+      * `<section class="why-this-plan">` — Phase 3 rationale
+      * `<section class="between-visits">` — Phase 4 between-visit watchpoints
       * `<section class="emergency-signals">` — emergency banner
       * `<div class="ask-doctor"…>` — question list
       * `<footer class="patient-disclaimer">` — disclaimer
@@ -207,6 +209,8 @@ def test_patient_html_has_required_sections(patient_html: str):
         '<div class="patient-report">',
         '<section class="what-was-found">',
         '<section class="what-now">',
+        '<section class="why-this-plan">',
+        '<section class="between-visits">',
         '<section class="emergency-signals">',
         '<div class="ask-doctor"',
         '<footer class="patient-disclaimer">',
@@ -779,3 +783,278 @@ def test_information_parity_smoke():
             f"Regimen {rid!r} missing from patient bundle "
             f"(present in clinician: {rid in clinician_html})"
         )
+
+
+# ── Section J — Phase 4: between-visit watchpoints ───────────────────
+
+
+def test_between_visits_section_renders_fallback_when_unauthored():
+    """A regimen with no `between_visit_watchpoints` produces the
+    fallback string per PATIENT_MODE_SPEC §3.4 — never fabricates."""
+    result = _build_synthetic_braf_v600e_mcrc_plan()
+    if result.plan is None or not result.plan.tracks:
+        pytest.skip("Synthetic mCRC plan should produce at least 1 track")
+    # Defensive: clear any watchpoints that might leak from KB.
+    for t in result.plan.tracks:
+        if isinstance(t.regimen_data, dict):
+            t.regimen_data["between_visit_watchpoints"] = []
+    html = render_plan_html(result, mode="patient")
+    assert '<section class="between-visits">' in html
+    visible = _visible_text(html)
+    assert "ще не узгоджено клінічною командою" in visible
+
+
+def test_between_visits_section_renders_authored_watchpoints():
+    """When watchpoints are present they group by urgency tier and the
+    headings appear in the rendered section."""
+    result = _build_synthetic_braf_v600e_mcrc_plan()
+    if result.plan is None or not result.plan.tracks:
+        pytest.skip("Synthetic mCRC plan should produce at least 1 track")
+    # Inject fixture watchpoints into the first track's regimen_data.
+    t = result.plan.tracks[0]
+    if not isinstance(t.regimen_data, dict):
+        pytest.skip("Track has no regimen_data dict to inject into")
+    t.regimen_data["between_visit_watchpoints"] = [
+        {
+            "trigger_ua": "Сильна слабкість на 7-10 день циклу",
+            "action_ua": "Це нормально для цього курсу — занотуйте і обговоріть на наступному візиті",
+            "urgency": "log_at_next_visit",
+            "cycle_day_window": "Day 7-14",
+        },
+        {
+            "trigger_ua": "Лихоманка вище 38°C",
+            "action_ua": "Подзвоніть у клініку того ж дня — нейтрофіли можуть бути низькі",
+            "urgency": "call_clinic_same_day",
+        },
+    ]
+    html = render_plan_html(result, mode="patient")
+    visible = _visible_text(html)
+    # Both urgency-group headings present
+    assert "Занотуйте і обговоріть на наступному візиті" in visible
+    assert "Подзвоніть у клініку того ж дня" in visible
+    # Both trigger texts surface
+    assert "Сильна слабкість на 7-10 день циклу" in visible
+    assert "Лихоманка вище 38°C" in visible
+    # Cycle window rendered for the first watchpoint
+    assert "Day 7-14" in visible
+    # CSS modifier classes present
+    assert 'bv-urgency-group bv-log' in html
+    assert 'bv-urgency-group bv-call' in html
+
+
+def test_between_visits_dedupe_with_emergency_banner():
+    """An `er_now` watchpoint whose `trigger_ua` first-sentence matches
+    an emergency RF gets dropped from `between-visits` (it surfaces in
+    the emergency banner instead). Per PATIENT_MODE_SPEC §3.4."""
+    result = _build_synthetic_braf_v600e_mcrc_plan()
+    if result.plan is None or not result.plan.tracks:
+        pytest.skip("Synthetic mCRC plan should produce at least 1 track")
+    # Inject a critical RF whose first-sentence matches a watchpoint.
+    rf_text = "Тяжка фебрильна нейтропенія потребує негайного звернення"
+    result.kb_resolved.setdefault("red_flags", {})["RF-DEDUPE-TEST"] = {
+        "id": "RF-DEDUPE-TEST",
+        "severity": "critical",
+        "definition_ua": rf_text + ". Подальше — деталі.",
+    }
+    # Watchpoint with matching trigger should be dropped, non-matching kept.
+    t = result.plan.tracks[0]
+    if not isinstance(t.regimen_data, dict):
+        pytest.skip("Track has no regimen_data dict to inject into")
+    t.regimen_data["between_visit_watchpoints"] = [
+        {
+            "trigger_ua": rf_text,  # exactly the same first sentence
+            "action_ua": "Викличте швидку",
+            "urgency": "er_now",
+        },
+        {
+            "trigger_ua": "Поява нової задишки",  # not in emergency list
+            "action_ua": "Викличте швидку, не чекайте візиту",
+            "urgency": "er_now",
+        },
+    ]
+    html = render_plan_html(result, mode="patient")
+    bv_match = re.search(
+        r'<section class="between-visits">.*?</section>',
+        html, flags=re.DOTALL,
+    )
+    assert bv_match
+    bv_block = bv_match.group(0)
+    # Non-matching `er_now` item still in between-visits.
+    assert "Поява нової задишки" in bv_block
+    # Matching item dropped from between-visits (still allowed elsewhere).
+    assert rf_text not in bv_block
+    # But does surface in the emergency banner.
+    em_match = re.search(
+        r'<section class="emergency-signals">.*?</section>',
+        html, flags=re.DOTALL,
+    )
+    assert em_match and rf_text in em_match.group(0)
+
+
+def test_between_visits_per_track_when_two_tracks():
+    """Two-track plans render a `bv-track` block per track, each with
+    its own dedicated fallback-or-watchpoints area."""
+    result = _build_hcv_mzl_two_track_plan()
+    if result.plan is None or len(result.plan.tracks) < 2:
+        pytest.skip("Reference HCV-MZL plan should produce ≥2 tracks")
+    html = render_plan_html(result, mode="patient")
+    bv_match = re.search(
+        r'<section class="between-visits">.*?</section>',
+        html, flags=re.DOTALL,
+    )
+    assert bv_match
+    bv_block = bv_match.group(0)
+    # Two `bv-track` cards (one per track).
+    track_card_count = bv_block.count('class="bv-track"')
+    assert track_card_count == 2, (
+        f"Expected 2 bv-track cards for a 2-track plan, got {track_card_count}"
+    )
+    # Both Cyrillic prefixes present.
+    visible = _visible_text(bv_block)
+    assert "А)" in visible and "Б)" in visible
+
+
+def test_between_visits_schema_rejects_bad_urgency():
+    """Pydantic Literal type on `urgency` blocks bogus values at load
+    time so the renderer never has to defend against typos."""
+    from knowledge_base.schemas.regimen import Regimen
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Regimen(
+            id="REG-BAD", name="Bad", components=[{"drug_id": "D"}],
+            between_visit_watchpoints=[
+                {"trigger_ua": "x", "action_ua": "y", "urgency": "asap_now"},
+            ],
+        )
+
+
+def test_between_visits_schema_accepts_three_tier_set():
+    """All three urgency tiers parse without error."""
+    from knowledge_base.schemas.regimen import Regimen
+
+    r = Regimen(
+        id="REG-OK", name="OK", components=[{"drug_id": "D"}],
+        between_visit_watchpoints=[
+            {"trigger_ua": "a1", "action_ua": "b1", "urgency": "log_at_next_visit"},
+            {"trigger_ua": "a2", "action_ua": "b2", "urgency": "call_clinic_same_day"},
+            {"trigger_ua": "a3", "action_ua": "b3", "urgency": "er_now"},
+        ],
+    )
+    urgencies = [w.urgency for w in r.between_visit_watchpoints]
+    assert urgencies == ["log_at_next_visit", "call_clinic_same_day", "er_now"]
+
+
+# ── Section K — Phase 5: Latin/abbreviation render gate ──────────────
+
+
+def _flag_unallowed_acronyms(visible_text: str) -> list[str]:
+    """Return uppercase abbreviation tokens in `visible_text` that are
+    NOT on the patient-mode allowlist. Tokens matching the trial-prefix
+    rule (KEYNOTE-189, etc.) pass."""
+    from knowledge_base.engine._patient_vocabulary import is_allowlisted_acronym
+    pattern = re.compile(r"\b[A-Z]{2,}[a-z]?(?:-[A-Z0-9]+)*\b")
+    found = set(pattern.findall(visible_text))
+    return sorted(t for t in found if not is_allowlisted_acronym(t))
+
+
+def _flag_unallowed_latin_words(visible_text: str) -> list[str]:
+    """Return Latin lowercase ≥4-char tokens in `visible_text` that are
+    NOT on the patient-mode allowlist."""
+    from knowledge_base.engine._patient_vocabulary import is_allowlisted_latin_word
+    pattern = re.compile(r"\b[a-z]{4,}\b")
+    found = set(pattern.findall(visible_text))
+    return sorted(t for t in found if not is_allowlisted_latin_word(t))
+
+
+# Anchor cases the gates run against. Each tuple is (label, fixture-builder).
+# Adding a fixture here surfaces any new Latin token introduced by KB shifts
+# or render-layer changes — the failure message points at the fixture.
+_GATE_CASES = [
+    ("synthetic mCRC + BRAF V600E", _build_synthetic_braf_v600e_mcrc_plan),
+    ("reference HCV-MZL two-track", _build_hcv_mzl_two_track_plan),
+]
+
+
+@pytest.mark.parametrize("label,builder", _GATE_CASES, ids=lambda x: getattr(x, "__name__", str(x)))
+def test_patient_html_no_latin_abbreviations_in_visible_text(label, builder):
+    """Visible patient body MUST NOT contain uppercase abbreviations
+    outside the allowlist. PATIENT_MODE_SPEC §5.4."""
+    if not callable(builder):
+        return
+    result = builder()
+    if result.plan is None:
+        pytest.skip(f"{label!r}: builder produced no plan")
+    html = render_plan_html(result, mode="patient")
+    visible = _visible_text(html)
+    leaks = _flag_unallowed_acronyms(visible)
+    assert not leaks, (
+        f"[{label}] Unallowed uppercase abbreviations leaked into the patient body:\n"
+        f"  {leaks}\n"
+        f"Fix options:\n"
+        f"  1. Rewrite the offending renderer-controlled prose to drop the abbreviation.\n"
+        f"  2. Add a first-use expansion to ABBREVIATION_FIRST_USE_UA in _patient_vocabulary.py.\n"
+        f"  3. Add the token to PATIENT_ALLOWLIST_ACRONYMS if it's a canonical clinical name.\n"
+    )
+
+
+@pytest.mark.parametrize("label,builder", _GATE_CASES, ids=lambda x: getattr(x, "__name__", str(x)))
+def test_patient_html_no_bare_latin_words(label, builder):
+    """Visible patient body MUST NOT contain Latin lowercase words
+    ≥4 chars outside the allowlist. PATIENT_MODE_SPEC §5.4."""
+    if not callable(builder):
+        return
+    result = builder()
+    if result.plan is None:
+        pytest.skip(f"{label!r}: builder produced no plan")
+    html = render_plan_html(result, mode="patient")
+    visible = _visible_text(html)
+    leaks = _flag_unallowed_latin_words(visible)
+    assert not leaks, (
+        f"[{label}] Unallowed Latin words leaked into the patient body:\n"
+        f"  {leaks}\n"
+        f"Fix options:\n"
+        f"  1. Rewrite the offending renderer-controlled prose to use Ukrainian.\n"
+        f"  2. Add the word to PATIENT_ALLOWLIST_LATIN_WORDS if it's a canonical loanword,\n"
+        f"     biology stem, or unavoidable KB regimen-name fragment.\n"
+    )
+
+
+def test_first_use_expansion_inserts_gloss_for_escat():
+    """When the patient body mentions ESCAT, the first occurrence is
+    expanded to include the parenthesized gloss."""
+    from knowledge_base.engine._patient_vocabulary import expand_first_use
+
+    sample = "<p>За шкалою ESCAT це найвищий рівень доказів.</p>"
+    out = expand_first_use(sample)
+    # First use becomes the expanded form.
+    assert "ESCAT (рівень доказів" in out
+    # Idempotency sentinel attached.
+    assert "abbrev-expanded" in out
+
+
+def test_first_use_expansion_idempotent():
+    """Calling `expand_first_use` twice on the same input is a no-op
+    after the first call (sentinel guard). Lets render flows toggle
+    audience / language without double-expanding."""
+    from knowledge_base.engine._patient_vocabulary import expand_first_use
+
+    sample = "<p>ESCAT — це шкала.</p>"
+    once = expand_first_use(sample)
+    twice = expand_first_use(once)
+    assert once == twice
+
+
+def test_first_use_expansion_skips_when_key_absent():
+    """If a key from `ABBREVIATION_FIRST_USE_UA` doesn't appear in the
+    text, no replacement happens for that key — only the sentinel is
+    appended."""
+    from knowledge_base.engine._patient_vocabulary import expand_first_use
+
+    sample = "<p>Самі лише українські слова — без жодних абревіатур.</p>"
+    out = expand_first_use(sample)
+    # No expansion text should be inserted.
+    assert "рівень доказів" not in out
+    assert "вірус гепатиту" not in out
+    # Sentinel still appended.
+    assert "abbrev-expanded" in out


### PR DESCRIPTION
## Summary

Closes phases 4 + 5 of the patient-mode v2.1 plan ([`docs/plans/patient_simplified_report_2026-05-01-1300.md`](docs/plans/patient_simplified_report_2026-05-01-1300.md)). Phases 1-3 + 6 shipped earlier today in [#269](https://github.com/romeo111/OpenOnco/pull/269); this PR lands the deferred two so the patient-mode contract from `specs/PATIENT_MODE_SPEC.md` is fully implemented.

User's stated bar (2026-05-01): _"без латини, без абревіатур, з поясненням, чому призначено саме це і **на що звертати увагу між візитами**"_.

### Phase 4 — between-visit watchpoints

- **Schema** ([`knowledge_base/schemas/regimen.py`](knowledge_base/schemas/regimen.py)): new `BetweenVisitWatchpoint` Pydantic model with `trigger_ua` + `action_ua` + `urgency: Literal[log_at_next_visit, call_clinic_same_day, er_now]` + optional `cycle_day_window` + `sources`. Bogus urgency values rejected at load. `Regimen.between_visit_watchpoints: list[BetweenVisitWatchpoint] = Field(default_factory=list)` — existing 244 regimens stay valid.
- **Renderer** ([`knowledge_base/engine/render.py`](knowledge_base/engine/render.py)): new `_render_between_visits_section` — per-track `<section class="between-visits">` grouped by urgency (calmer first, ER last). Empty list ≡ unauthored, surfaces fallback ("Список ... ще не узгоджено клінічною командою") rather than fabricating.
- **Emergency-banner dedupe**: `er_now` watchpoints whose first-sentence matches an emergency RedFlag are dropped from `between-visits` (they surface in the emergency banner instead). Implemented via `_emergency_trigger_keys` keyed on lowercase first-sentence text.
- **CSS** ([`knowledge_base/engine/render_styles.py`](knowledge_base/engine/render_styles.py)): `.between-visits` + `.bv-track` + per-tier color modifiers (bv-log/bv-call/bv-er).
- **Authoring queue** ([`docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md`](docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md)): 12 anchor regimens prioritized for Wave 1 (CHOP, R-CHOP, FOLFOX, FOLFOX-bev, DAA-SOF-VEL, BR-standard, VRD, DARA-VRD, A-AVD, ATRA-ATO-APL, VEN-AZA-AML, pembro-mono) — covers ~30-40% of plan paths via reuse across diseases. Each regimen needs CHARTER §6.1 two-Co-Lead signoff before authored content surfaces.

### Phase 5 — Latin / abbreviation hardening

- **First-use expansion** ([`knowledge_base/engine/_patient_vocabulary.py`](knowledge_base/engine/_patient_vocabulary.py)): new `ABBREVIATION_FIRST_USE_UA` table (10 entries: ESCAT, FDA, MDT, ECOG, MSI, PD-1, PD-L1, HCV, HBV, CAR-T). First occurrence of each key in body prose is replaced with the parenthesized expansion ("ESCAT (рівень доказів — як міцно доведено, що препарат працює)"); subsequent occurrences stay bare. `expand_first_use(html)` is idempotent via sentinel comment so re-renders on mode/lang toggle don't double-expand.
- **Allowlists**: `PATIENT_ALLOWLIST_ACRONYMS` (~140 entries — gene symbols, disease abbrevs, regimen acronyms, lab terms, drug brand acronyms, ESCAT tier labels), `PATIENT_ALLOWLIST_LATIN_WORDS` (~50 entries — biology stems, KB regimen-name vocabulary, URL fragments), `PATIENT_ALLOWLIST_TRIAL_PREFIXES` (~50 entries) covers trial-name acronyms via prefix match (KEYNOTE-189, CHECKMATE-067) so new trials don't require allowlist updates.
- **Vocabulary audit**: rewrote 9 values in `DRUG_CLASS_PLAIN_UA` / `VARIANT_TYPE_PLAIN_UA` / `AE_PLAIN_UA` to remove residual Latin. Examples: "ключовий 'driver' пухлини" → "ключову рушійну мутацію пухлини"; "trametinib/cobimetinib" → "траметинібу/кобіметинібу"; "immune effector cell-associated neurotoxicity" → "нейротоксичність, пов'язана з імунною клітинною терапією".
- **Renderer fallback rewrite**: rationale "немає сигналів (redflags)" → "немає клінічних сигналів-тривоги".

## Test plan

- [x] **62 patient-render tests green** (was 49; +13 new across two new sections — Phase 4 watchpoints + Phase 5 Latin/abbrev gate). 1 pre-existing skip.
- [x] **Full suite: 2075 green, 9 skipped** (pre-existing). Up from 2049 baseline; new tests + KB regenerated counts.
- [x] **KB validator clean** — 0 schema, 0 ref errors (2474 entities). Existing 244 regimens load unchanged.
- [x] **Two parametrized gate tests** scan visible body for unallowed uppercase / Latin tokens across (synthetic mCRC + BRAF V600E, HCV-MZL two-track) reference fixtures. Failure messages point at the offending token plus three concrete fix options (rewrite prose / add expansion / add allowlist entry).

## CHARTER constraints respected

- **§8.3 render-only** — vocabulary tables, allowlists, `expand_first_use`, watchpoint renderer all forbidden as engine selection signals (existing module docstrings tightened).
- **§6.1 two-reviewer** — `Regimen.between_visit_watchpoints` content needs two Clinical Co-Lead signoffs per regimen before it counts as authored; renderer falls back to "ще не узгоджено" until then. The schema + renderer landing here is plumbing, not clinical content.
- **§15 not a medical device** — patient disclaimer preserved across all render shapes.

## Open questions for reviewer (also parked in `docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md`)

1. **Tier consistency** — should the same trigger always map to the same urgency tier across regimens (e.g. "лихоманка >38°C" → always `call_clinic_same_day`)? Or can it shift based on regimen-specific risk?
2. **Source-anchor floor** — should every watchpoint require ≥1 `SRC-*` citation, or is the regimen-level source list (already required) sufficient?
3. **Rare-event reporting** — soft <5% incidence threshold OK?

## What's next

After this lands, the full `specs/PATIENT_MODE_SPEC.md` contract is implemented. Remaining work is purely content authoring:

- **Wave 1**: 12 anchor regimens × ~5 watchpoints = ~80-100 items. Single co-lead review session.
- **Wave 2**: ~50 disease-anchor regimens.
- **Wave 3**: ~190 long-tail regimens.

Each authored regimen lands as a separate small PR (`feat(kb): patient watchpoints for REG-FOLFOX` etc.) gated on two-Co-Lead signoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)