### PR TITLE
docs: Q-axis dispatch template (batch 5a retrospective)

### DIFF
--- a/docs/plans/q_axis_dispatch_template_2026-05-01.md
+++ b/docs/plans/q_axis_dispatch_template_2026-05-01.md
@@ -1,0 +1,110 @@
+# Q-axis (W12a/W12b) agent-dispatch prompt template
+
+Date authored: 2026-05-01
+Author: orchestrator session `musing-murdock-c08478` (post-batch-5a retrospective)
+
+## Context
+
+Batch 5a of W12a/W12b dispatched 12 agents with prompts that conflicted with the
+canonical chunk-spec encoded in each issue body. 11/12 agents self-corrected by
+following the issue body and consulting advisor; 2 stalled mid-task and needed
+manual recovery; some hit branch-name drift (`chunk/...` vs `tasktorrent/...`).
+
+The template below is what the orchestrator-level prompt SHOULD look like for
+W12a/W12b agents — aligned with the issue body so the agent doesn't have to
+reconcile two sources of truth.
+
+## Authoritative differences vs W7-W11 dispatch pattern
+
+| Dimension | W7-W11 (Tier-2 KB authoring) | W12a/W12b (Q-axis quality) |
+|---|---|---|
+| Output mode | Direct edits to `knowledge_base/hosted/content/...` | Sidecar files under `contributions/<chunk-id>/` only |
+| Branch prefix | `chunk/...` | `tasktorrent/...` |
+| Quality gate | `validate_kb` + `pytest tests/test_curated_chunk_e2e.py` (82 passed) | `scripts.tasktorrent.validate_contributions <chunk-id>` only |
+| Manifest size | Variable, read from issue | Variable (4-5 IDs typical), read from issue |
+| Hosted KB rejection | n/a (you ARE editing hosted) | Editing hosted = REJECT per issue's "Rejection Criteria" |
+
+## Template (parameterize {ISSUE_NUM} and {CHUNK_TYPE} per agent)
+
+```
+Execute GitHub issue #{ISSUE_NUM}.
+
+You are one of N parallel Q-axis agents. Repo: OpenOnco. READ CLAUDE.md in your worktree before any write.
+
+CRITICAL — WORKTREE ISOLATION:
+- Work ONLY in your assigned isolated worktree.
+- NEVER `cd C:\Users\805\cancer-autoresearch` or `cd /c/Users/805/cancer-autoresearch` — that is the user's main tree (incident #241).
+- All git ops happen in your worktree path.
+
+Pre-flight (mandatory before any write):
+1. `pwd` — confirm path is under `.claude/worktrees/agent-*/`, NOT the main tree
+2. `git rev-parse --abbrev-ref HEAD` and `git status --short` — record + confirm clean
+
+CANONICAL CHUNK SPEC: the issue body is authoritative. If anything in this
+prompt conflicts with the issue body, follow the issue body.
+
+Steps:
+1. `gh issue view {ISSUE_NUM} --json title,body -q '.body'` — extract ALL manifest IDs (do NOT assume count; some chunks have 4, some 5).
+2. Sidecar contract (issue's Quality Gate):
+   - Output ONLY under `contributions/<chunk-id>/`
+   - Branch prefix: `tasktorrent/<chunk-id>`
+   - Hosted KB edits = REJECT per issue's Rejection Criteria
+3. For each manifest ID, follow the per-chunk-type guidance below.
+4. Required sidecar files (mirrors wave-1 reference pattern):
+   - `_contribution_meta.yaml`
+   - `task_manifest.txt`
+   - `audit-report.yaml` (BMA chunks) OR `source_recency_audit.yaml` (source chunks)
+   - `refresh_summary.yaml` (source chunks only)
+   - `unreachable.yaml` (source chunks, when applicable)
+   - per-entity upsert YAMLs for matched/verifiable items
+5. Quality gate: `C:/Python312/python.exe -m scripts.tasktorrent.validate_contributions <chunk-id>` → must PASS.
+6. Diff scope: `git diff --name-only origin/master..HEAD` — all paths must be under `contributions/<chunk-id>/`. No hosted KB files.
+7. Commit with explicit pathspecs (NEVER `git add -A`/`.` — banned per CLAUDE.md). Push origin. Comment on issue with branch+SHA+per-entity result.
+
+Self-push authorized (CLAUDE.md commit `3a60901b`) on feature branch with green gates.
+
+For W12a (BMA-CIViC backfill):
+- Reference pattern: closed issue #43 (`bma-civic-backfill-2026-04-29-001/-009`).
+- For each BMA: lookup CIViC snapshot at `knowledge_base/hosted/civic/<latest>/`, match by gene + variant + disease (use disease synonym expansion if needed).
+- Variant-aware filter: exclude evidence items whose variant inverts the BMA's clinical message (e.g. for PDGFRA-EXON12 BMA, exclude exon-18 D842/I843 imatinib-resistant items).
+- Match → write upsert sidecar with `evidence_sources.civic_*` block (level/direction/statement/citation_id), preserve `actionability_review_required: true` for maintainer adjudication.
+- No match → audit-only row in `audit-report.yaml` with structured reason (`gene_not_in_civic` / `gene_in_civic_no_disease_overlap` / `gene_disease_match_but_alteration_mismatch` / etc).
+
+For W12b (source-recency-refresh):
+- Reference pattern: closed issues #92-#121 (`source-recency-refresh-2026-04-29-*`).
+- For each Source: httpx GET `url` (30s timeout, 3 retries, follow redirects, **`User-Agent: Mozilla/5.0 (compatible; OpenOnco-recency-bot)` header to reduce bot-walls**).
+- 200 → upsert with `last_verified: 2026-05-01`, bump `current_as_of` if older than 2026-04-01.
+- 301/302 to different URL → upsert with new `url` + `url_redirected_from`.
+- 404/410 → unreachable.yaml entry with `url_status: dead`, `url_replacement_needed: true`.
+- 403 (publisher bot-wall) → unreachable.yaml entry with `url_status: blocked_by_bot_protection`. **Do NOT bump `current_as_of`** unless content is independently verified (PMID/DOI lookup). Suggest DOI canonical URL replacement in audit notes.
+- No URL field on stub → unreachable.yaml entry, suggest PMID/DOI in notes.
+
+Stop conditions per CLAUDE.md (abort + report):
+- Edits would touch files outside `contributions/<chunk-id>/`
+- HEAD on different branch than expected
+- Working tree mutated unexpectedly
+- Validator regresses (new errors)
+
+Report back: branch + SHA + push URL + comment URL + per-entity outcome table.
+```
+
+## Known issues fixed in this template
+
+1. **Branch name drift**: prompt now matches issue's `tasktorrent/...` convention (was `chunk/...`).
+2. **Hosted KB rejection**: prompt explicitly states sidecar-only (was "edit hosted YAML").
+3. **Wrong gate**: prompt now uses `validate_contributions` (was `validate_kb` + pytest).
+4. **Manifest count**: prompt no longer hardcodes "4 IDs" — agents read from issue.
+5. **Pytest baseline drift**: prompt no longer cites "82 passed" (full suite has 6 pre-existing failures unrelated).
+6. **Synchronous gate execution**: agents in batch 5a stalled when they spawned background pytest — prompt now implies synchronous execution. (Two agents `#186`/`#204` returned mid-stream "Now let me wait for pytest" / "Background tasks just started. Let me wait for the notification." and never resumed.)
+7. **403 bot-wall handling**: prompt prescribes `User-Agent` header AND advises NOT to bump `current_as_of` for blocked items unless independently verified.
+
+## Open template gaps (not yet addressed)
+
+- **Wave-1 sidecar redundancy detection**: agents should grep for existing
+  `contributions/bma-civic-backfill-2026-04-29-*/<bma-id>.yaml` and skip
+  redundant work or explicitly supersede with rationale. Current template
+  doesn't surface this.
+- **Per-source DOI canonical fallback**: when 403 hits a publisher URL, the
+  template should suggest the agent attempts `https://doi.org/<doi>` resolution
+  before classifying as `blocked_by_bot_protection`. Several batch-5a agents
+  flagged this manually but didn't try the fallback.

