### PR TITLE
feat(kb): patient watchpoints — Wave 3C (17 salvage + 2L+ regimens)

### DIFF
--- a/knowledge_base/hosted/content/regimens/alemtuzumab_iv.yaml
+++ b/knowledge_base/hosted/content/regimens/alemtuzumab_iv.yaml
@@ -36,6 +36,46 @@ ukraine_availability:
   notes: "Alemtuzumab — обмежений у Україні (off-label використання для T-PLL; on-label для MS). Імпортний access required."
 
 sources: [SRC-NCCN-BCELL-2025]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Alemtuzumab IV for T-PLL or rare T-cell lymphomas. Anti-CD52 mAb —
+# profound prolonged immunosuppression (CD4 < 200 for months);
+# infusion reactions are dramatic. STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома після інфузій"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка з ознобом, кашель"
+    action_ua: "Звертайтесь у лікарню негайно — алемтузумаб дає глибоку тривалу імуносупресію; критично виключити інфекцію"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Висип у вигляді пухирців на смузі шкіри"
+    action_ua: "Подзвоніть у клініку того ж дня — реактивація опериєзу часта"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Сухий кашель, нова задишка"
+    action_ua: "Подзвоніть у клініку того ж дня — на тлі лімфопенії можлива опортуністична інфекція легень (PJP)"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Тяжка інфузійна реакція: задишка, гарячка, висип, втрата свідомості"
+    action_ua: "Інфузія в клініці — медперсонал реагує негайно"
+    urgency: er_now
+    cycle_day_window: "First infusions"
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сплутаність свідомості, виражена слабкість"
+    action_ua: "Звертайтесь у лікарню негайно — можливий сепсис або реактивація CMV"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   STUB. SC alemtuzumab менш efektivна для T-PLL — IV preferred. Severe

--- a/knowledge_base/hosted/content/regimens/drc_wm.yaml
+++ b/knowledge_base/hosted/content/regimens/drc_wm.yaml
@@ -22,6 +22,45 @@ dose_adjustments:
 
 ukraine_availability: {all_components_registered: true, all_components_reimbursed: true}
 sources: [SRC-NCCN-BCELL-2025]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# DRC (dexa + R + cyclophos) for WM 1L. Lower-toxicity alt.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, нудота"
+    action_ua: "Приймайте призначені протиблювотні"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Безсоння у дні дексаметазону"
+    action_ua: "Очікувано — приймайте дексаметазон зранку"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — циклофосфамід дає нейтропенію"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кров у сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — циклофосфамід може спричиняти геморагічний цистит; пийте багато води"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Сильний головний біль, розмиття зору, шум у вухах"
+    action_ua: "Подзвоніть у клініку того ж дня — у WM ризик гіпервіскозного синдрому"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Тяжка інфузійна реакція на ритуксимаб"
+    action_ua: "Інфузія в клініці — медперсонал реагує негайно"
+    urgency: er_now
+    cycle_day_window: "Day 1 of cycle 1"
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   Time-limited (6 months) chemoimmuno for WM — preferred when BTKi

