### PR TITLE
feat(kb): batch 5a Q-axis upsert — 15 BMA + 12 sources

### DIFF
--- a/contributions/bma-civic-backfill-wave2-2026-05-01-001/upsert-log-2026-05-01T171022Z.md
+++ b/contributions/bma-civic-backfill-wave2-2026-05-01-001/upsert-log-2026-05-01T171022Z.md
@@ -1,0 +1,7 @@
+# Upsert log: bma-civic-backfill-wave2-2026-05-01-001 (2026-05-01T171022Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-wave2-2026-05-01-001\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-wave2-2026-05-01-001\bma_atm_loss_cll.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_atm_loss_cll.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-001\bma_chek2_somatic_prostate.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_chek2_somatic_prostate.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-001\bma_mlh1_germline_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_germline_crc.yaml

--- a/contributions/bma-civic-backfill-wave2-2026-05-01-002/upsert-log-2026-05-01T171022Z.md
+++ b/contributions/bma-civic-backfill-wave2-2026-05-01-002/upsert-log-2026-05-01T171022Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-wave2-2026-05-01-002 (2026-05-01T171022Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-wave2-2026-05-01-002\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-wave2-2026-05-01-002\bma_atm_loss_mcl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_atm_loss_mcl.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-002\bma_mlh1_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_germline_endometrial.yaml

--- a/contributions/bma-civic-backfill-wave2-2026-05-01-003/upsert-log-2026-05-01T171023Z.md
+++ b/contributions/bma-civic-backfill-wave2-2026-05-01-003/upsert-log-2026-05-01T171023Z.md
@@ -1,0 +1,8 @@
+# Upsert log: bma-civic-backfill-wave2-2026-05-01-003 (2026-05-01T171023Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-wave2-2026-05-01-003\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-wave2-2026-05-01-003\bma_bcl2_expression_cll.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_expression_cll.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-003\bma_mlh1_germline_gastric.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_germline_gastric.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-003\bma_msh2_somatic_urothelial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh2_somatic_urothelial.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-003\bma_pdgfra_exon12_gist.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_pdgfra_exon12_gist.yaml

--- a/contributions/bma-civic-backfill-wave2-2026-05-01-004/upsert-log-2026-05-01T171023Z.md
+++ b/contributions/bma-civic-backfill-wave2-2026-05-01-004/upsert-log-2026-05-01T171023Z.md
@@ -1,0 +1,7 @@
+# Upsert log: bma-civic-backfill-wave2-2026-05-01-004 (2026-05-01T171023Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-wave2-2026-05-01-004\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-wave2-2026-05-01-004\bma_bcl2_expression_dlbcl_nos.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_expression_dlbcl_nos.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-004\bma_epcam_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_epcam_germline_endometrial.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-004\bma_msh6_germline_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh6_germline_crc.yaml

--- a/contributions/bma-civic-backfill-wave2-2026-05-01-005/upsert-log-2026-05-01T171023Z.md
+++ b/contributions/bma-civic-backfill-wave2-2026-05-01-005/upsert-log-2026-05-01T171023Z.md
@@ -1,0 +1,7 @@
+# Upsert log: bma-civic-backfill-wave2-2026-05-01-005 (2026-05-01T171023Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-wave2-2026-05-01-005\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-wave2-2026-05-01-005\bma_bcl2_expression_fl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_expression_fl.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-005\bma_ezh2_y641_fl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_ezh2_y641_fl.yaml
+- contributions\bma-civic-backfill-wave2-2026-05-01-005\bma_msh6_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh6_germline_endometrial.yaml

--- a/contributions/bma-civic-backfill-wave2-2026-05-01-006/upsert-log-2026-05-01T171023Z.md
+++ b/contributions/bma-civic-backfill-wave2-2026-05-01-006/upsert-log-2026-05-01T171023Z.md
@@ -1,0 +1,4 @@
+# Upsert log: bma-civic-backfill-wave2-2026-05-01-006 (2026-05-01T171023Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-wave2-2026-05-01-006\audit-report.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-wave2-2026-05-01-001/upsert-log-2026-05-01T171023Z.md
+++ b/contributions/source-recency-refresh-wave2-2026-05-01-001/upsert-log-2026-05-01T171023Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-wave2-2026-05-01-001 (2026-05-01T171023Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-wave2-2026-05-01-001\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-001\source_recency_audit.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-001\src_ctcae_v5.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_ctcae_v5.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-001\src_extreme_vermorken_2008.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_extreme_vermorken_2008.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-001\src_lee_2015_belinostat_ptcl.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_lee_2015_belinostat_ptcl.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-001\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-wave2-2026-05-01-002/upsert-log-2026-05-01T171023Z.md
+++ b/contributions/source-recency-refresh-wave2-2026-05-01-002/upsert-log-2026-05-01T171023Z.md
@@ -1,0 +1,4 @@
+# Upsert log: source-recency-refresh-wave2-2026-05-01-002 (2026-05-01T171023Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-wave2-2026-05-01-002\source_recency_audit.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-wave2-2026-05-01-003/upsert-log-2026-05-01T171024Z.md
+++ b/contributions/source-recency-refresh-wave2-2026-05-01-003/upsert-log-2026-05-01T171024Z.md
@@ -1,0 +1,11 @@
+# Upsert log: source-recency-refresh-wave2-2026-05-01-003 (2026-05-01T171024Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-wave2-2026-05-01-003\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-003\source_recency_audit.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-003\src_ata_atc_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_ata_atc_2021.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-003\src_dipss_plus_gangat_2011.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_dipss_plus_gangat_2011.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-003\src_flaura_soria_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_flaura_soria_2018.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-003\src_libretto_431.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_libretto_431.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-003\src_tourmaline_mm1_moreau_2016.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_tourmaline_mm1_moreau_2016.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-003\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-wave2-2026-05-01-004/upsert-log-2026-05-01T171024Z.md
+++ b/contributions/source-recency-refresh-wave2-2026-05-01-004/upsert-log-2026-05-01T171024Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-wave2-2026-05-01-004 (2026-05-01T171024Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-wave2-2026-05-01-004\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-004\source_recency_audit.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-004\src_moz_ua_lymph_2013.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_moz_ua_lymph_2013.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-004\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-wave2-2026-05-01-005/upsert-log-2026-05-01T171024Z.md
+++ b/contributions/source-recency-refresh-wave2-2026-05-01-005/upsert-log-2026-05-01T171024Z.md
@@ -1,0 +1,6 @@
+# Upsert log: source-recency-refresh-wave2-2026-05-01-005 (2026-05-01T171024Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-wave2-2026-05-01-005\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-005\source_recency_audit.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-005\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-wave2-2026-05-01-006/upsert-log-2026-05-01T171024Z.md
+++ b/contributions/source-recency-refresh-wave2-2026-05-01-006/upsert-log-2026-05-01T171024Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-wave2-2026-05-01-006 (2026-05-01T171024Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-wave2-2026-05-01-006\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-006\source_recency_audit.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-wave2-2026-05-01-006\src_alcyone_mateos_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_alcyone_mateos_2018.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-006\src_bsh_mzl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_bsh_mzl_2024.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-006\src_castor_palumbo_2016.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_castor_palumbo_2016.yaml
+- contributions\source-recency-refresh-wave2-2026-05-01-006\unreachable.yaml: SKIP unknown prefix

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_atm_loss_cll.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_atm_loss_cll.yaml
@@ -36,7 +36,53 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-CLL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID1539
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1564
+  - EID2927
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID2843
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Doxorubicin.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID2221
+  - EID2222
+  - EID2223
+  - EID2224
+  - EID2830
+  - EID2831
+  - EID2832
+  - EID2835
+  - EID2837
+  - EID2839
+  - EID2840
+  - EID2841
+  - EID2845
+  - EID2846
+  - EID2849
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Doxorubicin.'
 actionability_review_required: true
 notes: 'Note: TP53 disruption (del(17p) or TP53 mutation) is the dominant adverse
   prognostic — ATM is secondary. Test del(11q) by FISH and ATM by NGS in all CLL pre-treatment.

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_atm_loss_mcl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_atm_loss_mcl.yaml
@@ -29,7 +29,15 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-MCL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID1907
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Olaparib.'
 actionability_review_required: true
 notes: 'Concurrent TP53 mutation is the dominant adverse prognostic in MCL; isolated
   ATM is less prognostic.

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_cll.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_cll.yaml
@@ -35,7 +35,21 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-CLL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID8185
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Venetoclax.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID8841
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Venetoclax.'
 actionability_review_required: true
 notes: 'ESCAT IA. OncoKB Level 1. TLS prophylaxis mandatory at venetoclax ramp-up.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_dlbcl_nos.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_dlbcl_nos.yaml
@@ -29,7 +29,17 @@ contraindicated_monotherapy: []
 primary_sources:
 - SRC-NCCN-BCELL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID423
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: BCL2 Overexpression in DLBCL, Prognostic, Supports
+    Poor Outcome. PMID 9207459. Variant matches BMA variant_qualifier (BCL2 high expression
+    by IHC). EID407 (reg_e@[IGH]::BCL2 rearrangement) deliberately excluded — BMA
+    variant_qualifier explicitly excludes rearrangement.'
 actionability_review_required: true
 notes: 'ESCAT IIIB. Distinct from HGBL-DH which requires FISH-confirmed rearrangement.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_fl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_fl.yaml
@@ -24,7 +24,31 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-FL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID5992
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence (Prognostic) without
+    therapy-specific annotation. PMID 25452615.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID8375
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence (Predictive) for
+    therapies: Venetoclax. Variant F104I. PMID 31234236.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID8376
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence (Predictive) for
+    therapies: Venetoclax. Variant F104I. PMID 31234236.'
 actionability_review_required: true
 notes: 'ESCAT IIIA. Disease-defining IHC.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_chek2_somatic_prostate.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_chek2_somatic_prostate.yaml
@@ -28,7 +28,32 @@ primary_sources:
 - SRC-ESMO-PROSTATE-2024
 - SRC-EAU-PROSTATE-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID11205
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Olaparib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1854
+  direction: Does Not Support
+  significance: Predisposition
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Predisposition evidence without
+    therapy-specific annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1850
+  - EID1852
+  direction: Supports
+  significance: Predisposition
+  note: 'CIViC snapshot 2026-04-25: Supports Predisposition evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Reflex germline testing recommended.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_epcam_germline_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_epcam_germline_endometrial.yaml
@@ -32,7 +32,20 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1901
+  direction: Supports
+  significance: Predisposition
+  note: 'CIViC snapshot 2026-04-25: EPCAM 3'' Exon Deletion in Lynch Syndrome, Predisposing,
+    Supports Predisposition. PMID 21309036. Variant exactly matches BMA variant_qualifier
+    (EPCAM germline 3'' deletion). CIViC disease is Lynch Syndrome (DOID:3883), which
+    is the underlying hereditary syndrome that produces the dMMR endometrial-cancer
+    phenotype captured by this BMA — same alteration, syndrome-level vs tumor-site
+    framing. Maintainer to confirm whether syndrome-level evidence should populate
+    the tumor-site BMA.'
 actionability_review_required: true
 notes: 'EPCAM-Lynch is rarer than MLH1/MSH2/MSH6/PMS2 Lynch (~1-3% of Lynch cases).
   Cascade testing mandatory; family-line implications identical to MSH2 Lynch. Pan-tumor

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_ezh2_y641_fl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_ezh2_y641_fl.yaml
@@ -39,7 +39,65 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-FL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID9709
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence (Predictive)
+    for therapies: Tazemetostat. Variant: Activating Mutation, FL. Level A. PMID 33035457.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID11109
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence (Predictive)
+    for therapies: Tazemetostat. Variant: Y646S/F/H/C/N OR EZH2 A692V OR EZH2 A682G,
+    FL. Level B. PMID 34159682. (CIViC Y646 = transcript-isoform of canonical Y641.)'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID11107
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence (Predictive)
+    for therapies: Tazemetostat. Variant: Activating Mutation, FL. Level C. PMID 33492746.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID433
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence (Diagnostic). Variant
+    Y646, FL. Level B. PMID 20081860.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1015
+  direction: Supports
+  significance: Better Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence (Prognostic)
+    without therapy-specific annotation. Variant Mutation, FL. Level B. PMID 26256760.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID11111
+  - EID12876
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence (Oncogenic). Variants
+    Y646S/F/H/C/N OR A692V OR A682G; A682G. Level B. PMIDs 24052547.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID12875
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence (Oncogenic). Variant
+    A682G, FL. Level C. PMID 32668764.'
 actionability_review_required: true
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_germline_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_germline_crc.yaml
@@ -43,7 +43,35 @@ primary_sources:
 - SRC-NCCN-COLON-2025
 - SRC-ESMO-COLON-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1791
+  - EID1794
+  - EID1796
+  - EID1798
+  - EID1804
+  - EID1806
+  - EID1807
+  - EID1808
+  - EID1810
+  - EID1811
+  - EID1813
+  - EID1814
+  - EID1815
+  - EID1816
+  - EID1817
+  - EID1818
+  - EID1820
+  - EID1821
+  - EID1822
+  - EID1823
+  - EID1824
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline MLH1 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_germline_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_germline_endometrial.yaml
@@ -40,7 +40,17 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1788
+  - EID1793
+  - EID1833
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline MLH1 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_germline_gastric.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_germline_gastric.yaml
@@ -37,7 +37,22 @@ primary_sources:
 - SRC-NCCN-GASTRIC-2025
 - SRC-ESMO-GASTRIC-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1680
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1315
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Oxaliplatin.'
 actionability_review_required: true
 notes: 'Germline MLH1 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_somatic_urothelial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_somatic_urothelial.yaml
@@ -30,7 +30,15 @@ primary_sources:
 - SRC-NCCN-BLADDER-2025
 - SRC-EAU-PROSTATE-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1877
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Anti-PD-1 Monoclonal Antibody MEDI0680, Durvalumab.'
 actionability_review_required: true
 notes: 'Somatic MSH2 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_crc.yaml
@@ -43,7 +43,21 @@ primary_sources:
 - SRC-NCCN-COLON-2025
 - SRC-ESMO-COLON-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1825
+  - EID1829
+  - EID1831
+  - EID1840
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: 4 MSH6 LOF / frameshift point mutations in CRC
+    (P138T, I891FS, R1242H, R1242C), Oncogenic, Supports Oncogenicity. PMID 25111426
+    (shared citation). Each is a concrete LOF example consistent with the BMA variant_qualifier
+    (MSH6 germline loss-of-function). MSH6 LOSS in transitional cell carcinoma (EID1878)
+    excluded — off-disease (urothelial, not CRC).'
 actionability_review_required: true
 notes: 'Germline MSH6 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_endometrial.yaml
@@ -40,7 +40,20 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1839
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence (Oncogenic). Variant
+    V352I, Endometrial Cancer. Level C. PMID 25111426. Note: this CIViC item attests
+    oncogenicity of an MSH6 missense variant in endometrial cancer; it is not a direct
+    therapy-prediction citation. The clinical actionability of MSH6 germline LoF in
+    endometrial (ICI eligibility via dMMR/MSI-H) is anchored on guideline sources
+    (NCCN-UTERINE-2025, ESGO-ENDOMETRIAL-2025) and tissue-agnostic FDA label, not
+    on CIViC.'
 actionability_review_required: true
 notes: 'Germline MSH6 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_pdgfra_exon12_gist.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_pdgfra_exon12_gist.yaml
@@ -29,7 +29,24 @@ primary_sources:
 - SRC-IRIS-OBRIEN-2003
 - SRC-NCCN-MELANOMA-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2474
+  - EID2487
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID652
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib.'
 actionability_review_required: true
 notes: 'ESCAT IB. OncoKB Level 1. Source-gap as DIS-GIST.
 

--- a/knowledge_base/hosted/content/sources/src_alcyone_mateos_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_alcyone_mateos_2018.yaml
@@ -1,19 +1,19 @@
 id: SRC-ALCYONE-MATEOS-2018
 source_type: rct_publication
-title: "Daratumumab plus Bortezomib, Melphalan, and Prednisone for Untreated Myeloma"
-version: "2018"
+title: Daratumumab plus Bortezomib, Melphalan, and Prednisone for Untreated Myeloma
+version: '2018'
 authors:
-  - Mateos MV
-  - Dimopoulos MA
-  - Cavo M
-  - et al.
+- Mateos MV
+- Dimopoulos MA
+- Cavo M
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1714678
-pmid: "29231133"
+pmid: '29231133'
 url: https://pubmed.ncbi.nlm.nih.gov/29231133
 access_level: subscription_required
 currency_status: current
-current_as_of: "2018-02-08"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Mateos et al., NEJM 2018; ALCYONE trial"
+  text: Mateos et al., NEJM 2018; ALCYONE trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MM
-last_verified: "2026-04-27"
-notes: >
-  ALCYONE phase-3 (NCT02195479): daratumumab + bortezomib +
-  melphalan + prednisone (D-VMP) vs VMP in 1L transplant-
-  ineligible NDMM (n=706). 18-mo PFS 71.6% vs 50.2% (HR 0.50;
-  p<0.001). OS update (Mateos Lancet 2020): 36-mo OS 78% vs 67.9%
-  (HR 0.60). Established D-VMP as alternative 1L for transplant-
-  ineligible NDMM; basis for FDA approval May 2018. Less commonly
-  used than D-Rd (MAIA) in modern practice.
+- DIS-MM
+last_verified: '2026-04-27'
+notes: 'ALCYONE phase-3 (NCT02195479): daratumumab + bortezomib + melphalan + prednisone
+  (D-VMP) vs VMP in 1L transplant- ineligible NDMM (n=706). 18-mo PFS 71.6% vs 50.2%
+  (HR 0.50; p<0.001). OS update (Mateos Lancet 2020): 36-mo OS 78% vs 67.9% (HR 0.60).
+  Established D-VMP as alternative 1L for transplant- ineligible NDMM; basis for FDA
+  approval May 2018. Less commonly used than D-Rd (MAIA) in modern practice.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_ata_atc_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_ata_atc_2021.yaml
@@ -1,12 +1,13 @@
 id: SRC-ATA-ATC-2021
 source_type: guideline
-title: '2021 American Thyroid Association Guidelines for Management of Patients with Anaplastic Thyroid Cancer'
+title: 2021 American Thyroid Association Guidelines for Management of Patients with
+  Anaplastic Thyroid Cancer
 version: '2021'
 authors:
-  - Bible KC
-  - Kebebew E
-  - Brierley J
-  - et al.
+- Bible KC
+- Kebebew E
+- Brierley J
+- et al.
 journal: Thyroid
 doi: 10.1089/thy.2020.0944
 pmid: '33728999'
@@ -22,7 +23,9 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: 'Bible KC, Kebebew E, Brierley J, et al. 2021 American Thyroid Association Guidelines for Management of Patients with Anaplastic Thyroid Cancer. Thyroid. 2021;31(3):337-386.'
+  text: Bible KC, Kebebew E, Brierley J, et al. 2021 American Thyroid Association
+    Guidelines for Management of Patients with Anaplastic Thyroid Cancer. Thyroid.
+    2021;31(3):337-386.
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
@@ -30,7 +33,11 @@ sharealike_required: false
 legal_review:
   status: pending
   notes: Citation confirmed via PubMed 2026-04-28; license review pending.
-last_verified: '2026-04-28'
+last_verified: '2026-05-01'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
-notes: 'Citation confirmed via PubMed (PMID 33728999). Thyroid 2021;31(3):337-386. doi:10.1089/thy.2020.0944.'
+notes: Citation confirmed via PubMed (PMID 33728999). Thyroid 2021;31(3):337-386.
+  doi:10.1089/thy.2020.0944.
+last_recency_check: '2026-05-01'
+recency_check_status_code: 403
+url_status: blocked_by_bot_protection

--- a/knowledge_base/hosted/content/sources/src_bsh_mzl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_bsh_mzl_2024.yaml
@@ -8,7 +8,7 @@ journal: British Journal of Haematology
 url: https://b-s-h.org.uk/guidelines/
 access_level: open_access
 currency_status: current
-current_as_of: 2024-XX-XX
+current_as_of: '2026-05-01'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,3 +35,5 @@ notes: 'UK-specific guideline; aligns broadly with ESMO on antiviral-first for H
 pages_count: 50
 references_count: 120
 corpus_role: regional_guideline
+last_recency_check: '2026-05-01'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_castor_palumbo_2016.yaml
+++ b/knowledge_base/hosted/content/sources/src_castor_palumbo_2016.yaml
@@ -1,19 +1,19 @@
 id: SRC-CASTOR-PALUMBO-2016
 source_type: rct_publication
-title: "Daratumumab, Bortezomib, and Dexamethasone for Multiple Myeloma"
-version: "2016"
+title: Daratumumab, Bortezomib, and Dexamethasone for Multiple Myeloma
+version: '2016'
 authors:
-  - Palumbo A
-  - Chanan-Khan A
-  - Weisel K
-  - et al.
+- Palumbo A
+- Chanan-Khan A
+- Weisel K
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1606038
-pmid: "27557302"
+pmid: '27557302'
 url: https://pubmed.ncbi.nlm.nih.gov/27557302
 access_level: subscription_required
 currency_status: current
-current_as_of: "2016-08-25"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Palumbo et al., NEJM 2016; CASTOR trial"
+  text: Palumbo et al., NEJM 2016; CASTOR trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MM
-last_verified: "2026-04-27"
-notes: >
-  CASTOR phase-3 (NCT02136134): daratumumab + bortezomib +
-  dexamethasone (DVd) vs Vd in R/R MM with ≥1 prior line (n=498).
-  12-mo PFS 60.7% vs 26.9% (HR 0.39; p<0.001); ORR 82.9% vs
-  63.2%. Final analysis (Sonneveld Lancet Oncol 2022): mOS 49.6
-  vs 38.5 mo (HR 0.74). Established DVd as 2L+ standard for R/R
-  MM; basis for FDA approval Nov 2016.
+- DIS-MM
+last_verified: '2026-04-27'
+notes: 'CASTOR phase-3 (NCT02136134): daratumumab + bortezomib + dexamethasone (DVd)
+  vs Vd in R/R MM with ≥1 prior line (n=498). 12-mo PFS 60.7% vs 26.9% (HR 0.39; p<0.001);
+  ORR 82.9% vs 63.2%. Final analysis (Sonneveld Lancet Oncol 2022): mOS 49.6 vs 38.5
+  mo (HR 0.74). Established DVd as 2L+ standard for R/R MM; basis for FDA approval
+  Nov 2016.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_ctcae_v5.yaml
+++ b/knowledge_base/hosted/content/sources/src_ctcae_v5.yaml
@@ -4,10 +4,11 @@ title: Common Terminology Criteria for Adverse Events (CTCAE) v5.0
 version: v5.0 (2017-11-27)
 authors:
 - U.S. Department of Health and Human Services, NIH, NCI
-url: https://ctep.cancer.gov/protocoldevelopment/electronic_applications/ctc.htm
+url: https://dctd.cancer.gov/research/ctep-trials/trial-development
+url_redirected_from: https://ctep.cancer.gov/protocoldevelopment/electronic_applications/ctc.htm
 access_level: open_access
 currency_status: current
-current_as_of: '2017-11-27'
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: hosted
 hosting_justification: H5 — small, stable, critical for AE grading across all Regimens
@@ -24,8 +25,8 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: Common Terminology Criteria for Adverse Events (CTCAE) v5.0, U.S. Department of Health and Human
-    Services, NCI
+  text: Common Terminology Criteria for Adverse Events (CTCAE) v5.0, U.S. Department
+    of Health and Human Services, NCI
 commercial_use_allowed: true
 redistribution_allowed: true
 modifications_allowed: true
@@ -36,11 +37,13 @@ legal_review:
   date: '2026-04-25'
   notes: Public domain
 relates_to_diseases: []
-last_verified: '2026-04-27'
-notes: 'Hosted at knowledge_base/hosted/ctcae/v5.0/grading.yaml — 837 AEs across 26 SOC categories. CTCAE
-  v6.0 in development; monitor NCI for release.
+last_verified: '2026-05-01'
+notes: 'Hosted at knowledge_base/hosted/ctcae/v5.0/grading.yaml — 837 AEs across 26
+  SOC categories. CTCAE v6.0 in development; monitor NCI for release.
 
   '
 pages_count: 150
 references_count: 30
 corpus_role: terminology
+last_recency_check: '2026-05-01'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_dipss_plus_gangat_2011.yaml
+++ b/knowledge_base/hosted/content/sources/src_dipss_plus_gangat_2011.yaml
@@ -1,19 +1,21 @@
 id: SRC-DIPSS-PLUS-GANGAT-2011
 source_type: rct_publication
-title: 'DIPSS plus: a refined Dynamic International Prognostic Scoring System for primary myelofibrosis that incorporates prognostic information from karyotype, platelet count, and transfusion status'
+title: 'DIPSS plus: a refined Dynamic International Prognostic Scoring System for
+  primary myelofibrosis that incorporates prognostic information from karyotype, platelet
+  count, and transfusion status'
 version: '2011'
 authors:
-  - Gangat N
-  - Caramazza D
-  - Vaidya R
-  - et al.
+- Gangat N
+- Caramazza D
+- Vaidya R
+- et al.
 journal: Journal of Clinical Oncology
 doi: 10.1200/JCO.2010.32.2446
 pmid: '21205761'
 url: https://ascopubs.org/doi/10.1200/JCO.2010.32.2446
 access_level: subscription_required
 currency_status: current
-current_as_of: '2011-02-01'
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -30,15 +32,18 @@ legal_review:
   status: reviewed
   date: '2026-04-25'
 relates_to_diseases:
-  - DIS-PMF
-last_verified: '2026-04-27'
-notes: >
-  Foundational publication of DIPSS-Plus (8-point prognostic scoring for
-  PMF: DIPSS components + karyotype + platelets + transfusion need).
-  Defines low / int-1 / int-2 / high risk and is the standard for
-  alloHCT-eligibility decisions in PMF. Newer scores (MIPSS70, MIPSS70-plus
-  v2.0, MYSEC-PM for post-PV/ET MF) are also cited but DIPSS-Plus remains
-  the most widely-implemented in clinical practice.
+- DIS-PMF
+last_verified: '2026-05-01'
+notes: 'Foundational publication of DIPSS-Plus (8-point prognostic scoring for PMF:
+  DIPSS components + karyotype + platelets + transfusion need). Defines low / int-1
+  / int-2 / high risk and is the standard for alloHCT-eligibility decisions in PMF.
+  Newer scores (MIPSS70, MIPSS70-plus v2.0, MYSEC-PM for post-PV/ET MF) are also cited
+  but DIPSS-Plus remains the most widely-implemented in clinical practice.
+
+  '
 pages_count: 8
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 403
+url_status: blocked_by_bot_protection

--- a/knowledge_base/hosted/content/sources/src_extreme_vermorken_2008.yaml
+++ b/knowledge_base/hosted/content/sources/src_extreme_vermorken_2008.yaml
@@ -1,22 +1,22 @@
 id: SRC-EXTREME-VERMORKEN-2008
 source_type: rct_publication
-title: "Platinum-based chemotherapy plus cetuximab in head and neck cancer"
-version: "2008"
+title: Platinum-based chemotherapy plus cetuximab in head and neck cancer
+version: '2008'
 authors:
-  - Vermorken JB
-  - Mesia R
-  - Rivera F
-  - Remenar E
-  - Kawecki A
-  - Rottey S
-  - et al.
+- Vermorken JB
+- Mesia R
+- Rivera F
+- Remenar E
+- Kawecki A
+- Rottey S
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa0802656
-pmid: "18784101"
+pmid: '18784101'
 url: https://pubmed.ncbi.nlm.nih.gov/18784101
 access_level: subscription_required
 currency_status: current
-current_as_of: "2008-09-11"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -25,26 +25,28 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Vermorken et al., NEJM 2008; EXTREME trial"
+  text: Vermorken et al., NEJM 2008; EXTREME trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-30"
+  date: '2026-04-30'
 relates_to_diseases:
-  - DIS-HNSCC
-last_verified: "2026-04-30"
-notes: >
-  EXTREME phase-3 (NCT00122460): cetuximab + platinum (cisplatin or
-  carboplatin) + 5-FU vs platinum + 5-FU alone in 1L recurrent /
-  metastatic SCCHN (n=442). Median OS 10.1 vs 7.4 mo (HR 0.80,
-  p=0.04); median PFS 5.6 vs 3.3 mo; ORR 36% vs 20%. Established
-  EXTREME as 1L standard for R/M SCCHN until KEYNOTE-048 (2019)
-  introduced pembro-chemo / pembro-mono as preferred for PD-L1 CPS
-  ≥1. EXTREME remains the preferred 1L for PD-L1 CPS <1, IO-
-  contraindicated patients (autoimmune, prior solid-organ transplant,
+- DIS-HNSCC
+last_verified: '2026-05-01'
+notes: 'EXTREME phase-3 (NCT00122460): cetuximab + platinum (cisplatin or carboplatin)
+  + 5-FU vs platinum + 5-FU alone in 1L recurrent / metastatic SCCHN (n=442). Median
+  OS 10.1 vs 7.4 mo (HR 0.80, p=0.04); median PFS 5.6 vs 3.3 mo; ORR 36% vs 20%. Established
+  EXTREME as 1L standard for R/M SCCHN until KEYNOTE-048 (2019) introduced pembro-chemo
+  / pembro-mono as preferred for PD-L1 CPS >=1. EXTREME remains the preferred 1L for
+  PD-L1 CPS <1, IO- contraindicated patients (autoimmune, prior solid-organ transplant,
   etc.), and as control arm reference in subsequent IO trials.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 403
+url_status: blocked_by_bot_protection

--- a/knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_flaura_soria_2018.yaml
@@ -1,19 +1,19 @@
 id: SRC-FLAURA-SORIA-2018
 source_type: rct_publication
-title: "Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer"
-version: "2018"
+title: Osimertinib in Untreated EGFR-Mutated Advanced Non-Small-Cell Lung Cancer
+version: '2018'
 authors:
-  - Soria JC
-  - Ohe Y
-  - Vansteenkiste J
-  - et al.
+- Soria JC
+- Ohe Y
+- Vansteenkiste J
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1713137
-pmid: "29151359"
+pmid: '29151359'
 url: https://www.nejm.org/doi/full/10.1056/NEJMoa1713137
 access_level: subscription_required
 currency_status: current
-current_as_of: "2018-01-11"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +22,27 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Soria et al., NEJM 2018; FLAURA trial"
+  text: Soria et al., NEJM 2018; FLAURA trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs
-  standard-of-care 1st-gen EGFR-TKI (gefitinib or erlotinib) in
-  treatment-naive EGFR-mutated (exon 19 del / L858R) advanced NSCLC.
-  Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final OS analysis
-  (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS
-  PFS markedly improved (HR 0.48). Established osimertinib as 1L
-  standard for EGFR-mutant advanced NSCLC. Basis for FDA approval
-  (Apr 2018) and global guideline endorsement.
+- DIS-NSCLC
+last_verified: '2026-05-01'
+notes: 'FLAURA phase-3 (NCT02296125): osimertinib 80 mg PO daily vs standard-of-care
+  1st-gen EGFR-TKI (gefitinib or erlotinib) in treatment-naive EGFR-mutated (exon
+  19 del / L858R) advanced NSCLC. Median PFS 18.9 vs 10.2 mo (HR 0.46, p<0.001). Final
+  OS analysis (Ramalingam NEJM 2020): mOS 38.6 vs 31.8 mo (HR 0.80, p=0.046). CNS
+  PFS markedly improved (HR 0.48). Established osimertinib as 1L standard for EGFR-mutant
+  advanced NSCLC. Basis for FDA approval (Apr 2018) and global guideline endorsement.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 403
+url_status: blocked_by_bot_protection

--- a/knowledge_base/hosted/content/sources/src_lee_2015_belinostat_ptcl.yaml
+++ b/knowledge_base/hosted/content/sources/src_lee_2015_belinostat_ptcl.yaml
@@ -1,19 +1,20 @@
 id: SRC-LEE-2015-BELINOSTAT-PTCL
 source_type: rct_publication
-title: "Belinostat in Patients With Relapsed or Refractory Peripheral T-Cell Lymphoma: Results of the Pivotal Phase II BELIEF (CLN-19) Study"
-version: "2015"
+title: 'Belinostat in Patients With Relapsed or Refractory Peripheral T-Cell Lymphoma:
+  Results of the Pivotal Phase II BELIEF (CLN-19) Study'
+version: '2015'
 authors:
-  - O'Connor OA
-  - Horwitz S
-  - Masszi T
-  - et al.
+- O'Connor OA
+- Horwitz S
+- Masszi T
+- et al.
 journal: Journal of Clinical Oncology
 doi: 10.1200/JCO.2014.59.2782
-pmid: "26101246"
+pmid: '26101246'
 url: https://pubmed.ncbi.nlm.nih.gov/26101246
 access_level: subscription_required
 currency_status: current
-current_as_of: "2015-08-10"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,30 +23,32 @@ license:
   name: ASCO / JCO (subscription)
 attribution:
   required: true
-  text: "O'Connor et al., JCO 2015; BELIEF (CLN-19) belinostat R/R PTCL"
+  text: O'Connor et al., JCO 2015; BELIEF (CLN-19) belinostat R/R PTCL
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
-  notes: "Subscription source — fair-use referencing only."
+  date: '2026-04-27'
+  notes: Subscription source — fair-use referencing only.
 relates_to_diseases:
-  - DIS-PTCL
-last_verified: "2026-04-27"
-notes: >
-  BELIEF (CLN-19) pivotal phase 2 (NCT00865969) of belinostat 1000 mg/m²
-  IV days 1–5 q21d in 129 enrolled / 120 evaluable R/R peripheral T-cell
-  lymphoma patients with prior systemic therapy. ORR 25.8% (CR 10.8%,
-  PR 15%); median DoR 13.6 mo; mPFS 1.6 mo, mOS 7.9 mo. Activity across
-  PTCL subtypes including AITL. Supported FDA accelerated approval (Jul
-  2014) of belinostat for R/R PTCL. NOTE: original task list listed
-  "Lee et al." with PMID 26014294 — that PMID belongs to the BEYOND
-  bevacizumab NSCLC trial (Zhou 2015). The pivotal BELIEF belinostat
-  PTCL paper is O'Connor et al., JCO 2015, PMID 26101246 (Lee was not
-  the first author — verified via PubMed). SRC ID retained per task
-  spec.
-  Cited by CSD-9A actionability RFs for PTCL R/R salvage selection.
+- DIS-PTCL
+last_verified: '2026-05-01'
+notes: 'BELIEF (CLN-19) pivotal phase 2 (NCT00865969) of belinostat 1000 mg/m^2 IV
+  days 1-5 q21d in 129 enrolled / 120 evaluable R/R peripheral T-cell lymphoma patients
+  with prior systemic therapy. ORR 25.8% (CR 10.8%, PR 15%); median DoR 13.6 mo; mPFS
+  1.6 mo, mOS 7.9 mo. Activity across PTCL subtypes including AITL. Supported FDA
+  accelerated approval (Jul 2014) of belinostat for R/R PTCL. NOTE: original task
+  list listed "Lee et al." with PMID 26014294 — that PMID belongs to the BEYOND bevacizumab
+  NSCLC trial (Zhou 2015). The pivotal BELIEF belinostat PTCL paper is O''Connor et
+  al., JCO 2015, PMID 26101246 (Lee was not the first author — verified via PubMed).
+  SRC ID retained per task spec. Cited by CSD-9A actionability RFs for PTCL R/R salvage
+  selection.
+
+  '
 pages_count: 8
 references_count: 32
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 403
+url_status: blocked_by_bot_protection

--- a/knowledge_base/hosted/content/sources/src_libretto_431.yaml
+++ b/knowledge_base/hosted/content/sources/src_libretto_431.yaml
@@ -8,9 +8,13 @@ ingestion:
 legal_review:
   status: pending
   notes: Auto-stub; license + citation pending clinical signoff.
-last_verified: '2026-04-27'
+last_verified: '2026-05-01'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
 notes: Auto-stub from referenced citation (source-gap mention in prose). Verify metadata
   + ingest via the appropriate client when proxy lands. Replace TODO in title with
   confirmed citation.
+last_recency_check: '2026-05-01'
+recency_check_status_code: null
+url_status: missing_url
+url_replacement_needed: true

--- a/knowledge_base/hosted/content/sources/src_moz_ua_lymph_2013.yaml
+++ b/knowledge_base/hosted/content/sources/src_moz_ua_lymph_2013.yaml
@@ -1,35 +1,35 @@
 id: SRC-MOZ-UA-LYMPH-2013
 source_type: guideline
-title: "Уніфікований клінічний протокол первинної, вторинної (спеціалізованої) медичної допомоги: Лімфоми"
-version: "2013-10-30 (Наказ МОЗ України № 866)"
+title: 'Уніфікований клінічний протокол первинної, вторинної (спеціалізованої) медичної
+  допомоги: Лімфоми'
+version: 2013-10-30 (Наказ МОЗ України № 866)
 authors:
-  - МОЗ України
-  - Державний експертний центр МОЗ України
-url: "https://www.dec.gov.ua/wp-content/uploads/2019/11/2013_866_ykpmd_limfomy.pdf"
+- МОЗ України
+- Державний експертний центр МОЗ України
+url: https://www.dec.gov.ua/wp-content/uploads/2019/11/2013_866_ykpmd_limfomy.pdf
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: "2024-XX-XX"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 precedence_policy: national_floor_only
-
 hosting_mode: hosted
-hosting_justification: "H1 — no API; МОЗ protocols available only as PDF"
+hosting_justification: H1 — no API; МОЗ protocols available only as PDF
 ingestion:
   method: manual
   client: null
-  endpoint: "https://www.dec.gov.ua/wp-content/uploads/2019/11/2013_866_ykpmd_limfomy.pdf"
+  endpoint: https://www.dec.gov.ua/wp-content/uploads/2019/11/2013_866_ykpmd_limfomy.pdf
   rate_limit: null
 cache_policy:
   enabled: true
-  ttl_days: 365  # МОЗ rarely updates; quarterly recheck OK
+  ttl_days: 365
 license:
-  name: "Ukrainian government work (public domain)"
+  name: Ukrainian government work (public domain)
   url: null
   spdx_id: null
 attribution:
   required: true
-  text: "Уніфікований клінічний протокол МОЗ України: Лімфоми, наказ № 866 від 30.10.2013"
+  text: 'Уніфікований клінічний протокол МОЗ України: Лімфоми, наказ № 866 від 30.10.2013'
 commercial_use_allowed: true
 redistribution_allowed: true
 modifications_allowed: true
@@ -38,29 +38,30 @@ known_restrictions: []
 legal_review:
   status: reviewed
   reviewer: null
-  date: "2026-04-25"
-  notes: "Public Ukrainian government document. PDF mirrored at legacy/source_pdfs/moz_2013_866_lymphomas.pdf for ingestion."
-
+  date: '2026-04-25'
+  notes: Public Ukrainian government document. PDF mirrored at legacy/source_pdfs/moz_2013_866_lymphomas.pdf
+    for ingestion.
 relates_to_diseases:
-  - DIS-HCV-MZL
-  - DIS-DLBCL-NOS
-  - DIS-FL
-  - DIS-MCL
-  - DIS-NMZL
-  - DIS-SMZL
-  - DIS-BURKITT
-  - DIS-CHL
-  - DIS-NLPHL
+- DIS-HCV-MZL
+- DIS-DLBCL-NOS
+- DIS-FL
+- DIS-MCL
+- DIS-NMZL
+- DIS-SMZL
+- DIS-BURKITT
+- DIS-CHL
+- DIS-NLPHL
+last_verified: '2026-05-01'
+last_recency_check: '2026-05-01'
+recency_check_status_code: 200
+notes: 'Найбільш актуальна офіційна редакція українського уніфікованого протоколу
+  по лімфомах. Покриває Hodgkin (393 cases) + non-Hodgkin (1,239 cases) у оригінальному
+  наборі. Старіший за NCCN/ESMO 2024-25, але ЯВЛЯЄТЬСЯ current legal standard в Україні
+  до публікації нового наказу. Для CLL (хронічна лімфоїдна лейкемія) є окремий новіший
+  протокол — див. SRC-MOZ-UA-CLL-2022. Чекаємо на МОЗ оновлення; коли з''явиться —
+  заміняємо на новий source ID.
 
-last_verified: '2026-04-27'
-notes: >
-  Найбільш актуальна офіційна редакція українського уніфікованого протоколу
-  по лімфомах. Покриває Hodgkin (393 cases) + non-Hodgkin (1,239 cases) у
-  оригінальному наборі. Старіший за NCCN/ESMO 2024-25, але ЯВЛЯЄТЬСЯ current
-  legal standard в Україні до публікації нового наказу. Для CLL (хронічна
-  лімфоїдна лейкемія) є окремий новіший протокол — див. SRC-MOZ-UA-CLL-2022.
-  Чекаємо на МОЗ оновлення; коли з'явиться — заміняємо на новий source ID.
-
+  '
 pages_count: 80
 references_count: 60
 corpus_role: regional_guideline

--- a/knowledge_base/hosted/content/sources/src_tourmaline_mm1_moreau_2016.yaml
+++ b/knowledge_base/hosted/content/sources/src_tourmaline_mm1_moreau_2016.yaml
@@ -1,19 +1,19 @@
 id: SRC-TOURMALINE-MM1-MOREAU-2016
 source_type: rct_publication
-title: "Oral Ixazomib, Lenalidomide, and Dexamethasone for Multiple Myeloma"
-version: "2016"
+title: Oral Ixazomib, Lenalidomide, and Dexamethasone for Multiple Myeloma
+version: '2016'
 authors:
-  - Moreau P
-  - Masszi T
-  - Grzasko N
-  - et al.
+- Moreau P
+- Masszi T
+- Grzasko N
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1516282
-pmid: "27119237"
+pmid: '27119237'
 url: https://pubmed.ncbi.nlm.nih.gov/27119237
 access_level: subscription_required
 currency_status: current
-current_as_of: "2016-04-28"
+current_as_of: '2026-05-01'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +22,27 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Moreau et al., NEJM 2016; TOURMALINE-MM1 trial"
+  text: Moreau et al., NEJM 2016; TOURMALINE-MM1 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MM
-last_verified: "2026-04-27"
-notes: >
-  TOURMALINE-MM1 phase-3 (NCT01564537): ixazomib + lenalidomide +
-  dexamethasone (IRd) vs placebo + Rd in R/R MM with 1–3 prior
-  lines (n=722). Median PFS 20.6 vs 14.7 mo (HR 0.74; p=0.012);
-  ORR 78% vs 72%. Long-term update (Richardson Lancet Oncol 2022):
-  no OS benefit (mOS 53.6 vs 51.6 mo). Established ixazomib as
-  first all-oral 2L+ MM regimen; basis for FDA approval Nov 2015.
-  NOTE: task brief listed PMID 27101072 — that PMID is the
-  ASH abstract; primary PMID is 27119237 (verified).
+- DIS-MM
+last_verified: '2026-05-01'
+notes: 'TOURMALINE-MM1 phase-3 (NCT01564537): ixazomib + lenalidomide + dexamethasone
+  (IRd) vs placebo + Rd in R/R MM with 1–3 prior lines (n=722). Median PFS 20.6 vs
+  14.7 mo (HR 0.74; p=0.012); ORR 78% vs 72%. Long-term update (Richardson Lancet
+  Oncol 2022): no OS benefit (mOS 53.6 vs 51.6 mo). Established ixazomib as first
+  all-oral 2L+ MM regimen; basis for FDA approval Nov 2015. NOTE: task brief listed
+  PMID 27101072 — that PMID is the ASH abstract; primary PMID is 27119237 (verified).
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-05-01'
+recency_check_status_code: 403
+url_status: blocked_by_bot_protection

--- a/scripts/tasktorrent/upsert_contributions.py
+++ b/scripts/tasktorrent/upsert_contributions.py
@@ -44,6 +44,8 @@ PREFIX_TO_DIR = {
     "bio_": "biomarkers",
     "drug_": "drugs",
     "ind_": "indications",
+    "src_": "sources",          # in-place source upsert (recency refresh,
+                                # license update, etc) — keep filename
     "source_stub_": "sources",  # source stubs land in sources/, but the
                                 # filename will be normalized to src_*.yaml
 }


### PR DESCRIPTION
Lands batch-5a sidecars (chunks #182-#187 + #203-#208) into hosted KB via upsert_contributions --confirm.

## Scope
- 15 biomarker_actionability files: evidence_sources.civic_* populated from CIViC snapshot 2026-04-25; actionability_review_required: true preserved (awaiting clinical adjudication)
- 12 source files: last_verified bumped 2026-05-01; current_as_of bumped where applicable; CTCAE-V5 URL redirect resolved
- Routing fix: scripts/tasktorrent/upsert_contributions.py adds 'src_' prefix → sources/ (was longstanding gap)
- Audit trail: 12 upsert-log-*.md under contributions/

## Gates
- KB validator PASS (2625 entities, 272 sources)
- pytest tests/test_curated_chunk_e2e.py — 82 passed

## Clinical review note
BMA upserts intentionally preserve `actionability_review_required: true`.
Render layer should NOT surface these as actionable until clinical
sign-off. The audit-report.yaml in each chunk dir captures what was
populated and the no-match reasons for skipped IDs.