--- a/knowledge_base/hosted/content/drugs/erdafitinib.yaml
+++ b/knowledge_base/hosted/content/drugs/erdafitinib.yaml
@@ -1,0 +1,120 @@
+id: DRUG-ERDAFITINIB
+names:
+  preferred: "Erdafitinib"
+  ukrainian: "Ердафітініб"
+  english: "Erdafitinib"
+  brand_names: ["Balversa"]
+atc_code: L01EN01
+rxnorm_id: null
+drug_class: "Pan-FGFR (FGFR1-4) tyrosine kinase inhibitor"
+mechanism: >
+  Oral, ATP-competitive pan-FGFR (1, 2, 3, 4) kinase inhibitor that
+  selectively targets tumors driven by FGFR2/FGFR3 activating mutations
+  or fusions. Pivotal BLC2001 Phase II (87 patients with locally
+  advanced/metastatic urothelial carcinoma harboring FGFR2/3 mutations
+  or fusions, post-platinum) showed ORR 40% (CR 3%, PR 37%), mDOR 5.6
+  months → FDA accelerated approval Apr 2019. Confirmatory THOR Phase
+  III (Cohort 1: erdafitinib vs investigator-choice chemotherapy in
+  post-platinum + post-IO 2L/3L FGFR-altered urothelial) demonstrated
+  mOS 12.1 vs 7.8 months (HR 0.64, p=0.005) → FDA full approval Jan
+  2024 with simultaneous restriction of indication to post-platinum +
+  post-PD-1/L1 setting (THOR Cohort 2 erdafitinib vs pembrolizumab in
+  IO-naive 2L was negative — pembrolizumab preferred when ICI-naive).
+
+regulatory_status:
+  fda:
+    approved: true
+  ema:
+    approved: true
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-04-29"
+    notes: |
+      Не зареєстровано в Україні (Держреєстр ЛЗ — РП відсутнє станом на
+      2026-04-29). Перший пан-FGFR (1-4) інгібітор для метастатичного
+      уротеліального раку з активуючою FGFR2/FGFR3 мутацією або
+      злиттям, після платини та анти-PD-1/PD-L1 терапії (FDA full
+      approval, січень 2024).
+
+      Шляхи доступу:
+      - Named-patient import (DEC спецдозвіл МОЗ) — потребує підтвердженої
+        FGFR2/3 мутації або злиття NGS / FoundationOne.
+      - EAP Janssen / Johnson & Johnson (Balversa access — FGFR-altered
+        urothelial 2L+).
+      - Cross-border (EU): SoC у EU онкоцентрах через "Лікування за
+        кордоном" (наказ МОЗ 988) для FGFR-altered uroth після IO+ХТ.
+
+      Передумова використання: молекулярне тестування (NGS / FISH /
+      RT-PCR — підтвердження FGFR2 чи FGFR3 активуючої мутації або
+      злиття; companion diagnostic в FDA — therascreen FGFR RGQ RT-PCR).
+      Source: drlz.com.ua пошук "erdafitinib"/"balversa" 2026-04-29 — РП
+      відсутнє.
+
+typical_dosing: >
+  Starting dose 8 mg PO once daily continuously; uptitrate to 9 mg QD on
+  day 14-21 if serum phosphate <5.5 mg/dL AND no significant ocular or
+  other AEs (achieves target steady-state phosphate ≥5.5 mg/dL,
+  associated with improved efficacy in BLC2001/THOR). Dose modifications
+  for hyperphosphatemia: hold for phosphate >7.0 mg/dL despite dietary
+  restriction + phosphate binders; reduce or discontinue for ocular
+  AEs (CSR, retinal detachment) detected on monthly OCT. Potent
+  CYP3A4/2C9 substrate — adjust dose with strong inhibitors/inducers
+  per label table.
+formulations: ["Tablets 3 mg / 4 mg / 5 mg"]
+
+absolute_contraindications:
+  - "Hypersensitivity to erdafitinib"
+  - "Active central serous retinopathy or retinal pigment epithelial detachment (CSR/RPED) — must resolve to baseline before resumption"
+  - "Pregnancy (embryo-fetal toxicity per animal data — class effect)"
+black_box_warnings: []
+major_interactions:
+  - "Strong CYP3A4 inhibitors (ketoconazole, ritonavir, clarithromycin) — avoid; if unavoidable, reduce dose"
+  - "Strong CYP3A4 inducers (rifampin, phenytoin, carbamazepine, St John's wort) — avoid (loss of efficacy)"
+  - "Moderate CYP2C9 inhibitors (fluconazole) — caution"
+  - "Drugs reducing serum phosphate (sevelamer, lanthanum) — coordinate with phosphate management"
+  - "OCT2 substrates (metformin) — monitor for substrate toxicity"
+common_adverse_events:
+  - "Hyperphosphatemia (>5.5 mg/dL — pharmacodynamic; managed with diet + binders)"
+  - "Stomatitis / mucositis"
+  - "Diarrhea"
+  - "Dry mouth / dry skin / dry eye"
+  - "Decreased appetite / weight loss"
+  - "Fatigue"
+  - "Onycholysis / nail dystrophy / paronychia"
+  - "Alopecia"
+  - "Dysgeusia (taste alterations)"
+  - "Hand-foot syndrome (palmar-plantar erythrodysesthesia)"
+  - "Constipation"
+serious_adverse_events:
+  - "Central serous retinopathy / retinal pigment epithelial detachment (CSR/RPED) — class FGFR effect; baseline + monthly OCT for first 4 mo, then per protocol"
+  - "Severe hyperphosphatemia with soft-tissue mineralization / vascular calcification (chronic)"
+  - "Severe stomatitis impairing oral intake"
+  - "Severe nail toxicity (onycholysis, paronychia with secondary infection)"
+  - "Embryo-fetal toxicity"
+
+pharmacology:
+  half_life: "~59 hours; CYP3A4 (major) + CYP2C9 substrate; high protein binding"
+
+sources:
+  - SRC-NCCN-BLADDER-2025
+  - SRC-CIVIC
+
+last_reviewed: "2026-04-29"
+notes: >
+  Erdafitinib is the first FGFR-targeted therapy in genitourinary
+  oncology and remains the only oral targeted agent for FGFR2/3-altered
+  metastatic urothelial carcinoma. NCCN-Bladder 2025 lists erdafitinib
+  category 1 in 2L+ FGFR-altered after platinum + PD-1/L1; therascreen
+  FGFR RGQ RT-PCR is the FDA-cleared companion diagnostic, but NGS
+  panels (FoundationOne, MSK-IMPACT, Caris) detecting the same alleles
+  + fusions are clinically interchangeable. Phosphate management
+  requires close coordination — target serum phosphate 5.5-7.0 mg/dL
+  for efficacy without crossing the soft-tissue mineralization
+  threshold. Monthly OCT for first 4 months is mandatory due to CSR
+  risk. THOR Cohort 2 (erdafitinib vs pembrolizumab in IO-naive 2L)
+  was negative — sequencing is platinum → IO → erdafitinib, not
+  IO-substitution. Missing source IDs to flag for follow-up:
+  SRC-BLC2001, SRC-THOR, SRC-FDA-BALVERSA not yet authored.