--- a/knowledge_base/hosted/content/regimens/folfox_cetuximab.yaml
+++ b/knowledge_base/hosted/content/regimens/folfox_cetuximab.yaml
@@ -49,6 +49,52 @@ ukraine_availability:
   notes: "Cetuximab typically out-of-pocket; selective NSZU coverage for RAS-WT left-sided mCRC pathway."
 
 sources: [SRC-NCCN-COLON-2025, SRC-ESMO-COLON-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# FOLFOX + cetuximab for RAS-WT-left mCRC 1L. Inherits FOLFOX
+# neuropathy + cold sensitivity + cytopenia + cetuximab rash + IRR.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Поколювання або оніміння в кистях/стопах"
+    action_ua: "Оксаліплатин — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Чутливість до холоду"
+    action_ua: "Уникайте холодного питва і повітря на обличчя"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-5"
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Акнеформний висип"
+    action_ua: "Цетуксимаб — використовуйте призначені креми"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — можлива нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-NCCN-COLON-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сильна діарея >4 разів/день"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик зневоднення"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Виражений висип з пухирями"
+    action_ua: "Подзвоніть у клініку того ж дня — тяжка шкірна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сильна реакція на інфузію"
+    action_ua: "Інфузія в клініці — медперсонал реагує негайно"
+    urgency: er_now
+    cycle_day_window: "First infusion"
+    sources:
+      - SRC-NCCN-COLON-2025
+
 last_reviewed: "2026-04-26"
 
 notes: >

--- a/knowledge_base/hosted/content/regimens/hyper_cvad_r.yaml
+++ b/knowledge_base/hosted/content/regimens/hyper_cvad_r.yaml
@@ -75,6 +75,45 @@ ukraine_availability:
   notes: "Усі компоненти НСЗУ-доступні. Ponatinib обмежено доступний; dasatinib generic available."
 
 sources: [SRC-NCCN-BCELL-2025]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Hyper-CVAD + R for B-ALL or aggressive Burkitt-like lymphomas.
+# Highly intensive 8-cycle alternating regimen with HD-MTX/HiDAC
+# in even cycles. Inpatient. STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена втома, мукозит порожнини рота"
+    action_ua: "Поширене — полоскання, м'яка їжа"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Випадання волосся, помірна нудота"
+    action_ua: "Очікувано — приймайте призначені протиблювотні"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Поколювання або оніміння в кистях/стопах"
+    action_ua: "Вінкристин спричиняє нейропатію — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Зменшення кількості сечі, набряки — у дні HD-MTX (парні цикли)"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібен суворий контроль функції нирок"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Розмиття мислення після HiDAC-доз"
+    action_ua: "Подзвоніть у клініку того ж дня — церебелярна токсичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Звертайтесь у лікарню негайно — тривала нейтропенія, ризик сепсису"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-25"
 notes: >
   STUB — pending Clinical Co-Lead approval. MD Anderson regimen (Kantarjian

--- a/knowledge_base/hosted/content/regimens/ice.yaml
+++ b/knowledge_base/hosted/content/regimens/ice.yaml
@@ -36,6 +36,44 @@ ukraine_availability:
   notes: "Усі компоненти доступні в Україні."
 
 sources: [SRC-NCCN-BCELL-2025]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# ICE (ifosfamide + carbo + etoposide) salvage for relapsed lymphoma.
+# Inpatient. Ifosfamide adds CNS toxicity + hemorrhagic cystitis.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена втома, мукозит"
+    action_ua: "Поширене — м'яка їжа, полоскання порожнини рота"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Випадання волосся"
+    action_ua: "Очікувано — повертається після курсу"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Кров у сечі або біль при сечовипусканні"
+    action_ua: "Подзвоніть у клініку того ж дня — іфосфамід може спричиняти геморагічний цистит; пийте багато води"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Розмиття мислення, сонливість, плутаність"
+    action_ua: "Подзвоніть у клініку того ж дня — іфосфамід може спричиняти енцефалопатію"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Звертайтесь у лікарню негайно — глибока тривала нейтропенія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Судомний напад або втрата свідомості"
+    action_ua: "Звертайтесь у лікарню негайно — тяжка іфосфамід-енцефалопатія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   STUB. Salvage / pre-transplant cytoreduction. Hemorrhagic cystitis ризик

--- a/knowledge_base/hosted/content/regimens/reg_5fu_lv_bev_ckd_modified.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_5fu_lv_bev_ckd_modified.yaml
@@ -56,6 +56,43 @@ sources:
   - SRC-NCCN-COLON-2025
   - SRC-ESMO-COLON-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# 5-FU + LV + bevacizumab for mCRC patients with CKD (CrCl <30 where
+# capecitabine + oxaliplatin contraindicated). Inherits FU + bev
+# pattern. STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, легка діарея"
+    action_ua: "Зустрічається — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Підвищений тиск (вимірюйте 1-2 рази на тиждень)"
+    action_ua: "Бевацизумаб може підвищувати тиск"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Зменшення кількості сечі, погіршення набряків"
+    action_ua: "Подзвоніть у клініку того ж дня — на тлі CKD потрібен суворий контроль функції нирок"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сильна діарея >4 разів/день"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик зневоднення особливо небезпечний при CKD"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кров у сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — бевацизумаб може впливати на нирки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Раптовий гострий біль у животі"
+    action_ua: "Звертайтесь у лікарню негайно — рідко бевацизумаб може спричиняти перфорацію кишківника"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-COLON-2025
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_aaml1031_pediatric.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_aaml1031_pediatric.yaml
@@ -68,6 +68,43 @@ sources:
   - SRC-NCCN-AML-2025
   - SRC-ESMO-AML-2020
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# AAML1031 pediatric AML 1L. Same induction toxicity as adult 7+3 +
+# pediatric-specific concerns (growth, fertility, late effects).
+# STUB pending §6.1 signoff. Watchpoints written for the parent.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена втома у дитини, що триває тижнями"
+    action_ua: "Очікувано — кістковий мозок відновлюється повільно; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Випадання волосся"
+    action_ua: "Очікувано — повертається після курсу"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Лихоманка вище 38°C у дитини"
+    action_ua: "Звертайтесь у лікарню негайно — на тлі тривалої нейтропенії інфекція може швидко переходити у сепсис"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Незвичні синці, кровотеча ясен або носа у дитини"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібен контроль показників крові"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Нова задишка при невеликому навантаженні"
+    action_ua: "Подзвоніть у клініку того ж дня — антрациклін впливає на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Сплутаність свідомості, висока лихоманка з ознобом"
+    action_ua: "Звертайтесь у лікарню негайно — ознаки сепсису"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_amivantamab_lazertinib_nsclc_2l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_amivantamab_lazertinib_nsclc_2l.yaml
@@ -60,6 +60,45 @@ sources:
   - SRC-NCCN-NSCLC-2025
   - SRC-ESMO-NSCLC-METASTATIC-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Amivantamab + lazertinib for EGFR-mut NSCLC post-osimertinib
+# (MARIPOSA-2). EGFR + MET bispecific + 3rd-gen EGFR TKI. Signature:
+# acneiform rash, paronychia, infusion reactions, VTE.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Акнеформний висип на обличчі, шиї"
+    action_ua: "Очікувано на тлі амівантамабу/лазертинібу — використовуйте призначені креми"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Запалення та біль навколо нігтів (паронихії)"
+    action_ua: "Поширене — носіть м'яке взуття, уникайте травм нігтів"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Помірна нудота, помірна діарея"
+    action_ua: "Зустрічається — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Біль або припухлість в одній нозі"
+    action_ua: "Подзвоніть у клініку того ж дня — амівантамаб підвищує ризик тромбозу; антикоагулянти зазвичай призначаються профілактично"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+      - SRC-MARIPOSA2-PASSARO-2024
+  - trigger_ua: "Виражена реакція на інфузію амівантамабу: задишка, висип, набряк"
+    action_ua: "Інфузія в клініці — медперсонал реагує негайно. Премедикація стероїдами + антигістамінними знижує ризик"
+    urgency: er_now
+    cycle_day_window: "First infusion"
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Раптова задишка, біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно — можлива легенева тромбоемболія або пневмоніт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NSCLC-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   MARIPOSA-2: ami+laz+chemo PFS HR 0.44 vs chemo alone in EGFR-mutated

--- a/knowledge_base/hosted/content/regimens/reg_bendamustine_ptcl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_bendamustine_ptcl.yaml
@@ -49,6 +49,38 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-PTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Bendamustine monotherapy for relapsed PTCL. Same as BR pattern but
+# without rituximab IRR. STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, помірна нудота"
+    action_ua: "Зустрічається — приймайте призначені протиблювотні"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C — особливо на 14-21 день"
+    action_ua: "Подзвоніть у клініку того ж дня — бендамустин дає глибоку тривалу нейтропенію"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 14-21"
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Висип у вигляді почервонілих плям, які злущуються"
+    action_ua: "Подзвоніть у клініку того ж дня — рідко бендамустин може спричиняти тяжкі шкірні реакції"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Незвичні синці, кровотеча ясен"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібен контроль показників крові"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сепсис: лихоманка з ознобом, плутаність свідомості"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-25"
 notes: >
   BENTLY trial (Damaj 2013): r/r PTCL — ORR 50%, CR 28% in mixed cohort

--- a/knowledge_base/hosted/content/regimens/reg_carfilzomib_wm.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_carfilzomib_wm.yaml
@@ -58,6 +58,44 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-WM-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Carfilzomib + R + dexamethasone for WM. Carfilzomib signature:
+# cardiac toxicity (heart failure, hypertension), pulmonary, infusion
+# reactions. Less neuropathy than bortezomib. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Підвищений тиск (вимірюйте 1-2 рази на тиждень)"
+    action_ua: "Карфілзоміб може підвищувати тиск — занотовуйте показники"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна нудота, втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Нова задишка при навантаженні, набряки гомілок"
+    action_ua: "Подзвоніть у клініку того ж дня — карфілзоміб може спричиняти серцеву недостатність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Реакція на інфузію — задишка, гарячка, біль у грудях"
+    action_ua: "Інфузія в клініці — повідомте медсестру негайно"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 1 of cycle 1"
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — імуносупресія від анти-CD20"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Раптова сильна задишка у спокої, біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно — можлива серцева подія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   CaRD trial (Treon 2014): r/r WM — major response rate 87%, VGPR

--- a/knowledge_base/hosted/content/regimens/reg_loncastuximab_tesirine.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_loncastuximab_tesirine.yaml
@@ -62,6 +62,43 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-DLBCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Loncastuximab tesirine CD19 ADC for R/R DLBCL 3L+ (LOTIS-2). PBD
+# payload signature: photosensitivity, edema, pleural effusions, GI.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Чутливість шкіри до сонця, легкі опіки"
+    action_ua: "Завжди користуйтесь сонцезахисним кремом SPF 50+ і одягом, що закриває шкіру; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Набряки гомілок, обличчя"
+    action_ua: "Поширене — підніміть ноги відпочиваючи; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна нудота, втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Виражена задишка при навантаженні, біль у грудях"
+    action_ua: "Подзвоніть у клініку того ж дня — лонкастуксимаб може спричиняти випіт у грудній порожнині"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-LOTIS-2-CAIMI-2021
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібен контроль показників крові"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова сильна задишка у спокої"
+    action_ua: "Звертайтесь у лікарню негайно — можливий тяжкий легеневий випіт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-30"
 reviewer_signoffs: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_nivo_avd.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_nivo_avd.yaml
@@ -59,6 +59,48 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-HODGKIN-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Nivolumab + AVD for advanced cHL (SWOG S1826). Combines IO irAEs
+# with AVD chemo (cytopenia + cardiac + alopecia). STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома після інфузії"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Випадання волосся"
+    action_ua: "Очікувано — повертається після курсу"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Шкірний свербіж"
+    action_ua: "Часто від ніволумабу — використовуйте зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія можлива"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Помірна діарея (3-4 рази на день)"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Нова задишка, прискорене серцебиття"
+    action_ua: "Подзвоніть у клініку того ж дня — доксорубіцин впливає на серце; може бути імунний пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   SWOG S1826 trial (Herrera 2024 NEJM): newly diagnosed advanced cHL

--- a/knowledge_base/hosted/content/regimens/reg_pola_r_bendamustine.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pola_r_bendamustine.yaml
@@ -65,6 +65,45 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-DLBCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Pola-R-bendamustine for R/R DLBCL transplant-ineligible (GO29365).
+# Polatuzumab neuropathy + bendamustine cytopenia + rituximab IRR.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Поколювання або оніміння в кистях/стопах"
+    action_ua: "Полатузумаб може спричиняти нейропатію — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна втома, нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C — особливо на 14-21 день"
+    action_ua: "Подзвоніть у клініку того ж дня — бендамустин дає глибоку тривалу нейтропенію"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 14-21"
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Поколювання стає сильним болем"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна корекція дози полатузумабу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна реакція на інфузію ритуксимабу"
+    action_ua: "Повідомте медсестру негайно — інфузію сповільнюють"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 1 of cycle 1"
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Тяжка інфузійна реакція або сепсис"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   GO29365 randomized phase 1b/2 (Sehn 2020): in r/r DLBCL ineligible for

--- a/knowledge_base/hosted/content/regimens/reg_regorafenib.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_regorafenib.yaml
@@ -57,6 +57,48 @@ sources:
   - SRC-NCCN-COLON-2025
   - SRC-ESMO-COLON-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Regorafenib for mCRC 3L+ (CORRECT). Multi-kinase TKI. Tox profile
+# similar to sorafenib but more pronounced: HFS, fatigue, HTN, GI,
+# hepatic. Quality-of-life impact is significant. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Почервоніння, лущення, болючі тріщини на долонях і стопах"
+    action_ua: "Hand-foot синдром від реґорафенібу — крем, м'яке взуття; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Виражена втома"
+    action_ua: "Поширене на реґорафенібі — обговоріть на візиті, якщо заважає в побуті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Контролюється лоперамідом — занотовуйте частоту"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Підвищений тиск"
+    action_ua: "Подзвоніть у клініку того ж дня — реґорафеніб може значно підвищувати тиск"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Жовтяниця, потемніння сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — реґорафеніб впливає на печінку"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Виражений біль на долонях / стопах, заважає ходити"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна корекція дози"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Кровохаркання або значна кровотеча"
+    action_ua: "Звертайтесь у лікарню негайно — реґорафеніб підвищує ризик кровотеч"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-COLON-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   CORRECT trial (Grothey 2013): 3L+ chemo-refractory mCRC — regorafenib

--- a/knowledge_base/hosted/content/regimens/reg_relatlimab_nivolumab_melanoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_relatlimab_nivolumab_melanoma.yaml
@@ -41,6 +41,42 @@ sources:
   - SRC-ESMO-MELANOMA-2024
   - SRC-RELATIVITY-047-TAWBI-2022
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Relatlimab + nivolumab (Opdualag) for melanoma 1L (RELATIVITY-047).
+# LAG-3 + PD-1 dual checkpoint — slightly higher irAE rate than
+# nivo mono but lower than nivo+ipi. STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, шкірний свербіж"
+    action_ua: "Очікувано — використовуйте зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Помірна діарея (3-4 рази на день)"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Жовтяниця, біль у правому верхньому квадранті живота"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага"
+    action_ua: "Подзвоніть у клініку того ж дня — імунна реакція щитоподібної залози або новий діабет"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Нова задишка, сухий кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   RELATIVITY-047 phase 2/3: nivo+rela vs nivo mono in 1L melanoma —

--- a/knowledge_base/hosted/content/regimens/reg_trifluridine_tipiracil_gastric.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_trifluridine_tipiracil_gastric.yaml
@@ -44,6 +44,38 @@ sources:
   - SRC-NCCN-GASTRIC-2025
   - SRC-ESMO-GASTRIC-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Trifluridine-tipiracil for gastric 3L+ (TAGS). Same TAS-102 pattern
+# as in mCRC. STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, втома"
+    action_ua: "Приймайте препарат після їжі"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-GASTRIC-2025
+  - trigger_ua: "Помірна діарея або запор"
+    action_ua: "Занотовуйте, обговоріть на візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — TAS-102 дає нейтропенію"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 14-21"
+    sources:
+      - SRC-NCCN-GASTRIC-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Незвичні синці, кровотеча"
+    action_ua: "Подзвоніть у клініку того ж дня"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Тяжка діарея або сепсис"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-26"
 notes: >
   TAGS trial (Shitara 2018): 3L+ gastric/GEJ adenocarcinoma after ≥2

--- a/knowledge_base/hosted/content/regimens/reg_trifluridine_tipiracil_mono.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_trifluridine_tipiracil_mono.yaml
@@ -42,6 +42,44 @@ ukraine_availability:
     pathway. Servier Ukraine PAP (де доступна).
 
 sources: [SRC-NCCN-COLON-2025, SRC-ESMO-COLON-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Trifluridine-tipiracil (TAS-102) for mCRC 3L+ (RECOURSE). Oral
+# fluoropyrimidine. Cytopenia + GI dominate. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, втома"
+    action_ua: "Приймайте препарат після їжі; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Помірна діарея або запор"
+    action_ua: "Занотовуйте, обговоріть на наступному візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — TAS-102 дає значну нейтропенію"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 14-21"
+    sources:
+      - SRC-NCCN-COLON-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Незвичні синці, кровотеча ясен"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібен контроль тромбоцитів"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Тяжка діарея (≥6 разів на день, з кров'ю)"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик зневоднення"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сепсис: лихоманка з ознобом, плутаність свідомості"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-27"
 
 notes: >


### PR DESCRIPTION
## Summary

Continues Wave 3 from [`docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md`](docs/plans/patient_watchpoints_authoring_queue_2026-05-01-0100.md). Builds on Waves 1-3B (93 anchors). Targets salvage + 2L+ pathways across heme + solid tumors.

After this lands: **110 anchor regimens authored** across 8 Waves; ~830 authored watchpoints in patient mode.

## Authored regimens (~115 watchpoints)

**DLBCL / lymphoma 2L+ (5):** pola-R-bendamustine, loncastuximab tesirine, ICE, hyper-CVAD+R, bendamustine PTCL

**Heme other (5):** carfilzomib WM, DRC WM, AAML1031 pediatric AML, nivo+AVD cHL, alemtuzumab T-PLL

**Solid 2L+ / specialty (7):** regorafenib mCRC, TAS-102 (mCRC + gastric), relatlimab+nivo melanoma, FOLFOX+cetuximab, amivantamab+lazertinib NSCLC 2L, 5FU+LV+bev CKD-modified

## Test plan

- [x] 62 patient-render tests green
- [x] 11 bundle-optimization tests green (no ceiling bump)
- [x] KB validator clean (2613 entities)

## CHARTER

§6.1 — STUB; reviewer_signoffs: 0 per dev-mode exemption.

## Wave progress

| Wave | Status | Authored |
|---|---|---:|
| Wave 1 | done | 11/12 |
| Wave 2 (incl. 2B+2C) | done | 48/~50 |
| Wave 3 (incl. 3B+3C) | partial | 51/~190 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)