### PR TITLE
feat(render): cross-link missing fields to blocked RedFlags in data quality section

### DIFF
--- a/knowledge_base/engine/mdt_orchestrator.py
+++ b/knowledge_base/engine/mdt_orchestrator.py
@@ -756,6 +756,32 @@ def _unevaluated_red_flags(
     return sorted(out)
 
 
+def _field_unlocks_map(
+    missing_fields: list[str],
+    disease_data: Optional[dict],
+    entities: dict,
+) -> dict[str, list[str]]:
+    """Return {field: [rf_id, ...]} for each missing field that is referenced
+    by at least one relevant RedFlag trigger. Used to cross-link the 'missing'
+    and 'unevaluated' sections so a clinician sees why a field matters."""
+    if not missing_fields or not entities:
+        return {}
+    disease_id = (disease_data or {}).get("id")
+    result: dict[str, list[str]] = {f: [] for f in missing_fields}
+    for eid, info in entities.items():
+        if info.get("type") != "redflags":
+            continue
+        rf = info.get("data") or {}
+        relevant = rf.get("relevant_diseases") or []
+        if relevant and disease_id and disease_id not in relevant:
+            continue
+        refs = set(_trigger_referenced_fields(rf.get("trigger") or {}))
+        for field in missing_fields:
+            if field in refs:
+                result[field].append(eid)
+    return {f: sorted(rfs) for f, rfs in result.items() if rfs}
+
+
 def _data_quality(
     findings: dict[str, Any],
     disease_data: Optional[dict],
@@ -768,12 +794,16 @@ def _data_quality(
     missing_critical = [f for f in critical if not _has(findings, f)]
     missing_recommended = [f for f in recommended if not _has(findings, f)]
     unevaluated = _unevaluated_red_flags(findings, disease_data, entities)
+    field_unlocks = _field_unlocks_map(
+        missing_critical + missing_recommended, disease_data, entities
+    )
 
     return {
         "missing_critical_fields": missing_critical,
         "missing_recommended_fields": missing_recommended,
         "ambiguous_findings": [],
         "unevaluated_red_flags": unevaluated,
+        "field_unlocks": field_unlocks,
         "fields_present_count": sum(1 for v in findings.values() if v not in (None, "")),
         "fields_expected_count": len(critical) + len(recommended),
     }

--- a/knowledge_base/engine/render.py
+++ b/knowledge_base/engine/render.py
@@ -697,12 +697,28 @@ def _render_mdt_section(mdt: Optional[MDTOrchestrationResult],
     crit = dq.get("missing_critical_fields") or []
     rec = dq.get("missing_recommended_fields") or []
     unevaluated = dq.get("unevaluated_red_flags") or []
+    field_unlocks = dq.get("field_unlocks") or {}
+
+    def _dq_field(f: str) -> str:
+        rfs = field_unlocks.get(f)
+        if not rfs:
+            return _h(f)
+        rf_txt = _h(", ".join(rfs))
+        return (
+            f'{_h(f)} <span style="color:var(--gray-500);font-size:11px;">'
+            f"blocks: {rf_txt}</span>"
+        )
+
     if crit or rec or unevaluated:
         parts.append("<h3>Data quality</h3><ul>")
         if crit:
-            parts.append(f"<li>Missing critical: {_h(', '.join(crit))}</li>")
+            parts.append(
+                f"<li>Missing critical: {', '.join(_dq_field(f) for f in crit)}</li>"
+            )
         if rec:
-            parts.append(f"<li>Missing recommended: {_h(', '.join(rec))}</li>")
+            parts.append(
+                f"<li>Missing recommended: {', '.join(_dq_field(f) for f in rec)}</li>"
+            )
         if unevaluated:
             parts.append(f"<li>Unevaluated RedFlags: {_h(', '.join(unevaluated))}</li>")
         parts.append("</ul>")


### PR DESCRIPTION
## Summary

- Adds `_field_unlocks_map()` to `mdt_orchestrator.py` — inverts `_trigger_referenced_fields()` to produce `{field: [rf_id, ...]}` for each missing critical/recommended field that appears in a relevant RedFlag trigger
- Threads the map through `_data_quality()` as a new `field_unlocks` key in the summary dict
- Updates the data quality renderer in `render.py` to annotate each missing field with a muted `blocks: RF-X, RF-Y` note where applicable

## Why

The previous output listed "Missing critical" and "Unevaluated RedFlags" as two disconnected bullet lists, forcing the reader to mentally join them. For example:

```
Missing critical: hbsag, anti_hbc_total
Unevaluated RedFlags: RF-ALCL-INFECTION-SCREENING
```

These are the same fact. The cross-link makes the dependency explicit at a glance:

```
Missing critical: hbsag (blocks: RF-ALCL-INFECTION-SCREENING), anti_hbc_total (blocks: RF-ALCL-INFECTION-SCREENING)
```

Fields with no linked RFs render unchanged. Non-lymphoma cases are unaffected (field_unlocks returns `{}`).

## Reviewer notes

- No clinical content changed — purely engine + render layer
- Uses the same `_trigger_referenced_fields()` walker and disease relevance filter already used by `_unevaluated_red_flags()`, so the cross-link is consistent with what's already being evaluated
- 36 targeted tests + full suite pass (Python 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)