--- a/knowledge_base/hosted/content/drugs/lurbinectedin.yaml
+++ b/knowledge_base/hosted/content/drugs/lurbinectedin.yaml
@@ -1,0 +1,102 @@
+id: DRUG-LURBINECTEDIN
+names:
+  preferred: "Lurbinectedin"
+  ukrainian: "Лурбінектедин"
+  english: "Lurbinectedin"
+  brand_names: ["Zepzelca"]
+atc_code: L01CX02
+rxnorm_id: null
+drug_class: "Selective RNA polymerase II inhibitor (alkylating-like trabectedin analogue)"
+mechanism: >
+  Synthetic tetrahydroisoquinoline alkaloid that binds the minor groove
+  of DNA and stalls RNA polymerase II elongation, triggering RNAPII
+  ubiquitination, double-strand breaks, and apoptosis selectively in
+  transcription-addicted tumor cells. Also depletes tumor-associated
+  macrophages. ATLANTIS (Phase III lurbinectedin + doxorubicin vs
+  topotecan/CAV in 2L SCLC) failed its OS primary endpoint, but the
+  pivotal single-arm Phase II Basket Study (NCT02454972, lurbinectedin
+  monotherapy 3.2 mg/m² q21d) showed ORR 35% in 2L SCLC (CTFI ≥90 d
+  ORR 45%; CTFI <90 d ORR 22%), supporting accelerated FDA approval
+  Jun 2020.
+
+regulatory_status:
+  fda:
+    approved: true
+  ema:
+    approved: false
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-04-29"
+    notes: |
+      Не зареєстровано в Україні (Держреєстр ЛЗ — РП відсутнє станом на
+      2026-04-29). Селективний інгібітор RNA-полімерази II для метастатичного
+      дрібноклітинного раку легень (SCLC) у 2-й лінії після платинвмісної ХТ
+      (FDA accelerated approval, червень 2020).
+
+      Шляхи доступу:
+      - Named-patient import (DEC спецдозвіл МОЗ).
+      - EAP / compassionate use Jazz Pharmaceuticals (країни без реєстрації).
+      - Cross-border (US): SoC у США як 2L SCLC; EMA рішення відмовне (CHMP
+        2022) — обмежений доступ у EU.
+      Source: drlz.com.ua пошук "lurbinectedin"/"zepzelca" 2026-04-29 — РП
+      відсутнє.
+
+typical_dosing: >
+  3.2 mg/m² IV over 60 minutes once every 21 days (Q21D), with
+  prophylactic 5-HT3 antiemetics + dexamethasone 8 mg PO/IV ≥30 min
+  pre-infusion. Dose reductions to 2.6 mg/m² and 2.0 mg/m² for grade
+  ≥3 hematologic or hepatic toxicity. Discontinue if febrile neutropenia
+  recurs at 2.0 mg/m² or for any unresolved grade 4 toxicity.
+formulations: ["Lyophilized powder for solution 4 mg/vial (single-dose)"]
+
+absolute_contraindications:
+  - "Hypersensitivity to lurbinectedin"
+  - "Severe active infection (myelosuppression risk)"
+  - "Severe hepatic impairment (Child-Pugh C — not studied)"
+  - "Pregnancy (embryo-fetal toxicity per animal data)"
+black_box_warnings: []
+major_interactions:
+  - "Strong CYP3A4 inhibitors (ketoconazole, ritonavir, clarithromycin) — avoid; if unavoidable, monitor for AEs"
+  - "Strong CYP3A4 inducers (rifampin, phenytoin, carbamazepine) — avoid (reduces exposure)"
+  - "Live vaccines — avoid during therapy and ≥3 months after last dose"
+common_adverse_events:
+  - "Myelosuppression — neutropenia (grade ≥3 ~46%), thrombocytopenia, anemia"
+  - "Fatigue / asthenia"
+  - "Nausea / vomiting"
+  - "Decreased appetite"
+  - "Musculoskeletal pain"
+  - "Diarrhea or constipation"
+  - "Increased ALT/AST and creatinine"
+serious_adverse_events:
+  - "Febrile neutropenia (grade ≥3 ~5% — primary cause of treatment-related death in basket study)"
+  - "Sepsis (in setting of grade 4 neutropenia)"
+  - "Rhabdomyolysis with marked CPK elevation (rare)"
+  - "Hepatotoxicity — grade ≥3 ALT elevation"
+  - "Extravasation injury (vesicant — administer via central line preferred)"
+
+pharmacology:
+  half_life: "~51 hours; CYP3A4 substrate; >99% protein-bound; biliary clearance"
+
+sources:
+  - SRC-NCCN-SCLC-2025
+  - SRC-ESMO-SCLC-2021
+  - SRC-CIVIC
+
+last_reviewed: "2026-04-29"
+notes: >
+  FDA-accelerated approval (Jun 2020) for metastatic SCLC progressing on
+  or after platinum-containing chemotherapy, based on single-arm Basket
+  Study (NCT02454972) ORR 35%, mDOR 5.3 months. The confirmatory
+  ATLANTIS Phase III (lurbinectedin + doxorubicin vs topotecan/CAV)
+  failed its OS primary endpoint (mOS 8.6 vs 7.6 mo, HR 0.97, NS),
+  prompting EMA refusal (2022) but did not trigger US withdrawal —
+  monotherapy benefit-risk in platinum-sensitive 2L SCLC remained
+  acceptable. NCCN-SCLC 2025 lists lurbinectedin (category 2A) for
+  relapsed SCLC alongside topotecan; preferred when CTFI ≥90 days.
+  Missing trial-source IDs (SRC-ATLANTIS, SRC-LURBINECTEDIN-BASKET,
+  SRC-FDA-ZEPZELCA) — flagged in commit body for follow-up source
+  ingestion. Active investigations: lurbinectedin + atezolizumab
+  (IMforte 1L maintenance, positive Phase III readout 2025).

--- a/knowledge_base/hosted/content/drugs/retifanlimab.yaml
+++ b/knowledge_base/hosted/content/drugs/retifanlimab.yaml
@@ -1,0 +1,107 @@
+id: DRUG-RETIFANLIMAB
+names:
+  preferred: "Retifanlimab"
+  ukrainian: "Ретифанлімаб"
+  english: "Retifanlimab"
+  brand_names: ["Zynyz"]
+atc_code: L01FF11
+rxnorm_id: null
+drug_class: "Anti-PD-1 humanized IgG4κ monoclonal antibody (immune checkpoint inhibitor)"
+mechanism: >
+  Humanized IgG4 monoclonal antibody (S228P-stabilized hinge to prevent
+  Fab-arm exchange) that binds programmed death-1 (PD-1) on T-cells and
+  blocks engagement with PD-L1/PD-L2, restoring anti-tumor T-cell
+  effector function. Pivotal POD1UM-202 Phase II in 94 patients with
+  locally advanced or metastatic anal squamous cell carcinoma (SCC)
+  progressing on or intolerant to platinum chemotherapy: ORR 14% (CR 1%,
+  PR 13%), mDOR 9.5 months, supporting FDA accelerated approval Mar
+  2023 — first PD-1 inhibitor approved for 2L anal SCC. Also under
+  investigation in 1L Merkel cell carcinoma (POD1UM-201) and 1L NSCLC
+  combinations.
+
+regulatory_status:
+  fda:
+    approved: true
+  ema:
+    approved: true
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-04-29"
+    notes: |
+      Не зареєстровано в Україні (Держреєстр ЛЗ — РП відсутнє станом на
+      2026-04-29). Анти-PD-1 моноклональне антитіло для метастатичного
+      або місцево-поширеного анального плоскоклітинного раку (SCC) у
+      2-й лінії після платини (FDA accelerated approval, березень 2023;
+      EMA approval серпень 2023).
+
+      Шляхи доступу:
+      - Named-patient import (DEC спецдозвіл МОЗ).
+      - EAP Incyte Corporation (Zynyz access — 2L anal SCC).
+      - Альтернативні PD-1 інгібітори (pembrolizumab, nivolumab) у деяких
+        країнах використовуються off-label у 2L anal SCC до Zynyz, але
+        не зареєстровані в цій нозології.
+      Source: drlz.com.ua пошук "retifanlimab"/"zynyz" 2026-04-29 — РП
+      відсутнє.
+
+typical_dosing: >
+  500 mg IV over 30 minutes once every 4 weeks (Q4W) until disease
+  progression, unacceptable toxicity, or up to 24 months. Permanently
+  discontinue for grade 4 immune-mediated AE, recurrent grade 3 immune
+  AE despite corticosteroids, or grade ≥3 myocarditis / encephalitis /
+  Stevens-Johnson syndrome.
+formulations: ["Solution for IV infusion 500 mg/20 mL (single-dose vial)"]
+
+absolute_contraindications:
+  - "Hypersensitivity to retifanlimab"
+  - "History of prior life-threatening immune-related AE on PD-1/PD-L1 therapy"
+  - "Active pneumonitis grade ≥2"
+  - "Pregnancy (embryo-fetal toxicity per IgG4 placental transfer)"
+black_box_warnings: []
+major_interactions:
+  - "Systemic corticosteroids / immunosuppressants — avoid baseline use (impairs efficacy); reserve for irAE management"
+  - "Live vaccines — contraindicated during therapy"
+common_adverse_events:
+  - "Fatigue / asthenia"
+  - "Musculoskeletal pain / arthralgia"
+  - "Pyrexia"
+  - "Nausea / decreased appetite"
+  - "Pruritus / rash"
+  - "Diarrhea"
+  - "Hypothyroidism / hyperthyroidism (immune-mediated thyroiditis)"
+  - "Cough / dyspnea"
+serious_adverse_events:
+  - "Immune-mediated pneumonitis (grade ≥3 ~2%; can be fatal)"
+  - "Immune-mediated colitis (grade ≥3 ~1-2%)"
+  - "Immune-mediated hepatitis (transaminitis; corticosteroids)"
+  - "Immune-mediated endocrinopathies — adrenal insufficiency, type 1 DM, hypophysitis"
+  - "Immune-mediated nephritis with renal dysfunction"
+  - "Immune-mediated dermatologic AE — SJS / TEN (rare)"
+  - "Myocarditis / pericarditis (rare, can be fatal — high-suspicion ECG + troponin)"
+  - "Infusion reactions"
+  - "Solid-organ-transplant rejection / GvHD post-allo-HSCT"
+
+pharmacology:
+  half_life: "~21 days (IgG4); linear PK; no metabolism via CYP/transporters"
+
+sources:
+  - SRC-CIVIC
+
+last_reviewed: "2026-04-29"
+notes: >
+  FDA accelerated approval (Mar 2023, Zynyz) for metastatic or
+  recurrent locally advanced anal SCC progressing on or intolerant to
+  platinum-based chemotherapy — first PD-1 inhibitor approved in this
+  indication. EMA approval Aug 2023. POD1UM-303 (1L anal SCC, retifanlimab
+  + carboplatin/paclitaxel vs carboplatin/paclitaxel placebo) reported
+  positive PFS in 2024, supporting label expansion. Retifanlimab carries
+  the standard PD-1 irAE spectrum (pneumonitis, colitis, endocrinopathies,
+  hepatitis, nephritis, myocarditis); baseline TSH/T4, cortisol, and
+  full immune-mediated AE counseling are required. Missing source IDs
+  to flag for follow-up: SRC-POD1UM-202, SRC-POD1UM-303, SRC-FDA-ZYNYZ
+  not yet authored — citation thin (SRC-CIVIC only). NCCN does not yet
+  publish a stand-alone Anal Carcinoma guideline source in this KB
+  catalog (would be SRC-NCCN-ANAL-202X); flag for source-ingestion
+  workstream.

--- a/knowledge_base/hosted/content/drugs/ripretinib.yaml
+++ b/knowledge_base/hosted/content/drugs/ripretinib.yaml
@@ -1,0 +1,104 @@
+id: DRUG-RIPRETINIB
+names:
+  preferred: "Ripretinib"
+  ukrainian: "Рипретиніб"
+  english: "Ripretinib"
+  brand_names: ["Qinlock"]
+atc_code: L01EX19
+rxnorm_id: null
+drug_class: "Broad-spectrum switch-control KIT/PDGFRA tyrosine kinase inhibitor"
+mechanism: >
+  First-in-class KIT/PDGFRA switch-control inhibitor that uses a
+  dual-mechanism: it locks the kinase activation loop in the inactive
+  conformation by binding both the switch pocket (αC-out) and the
+  activation loop, broadly inhibiting primary exon 9/11/17 KIT mutations
+  AND secondary resistance mutations across exons 13/14/17/18 — the
+  vulnerability gap left by sequential prior TKIs (imatinib → sunitinib →
+  regorafenib). Pivotal INVICTUS Phase III (4L+ advanced GIST,
+  ripretinib 150 mg QD vs placebo) showed mPFS 6.3 vs 1.0 months
+  (HR 0.15, p<0.0001) and mOS 15.1 vs 6.6 months (HR 0.36); FDA approval
+  May 2020.
+
+regulatory_status:
+  fda:
+    approved: true
+  ema:
+    approved: true
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-04-29"
+    notes: |
+      Не зареєстровано в Україні (Держреєстр ЛЗ — РП відсутнє станом на
+      2026-04-29). Перемикач-конформаційний KIT/PDGFRA інгібітор для
+      4-ї+ лінії резистентного GIST (після іматинібу, сунітинібу,
+      регорафенібу).
+
+      Шляхи доступу:
+      - Named-patient import (DEC спецдозвіл МОЗ).
+      - EAP Deciphera Pharmaceuticals (Qinlock access — 4L+ GIST).
+      - Cross-border (EU): SoC у EU онкоцентрах як 4L GIST через "Лікування
+        за кордоном" (наказ МОЗ 988).
+      Source: drlz.com.ua пошук "ripretinib"/"qinlock" 2026-04-29 — РП
+      відсутнє.
+
+typical_dosing: >
+  150 mg PO once daily, with or without food, until disease progression
+  or unacceptable toxicity. Intra-patient dose escalation to 150 mg
+  twice daily on progression is supported by INTRIGUE post-hoc and the
+  INSIGHT Phase III (positive vs sunitinib in PDGFRA D842V-negative,
+  KIT exon 11 + 17/18 mutated 2L). Dose modifications: hold for grade
+  ≥3 hand-foot syndrome, hypertension, cardiac dysfunction (LVEF drop),
+  or severe rash; resume at 100 mg QD.
+formulations: ["Tablets 50 mg"]
+
+absolute_contraindications:
+  - "Hypersensitivity to ripretinib"
+  - "Severe hepatic impairment (Child-Pugh C — not studied)"
+  - "LVEF <50% at baseline (cardiac monitoring required)"
+black_box_warnings: []
+major_interactions:
+  - "Strong CYP3A4 inhibitors (ketoconazole, ritonavir) — avoid"
+  - "Strong CYP3A4 inducers (rifampin) — avoid (reduces exposure ~60%)"
+  - "Drugs prolonging QT — caution (modest QT effect on ECG)"
+common_adverse_events:
+  - "Alopecia (~52%, often within 1st cycle)"
+  - "Fatigue"
+  - "Nausea / vomiting"
+  - "Constipation or diarrhea"
+  - "Myalgia / arthralgia"
+  - "Palmar-plantar erythrodysesthesia (hand-foot syndrome)"
+  - "Decreased appetite / weight loss"
+  - "Hypertension"
+serious_adverse_events:
+  - "Cardiac dysfunction — LVEF decline / heart failure (baseline + on-treatment ECHO)"
+  - "Hypertension (grade ≥3 ~7%)"
+  - "Cutaneous SCC / keratoacanthoma (RAS-pathway paradoxical activation; surveillance + excision)"
+  - "Wound healing impairment — hold ≥1 week pre-elective surgery"
+  - "QT prolongation (modest)"
+  - "Embryo-fetal toxicity"
+
+pharmacology:
+  half_life: "~14 hours (parent); active DP-5439 metabolite ~17.8 hours; CYP3A4 substrate"
+
+sources:
+  - SRC-NCCN-GIST-2025
+  - SRC-INVICTUS
+  - SRC-CIVIC
+
+last_reviewed: "2026-04-29"
+notes: >
+  FDA approval (May 2020) for 4L+ advanced GIST after ≥3 prior kinase
+  inhibitors (imatinib → sunitinib → regorafenib). NCCN-GIST 2025
+  lists ripretinib as preferred 4L (category 1). The INTRIGUE Phase III
+  (ripretinib 150 mg QD vs sunitinib 50 mg 4-on/2-off in 2L GIST)
+  failed its 2L primary endpoint (mPFS 8.0 vs 8.3 mo, HR 1.05, NS) but
+  pre-specified KIT exon 11 + 17/18 ctDNA subgroup showed a striking
+  ripretinib benefit (mPFS 14.2 vs 1.5 mo) — INSIGHT Phase III is the
+  confirmatory study in this genotype-defined 2L population. Cardiac
+  surveillance (LVEF) and dermatologic surveillance (cutaneous SCC) are
+  ongoing-treatment requirements. Missing trial-source IDs to flag for
+  follow-up: SRC-INVICTUS exists as a stub awaiting clinical signoff;
+  SRC-INTRIGUE, SRC-INSIGHT, SRC-FDA-QINLOCK not yet authored.


### PR DESCRIPTION
Post-mortem of batch 5a (12 Q-axis agents): 11/12 self-corrected from incorrect prompt; 2 stalled mid-task. This file captures the canonical W12a/W12b agent-prompt shape so future batches don't need agents to reconcile two sources of truth.

Fixes for next wave:
- branch prefix: tasktorrent/
- output mode: sidecar-only under contributions/<chunk-id>/
- gate: validate_contributions (not validate_kb + pytest 82)
- 403 handling: User-Agent header + DOI canonical fallback
- synchronous gate execution (avoid background-task stalls)