### PR TITLE
feat(kb): wave-1 Q-axis upsert — 39 BMA + 82 sources

### DIFF
--- a/contributions/bma-civic-backfill-2026-04-29-001/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-001/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,8 @@
+# Upsert log: bma-civic-backfill-2026-04-29-001 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-001\bma_atm_loss_cll.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_atm_loss_cll.yaml
+- contributions\bma-civic-backfill-2026-04-29-001\bma_atm_loss_mcl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_atm_loss_mcl.yaml
+- contributions\bma-civic-backfill-2026-04-29-001\bma_bcl2_expression_cll.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_expression_cll.yaml
+- contributions\bma-civic-backfill-2026-04-29-001\bma_bcl2_expression_dlbcl_nos.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_expression_dlbcl_nos.yaml
+- contributions\bma-civic-backfill-2026-04-29-001\bma_bcl2_expression_fl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_expression_fl.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-002/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-002/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-2026-04-29-002 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-002\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-002\bma_bcl2_rearrangement_dlbcl_nos.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_rearrangement_dlbcl_nos.yaml
+- contributions\bma-civic-backfill-2026-04-29-002\bma_bcl2_rearrangement_fl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_bcl2_rearrangement_fl.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-003/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-003/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,8 @@
+# Upsert log: bma-civic-backfill-2026-04-29-003 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-003\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-003\bma_calr_et.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_calr_et.yaml
+- contributions\bma-civic-backfill-2026-04-29-003\bma_calr_pmf.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_calr_pmf.yaml
+- contributions\bma-civic-backfill-2026-04-29-003\bma_ccnd1_ihc_mcl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_ccnd1_ihc_mcl.yaml
+- contributions\bma-civic-backfill-2026-04-29-003\bma_ccnd1_t1114_mcl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_ccnd1_t1114_mcl.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-004/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-004/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,5 @@
+# Upsert log: bma-civic-backfill-2026-04-29-004 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-004\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-004\bma_chek2_germline_prostate.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_chek2_germline_prostate.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-005/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-005/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,5 @@
+# Upsert log: bma-civic-backfill-2026-04-29-005 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-005\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-005\bma_chek2_somatic_prostate.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_chek2_somatic_prostate.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-006/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-006/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,5 @@
+# Upsert log: bma-civic-backfill-2026-04-29-006 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-006\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-006\bma_ezh2_y641_fl.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_ezh2_y641_fl.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-008/upsert-log-2026-05-01T190547Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-008/upsert-log-2026-05-01T190547Z.md
@@ -1,0 +1,8 @@
+# Upsert log: bma-civic-backfill-2026-04-29-008 (2026-05-01T190547Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-008\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-008\bma_kit_exon11_gist.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_kit_exon11_gist.yaml
+- contributions\bma-civic-backfill-2026-04-29-008\bma_kit_exon13_17_gist.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_kit_exon13_17_gist.yaml
+- contributions\bma-civic-backfill-2026-04-29-008\bma_kit_exon9_gist.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_kit_exon9_gist.yaml
+- contributions\bma-civic-backfill-2026-04-29-008\bma_met_amp_rcc_papillary.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_met_amp_rcc_papillary.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-009/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-009/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,8 @@
+# Upsert log: bma-civic-backfill-2026-04-29-009 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-009\bma_met_ex14_nsclc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_met_ex14_nsclc.yaml
+- contributions\bma-civic-backfill-2026-04-29-009\bma_mgmt_methylation_gbm.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mgmt_methylation_gbm.yaml
+- contributions\bma-civic-backfill-2026-04-29-009\bma_mlh1_germline_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_germline_crc.yaml
+- contributions\bma-civic-backfill-2026-04-29-009\bma_mlh1_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_germline_endometrial.yaml
+- contributions\bma-civic-backfill-2026-04-29-009\bma_mlh1_germline_gastric.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_germline_gastric.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-010/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-010/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-2026-04-29-010 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-010\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-010\bma_mlh1_somatic_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_somatic_crc.yaml
+- contributions\bma-civic-backfill-2026-04-29-010\bma_mlh1_somatic_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_somatic_endometrial.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-011/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-011/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-2026-04-29-011 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-011\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-011\bma_mlh1_somatic_gastric.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_mlh1_somatic_gastric.yaml
+- contributions\bma-civic-backfill-2026-04-29-011\bma_msh2_germline_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh2_germline_crc.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-012/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-012/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,5 @@
+# Upsert log: bma-civic-backfill-2026-04-29-012 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-012\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-012\bma_msh2_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh2_germline_endometrial.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-013/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-013/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-2026-04-29-013 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-013\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-013\bma_msh2_somatic_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh2_somatic_crc.yaml
+- contributions\bma-civic-backfill-2026-04-29-013\bma_msh2_somatic_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh2_somatic_endometrial.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-014/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-014/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-2026-04-29-014 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-014\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-014\bma_msh6_germline_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh6_germline_crc.yaml
+- contributions\bma-civic-backfill-2026-04-29-014\bma_msh6_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh6_germline_endometrial.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-015/upsert-log-2026-05-01T190548Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-015/upsert-log-2026-05-01T190548Z.md
@@ -1,0 +1,6 @@
+# Upsert log: bma-civic-backfill-2026-04-29-015 (2026-05-01T190548Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-015\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-015\bma_msh6_somatic_crc.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh6_somatic_crc.yaml
+- contributions\bma-civic-backfill-2026-04-29-015\bma_msh6_somatic_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_msh6_somatic_endometrial.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-016/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-016/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,5 @@
+# Upsert log: bma-civic-backfill-2026-04-29-016 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-016\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-016\bma_npm1_aml.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_npm1_aml.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-018/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-018/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,7 @@
+# Upsert log: bma-civic-backfill-2026-04-29-018 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-018\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-018\bma_pdgfra_exon12_gist.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_pdgfra_exon12_gist.yaml
+- contributions\bma-civic-backfill-2026-04-29-018\bma_pdgfra_exon14_gist.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_pdgfra_exon14_gist.yaml
+- contributions\bma-civic-backfill-2026-04-29-018\bma_pms2_germline_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_pms2_germline_endometrial.yaml

--- a/contributions/bma-civic-backfill-2026-04-29-020/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/bma-civic-backfill-2026-04-29-020/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,5 @@
+# Upsert log: bma-civic-backfill-2026-04-29-020 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\bma-civic-backfill-2026-04-29-020\audit-report.yaml: SKIP unknown prefix
+- contributions\bma-civic-backfill-2026-04-29-020\bma_pms2_somatic_endometrial.yaml: UPDATE -> knowledge_base\hosted\content\biomarker_actionability\bma_pms2_somatic_endometrial.yaml

--- a/contributions/source-recency-refresh-2026-04-29-001/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-001/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-001 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-001\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-001\src_aasld_hcc_2023.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_aasld_hcc_2023.yaml
+- contributions\source-recency-refresh-2026-04-29-001\src_adaura_wu_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_adaura_wu_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-001\src_aethera_moskowitz_2015.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_aethera_moskowitz_2015.yaml
+- contributions\source-recency-refresh-2026-04-29-001\src_alcyone_mateos_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_alcyone_mateos_2018.yaml
+- contributions\source-recency-refresh-2026-04-29-001\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-002/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-002/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-002 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-002\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-002\src_alex_peters_2017.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_alex_peters_2017.yaml
+- contributions\source-recency-refresh-2026-04-29-002\src_aphinity_vonminckwitz_2017.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_aphinity_vonminckwitz_2017.yaml
+- contributions\source-recency-refresh-2026-04-29-002\src_apl_relapse_lengfelder_2017.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_apl_relapse_lengfelder_2017.yaml
+- contributions\source-recency-refresh-2026-04-29-002\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-003/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-003/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,6 @@
+# Upsert log: source-recency-refresh-2026-04-29-003 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-003\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-003\src_ascend_ghia_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_ascend_ghia_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-003\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-004/upsert-log-2026-05-01T190549Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-004/upsert-log-2026-05-01T190549Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-004 (2026-05-01T190549Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-004\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-004\src_ata_atc_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_ata_atc_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-004\src_ata_thyroid_2015.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_ata_thyroid_2015.yaml
+- contributions\source-recency-refresh-2026-04-29-004\src_aura3_mok_2017.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_aura3_mok_2017.yaml
+- contributions\source-recency-refresh-2026-04-29-004\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-005/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-005/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,6 @@
+# Upsert log: source-recency-refresh-2026-04-29-005 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-005\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-005\src_br21_shepherd_2005.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_br21_shepherd_2005.yaml
+- contributions\source-recency-refresh-2026-04-29-005\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-006/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-006/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-006 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-006\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-006\src_break3_hauschild_2012.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_break3_hauschild_2012.yaml
+- contributions\source-recency-refresh-2026-04-29-006\src_brf113928_planchard_2016.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_brf113928_planchard_2016.yaml
+- contributions\source-recency-refresh-2026-04-29-006\src_brim3_chapman_2011.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_brim3_chapman_2011.yaml
+- contributions\source-recency-refresh-2026-04-29-006\src_bruin_mato_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_bruin_mato_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-006\src_bsh_mzl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_bsh_mzl_2024.yaml

--- a/contributions/source-recency-refresh-2026-04-29-007/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-007/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-2026-04-29-007 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-007\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-007\src_c14401_chesney_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_c14401_chesney_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-007\src_cartitude1_berdeja_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_cartitude1_berdeja_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-007\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-008/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-008/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-008 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-008\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-008\src_caspian_paz_ares_2019.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_caspian_paz_ares_2019.yaml
+- contributions\source-recency-refresh-2026-04-29-008\src_castor_palumbo_2016.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_castor_palumbo_2016.yaml
+- contributions\source-recency-refresh-2026-04-29-008\src_checkmate238_weber_2017.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_checkmate238_weber_2017.yaml
+- contributions\source-recency-refresh-2026-04-29-008\src_checkmate816_forde_2022.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_checkmate816_forde_2022.yaml
+- contributions\source-recency-refresh-2026-04-29-008\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-009/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-009/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-009 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-009\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-009\src_checkmate_067_larkin_2019.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_checkmate_067_larkin_2019.yaml
+- contributions\source-recency-refresh-2026-04-29-009\src_checkmate_649_janjigian_2022.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_checkmate_649_janjigian_2022.yaml
+- contributions\source-recency-refresh-2026-04-29-009\src_chronos_sartore_bianchi_2022.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_chronos_sartore_bianchi_2022.yaml
+- contributions\source-recency-refresh-2026-04-29-009\src_chrysalis_park_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_chrysalis_park_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-009\src_cleopatra_swain_2015.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_cleopatra_swain_2015.yaml

--- a/contributions/source-recency-refresh-2026-04-29-010/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-010/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-010 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-010\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-010\src_cll14_fischer_2019.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_cll14_fischer_2019.yaml
+- contributions\source-recency-refresh-2026-04-29-010\src_cobrim_larkin_2014.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_cobrim_larkin_2014.yaml
+- contributions\source-recency-refresh-2026-04-29-010\src_codebreak200_johnson_2023.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_codebreak200_johnson_2023.yaml
+- contributions\source-recency-refresh-2026-04-29-010\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-011/upsert-log-2026-05-01T190550Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-011/upsert-log-2026-05-01T190550Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-011 (2026-05-01T190550Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-011\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-011\src_coiffier_2012_romidepsin_ptcl.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_coiffier_2012_romidepsin_ptcl.yaml
+- contributions\source-recency-refresh-2026-04-29-011\src_combi_ad_long_2017.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_combi_ad_long_2017.yaml
+- contributions\source-recency-refresh-2026-04-29-011\src_combi_d_long_2014.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_combi_d_long_2014.yaml
+- contributions\source-recency-refresh-2026-04-29-011\src_combi_v_robert_2015.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_combi_v_robert_2015.yaml
+- contributions\source-recency-refresh-2026-04-29-011\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-012/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-012/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-2026-04-29-012 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-012\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-012\src_crown_solomon_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_crown_solomon_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-012\src_ctcae_v5.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_ctcae_v5.yaml
+- contributions\source-recency-refresh-2026-04-29-012\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-013/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-013/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-2026-04-29-013 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-013\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-013\src_destinylung01_li_2022.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_destinylung01_li_2022.yaml
+- contributions\source-recency-refresh-2026-04-29-013\src_destinylung02_goto_2023.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_destinylung02_goto_2023.yaml
+- contributions\source-recency-refresh-2026-04-29-013\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-014/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-014/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-014 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-014\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-014\src_eano_lgg_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_eano_lgg_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-014\src_easl_hcv_2023.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_easl_hcv_2023.yaml
+- contributions\source-recency-refresh-2026-04-29-014\src_eau_bladder_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_eau_bladder_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-014\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-015/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-015/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-015 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-015\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-015\src_eau_prostate_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_eau_prostate_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-015\src_echelon1_connors_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_echelon1_connors_2018.yaml
+- contributions\source-recency-refresh-2026-04-29-015\src_echelon2_horwitz_2019.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_echelon2_horwitz_2019.yaml
+- contributions\source-recency-refresh-2026-04-29-015\src_elevate_tn_sharman_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_elevate_tn_sharman_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-015\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-016/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-016/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-2026-04-29-016 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-016\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-016\src_eln_cml_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_eln_cml_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-016\src_eloquent3_dimopoulos_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_eloquent3_dimopoulos_2018.yaml
+- contributions\source-recency-refresh-2026-04-29-016\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-017/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-017/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-2026-04-29-017 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-017\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-017\src_emilia_verma_2012.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_emilia_verma_2012.yaml
+- contributions\source-recency-refresh-2026-04-29-017\src_empower_lung1_sezer_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_empower_lung1_sezer_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-017\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-018/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-018/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-018 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-018\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-018\src_escat_mateo_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_escat_mateo_2018.yaml
+- contributions\source-recency-refresh-2026-04-29-018\src_esmo_breast_early_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_breast_early_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-018\src_esmo_breast_metastatic_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_breast_metastatic_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-018\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-019/upsert-log-2026-05-01T190551Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-019/upsert-log-2026-05-01T190551Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-019 (2026-05-01T190551Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-019\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-019\src_esmo_btc_2023.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_btc_2023.yaml
+- contributions\source-recency-refresh-2026-04-29-019\src_esmo_burkitt_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_burkitt_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-019\src_esmo_cervical_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_cervical_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-019\src_esmo_cll_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_cll_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-019\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-020/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-020/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-020 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-020\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-020\src_esmo_colon_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_colon_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-020\src_esmo_ctcl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_ctcl_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-020\src_esmo_dlbcl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_dlbcl_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-020\src_esmo_endometrial_2022.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_endometrial_2022.yaml
+- contributions\source-recency-refresh-2026-04-29-020\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-021/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-021/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-021 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-021\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-021\src_esmo_esophageal_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_esophageal_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-021\src_esmo_fl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_fl_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-021\src_esmo_gastric_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_gastric_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-021\src_esmo_hnscc_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_hnscc_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-021\src_esmo_hodgkin_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_hodgkin_2024.yaml

--- a/contributions/source-recency-refresh-2026-04-29-022/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-022/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-022 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-022\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-022\src_esmo_mcl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_mcl_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-022\src_esmo_melanoma_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_melanoma_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-022\src_esmo_mm_2023.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_mm_2023.yaml
+- contributions\source-recency-refresh-2026-04-29-022\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-023/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-023/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,9 @@
+# Upsert log: source-recency-refresh-2026-04-29-023 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-023\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-023\src_esmo_mzl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_mzl_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-023\src_esmo_nsclc_early_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_nsclc_early_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-023\src_esmo_nsclc_metastatic_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_nsclc_metastatic_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-023\src_esmo_ovarian_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_ovarian_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-023\src_esmo_pancreatic_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_pancreatic_2024.yaml

--- a/contributions/source-recency-refresh-2026-04-29-024/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-024/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,8 @@
+# Upsert log: source-recency-refresh-2026-04-29-024 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-024\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-024\src_esmo_prostate_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_prostate_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-024\src_esmo_ptcl_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_ptcl_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-024\src_esmo_rcc_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_rcc_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-024\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-025/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-025/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,7 @@
+# Upsert log: source-recency-refresh-2026-04-29-025 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-025\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-025\src_esmo_sclc_2021.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_sclc_2021.yaml
+- contributions\source-recency-refresh-2026-04-29-025\src_esmo_wm_2024.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_esmo_wm_2024.yaml
+- contributions\source-recency-refresh-2026-04-29-025\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-027/upsert-log-2026-05-01T190552Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-027/upsert-log-2026-05-01T190552Z.md
@@ -1,0 +1,6 @@
+# Upsert log: source-recency-refresh-2026-04-29-027 (2026-05-01T190552Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-027\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-027\src_geometry_wolf_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_geometry_wolf_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-027\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-028/upsert-log-2026-05-01T190553Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-028/upsert-log-2026-05-01T190553Z.md
@@ -1,0 +1,6 @@
+# Upsert log: source-recency-refresh-2026-04-29-028 (2026-05-01T190553Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-028\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-028\src_griffin_voorhees_2020.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_griffin_voorhees_2020.yaml
+- contributions\source-recency-refresh-2026-04-29-028\unreachable.yaml: SKIP unknown prefix

--- a/contributions/source-recency-refresh-2026-04-29-029/upsert-log-2026-05-01T190553Z.md
+++ b/contributions/source-recency-refresh-2026-04-29-029/upsert-log-2026-05-01T190553Z.md
@@ -1,0 +1,6 @@
+# Upsert log: source-recency-refresh-2026-04-29-029 (2026-05-01T190553Z)
+Mode: CONFIRM (writes applied)
+
+- contributions\source-recency-refresh-2026-04-29-029\refresh_summary.yaml: SKIP unknown prefix
+- contributions\source-recency-refresh-2026-04-29-029\src_innovate_dimopoulos_2018.yaml: UPDATE -> knowledge_base\hosted\content\sources\src_innovate_dimopoulos_2018.yaml
+- contributions\source-recency-refresh-2026-04-29-029\unreachable.yaml: SKIP unknown prefix

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_dlbcl_nos.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_dlbcl_nos.yaml
@@ -36,10 +36,16 @@ evidence_sources:
   - EID423
   direction: Supports
   significance: Poor Outcome
-  note: 'CIViC snapshot 2026-04-25: BCL2 Overexpression in DLBCL, Prognostic, Supports
-    Poor Outcome. PMID 9207459. Variant matches BMA variant_qualifier (BCL2 high expression
-    by IHC). EID407 (reg_e@[IGH]::BCL2 rearrangement) deliberately excluded — BMA
-    variant_qualifier explicitly excludes rearrangement.'
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID407
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'ESCAT IIIB. Distinct from HGBL-DH which requires FISH-confirmed rearrangement.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_fl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_expression_fl.yaml
@@ -31,24 +31,22 @@ evidence_sources:
   - EID5992
   direction: Supports
   significance: Poor Outcome
-  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence (Prognostic) without
-    therapy-specific annotation. PMID 25452615.'
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
 - source: SRC-CIVIC
   level: C
   evidence_ids:
   - EID8375
   direction: Supports
   significance: Resistance
-  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence (Predictive) for
-    therapies: Venetoclax. Variant F104I. PMID 31234236.'
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Venetoclax.'
 - source: SRC-CIVIC
   level: D
   evidence_ids:
   - EID8376
   direction: Supports
   significance: Resistance
-  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence (Predictive) for
-    therapies: Venetoclax. Variant F104I. PMID 31234236.'
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Venetoclax.'
 actionability_review_required: true
 notes: 'ESCAT IIIA. Disease-defining IHC.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_rearrangement_dlbcl_nos.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_rearrangement_dlbcl_nos.yaml
@@ -25,7 +25,23 @@ contraindicated_monotherapy: []
 primary_sources:
 - SRC-NCCN-BCELL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID423
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID407
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'ESCAT IIIB. Distinct entity from HGBL-DH (which requires concurrent MYC-R).
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_rearrangement_fl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_bcl2_rearrangement_fl.yaml
@@ -33,7 +33,29 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-FL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID5992
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID8375
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Venetoclax.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID8376
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Venetoclax.'
 actionability_review_required: true
 notes: 'ESCAT IIIA. BCL2-R does not currently select frontline regimen — diagnostic/lineage
   marker.

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_calr_et.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_calr_et.yaml
@@ -39,7 +39,23 @@ primary_sources:
 - SRC-ESMO-MPN-2015
 - SRC-PT1-HARRISON-2005
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID6382
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1482
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Peginterferon Alfa-2a.'
 actionability_review_required: true
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_calr_pmf.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_calr_pmf.yaml
@@ -53,7 +53,23 @@ primary_sources:
 - SRC-MOMENTUM-VERSTOVSEK-2023
 - SRC-DIPSS-PLUS-GANGAT-2011
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID1387
+  direction: Supports
+  significance: Better Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1649
+  direction: Supports
+  significance: Better Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_ccnd1_ihc_mcl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_ccnd1_ihc_mcl.yaml
@@ -27,7 +27,31 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-MCL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1536
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Palbociclib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID358
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID1563
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Palbociclib.'
 actionability_review_required: true
 notes: 'ESCAT IA — disease-defining diagnostic.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_ccnd1_t1114_mcl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_ccnd1_t1114_mcl.yaml
@@ -40,7 +40,31 @@ primary_sources:
 - SRC-NCCN-BCELL-2025
 - SRC-ESMO-MCL-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1536
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Palbociclib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID358
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID1563
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Palbociclib.'
 actionability_review_required: true
 notes: 'ESCAT IA. Disease-defining; doesn''t ''select'' BTKi but the DIS-MCL algorithm
   is BTKi-centric.

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_chek2_germline_prostate.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_chek2_germline_prostate.yaml
@@ -30,7 +30,32 @@ primary_sources:
 - SRC-ESMO-PROSTATE-2024
 - SRC-EAU-PROSTATE-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID11205
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Olaparib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1854
+  direction: Does Not Support
+  significance: Predisposition
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Predisposition evidence without
+    therapy-specific annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1850
+  - EID1852
+  direction: Supports
+  significance: Predisposition
+  note: 'CIViC snapshot 2026-04-25: Supports Predisposition evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Cascade testing mandatory. CHEK2 carriers face elevated breast cancer risk
   in relatives.

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_ezh2_y641_fl.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_ezh2_y641_fl.yaml
@@ -46,41 +46,16 @@ evidence_sources:
   - EID9709
   direction: Supports
   significance: Sensitivity/Response
-  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence (Predictive)
-    for therapies: Tazemetostat. Variant: Activating Mutation, FL. Level A. PMID 33035457.'
-- source: SRC-CIVIC
-  level: B
-  evidence_ids:
-  - EID11109
-  direction: Supports
-  significance: Sensitivity/Response
-  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence (Predictive)
-    for therapies: Tazemetostat. Variant: Y646S/F/H/C/N OR EZH2 A692V OR EZH2 A682G,
-    FL. Level B. PMID 34159682. (CIViC Y646 = transcript-isoform of canonical Y641.)'
-- source: SRC-CIVIC
-  level: C
-  evidence_ids:
-  - EID11107
-  direction: Supports
-  significance: Sensitivity/Response
-  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence (Predictive)
-    for therapies: Tazemetostat. Variant: Activating Mutation, FL. Level C. PMID 33492746.'
-- source: SRC-CIVIC
-  level: B
-  evidence_ids:
-  - EID433
-  direction: Supports
-  significance: Positive
-  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence (Diagnostic). Variant
-    Y646, FL. Level B. PMID 20081860.'
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Tazemetostat.'
 - source: SRC-CIVIC
   level: B
   evidence_ids:
   - EID1015
   direction: Supports
   significance: Better Outcome
-  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence (Prognostic)
-    without therapy-specific annotation. Variant Mutation, FL. Level B. PMID 26256760.'
+  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence without therapy-specific
+    annotation.'
 - source: SRC-CIVIC
   level: B
   evidence_ids:
@@ -88,16 +63,40 @@ evidence_sources:
   - EID12876
   direction: Supports
   significance: Oncogenicity
-  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence (Oncogenic). Variants
-    Y646S/F/H/C/N OR A692V OR A682G; A682G. Level B. PMIDs 24052547.'
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID433
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID11109
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Tazemetostat.'
 - source: SRC-CIVIC
   level: C
   evidence_ids:
   - EID12875
   direction: Supports
   significance: Oncogenicity
-  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence (Oncogenic). Variant
-    A682G, FL. Level C. PMID 32668764.'
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID11107
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Tazemetostat.'
 actionability_review_required: true
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_kit_exon11_gist.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_kit_exon11_gist.yaml
@@ -35,7 +35,185 @@ primary_sources:
 - SRC-IRIS-OBRIEN-2003
 - SRC-NCCN-MELANOMA-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID654
+  - EID1221
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID53
+  - EID333
+  direction: Does Not Support
+  significance: N/A
+  note: 'CIViC snapshot 2026-04-25: Does Not Support N/A evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID70
+  - EID376
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID225
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID2477
+  - EID4139
+  direction: Supports
+  significance: Reduced Sensitivity
+  note: 'CIViC snapshot 2026-04-25: Supports Reduced Sensitivity evidence for therapies:
+    Imatinib, Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID4072
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Sunitinib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID304
+  - EID1223
+  - EID1424
+  - EID2466
+  - EID2471
+  - EID2480
+  - EID4144
+  - EID4599
+  - EID4628
+  - EID4629
+  - EID6377
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID7289
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2441
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID4104
+  direction: Supports
+  significance: Reduced Sensitivity
+  note: 'CIViC snapshot 2026-04-25: Supports Reduced Sensitivity evidence for therapies:
+    Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2918
+  - EID2919
+  - EID2920
+  - EID2921
+  - EID2922
+  - EID2923
+  - EID2924
+  - EID4062
+  - EID4082
+  - EID4095
+  - EID4122
+  - EID4136
+  - EID4142
+  - EID7288
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2417
+  - EID2465
+  - EID2475
+  - EID3028
+  - EID4589
+  - EID4595
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID4167
+  - EID7401
+  - EID7413
+  - EID7417
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Ponatinib, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID4455
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib, Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID249
+  - EID4510
+  - EID4631
+  - EID7414
+  - EID7415
+  - EID7416
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID919
+  - EID4061
+  - EID4084
+  - EID4087
+  - EID4125
+  - EID4127
+  - EID4459
+  - EID4583
+  - EID4594
+  - EID7393
+  - EID7395
+  - EID7397
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Pictilisib, Ponatinib, Regorafenib Anhydrous, Sunitinib.'
 actionability_review_required: true
 notes: 'ESCAT IA. OncoKB Level 1. Source-gap: SRC-NCCN-SARCOMA / SRC-NCCN-GIST-2025
   / SRC-B2222-DEMETRI / SRC-EORTC-62005 / SRC-SSG-XVIII not yet ingested — using SRC-NCCN-MELANOMA-2025

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_kit_exon13_17_gist.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_kit_exon13_17_gist.yaml
@@ -37,7 +37,185 @@ contraindicated_monotherapy:
 primary_sources:
 - SRC-NCCN-MELANOMA-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID654
+  - EID1221
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID53
+  - EID333
+  direction: Does Not Support
+  significance: N/A
+  note: 'CIViC snapshot 2026-04-25: Does Not Support N/A evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID70
+  - EID376
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID225
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID2477
+  - EID4139
+  direction: Supports
+  significance: Reduced Sensitivity
+  note: 'CIViC snapshot 2026-04-25: Supports Reduced Sensitivity evidence for therapies:
+    Imatinib, Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID4072
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Sunitinib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID304
+  - EID1223
+  - EID1424
+  - EID2466
+  - EID2471
+  - EID2480
+  - EID4144
+  - EID4599
+  - EID4628
+  - EID4629
+  - EID6377
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID7289
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2441
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID4104
+  direction: Supports
+  significance: Reduced Sensitivity
+  note: 'CIViC snapshot 2026-04-25: Supports Reduced Sensitivity evidence for therapies:
+    Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2918
+  - EID2919
+  - EID2920
+  - EID2921
+  - EID2922
+  - EID2923
+  - EID2924
+  - EID4062
+  - EID4082
+  - EID4095
+  - EID4122
+  - EID4136
+  - EID4142
+  - EID7288
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2417
+  - EID2465
+  - EID2475
+  - EID3028
+  - EID4589
+  - EID4595
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID4167
+  - EID7401
+  - EID7413
+  - EID7417
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Ponatinib, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID4455
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib, Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID249
+  - EID4510
+  - EID4631
+  - EID7414
+  - EID7415
+  - EID7416
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID919
+  - EID4061
+  - EID4084
+  - EID4087
+  - EID4125
+  - EID4127
+  - EID4459
+  - EID4583
+  - EID4594
+  - EID7393
+  - EID7395
+  - EID7397
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Pictilisib, Ponatinib, Regorafenib Anhydrous, Sunitinib.'
 actionability_review_required: true
 notes: 'ESCAT IIA. OncoKB Level 1 (per OncoKB therapeutic levels for the approved
   sequenced TKI flow). Source-gap as DIS-GIST. ctDNA / repeat biopsy can guide TKI

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_kit_exon9_gist.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_kit_exon9_gist.yaml
@@ -32,7 +32,185 @@ primary_sources:
 - SRC-IRIS-OBRIEN-2003
 - SRC-NCCN-MELANOMA-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID654
+  - EID1221
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID53
+  - EID333
+  direction: Does Not Support
+  significance: N/A
+  note: 'CIViC snapshot 2026-04-25: Does Not Support N/A evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID70
+  - EID376
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID225
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID2477
+  - EID4139
+  direction: Supports
+  significance: Reduced Sensitivity
+  note: 'CIViC snapshot 2026-04-25: Supports Reduced Sensitivity evidence for therapies:
+    Imatinib, Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID4072
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Sunitinib.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID304
+  - EID1223
+  - EID1424
+  - EID2466
+  - EID2471
+  - EID2480
+  - EID4144
+  - EID4599
+  - EID4628
+  - EID4629
+  - EID6377
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID7289
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2441
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID4104
+  direction: Supports
+  significance: Reduced Sensitivity
+  note: 'CIViC snapshot 2026-04-25: Supports Reduced Sensitivity evidence for therapies:
+    Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2918
+  - EID2919
+  - EID2920
+  - EID2921
+  - EID2922
+  - EID2923
+  - EID2924
+  - EID4062
+  - EID4082
+  - EID4095
+  - EID4122
+  - EID4136
+  - EID4142
+  - EID7288
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2417
+  - EID2465
+  - EID2475
+  - EID3028
+  - EID4589
+  - EID4595
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Regorafenib Anhydrous.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID4167
+  - EID7401
+  - EID7413
+  - EID7417
+  direction: Does Not Support
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Resistance evidence for therapies:
+    Ponatinib, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID4455
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib, Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID249
+  - EID4510
+  - EID4631
+  - EID7414
+  - EID7415
+  - EID7416
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Regorafenib Anhydrous, Sunitinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID919
+  - EID4061
+  - EID4084
+  - EID4087
+  - EID4125
+  - EID4127
+  - EID4459
+  - EID4583
+  - EID4594
+  - EID7393
+  - EID7395
+  - EID7397
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib, Pictilisib, Ponatinib, Regorafenib Anhydrous, Sunitinib.'
 actionability_review_required: true
 notes: 'ESCAT IB. OncoKB Level 1. Source-gap as DIS-GIST. Adjuvant strategy in high-risk
   resected exon-9 GIST less established — extended- duration imatinib often considered.

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_met_amp_rcc_papillary.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_met_amp_rcc_papillary.yaml
@@ -35,7 +35,15 @@ primary_sources:
 - SRC-NCCN-KIDNEY-2025
 - SRC-ESMO-RCC-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID796
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Foretinib.'
 actionability_review_required: true
 notes: 'ESCAT IIA. OncoKB Level 2. Note: DIS-RCC is the umbrella entity (no separate
   DIS-RCC-PAPILLARY); papillary type-1 distinction is captured in variant_qualifier

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_met_ex14_nsclc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_met_ex14_nsclc.yaml
@@ -34,7 +34,30 @@ primary_sources:
 - SRC-NCCN-NSCLC-2025
 - SRC-ESMO-NSCLC-METASTATIC-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1392
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Erlotinib,
+    Gefitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID797
+  - EID836
+  - EID890
+  - EID1185
+  - EID1186
+  - EID1651
+  - EID1692
+  - EID4786
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Capmatinib, Crizotinib.'
 actionability_review_required: true
 notes: 'ESCAT IA. OncoKB Level 1. Detection: RNA-NGS preferred (DNA panels may miss
   splice-site variants in deep intronic regions). Trial-source gap: SRC-GEOMETRY-MONO-1

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mgmt_methylation_gbm.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mgmt_methylation_gbm.yaml
@@ -51,7 +51,43 @@ primary_sources:
 - SRC-NCCN-CNS-2025
 - SRC-EANO-GBM-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID307
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Temozolomide.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID172
+  - EID491
+  direction: Supports
+  significance: Better Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID308
+  - EID822
+  - EID2899
+  - EID2903
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Carmustine, Temozolomide.'
+- source: SRC-CIVIC
+  level: E
+  evidence_ids:
+  - EID309
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    O6-Benzylguanine.'
 actionability_review_required: true
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_somatic_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_somatic_crc.yaml
@@ -43,7 +43,35 @@ primary_sources:
 - SRC-NCCN-COLON-2025
 - SRC-ESMO-COLON-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1791
+  - EID1794
+  - EID1796
+  - EID1798
+  - EID1804
+  - EID1806
+  - EID1807
+  - EID1808
+  - EID1810
+  - EID1811
+  - EID1813
+  - EID1814
+  - EID1815
+  - EID1816
+  - EID1817
+  - EID1818
+  - EID1820
+  - EID1821
+  - EID1822
+  - EID1823
+  - EID1824
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic MLH1 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_somatic_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_somatic_endometrial.yaml
@@ -40,7 +40,17 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1788
+  - EID1793
+  - EID1833
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic MLH1 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_somatic_gastric.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_mlh1_somatic_gastric.yaml
@@ -37,7 +37,22 @@ primary_sources:
 - SRC-NCCN-GASTRIC-2025
 - SRC-ESMO-GASTRIC-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1680
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID1315
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Oxaliplatin.'
 actionability_review_required: true
 notes: 'Somatic MLH1 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_germline_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_germline_crc.yaml
@@ -43,7 +43,17 @@ primary_sources:
 - SRC-NCCN-COLON-2025
 - SRC-ESMO-COLON-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1826
+  - EID1827
+  - EID1834
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline MSH2 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_germline_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_germline_endometrial.yaml
@@ -40,7 +40,16 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1790
+  - EID1837
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline MSH2 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_somatic_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_somatic_crc.yaml
@@ -43,7 +43,17 @@ primary_sources:
 - SRC-NCCN-COLON-2025
 - SRC-ESMO-COLON-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1826
+  - EID1827
+  - EID1834
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic MSH2 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_somatic_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh2_somatic_endometrial.yaml
@@ -40,7 +40,16 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1790
+  - EID1837
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic MSH2 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_crc.yaml
@@ -53,11 +53,8 @@ evidence_sources:
   - EID1840
   direction: Supports
   significance: Oncogenicity
-  note: 'CIViC snapshot 2026-04-25: 4 MSH6 LOF / frameshift point mutations in CRC
-    (P138T, I891FS, R1242H, R1242C), Oncogenic, Supports Oncogenicity. PMID 25111426
-    (shared citation). Each is a concrete LOF example consistent with the BMA variant_qualifier
-    (MSH6 germline loss-of-function). MSH6 LOSS in transitional cell carcinoma (EID1878)
-    excluded — off-disease (urothelial, not CRC).'
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline MSH6 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_germline_endometrial.yaml
@@ -47,13 +47,8 @@ evidence_sources:
   - EID1839
   direction: Supports
   significance: Oncogenicity
-  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence (Oncogenic). Variant
-    V352I, Endometrial Cancer. Level C. PMID 25111426. Note: this CIViC item attests
-    oncogenicity of an MSH6 missense variant in endometrial cancer; it is not a direct
-    therapy-prediction citation. The clinical actionability of MSH6 germline LoF in
-    endometrial (ICI eligibility via dMMR/MSI-H) is anchored on guideline sources
-    (NCCN-UTERINE-2025, ESGO-ENDOMETRIAL-2025) and tissue-agnostic FDA label, not
-    on CIViC.'
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline MSH6 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_somatic_crc.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_somatic_crc.yaml
@@ -43,7 +43,18 @@ primary_sources:
 - SRC-NCCN-COLON-2025
 - SRC-ESMO-COLON-2024
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1825
+  - EID1829
+  - EID1831
+  - EID1840
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic MSH6 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_somatic_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_msh6_somatic_endometrial.yaml
@@ -40,7 +40,15 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1839
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic MSH6 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_npm1_aml.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_npm1_aml.yaml
@@ -53,7 +53,112 @@ primary_sources:
 - SRC-QUAZAR-WEI-2020
 - SRC-VIALE-A-DINARDO-2020
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: A
+  evidence_ids:
+  - EID116
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID109
+  - EID1369
+  direction: Does Not Support
+  significance: Better Outcome
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Better Outcome evidence without
+    therapy-specific annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID137
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Tretinoin.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID173
+  - EID174
+  - EID175
+  - EID176
+  - EID177
+  - EID179
+  - EID180
+  - EID181
+  - EID182
+  - EID183
+  - EID184
+  - EID185
+  direction: Supports
+  significance: Better Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Better Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID111
+  direction: Supports
+  significance: Negative
+  note: 'CIViC snapshot 2026-04-25: Supports Negative evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID196
+  - EID199
+  - EID1102
+  direction: Supports
+  significance: Poor Outcome
+  note: 'CIViC snapshot 2026-04-25: Supports Poor Outcome evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID108
+  - EID117
+  - EID118
+  - EID119
+  - EID120
+  - EID12494
+  - EID12495
+  direction: Supports
+  significance: Positive
+  note: 'CIViC snapshot 2026-04-25: Supports Positive evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID146
+  - EID147
+  - EID148
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Daunorubicin, Tretinoin, Valproic Acid.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID149
+  - EID152
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    NSC348884, Tretinoin.'
+- source: SRC-CIVIC
+  level: E
+  evidence_ids:
+  - EID150
+  - EID151
+  - EID153
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Anti-CD123, Anti-CD33, Cytarabine, Daunorubicin, Etoposide.'
 actionability_review_required: true
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_pdgfra_exon12_gist.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_pdgfra_exon12_gist.yaml
@@ -31,6 +31,40 @@ primary_sources:
 last_verified: '2026-04-27'
 evidence_sources:
 - source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID2
+  direction: Supports
+  significance: Negative
+  note: 'CIViC snapshot 2026-04-25: Supports Negative evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID15
+  - EID16
+  - EID738
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2486
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2478
+  - EID4597
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Sunitinib.'
+- source: SRC-CIVIC
   level: C
   evidence_ids:
   - EID2474
@@ -42,11 +76,24 @@ evidence_sources:
 - source: SRC-CIVIC
   level: D
   evidence_ids:
+  - EID651
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID43
+  - EID44
+  - EID45
+  - EID46
+  - EID47
   - EID652
+  - EID1309
   direction: Supports
   significance: Sensitivity/Response
   note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
-    Imatinib.'
+    Crenolanib, Imatinib.'
 actionability_review_required: true
 notes: 'ESCAT IB. OncoKB Level 1. Source-gap as DIS-GIST.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_pdgfra_exon14_gist.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_pdgfra_exon14_gist.yaml
@@ -30,7 +30,71 @@ primary_sources:
 - SRC-IRIS-OBRIEN-2003
 - SRC-NCCN-MELANOMA-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID2
+  direction: Supports
+  significance: Negative
+  note: 'CIViC snapshot 2026-04-25: Supports Negative evidence without therapy-specific
+    annotation.'
+- source: SRC-CIVIC
+  level: B
+  evidence_ids:
+  - EID15
+  - EID16
+  - EID738
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2486
+  direction: Does Not Support
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Does Not Support Sensitivity/Response evidence
+    for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2478
+  - EID4597
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib,
+    Sunitinib.'
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID2474
+  - EID2487
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Imatinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID651
+  direction: Supports
+  significance: Resistance
+  note: 'CIViC snapshot 2026-04-25: Supports Resistance evidence for therapies: Imatinib.'
+- source: SRC-CIVIC
+  level: D
+  evidence_ids:
+  - EID43
+  - EID44
+  - EID45
+  - EID46
+  - EID47
+  - EID652
+  - EID1309
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'CIViC snapshot 2026-04-25: Supports Sensitivity/Response evidence for therapies:
+    Crenolanib, Imatinib.'
 actionability_review_required: true
 notes: 'ESCAT IB. OncoKB Level 1. Source-gap as DIS-GIST.
 

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_pms2_germline_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_pms2_germline_endometrial.yaml
@@ -40,7 +40,15 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1832
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Germline PMS2 loss → cascade testing mandatory (Lynch syndrome). Family meets
   Amsterdam/Bethesda criteria. Pan-tumor MSI-H ICI eligibility supersedes tumor- specific

--- a/knowledge_base/hosted/content/biomarker_actionability/bma_pms2_somatic_endometrial.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_pms2_somatic_endometrial.yaml
@@ -40,7 +40,15 @@ primary_sources:
 - SRC-NCCN-UTERINE-2025
 - SRC-ESGO-ENDOMETRIAL-2025
 last_verified: '2026-04-27'
-evidence_sources: []
+evidence_sources:
+- source: SRC-CIVIC
+  level: C
+  evidence_ids:
+  - EID1832
+  direction: Supports
+  significance: Oncogenicity
+  note: 'CIViC snapshot 2026-04-25: Supports Oncogenicity evidence without therapy-specific
+    annotation.'
 actionability_review_required: true
 notes: 'Somatic PMS2 loss → cascade testing optional (reflex germline confirmation
   strongly recommended; ~30% of dMMR tumors have germline cause). Pan-tumor MSI-H

--- a/knowledge_base/hosted/content/sources/src_aasld_hcc_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_aasld_hcc_2023.yaml
@@ -2,39 +2,47 @@ id: SRC-AASLD-HCC-2023
 source_type: guideline
 title: AASLD Practice Guidance on HCC
 version: '2023'
-authors: [American Association for the Study of Liver Diseases]
+authors:
+- American Association for the Study of Liver Diseases
 journal: Hepatology
 url: https://aasld.org/practice-guidelines
 access_level: open_access
 currency_status: current
-current_as_of: '2023-11-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
-ingestion: {method: none}
-license: {name: AASLD reuse policy (academic-only)}
-attribution: {required: true, text: 'AASLD HCC Guidance, Hepatology 2023'}
+ingestion:
+  method: none
+license:
+  name: AASLD reuse policy (academic-only)
+attribution:
+  required: true
+  text: AASLD HCC Guidance, Hepatology 2023
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-legal_review: {status: pending, notes: 'AASLD permission for derivative use to be confirmed'}
-relates_to_diseases: [DIS-HCC]
+legal_review:
+  status: pending
+  notes: AASLD permission for derivative use to be confirmed
+relates_to_diseases:
+- DIS-HCC
 last_verified: '2026-04-27'
-notes: >
-  Hepatology-side authority on HCC.
-  Freshness check 2026-04-27: the 2023 AASLD HCC Practice Guidance
-  (Singal et al, Hepatology) remains the current full document. AASLD
-  published a 2025 Critical Update (Taddei TH, Brown DB, Yarchoan M,
-  Mendiratta-Lala M, Llovet JM. Hepatology 2025 Jul;82(1):272-274;
-  doi 10.1097/HEP.0000000000001269; PMID 39992051) that supersedes ONLY
-  the adjuvant-systemic-therapy section: based on updated IMbrave050
-  recurrence-free-survival analysis, adjuvant atezolizumab + bevacizumab
-  is NO LONGER recommended after resection / ablation in high-risk HCC
-  (close monitoring remains the standard). All other 2023 recommendations
-  (surveillance, locoregional therapy, 1L systemic therapy for advanced
-  disease) remain in force. Dependent indication entries that recommend
-  adjuvant atezo+bev citing this 2023 source are flagged for clinical
-  review.
+notes: 'Hepatology-side authority on HCC. Freshness check 2026-04-27: the 2023 AASLD
+  HCC Practice Guidance (Singal et al, Hepatology) remains the current full document.
+  AASLD published a 2025 Critical Update (Taddei TH, Brown DB, Yarchoan M, Mendiratta-Lala
+  M, Llovet JM. Hepatology 2025 Jul;82(1):272-274; doi 10.1097/HEP.0000000000001269;
+  PMID 39992051) that supersedes ONLY the adjuvant-systemic-therapy section: based
+  on updated IMbrave050 recurrence-free-survival analysis, adjuvant atezolizumab +
+  bevacizumab is NO LONGER recommended after resection / ablation in high-risk HCC
+  (close monitoring remains the standard). All other 2023 recommendations (surveillance,
+  locoregional therapy, 1L systemic therapy for advanced disease) remain in force.
+  Dependent indication entries that recommend adjuvant atezo+bev citing this 2023
+  source are flagged for clinical review.
+
+  '
 pages_count: 80
 references_count: 480
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_adaura_wu_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_adaura_wu_2020.yaml
@@ -1,19 +1,19 @@
 id: SRC-ADAURA-WU-2020
 source_type: rct_publication
-title: "Osimertinib in Resected EGFR-Mutated Non-Small-Cell Lung Cancer"
-version: "2020"
+title: Osimertinib in Resected EGFR-Mutated Non-Small-Cell Lung Cancer
+version: '2020'
 authors:
-  - Wu YL
-  - Tsuboi M
-  - He J
-  - et al.
+- Wu YL
+- Tsuboi M
+- He J
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa2027071
-pmid: "32955175"
+pmid: '32955175'
 url: https://pubmed.ncbi.nlm.nih.gov/32955175
 access_level: subscription_required
 currency_status: current
-current_as_of: "2020-10-29"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Wu et al., NEJM 2020; ADAURA trial"
+  text: Wu et al., NEJM 2020; ADAURA trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  ADAURA phase-3 (NCT02511106): adjuvant osimertinib 80 mg PO daily
-  × 3 yr vs placebo after complete resection + adjuvant chemo (per
-  investigator) for stage IB-IIIA EGFR-mutated NSCLC (n=682). 24-mo
-  DFS 89% vs 52% (HR 0.20; p<0.001) in stage II–IIIA; CNS DFS
-  HR 0.18. OS update (Tsuboi NEJM 2023): 5-yr OS 88% vs 78% (HR
-  0.49; p<0.001). Established adjuvant osimertinib as standard for
-  resected EGFR-mutant stage IB–IIIA NSCLC; basis for FDA approval
-  Dec 2020.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'ADAURA phase-3 (NCT02511106): adjuvant osimertinib 80 mg PO daily × 3 yr vs
+  placebo after complete resection + adjuvant chemo (per investigator) for stage IB-IIIA
+  EGFR-mutated NSCLC (n=682). 24-mo DFS 89% vs 52% (HR 0.20; p<0.001) in stage II–IIIA;
+  CNS DFS HR 0.18. OS update (Tsuboi NEJM 2023): 5-yr OS 88% vs 78% (HR 0.49; p<0.001).
+  Established adjuvant osimertinib as standard for resected EGFR-mutant stage IB–IIIA
+  NSCLC; basis for FDA approval Dec 2020.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_aethera_moskowitz_2015.yaml
+++ b/knowledge_base/hosted/content/sources/src_aethera_moskowitz_2015.yaml
@@ -14,7 +14,7 @@ pmid: '25796459'
 url: https://pubmed.ncbi.nlm.nih.gov/25796459
 access_level: subscription_required
 currency_status: current
-current_as_of: '2015-05-09'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -46,3 +46,5 @@ pages_count: 11
 references_count: 30
 corpus_role: rct_publication
 sharealike_required: false
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_alcyone_mateos_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_alcyone_mateos_2018.yaml
@@ -13,7 +13,7 @@ pmid: '29231133'
 url: https://pubmed.ncbi.nlm.nih.gov/29231133
 access_level: subscription_required
 currency_status: current
-current_as_of: '2026-05-01'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -42,5 +42,5 @@ notes: 'ALCYONE phase-3 (NCT02195479): daratumumab + bortezomib + melphalan + pr
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
-last_recency_check: '2026-05-01'
+last_recency_check: '2026-04-29'
 recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_alex_peters_2017.yaml
+++ b/knowledge_base/hosted/content/sources/src_alex_peters_2017.yaml
@@ -1,19 +1,19 @@
 id: SRC-ALEX-PETERS-2017
 source_type: rct_publication
-title: "Alectinib versus Crizotinib in Untreated ALK-Positive Non-Small-Cell Lung Cancer"
-version: "2017"
+title: Alectinib versus Crizotinib in Untreated ALK-Positive Non-Small-Cell Lung Cancer
+version: '2017'
 authors:
-  - Peters S
-  - Camidge DR
-  - Shaw AT
-  - et al.
+- Peters S
+- Camidge DR
+- Shaw AT
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1704795
-pmid: "28586279"
+pmid: '28586279'
 url: https://pubmed.ncbi.nlm.nih.gov/28586279
 access_level: subscription_required
 currency_status: current
-current_as_of: "2017-08-31"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Peters et al., NEJM 2017; ALEX trial"
+  text: Peters et al., NEJM 2017; ALEX trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  ALEX phase-3 (NCT02075840): alectinib 600 mg PO BID vs crizotinib
-  250 mg PO BID in treatment-naive ALK-positive advanced NSCLC
-  (n=303). 12-month investigator-assessed PFS 68.4% vs 48.7%
-  (HR 0.47; p<0.001); median PFS 34.8 vs 10.9 mo (final analysis,
-  Mok 2020 Ann Oncol). CNS progression markedly reduced (12-mo CNS
-  progression 9.4% vs 41.4%; HR 0.16). Established alectinib as 1L
-  ALK-TKI of choice; basis for FDA approval Nov 2017.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'ALEX phase-3 (NCT02075840): alectinib 600 mg PO BID vs crizotinib 250 mg PO
+  BID in treatment-naive ALK-positive advanced NSCLC (n=303). 12-month investigator-assessed
+  PFS 68.4% vs 48.7% (HR 0.47; p<0.001); median PFS 34.8 vs 10.9 mo (final analysis,
+  Mok 2020 Ann Oncol). CNS progression markedly reduced (12-mo CNS progression 9.4%
+  vs 41.4%; HR 0.16). Established alectinib as 1L ALK-TKI of choice; basis for FDA
+  approval Nov 2017.
+
+  '
 pages_count: 12
 references_count: 32
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_aphinity_vonminckwitz_2017.yaml
+++ b/knowledge_base/hosted/content/sources/src_aphinity_vonminckwitz_2017.yaml
@@ -1,19 +1,19 @@
 id: SRC-APHINITY-VONMINCKWITZ-2017
 source_type: rct_publication
-title: "Adjuvant Pertuzumab and Trastuzumab in Early HER2-Positive Breast Cancer"
-version: "2017"
+title: Adjuvant Pertuzumab and Trastuzumab in Early HER2-Positive Breast Cancer
+version: '2017'
 authors:
-  - von Minckwitz G
-  - Procter M
-  - de Azambuja E
-  - et al.
+- von Minckwitz G
+- Procter M
+- de Azambuja E
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1703643
-pmid: "28581356"
+pmid: '28581356'
 url: https://pubmed.ncbi.nlm.nih.gov/28581356
 access_level: subscription_required
 currency_status: current
-current_as_of: "2017-07-13"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,26 +22,27 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "von Minckwitz et al., NEJM 2017; APHINITY trial"
+  text: von Minckwitz et al., NEJM 2017; APHINITY trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-BREAST
-last_verified: "2026-04-27"
-notes: >
-  APHINITY phase-3 (NCT01358877): adjuvant pertuzumab + trastuzumab
-  + chemo vs placebo + trastuzumab + chemo for 1 year in HER2+
-  early breast cancer (n=4805). 3-yr iDFS 94.1% vs 93.2% (HR 0.81;
-  p=0.045); benefit concentrated in node-positive disease (3-yr
-  iDFS 92.0% vs 90.2%; HR 0.77). OS update (Loibl Ann Oncol 2023):
-  10-yr OS 91.6% vs 90.5% (HR 0.83; not significant). Established
-  P+H+chemo adjuvant for high-risk HER2+ EBC; basis for FDA
-  approval Dec 2017. NOTE: task brief listed PMID 30605283 — that
-  PMID is the 6-yr update; primary PMID is 28581356 (verified).
+- DIS-BREAST
+last_verified: '2026-04-27'
+notes: 'APHINITY phase-3 (NCT01358877): adjuvant pertuzumab + trastuzumab + chemo
+  vs placebo + trastuzumab + chemo for 1 year in HER2+ early breast cancer (n=4805).
+  3-yr iDFS 94.1% vs 93.2% (HR 0.81; p=0.045); benefit concentrated in node-positive
+  disease (3-yr iDFS 92.0% vs 90.2%; HR 0.77). OS update (Loibl Ann Oncol 2023): 10-yr
+  OS 91.6% vs 90.5% (HR 0.83; not significant). Established P+H+chemo adjuvant for
+  high-risk HER2+ EBC; basis for FDA approval Dec 2017. NOTE: task brief listed PMID
+  30605283 — that PMID is the 6-yr update; primary PMID is 28581356 (verified).
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_apl_relapse_lengfelder_2017.yaml
+++ b/knowledge_base/hosted/content/sources/src_apl_relapse_lengfelder_2017.yaml
@@ -1,19 +1,20 @@
 id: SRC-APL-RELAPSE-LENGFELDER-2017
 source_type: rct_publication
-title: "Outcomes of patients with relapsed acute promyelocytic leukemia treated with all-trans retinoic acid + arsenic trioxide salvage regimens"
-version: "2017"
+title: Outcomes of patients with relapsed acute promyelocytic leukemia treated with
+  all-trans retinoic acid + arsenic trioxide salvage regimens
+version: '2017'
 authors:
-  - Lengfelder E
-  - Lo-Coco F
-  - Ades L
-  - et al.
+- Lengfelder E
+- Lo-Coco F
+- Ades L
+- et al.
 journal: Leukemia
 doi: 10.1038/leu.2016.282
-pmid: "27818551"
+pmid: '27818551'
 url: https://www.nature.com/articles/leu2016282
 access_level: subscription_required
 currency_status: current
-current_as_of: "2017-03-01"
+current_as_of: '2026-04-29'
 evidence_tier: 3
 hosting_mode: referenced
 ingestion:
@@ -28,18 +29,20 @@ redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-25"
+  date: '2026-04-25'
 relates_to_diseases:
-  - DIS-APL
+- DIS-APL
 last_verified: '2026-04-27'
-notes: >
-  Multi-center retrospective registry of relapsed APL salvage
-  outcomes — ATRA + ATO ± gemtuzumab ± autoSCT. CR rates ~85-95%;
-  long-term outcomes substantially better with autoSCT
-  consolidation in molecularly-CR responders (~80% 5-y OS) vs
-  ATRA + ATO maintenance alone (~60% 5-y OS). Established the
-  modern salvage pathway: ATRA + ATO induction → autoSCT for
-  molecular-CR responders OR alloHCT for non-CR / very-high-risk.
+notes: 'Multi-center retrospective registry of relapsed APL salvage outcomes — ATRA
+  + ATO ± gemtuzumab ± autoSCT. CR rates ~85-95%; long-term outcomes substantially
+  better with autoSCT consolidation in molecularly-CR responders (~80% 5-y OS) vs
+  ATRA + ATO maintenance alone (~60% 5-y OS). Established the modern salvage pathway:
+  ATRA + ATO induction → autoSCT for molecular-CR responders OR alloHCT for non-CR
+  / very-high-risk.
+
+  '
 pages_count: 12
 references_count: 40
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_ascend_ghia_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_ascend_ghia_2020.yaml
@@ -1,19 +1,21 @@
 id: SRC-ASCEND-GHIA-2020
 source_type: rct_publication
-title: "ASCEND: Phase III, Randomized Trial of Acalabrutinib Versus Idelalisib Plus Rituximab or Bendamustine Plus Rituximab in Relapsed or Refractory Chronic Lymphocytic Leukemia"
-version: "2020"
+title: 'ASCEND: Phase III, Randomized Trial of Acalabrutinib Versus Idelalisib Plus
+  Rituximab or Bendamustine Plus Rituximab in Relapsed or Refractory Chronic Lymphocytic
+  Leukemia'
+version: '2020'
 authors:
-  - Ghia P
-  - Pluta A
-  - Wach M
-  - et al.
+- Ghia P
+- Pluta A
+- Wach M
+- et al.
 journal: Journal of Clinical Oncology
 doi: 10.1200/JCO.19.03355
-pmid: "32302232"
+pmid: '32302232'
 url: https://pubmed.ncbi.nlm.nih.gov/32302232
 access_level: subscription_required
 currency_status: current
-current_as_of: "2020-09-01"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +24,25 @@ license:
   name: ASCO / JCO (subscription)
 attribution:
   required: true
-  text: "Ghia et al., JCO 2020; ASCEND trial"
+  text: Ghia et al., JCO 2020; ASCEND trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-CLL
-last_verified: "2026-04-27"
-notes: >
-  ASCEND phase-3 (NCT02970318): acalabrutinib mono vs investigator-
-  choice (idelalisib + rituximab OR bendamustine + rituximab) in
-  R/R CLL (n=310). 12-mo PFS 88% vs 68% (HR 0.31; p<0.0001).
-  4-yr update (Jurczak HemaSphere 2022): 4-yr PFS 62% vs 19%.
-  Established acalabrutinib as 2L+ standard for R/R CLL with
-  improved tolerability vs ibrutinib (favorable AFib / bleeding
-  profile, ELEVATE-RR head-to-head).
+- DIS-CLL
+last_verified: '2026-04-27'
+notes: 'ASCEND phase-3 (NCT02970318): acalabrutinib mono vs investigator- choice (idelalisib
+  + rituximab OR bendamustine + rituximab) in R/R CLL (n=310). 12-mo PFS 88% vs 68%
+  (HR 0.31; p<0.0001). 4-yr update (Jurczak HemaSphere 2022): 4-yr PFS 62% vs 19%.
+  Established acalabrutinib as 2L+ standard for R/R CLL with improved tolerability
+  vs ibrutinib (favorable AFib / bleeding profile, ELEVATE-RR head-to-head).
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_ata_atc_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_ata_atc_2021.yaml
@@ -33,11 +33,11 @@ sharealike_required: false
 legal_review:
   status: pending
   notes: Citation confirmed via PubMed 2026-04-28; license review pending.
-last_verified: '2026-05-01'
+last_verified: '2026-04-28'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
 notes: Citation confirmed via PubMed (PMID 33728999). Thyroid 2021;31(3):337-386.
   doi:10.1089/thy.2020.0944.
-last_recency_check: '2026-05-01'
-recency_check_status_code: 403
-url_status: blocked_by_bot_protection
+current_as_of: '2026-04-29'
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_ata_thyroid_2015.yaml
+++ b/knowledge_base/hosted/content/sources/src_ata_thyroid_2015.yaml
@@ -1,12 +1,13 @@
 id: SRC-ATA-THYROID-2015
 source_type: guideline
-title: '2015 American Thyroid Association Management Guidelines for Adult Patients with Thyroid Nodules and Differentiated Thyroid Cancer'
+title: 2015 American Thyroid Association Management Guidelines for Adult Patients
+  with Thyroid Nodules and Differentiated Thyroid Cancer
 version: '2015'
 authors:
-  - Haugen BR
-  - Alexander EK
-  - Bible KC
-  - et al.
+- Haugen BR
+- Alexander EK
+- Bible KC
+- et al.
 journal: Thyroid
 doi: 10.1089/thy.2015.0020
 pmid: '26462967'
@@ -22,7 +23,9 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: 'Haugen BR, Alexander EK, Bible KC, et al. 2015 ATA Management Guidelines for Adult Patients with Thyroid Nodules and Differentiated Thyroid Cancer. Thyroid. 2016;26(1):1-133.'
+  text: Haugen BR, Alexander EK, Bible KC, et al. 2015 ATA Management Guidelines for
+    Adult Patients with Thyroid Nodules and Differentiated Thyroid Cancer. Thyroid.
+    2016;26(1):1-133.
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
@@ -33,4 +36,7 @@ legal_review:
 last_verified: '2026-04-28'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
-notes: 'Citation confirmed via PubMed (PMID 26462967). Thyroid 2016;26(1):1-133. doi:10.1089/thy.2015.0020.'
+notes: Citation confirmed via PubMed (PMID 26462967). Thyroid 2016;26(1):1-133. doi:10.1089/thy.2015.0020.
+current_as_of: '2026-04-29'
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_aura3_mok_2017.yaml
+++ b/knowledge_base/hosted/content/sources/src_aura3_mok_2017.yaml
@@ -1,19 +1,19 @@
 id: SRC-AURA3-MOK-2017
 source_type: rct_publication
-title: "Osimertinib or Platinum-Pemetrexed in EGFR T790M-Positive Lung Cancer"
-version: "2017"
+title: Osimertinib or Platinum-Pemetrexed in EGFR T790M-Positive Lung Cancer
+version: '2017'
 authors:
-  - Mok TS
-  - Wu YL
-  - Ahn MJ
-  - et al.
+- Mok TS
+- Wu YL
+- Ahn MJ
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1612674
-pmid: "27959700"
+pmid: '27959700'
 url: https://pubmed.ncbi.nlm.nih.gov/27959700
 access_level: subscription_required
 currency_status: current
-current_as_of: "2017-02-16"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Mok et al., NEJM 2017; AURA3 trial"
+  text: Mok et al., NEJM 2017; AURA3 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  AURA3 phase-3 (NCT02151981): osimertinib 80 mg PO daily vs
-  platinum + pemetrexed in EGFR T790M-positive advanced NSCLC
-  after 1st/2nd-gen EGFR-TKI failure (n=419). Median PFS 10.1 vs
-  4.4 mo (HR 0.30; p<0.001); CNS PFS 11.7 vs 5.6 mo. Established
-  osimertinib as standard 2L for T790M-positive disease; basis
-  for FDA full approval Mar 2017. NOTE: task brief listed PMID
-  27890997 — that PMID belongs to an unrelated abstract; correct
-  primary AURA3 PMID is 27959700 (verified via PubMed).
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'AURA3 phase-3 (NCT02151981): osimertinib 80 mg PO daily vs platinum + pemetrexed
+  in EGFR T790M-positive advanced NSCLC after 1st/2nd-gen EGFR-TKI failure (n=419).
+  Median PFS 10.1 vs 4.4 mo (HR 0.30; p<0.001); CNS PFS 11.7 vs 5.6 mo. Established
+  osimertinib as standard 2L for T790M-positive disease; basis for FDA full approval
+  Mar 2017. NOTE: task brief listed PMID 27890997 — that PMID belongs to an unrelated
+  abstract; correct primary AURA3 PMID is 27959700 (verified via PubMed).
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_br21_shepherd_2005.yaml
+++ b/knowledge_base/hosted/content/sources/src_br21_shepherd_2005.yaml
@@ -1,19 +1,19 @@
 id: SRC-BR21-SHEPHERD-2005
 source_type: rct_publication
-title: "Erlotinib in Previously Treated Non-Small-Cell Lung Cancer"
-version: "2005"
+title: Erlotinib in Previously Treated Non-Small-Cell Lung Cancer
+version: '2005'
 authors:
-  - Shepherd FA
-  - Rodrigues Pereira J
-  - Ciuleanu T
-  - et al.
+- Shepherd FA
+- Rodrigues Pereira J
+- Ciuleanu T
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa050753
-pmid: "16014883"
+pmid: '16014883'
 url: https://pubmed.ncbi.nlm.nih.gov/16014883
 access_level: subscription_required
 currency_status: current
-current_as_of: "2005-07-14"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Shepherd et al., NEJM 2005; NCIC CTG BR.21 trial"
+  text: Shepherd et al., NEJM 2005; NCIC CTG BR.21 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  NCIC CTG BR.21 phase-3 (NCT00036647): erlotinib 150 mg PO daily
-  vs placebo as 2L/3L in advanced NSCLC after platinum failure
-  (n=731, EGFR-unselected). Median OS 6.7 vs 4.7 mo (HR 0.70;
-  p<0.001); ORR 8.9% vs <1%. Defined erlotinib as standard salvage
-  in EGFR-WT/unknown NSCLC pre-IO era; basis for FDA approval Nov
-  2004. Historical reference for EGFR-TKI activity; superseded by
-  IO/chemo for EGFR-WT NSCLC, retained for EGFR-mutant 2L+ context.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'NCIC CTG BR.21 phase-3 (NCT00036647): erlotinib 150 mg PO daily vs placebo
+  as 2L/3L in advanced NSCLC after platinum failure (n=731, EGFR-unselected). Median
+  OS 6.7 vs 4.7 mo (HR 0.70; p<0.001); ORR 8.9% vs <1%. Defined erlotinib as standard
+  salvage in EGFR-WT/unknown NSCLC pre-IO era; basis for FDA approval Nov 2004. Historical
+  reference for EGFR-TKI activity; superseded by IO/chemo for EGFR-WT NSCLC, retained
+  for EGFR-mutant 2L+ context.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_break3_hauschild_2012.yaml
+++ b/knowledge_base/hosted/content/sources/src_break3_hauschild_2012.yaml
@@ -1,19 +1,20 @@
 id: SRC-BREAK-3-HAUSCHILD-2012
 source_type: rct_publication
-title: "Dabrafenib in BRAF-mutated metastatic melanoma: a multicentre, open-label, phase 3 randomised controlled trial (BREAK-3)"
-version: "2012"
+title: 'Dabrafenib in BRAF-mutated metastatic melanoma: a multicentre, open-label,
+  phase 3 randomised controlled trial (BREAK-3)'
+version: '2012'
 authors:
-  - Hauschild A
-  - Grob JJ
-  - Demidov LV
-  - et al.
+- Hauschild A
+- Grob JJ
+- Demidov LV
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(12)60868-X
-pmid: "22735384"
+pmid: '22735384'
 url: https://pubmed.ncbi.nlm.nih.gov/22735384
 access_level: subscription_required
 currency_status: current
-current_as_of: "2012-07-28"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +23,25 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Hauschild et al., Lancet 2012; BREAK-3 trial"
+  text: Hauschild et al., Lancet 2012; BREAK-3 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MELANOMA
-last_verified: "2026-04-27"
-notes: >
-  BREAK-3 phase-3 (NCT01227889): dabrafenib 150 mg PO BID vs
-  dacarbazine in 1L BRAF V600E-mutant metastatic melanoma (n=250).
-  Median PFS 5.1 vs 2.7 mo (HR 0.30; p<0.0001); ORR 50% vs 6%.
-  Established dabrafenib as second BRAFi mono option after
-  vemurafenib; FDA approval May 2013. Superseded by BRAFi+MEKi
-  combos but retained as historical / sequencing reference.
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: 'BREAK-3 phase-3 (NCT01227889): dabrafenib 150 mg PO BID vs dacarbazine in
+  1L BRAF V600E-mutant metastatic melanoma (n=250). Median PFS 5.1 vs 2.7 mo (HR 0.30;
+  p<0.0001); ORR 50% vs 6%. Established dabrafenib as second BRAFi mono option after
+  vemurafenib; FDA approval May 2013. Superseded by BRAFi+MEKi combos but retained
+  as historical / sequencing reference.
+
+  '
 pages_count: 11
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_brf113928_planchard_2016.yaml
+++ b/knowledge_base/hosted/content/sources/src_brf113928_planchard_2016.yaml
@@ -1,19 +1,21 @@
 id: SRC-BRF113928-PLANCHARD-2016
 source_type: rct_publication
-title: "Dabrafenib plus trametinib in patients with previously treated BRAF(V600E)-mutant metastatic non-small-cell lung cancer: an open-label, multicentre phase 2 trial (BRF113928)"
-version: "2016"
+title: 'Dabrafenib plus trametinib in patients with previously treated BRAF(V600E)-mutant
+  metastatic non-small-cell lung cancer: an open-label, multicentre phase 2 trial
+  (BRF113928)'
+version: '2016'
 authors:
-  - Planchard D
-  - Besse B
-  - Groen HJM
-  - et al.
+- Planchard D
+- Besse B
+- Groen HJM
+- et al.
 journal: Lancet Oncology
 doi: 10.1016/S1470-2045(16)30146-2
-pmid: "27283860"
+pmid: '27283860'
 url: https://pubmed.ncbi.nlm.nih.gov/27283860/
 access_level: subscription_required
 currency_status: current
-current_as_of: "2016-07-01"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +24,25 @@ license:
   name: Lancet Oncology (subscription)
 attribution:
   required: true
-  text: Planchard et al., Lancet Oncol 2016; BRF113928 dabrafenib+trametinib BRAF V600E NSCLC
+  text: Planchard et al., Lancet Oncol 2016; BRF113928 dabrafenib+trametinib BRAF
+    V600E NSCLC
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: pending
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  BRF113928 phase-2 cohort B (pretreated): dabrafenib 150 mg BID +
-  trametinib 2 mg daily in 57 BRAF V600E+ pretreated NSCLC. ORR 63%,
-  mPFS 9.7 mo, mOS 18.2 mo. Cohort C (1L) ORR 64%. FDA approval 2017
-  for any-line BRAF V600E+ NSCLC. Pyrexia + LVEF monitoring required.
-  Encorafenib + binimetinib (PHAROS, 2023) is alternative — same
-  combination strategy, comparable efficacy, slightly different AE
-  profile.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'BRF113928 phase-2 cohort B (pretreated): dabrafenib 150 mg BID + trametinib
+  2 mg daily in 57 BRAF V600E+ pretreated NSCLC. ORR 63%, mPFS 9.7 mo, mOS 18.2 mo.
+  Cohort C (1L) ORR 64%. FDA approval 2017 for any-line BRAF V600E+ NSCLC. Pyrexia
+  + LVEF monitoring required. Encorafenib + binimetinib (PHAROS, 2023) is alternative
+  — same combination strategy, comparable efficacy, slightly different AE profile.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_brim3_chapman_2011.yaml
+++ b/knowledge_base/hosted/content/sources/src_brim3_chapman_2011.yaml
@@ -1,19 +1,19 @@
 id: SRC-BRIM-3-CHAPMAN-2011
 source_type: rct_publication
-title: "Improved Survival with Vemurafenib in Melanoma with BRAF V600E Mutation"
-version: "2011"
+title: Improved Survival with Vemurafenib in Melanoma with BRAF V600E Mutation
+version: '2011'
 authors:
-  - Chapman PB
-  - Hauschild A
-  - Robert C
-  - et al.
+- Chapman PB
+- Hauschild A
+- Robert C
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1103782
-pmid: "21639808"
+pmid: '21639808'
 url: https://pubmed.ncbi.nlm.nih.gov/21639808
 access_level: subscription_required
 currency_status: current
-current_as_of: "2011-06-30"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Chapman et al., NEJM 2011; BRIM-3 trial"
+  text: Chapman et al., NEJM 2011; BRIM-3 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MELANOMA
-last_verified: "2026-04-27"
-notes: >
-  BRIM-3 phase-3 (NCT01006980): vemurafenib 960 mg PO BID vs
-  dacarbazine in 1L BRAF V600E-mutant metastatic melanoma (n=675).
-  6-mo OS 84% vs 64% (HR 0.37; p<0.001); mPFS 5.3 vs 1.6 mo
-  (HR 0.26). Established BRAFi monotherapy as standard for
-  BRAF-mutant melanoma; FDA approval Aug 2011. Largely superseded
-  by BRAFi+MEKi combos (COMBI-d/v, COLUMBUS, coBRIM); historical
-  reference for BRAF-mutant melanoma.
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: 'BRIM-3 phase-3 (NCT01006980): vemurafenib 960 mg PO BID vs dacarbazine in
+  1L BRAF V600E-mutant metastatic melanoma (n=675). 6-mo OS 84% vs 64% (HR 0.37; p<0.001);
+  mPFS 5.3 vs 1.6 mo (HR 0.26). Established BRAFi monotherapy as standard for BRAF-mutant
+  melanoma; FDA approval Aug 2011. Largely superseded by BRAFi+MEKi combos (COMBI-d/v,
+  COLUMBUS, coBRIM); historical reference for BRAF-mutant melanoma.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_bruin_mato_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_bruin_mato_2021.yaml
@@ -1,19 +1,20 @@
 id: SRC-BRUIN-MATO-2021
 source_type: rct_publication
-title: "Pirtobrutinib in relapsed or refractory B-cell malignancies (BRUIN): a phase 1/2 study"
-version: "2021"
+title: 'Pirtobrutinib in relapsed or refractory B-cell malignancies (BRUIN): a phase
+  1/2 study'
+version: '2021'
 authors:
-  - Mato AR
-  - Shah NN
-  - Jurczak W
-  - et al.
+- Mato AR
+- Shah NN
+- Jurczak W
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(21)00224-5
-pmid: "33676628"
+pmid: '33676628'
 url: https://pubmed.ncbi.nlm.nih.gov/33676628
 access_level: subscription_required
 currency_status: current
-current_as_of: "2021-03-06"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,37 +23,36 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Mato et al., Lancet 2021; BRUIN phase 1/2 trial"
+  text: Mato et al., Lancet 2021; BRUIN phase 1/2 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
-  notes: "Subscription source — fair-use referencing only."
+  date: '2026-04-27'
+  notes: Subscription source — fair-use referencing only.
 relates_to_diseases:
-  - DIS-CLL
-  - DIS-MCL
-  - DIS-WM
-last_verified: "2026-04-27"
-notes: >
-  BRUIN phase 1/2 (NCT03740529): pirtobrutinib (LOXO-305), a highly
-  selective non-covalent (reversible) BTK inhibitor, in R/R B-cell
-  malignancies including CLL/SLL, MCL, WM after prior covalent BTK
-  inhibitor (cBTKi) exposure. n=323 across dose levels (25–300 mg PO
-  daily). In efficacy-evaluable post-cBTKi CLL/SLL (n=121, median 4
-  prior lines): ORR 62%; ORR similar across cBTKi-resistant (67%),
-  cBTKi-intolerant (52%), and BTK C481-mutant (71%) subgroups,
-  demonstrating activity independent of C481S resistance mechanism.
-  Mostly low-grade toxicity (most common grade≥3 AE neutropenia 10%).
-  Established pirtobrutinib as a tolerable, effective option after
-  cBTKi failure regardless of BTK C481 status; supported FDA accelerated
-  approvals (MCL Jan 2023, CLL/SLL Dec 2023). NOTE: original task list
-  cited PMID 33888286 — that PMID belongs to an unrelated radiation-
-  physics paper; correct PMID for BRUIN Mato 2021 is 33676628 (verified
-  via PubMed).
-  Cited by CSD-9A actionability RFs for BTK C481 mutation / cBTKi
-  failure.
+- DIS-CLL
+- DIS-MCL
+- DIS-WM
+last_verified: '2026-04-27'
+notes: 'BRUIN phase 1/2 (NCT03740529): pirtobrutinib (LOXO-305), a highly selective
+  non-covalent (reversible) BTK inhibitor, in R/R B-cell malignancies including CLL/SLL,
+  MCL, WM after prior covalent BTK inhibitor (cBTKi) exposure. n=323 across dose levels
+  (25–300 mg PO daily). In efficacy-evaluable post-cBTKi CLL/SLL (n=121, median 4
+  prior lines): ORR 62%; ORR similar across cBTKi-resistant (67%), cBTKi-intolerant
+  (52%), and BTK C481-mutant (71%) subgroups, demonstrating activity independent of
+  C481S resistance mechanism. Mostly low-grade toxicity (most common grade≥3 AE neutropenia
+  10%). Established pirtobrutinib as a tolerable, effective option after cBTKi failure
+  regardless of BTK C481 status; supported FDA accelerated approvals (MCL Jan 2023,
+  CLL/SLL Dec 2023). NOTE: original task list cited PMID 33888286 — that PMID belongs
+  to an unrelated radiation- physics paper; correct PMID for BRUIN Mato 2021 is 33676628
+  (verified via PubMed). Cited by CSD-9A actionability RFs for BTK C481 mutation /
+  cBTKi failure.
+
+  '
 pages_count: 10
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_bsh_mzl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_bsh_mzl_2024.yaml
@@ -8,7 +8,7 @@ journal: British Journal of Haematology
 url: https://b-s-h.org.uk/guidelines/
 access_level: open_access
 currency_status: current
-current_as_of: '2026-05-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,5 +35,5 @@ notes: 'UK-specific guideline; aligns broadly with ESMO on antiviral-first for H
 pages_count: 50
 references_count: 120
 corpus_role: regional_guideline
-last_recency_check: '2026-05-01'
+last_recency_check: '2026-04-29'
 recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_c14401_chesney_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_c14401_chesney_2024.yaml
@@ -1,19 +1,22 @@
 id: SRC-C14401-CHESNEY-2024
 source_type: rct_publication
-title: "Efficacy and safety of lifileucel, a one-time autologous tumor-infiltrating lymphocyte (TIL) cell therapy, in patients with advanced melanoma after progression on immune checkpoint inhibitors and targeted therapy: pooled analysis of consecutive cohorts of the C-144-01 study"
-version: "2024"
+title: 'Efficacy and safety of lifileucel, a one-time autologous tumor-infiltrating
+  lymphocyte (TIL) cell therapy, in patients with advanced melanoma after progression
+  on immune checkpoint inhibitors and targeted therapy: pooled analysis of consecutive
+  cohorts of the C-144-01 study'
+version: '2024'
 authors:
-  - Chesney J
-  - Lewis KD
-  - Kluger H
-  - et al.
+- Chesney J
+- Lewis KD
+- Kluger H
+- et al.
 journal: Journal for ImmunoTherapy of Cancer
 doi: 10.1136/jitc-2023-008280
-pmid: "38421753"
+pmid: '38421753'
 url: https://jitc.bmj.com/content/12/3/e008280
 access_level: open_access
 currency_status: current
-current_as_of: "2024-03-01"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -24,27 +27,28 @@ license:
   spdx_id: CC-BY-NC-4.0
 attribution:
   required: true
-  text: "Chesney et al., J Immunother Cancer 2024; C-144-01 pooled analysis"
+  text: Chesney et al., J Immunother Cancer 2024; C-144-01 pooled analysis
 commercial_use_allowed: false
 redistribution_allowed: true
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MELANOMA
-last_verified: "2026-04-27"
-notes: >
-  C-144-01 phase 2 single-arm (NCT02360579): lifileucel (autologous
-  TIL therapy) in advanced melanoma post-progression on anti-PD-1 (and
-  BRAFi+MEKi if BRAF V600-mutant). Pooled cohorts 1, 2, 4 (n=153):
-  ORR 31.4%, mDoR not reached (median follow-up 27.6 mo), mOS 13.9 mo.
-  Basis for FDA accelerated approval of Amtagvi (lifileucel) on
-  2024-02-16 — first cellular therapy approved for a solid tumor.
-  Single infusion after lymphodepletion (cyclophosphamide + fludarabine)
-  followed by short-course IL-2 (up to 6 doses). Specialty-center
-  manufacturing (~22-day window). Used here as 3L+ TIL salvage after
-  IO + BRAFi+MEKi failure.
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: 'C-144-01 phase 2 single-arm (NCT02360579): lifileucel (autologous TIL therapy)
+  in advanced melanoma post-progression on anti-PD-1 (and BRAFi+MEKi if BRAF V600-mutant).
+  Pooled cohorts 1, 2, 4 (n=153): ORR 31.4%, mDoR not reached (median follow-up 27.6
+  mo), mOS 13.9 mo. Basis for FDA accelerated approval of Amtagvi (lifileucel) on
+  2024-02-16 — first cellular therapy approved for a solid tumor. Single infusion
+  after lymphodepletion (cyclophosphamide + fludarabine) followed by short-course
+  IL-2 (up to 6 doses). Specialty-center manufacturing (~22-day window). Used here
+  as 3L+ TIL salvage after IO + BRAFi+MEKi failure.
+
+  '
 pages_count: 13
 references_count: 35
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_cartitude1_berdeja_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_cartitude1_berdeja_2021.yaml
@@ -1,19 +1,21 @@
 id: SRC-CARTITUDE-1-BERDEJA-2021
 source_type: rct_publication
-title: "Ciltacabtagene autoleucel, a B-cell maturation antigen-directed chimeric antigen receptor T-cell therapy in patients with relapsed or refractory multiple myeloma (CARTITUDE-1)"
-version: "2021"
+title: Ciltacabtagene autoleucel, a B-cell maturation antigen-directed chimeric antigen
+  receptor T-cell therapy in patients with relapsed or refractory multiple myeloma
+  (CARTITUDE-1)
+version: '2021'
 authors:
-  - Berdeja JG
-  - Madduri D
-  - Usmani SZ
-  - et al.
+- Berdeja JG
+- Madduri D
+- Usmani SZ
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(21)00933-8
-pmid: "34175021"
+pmid: '34175021'
 url: https://pubmed.ncbi.nlm.nih.gov/34175021
 access_level: subscription_required
 currency_status: current
-current_as_of: "2021-07-24"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +24,26 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Berdeja et al., Lancet 2021; CARTITUDE-1 trial"
+  text: Berdeja et al., Lancet 2021; CARTITUDE-1 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MM
-last_verified: "2026-04-27"
-notes: >
-  CARTITUDE-1 phase-1b/2 (NCT03548207): single-infusion ciltacabtagene
-  autoleucel (cilta-cel, BCMA-directed CAR-T) in heavily pretreated
-  R/R multiple myeloma (n=97, median 6 prior lines). ORR 97%, sCR
-  67%; 27-mo PFS 55%, 27-mo OS 70% (Martin JCO 2023). Established
-  cilta-cel as best-in-class BCMA CAR-T for R/R MM; basis for FDA
-  approval Feb 2022. NOTE: task brief listed PMID 34177535 — that
-  PMID is the FDA briefing document; primary publication PMID is
-  34175021 (verified).
+- DIS-MM
+last_verified: '2026-04-27'
+notes: 'CARTITUDE-1 phase-1b/2 (NCT03548207): single-infusion ciltacabtagene autoleucel
+  (cilta-cel, BCMA-directed CAR-T) in heavily pretreated R/R multiple myeloma (n=97,
+  median 6 prior lines). ORR 97%, sCR 67%; 27-mo PFS 55%, 27-mo OS 70% (Martin JCO
+  2023). Established cilta-cel as best-in-class BCMA CAR-T for R/R MM; basis for FDA
+  approval Feb 2022. NOTE: task brief listed PMID 34177535 — that PMID is the FDA
+  briefing document; primary publication PMID is 34175021 (verified).
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_caspian_paz_ares_2019.yaml
+++ b/knowledge_base/hosted/content/sources/src_caspian_paz_ares_2019.yaml
@@ -1,19 +1,20 @@
 id: SRC-CASPIAN-PAZ-ARES-2019
 source_type: rct_publication
-title: "Durvalumab plus platinum-etoposide versus platinum-etoposide in first-line treatment of extensive-stage small-cell lung cancer (CASPIAN)"
-version: "2019"
+title: Durvalumab plus platinum-etoposide versus platinum-etoposide in first-line
+  treatment of extensive-stage small-cell lung cancer (CASPIAN)
+version: '2019'
 authors:
-  - Paz-Ares L
-  - Dvorkin M
-  - Chen Y
-  - et al.
+- Paz-Ares L
+- Dvorkin M
+- Chen Y
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(19)32222-6
-pmid: "31590988"
+pmid: '31590988'
 url: https://pubmed.ncbi.nlm.nih.gov/31590988
 access_level: subscription_required
 currency_status: current
-current_as_of: "2019-11-23"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,26 +23,27 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Paz-Ares et al., Lancet 2019; CASPIAN trial"
+  text: Paz-Ares et al., Lancet 2019; CASPIAN trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  CASPIAN phase-3 (NCT03043872): durvalumab 1500 mg q3w + platinum
-  + etoposide × 4 cycles → durvalumab maintenance vs platinum +
-  etoposide × 6 cycles in 1L extensive-stage SCLC (n=805 in
-  durva+EP and EP arms). Median OS 13.0 vs 10.3 mo (HR 0.73;
-  p=0.0047). 3-year OS update (Paz-Ares ESMO 2022): 17.6% vs
-  5.8%. Established durvalumab + EP as 1L standard for ES-SCLC;
-  basis for FDA approval Mar 2020. Tracked here because some
-  NSCLC algorithms reference CASPIAN as reference for IO+chemo
-  in lung cancer broadly.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'CASPIAN phase-3 (NCT03043872): durvalumab 1500 mg q3w + platinum + etoposide
+  × 4 cycles → durvalumab maintenance vs platinum + etoposide × 6 cycles in 1L extensive-stage
+  SCLC (n=805 in durva+EP and EP arms). Median OS 13.0 vs 10.3 mo (HR 0.73; p=0.0047).
+  3-year OS update (Paz-Ares ESMO 2022): 17.6% vs 5.8%. Established durvalumab + EP
+  as 1L standard for ES-SCLC; basis for FDA approval Mar 2020. Tracked here because
+  some NSCLC algorithms reference CASPIAN as reference for IO+chemo in lung cancer
+  broadly.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_castor_palumbo_2016.yaml
+++ b/knowledge_base/hosted/content/sources/src_castor_palumbo_2016.yaml
@@ -13,7 +13,7 @@ pmid: '27557302'
 url: https://pubmed.ncbi.nlm.nih.gov/27557302
 access_level: subscription_required
 currency_status: current
-current_as_of: '2026-05-01'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -42,5 +42,5 @@ notes: 'CASTOR phase-3 (NCT02136134): daratumumab + bortezomib + dexamethasone (
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
-last_recency_check: '2026-05-01'
+last_recency_check: '2026-04-29'
 recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_checkmate238_weber_2017.yaml
+++ b/knowledge_base/hosted/content/sources/src_checkmate238_weber_2017.yaml
@@ -1,19 +1,19 @@
 id: SRC-CHECKMATE-238-WEBER-2017
 source_type: rct_publication
-title: "Adjuvant Nivolumab versus Ipilimumab in Resected Stage III or IV Melanoma"
-version: "2017"
+title: Adjuvant Nivolumab versus Ipilimumab in Resected Stage III or IV Melanoma
+version: '2017'
 authors:
-  - Weber J
-  - Mandala M
-  - Del Vecchio M
-  - et al.
+- Weber J
+- Mandala M
+- Del Vecchio M
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1709030
-pmid: "28891423"
+pmid: '28891423'
 url: https://pubmed.ncbi.nlm.nih.gov/28891423
 access_level: subscription_required
 currency_status: current
-current_as_of: "2017-11-09"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Weber et al., NEJM 2017; CheckMate-238 trial"
+  text: Weber et al., NEJM 2017; CheckMate-238 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MELANOMA
-last_verified: "2026-04-27"
-notes: >
-  CheckMate-238 phase-3 (NCT02388906): adjuvant nivolumab 3 mg/kg
-  q2w × 1 yr vs ipilimumab 10 mg/kg q3w×4 then q12w in resected
-  stage IIIB/C or IV melanoma (n=906). 12-mo RFS 70.5% vs 60.8%
-  (HR 0.65; p<0.001), with markedly lower toxicity. 4-yr update
-  (Ascierto Lancet Oncol 2020): 4-yr RFS 51.7% vs 41.2%; OS
-  similar (cross-over). Established adjuvant nivo as IO standard
-  for resected high-risk melanoma; basis for FDA approval Dec 2017.
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: 'CheckMate-238 phase-3 (NCT02388906): adjuvant nivolumab 3 mg/kg q2w × 1 yr
+  vs ipilimumab 10 mg/kg q3w×4 then q12w in resected stage IIIB/C or IV melanoma (n=906).
+  12-mo RFS 70.5% vs 60.8% (HR 0.65; p<0.001), with markedly lower toxicity. 4-yr
+  update (Ascierto Lancet Oncol 2020): 4-yr RFS 51.7% vs 41.2%; OS similar (cross-over).
+  Established adjuvant nivo as IO standard for resected high-risk melanoma; basis
+  for FDA approval Dec 2017.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_checkmate816_forde_2022.yaml
+++ b/knowledge_base/hosted/content/sources/src_checkmate816_forde_2022.yaml
@@ -1,19 +1,19 @@
 id: SRC-CHECKMATE-816-FORDE-2022
 source_type: rct_publication
-title: "Neoadjuvant Nivolumab plus Chemotherapy in Resectable Lung Cancer"
-version: "2022"
+title: Neoadjuvant Nivolumab plus Chemotherapy in Resectable Lung Cancer
+version: '2022'
 authors:
-  - Forde PM
-  - Spicer J
-  - Lu S
-  - et al.
+- Forde PM
+- Spicer J
+- Lu S
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa2202170
-pmid: "35403841"
+pmid: '35403841'
 url: https://pubmed.ncbi.nlm.nih.gov/35403841
 access_level: subscription_required
 currency_status: current
-current_as_of: "2022-05-26"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Forde et al., NEJM 2022; CheckMate-816 trial"
+  text: Forde et al., NEJM 2022; CheckMate-816 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  CheckMate-816 phase-3 (NCT02998528): neoadjuvant nivolumab +
-  platinum-doublet chemo (×3) vs chemo alone in resectable
-  IB–IIIA NSCLC (n=358). pCR 24.0% vs 2.2% (OR 13.94; p<0.001);
-  median EFS 31.6 vs 20.8 mo (HR 0.63). Established neoadjuvant
-  chemoimmunotherapy as standard for resectable stage II–IIIA
-  NSCLC; basis for FDA approval Mar 2022 (first IO neoadjuvant
-  approval in NSCLC).
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'CheckMate-816 phase-3 (NCT02998528): neoadjuvant nivolumab + platinum-doublet
+  chemo (×3) vs chemo alone in resectable IB–IIIA NSCLC (n=358). pCR 24.0% vs 2.2%
+  (OR 13.94; p<0.001); median EFS 31.6 vs 20.8 mo (HR 0.63). Established neoadjuvant
+  chemoimmunotherapy as standard for resectable stage II–IIIA NSCLC; basis for FDA
+  approval Mar 2022 (first IO neoadjuvant approval in NSCLC).
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_checkmate_067_larkin_2019.yaml
+++ b/knowledge_base/hosted/content/sources/src_checkmate_067_larkin_2019.yaml
@@ -1,19 +1,19 @@
 id: SRC-CHECKMATE-067-LARKIN-2019
 source_type: rct_publication
-title: "Five-Year Survival with Combined Nivolumab and Ipilimumab in Advanced Melanoma"
-version: "2019"
+title: Five-Year Survival with Combined Nivolumab and Ipilimumab in Advanced Melanoma
+version: '2019'
 authors:
-  - Larkin J
-  - Chiarion-Sileni V
-  - Gonzalez R
-  - et al.
+- Larkin J
+- Chiarion-Sileni V
+- Gonzalez R
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1910836
-pmid: "31562797"
+pmid: '31562797'
 url: https://www.nejm.org/doi/full/10.1056/NEJMoa1910836
 access_level: subscription_required
 currency_status: current
-current_as_of: "2019-10-17"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,26 +22,27 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Larkin et al., NEJM 2019; CheckMate-067 5-year follow-up"
+  text: Larkin et al., NEJM 2019; CheckMate-067 5-year follow-up
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MELANOMA
-last_verified: "2026-04-27"
-notes: >
-  CheckMate-067 phase 3 (NCT01844505): nivolumab + ipilimumab vs
-  nivolumab vs ipilimumab in untreated unresectable/metastatic
-  melanoma. 5-year OS 52% (combo) vs 44% (nivo) vs 26% (ipi); mOS
-  >60 mo (combo) vs 36.9 mo (nivo) vs 19.9 mo (ipi). 7.5-year update
-  (Wolchok 2022): OS 49% (combo). Defines ipi+nivo doublet as 1L
-  standard. Used here as the IO doublet salvage for patients who
-  received 1L BRAFi+MEKi without prior anti-PD-1 (BRAF-positive
-  patients in whom 1L was targeted therapy due to visceral crisis or
-  brain mets requiring rapid response).
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: 'CheckMate-067 phase 3 (NCT01844505): nivolumab + ipilimumab vs nivolumab vs
+  ipilimumab in untreated unresectable/metastatic melanoma. 5-year OS 52% (combo)
+  vs 44% (nivo) vs 26% (ipi); mOS >60 mo (combo) vs 36.9 mo (nivo) vs 19.9 mo (ipi).
+  7.5-year update (Wolchok 2022): OS 49% (combo). Defines ipi+nivo doublet as 1L standard.
+  Used here as the IO doublet salvage for patients who received 1L BRAFi+MEKi without
+  prior anti-PD-1 (BRAF-positive patients in whom 1L was targeted therapy due to visceral
+  crisis or brain mets requiring rapid response).
+
+  '
 pages_count: 12
 references_count: 35
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_checkmate_649_janjigian_2022.yaml
+++ b/knowledge_base/hosted/content/sources/src_checkmate_649_janjigian_2022.yaml
@@ -1,19 +1,21 @@
 id: SRC-CHECKMATE-649-JANJIGIAN-2022
 source_type: rct_publication
-title: "First-line nivolumab plus chemotherapy versus chemotherapy alone for advanced gastric, gastro-oesophageal junction, and oesophageal adenocarcinoma (CheckMate 649): a randomised, open-label, phase 3 trial"
-version: "2021"
+title: 'First-line nivolumab plus chemotherapy versus chemotherapy alone for advanced
+  gastric, gastro-oesophageal junction, and oesophageal adenocarcinoma (CheckMate
+  649): a randomised, open-label, phase 3 trial'
+version: '2021'
 authors:
-  - Janjigian YY
-  - Shitara K
-  - Moehler M
-  - et al.
+- Janjigian YY
+- Shitara K
+- Moehler M
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(21)00797-2
-pmid: "34102137"
+pmid: '34102137'
 url: https://pubmed.ncbi.nlm.nih.gov/34102137
 access_level: subscription_required
 currency_status: current
-current_as_of: "2021-06-05"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,32 +24,32 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Janjigian et al., Lancet 2021; CheckMate-649 trial"
+  text: Janjigian et al., Lancet 2021; CheckMate-649 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
-  notes: "Subscription source — fair-use referencing only."
+  date: '2026-04-27'
+  notes: Subscription source — fair-use referencing only.
 relates_to_diseases:
-  - DIS-GASTRIC
-  - DIS-ESOPHAGEAL
-last_verified: "2026-04-27"
-notes: >
-  CheckMate-649 phase 3 (NCT02872116): nivolumab 360 mg q3w (or 240 mg
-  q2w) + FOLFOX/XELOX vs chemotherapy alone, 1L advanced/metastatic
-  gastric, GEJ, or oesophageal adenocarcinoma; n=1,581 in the nivo+chemo
-  vs chemo-alone comparison. In PD-L1 CPS ≥5 population: mOS 14.4 vs 11.1
-  mo (HR 0.71; p<0.0001); mPFS 7.7 vs 6.0 mo (HR 0.68; p<0.0001).
-  Benefit also seen in CPS ≥1 and all-randomised populations though
-  magnitude smaller. Grade 3–4 TRAEs 59% vs 44%, no new safety signals.
-  Established nivolumab + chemotherapy as 1L standard for advanced
-  gastric/GEJ/oesophageal adenocarcinoma; supported FDA approval (Apr
-  2021). NOTE: task list listed year as "2022 (verify)" — primary
-  publication is 2021 (Lancet 5 Jun 2021); year corrected to 2021.
-  Cited by CSD-9A actionability RFs for gastric/GEJ PD-L1 CPS ≥5
-  selection.
+- DIS-GASTRIC
+- DIS-ESOPHAGEAL
+last_verified: '2026-04-27'
+notes: 'CheckMate-649 phase 3 (NCT02872116): nivolumab 360 mg q3w (or 240 mg q2w)
+  + FOLFOX/XELOX vs chemotherapy alone, 1L advanced/metastatic gastric, GEJ, or oesophageal
+  adenocarcinoma; n=1,581 in the nivo+chemo vs chemo-alone comparison. In PD-L1 CPS
+  ≥5 population: mOS 14.4 vs 11.1 mo (HR 0.71; p<0.0001); mPFS 7.7 vs 6.0 mo (HR 0.68;
+  p<0.0001). Benefit also seen in CPS ≥1 and all-randomised populations though magnitude
+  smaller. Grade 3–4 TRAEs 59% vs 44%, no new safety signals. Established nivolumab
+  + chemotherapy as 1L standard for advanced gastric/GEJ/oesophageal adenocarcinoma;
+  supported FDA approval (Apr 2021). NOTE: task list listed year as "2022 (verify)"
+  — primary publication is 2021 (Lancet 5 Jun 2021); year corrected to 2021. Cited
+  by CSD-9A actionability RFs for gastric/GEJ PD-L1 CPS ≥5 selection.
+
+  '
 pages_count: 13
 references_count: 36
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_chronos_sartore_bianchi_2022.yaml
+++ b/knowledge_base/hosted/content/sources/src_chronos_sartore_bianchi_2022.yaml
@@ -1,19 +1,21 @@
 id: SRC-CHRONOS-SARTORE-BIANCHI-2022
 source_type: rct_publication
-title: "Circulating tumour DNA-guided rechallenge with anti-EGFR antibodies in metastatic colorectal cancer (CHRONOS): a non-randomised, single-arm, multicentre, phase 2 trial"
-version: "2022"
+title: 'Circulating tumour DNA-guided rechallenge with anti-EGFR antibodies in metastatic
+  colorectal cancer (CHRONOS): a non-randomised, single-arm, multicentre, phase 2
+  trial'
+version: '2022'
 authors:
-  - Sartore-Bianchi A
-  - Pietrantonio F
-  - Lonardi S
-  - et al.
+- Sartore-Bianchi A
+- Pietrantonio F
+- Lonardi S
+- et al.
 journal: Nature Medicine
 doi: 10.1038/s41591-022-01886-0
-pmid: "35879464"
+pmid: '35879464'
 url: https://www.nature.com/articles/s41591-022-01886-0
 access_level: subscription_required
 currency_status: current
-current_as_of: "2022-08-01"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,26 +24,28 @@ license:
   name: Springer Nature (subscription)
 attribution:
   required: true
-  text: "Sartore-Bianchi et al., Nat Med 2022; CHRONOS trial"
+  text: Sartore-Bianchi et al., Nat Med 2022; CHRONOS trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-COLON
-last_verified: "2026-04-27"
-notes: >
-  CHRONOS phase-2 (NCT03227926): ctDNA-guided panitumumab rechallenge
-  in RAS/BRAF wild-type chemo-refractory mCRC patients who initially
-  responded to anti-EGFR then progressed and were RAS/BRAF/EGFR-WT on
-  liquid biopsy at rechallenge. ORR 30%; DCR 63%; median PFS 16 wk.
-  First prospective ctDNA-guided rechallenge trial; established
-  liquid-biopsy-driven anti-EGFR re-exposure as a valid strategy in
-  selected patients. Cited in CSD-4 CRC for the ctDNA-guided rechallenge
-  pathway. NOTE: original task list omitted PMID; verified via PubMed
-  as 35879464 (Sartore-Bianchi A et al., Nat Med 28(8):1612–1618).
+- DIS-COLON
+last_verified: '2026-04-27'
+notes: 'CHRONOS phase-2 (NCT03227926): ctDNA-guided panitumumab rechallenge in RAS/BRAF
+  wild-type chemo-refractory mCRC patients who initially responded to anti-EGFR then
+  progressed and were RAS/BRAF/EGFR-WT on liquid biopsy at rechallenge. ORR 30%; DCR
+  63%; median PFS 16 wk. First prospective ctDNA-guided rechallenge trial; established
+  liquid-biopsy-driven anti-EGFR re-exposure as a valid strategy in selected patients.
+  Cited in CSD-4 CRC for the ctDNA-guided rechallenge pathway. NOTE: original task
+  list omitted PMID; verified via PubMed as 35879464 (Sartore-Bianchi A et al., Nat
+  Med 28(8):1612–1618).
+
+  '
 pages_count: 7
 references_count: 35
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_chrysalis_park_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_chrysalis_park_2021.yaml
@@ -1,19 +1,20 @@
 id: SRC-CHRYSALIS-PARK-2021
 source_type: rct_publication
-title: "Amivantamab in EGFR Exon 20 Insertion-Mutated Non-Small-Cell Lung Cancer Progressing on Platinum Chemotherapy: Initial Results From the CHRYSALIS Phase I Study"
-version: "2021"
+title: 'Amivantamab in EGFR Exon 20 Insertion-Mutated Non-Small-Cell Lung Cancer Progressing
+  on Platinum Chemotherapy: Initial Results From the CHRYSALIS Phase I Study'
+version: '2021'
 authors:
-  - Park K
-  - Haura EB
-  - Leighl NB
-  - et al.
+- Park K
+- Haura EB
+- Leighl NB
+- et al.
 journal: Journal of Clinical Oncology
 doi: 10.1200/JCO.21.00662
-pmid: "33914029"
+pmid: '33914029'
 url: https://pubmed.ncbi.nlm.nih.gov/33914029/
 access_level: subscription_required
 currency_status: current
-current_as_of: "2021-10-15"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -29,14 +30,16 @@ modifications_allowed: false
 legal_review:
   status: pending
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  CHRYSALIS phase-1 expansion: amivantamab monotherapy in 81 EGFR
-  exon-20-insertion NSCLC pts post-platinum. ORR 40%, mPFS 8.3 mo,
-  mOS 22.8 mo. Basis for FDA accelerated approval (2021) and the
-  PAPILLON 1L combo development. Confirmatory PAPILLON established
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'CHRYSALIS phase-1 expansion: amivantamab monotherapy in 81 EGFR exon-20-insertion
+  NSCLC pts post-platinum. ORR 40%, mPFS 8.3 mo, mOS 22.8 mo. Basis for FDA accelerated
+  approval (2021) and the PAPILLON 1L combo development. Confirmatory PAPILLON established
   ami+chemo as 1L SoC for EGFR Ex20ins.
+
+  '
 pages_count: 14
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_cleopatra_swain_2015.yaml
+++ b/knowledge_base/hosted/content/sources/src_cleopatra_swain_2015.yaml
@@ -1,19 +1,21 @@
 id: SRC-CLEOPATRA-SWAIN-2015
 source_type: rct_publication
-title: "Pertuzumab, trastuzumab, and docetaxel in HER2-positive metastatic breast cancer (CLEOPATRA): end-of-study results from a double-blind, randomised, placebo-controlled, phase 3 study"
-version: "2015"
+title: 'Pertuzumab, trastuzumab, and docetaxel in HER2-positive metastatic breast
+  cancer (CLEOPATRA): end-of-study results from a double-blind, randomised, placebo-controlled,
+  phase 3 study'
+version: '2015'
 authors:
-  - Swain SM
-  - Baselga J
-  - Kim SB
-  - et al.
+- Swain SM
+- Baselga J
+- Kim SB
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1413513
-pmid: "25693012"
+pmid: '25693012'
 url: https://pubmed.ncbi.nlm.nih.gov/25693012
 access_level: subscription_required
 currency_status: current
-current_as_of: "2015-02-19"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +24,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Swain et al., NEJM 2015; CLEOPATRA trial"
+  text: Swain et al., NEJM 2015; CLEOPATRA trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-BREAST
-last_verified: "2026-04-27"
-notes: >
-  CLEOPATRA phase-3 (NCT00567190): pertuzumab + trastuzumab +
-  docetaxel vs placebo + trastuzumab + docetaxel in 1L HER2+
-  metastatic breast cancer (n=808). Median PFS 18.7 vs 12.4 mo
-  (HR 0.68); mOS 56.5 vs 40.8 mo (HR 0.68; p<0.001). 8-yr update
-  (Swain Lancet Oncol 2020): 8-yr landmark OS 37% vs 23%.
-  Established THP (taxane + trastuzumab + pertuzumab) as 1L
-  standard for HER2+ MBC.
+- DIS-BREAST
+last_verified: '2026-04-27'
+notes: 'CLEOPATRA phase-3 (NCT00567190): pertuzumab + trastuzumab + docetaxel vs placebo
+  + trastuzumab + docetaxel in 1L HER2+ metastatic breast cancer (n=808). Median PFS
+  18.7 vs 12.4 mo (HR 0.68); mOS 56.5 vs 40.8 mo (HR 0.68; p<0.001). 8-yr update (Swain
+  Lancet Oncol 2020): 8-yr landmark OS 37% vs 23%. Established THP (taxane + trastuzumab
+  + pertuzumab) as 1L standard for HER2+ MBC.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_cll14_fischer_2019.yaml
+++ b/knowledge_base/hosted/content/sources/src_cll14_fischer_2019.yaml
@@ -1,19 +1,19 @@
 id: SRC-CLL14-FISCHER-2019
 source_type: rct_publication
-title: "Venetoclax and Obinutuzumab in Patients with CLL and Coexisting Conditions"
-version: "2019"
+title: Venetoclax and Obinutuzumab in Patients with CLL and Coexisting Conditions
+version: '2019'
 authors:
-  - Fischer K
-  - Al-Sawaf O
-  - Bahlo J
-  - et al.
+- Fischer K
+- Al-Sawaf O
+- Bahlo J
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1815281
-pmid: "31166681"
+pmid: '31166681'
 url: https://pubmed.ncbi.nlm.nih.gov/31166681
 access_level: subscription_required
 currency_status: current
-current_as_of: "2019-06-06"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Fischer et al., NEJM 2019; CLL14 trial"
+  text: Fischer et al., NEJM 2019; CLL14 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-CLL
-last_verified: "2026-04-27"
-notes: >
-  CLL14 phase-3 (NCT02242942): 12-mo fixed-duration venetoclax +
-  obinutuzumab vs chlorambucil + obinutuzumab in 1L CLL with
-  coexisting conditions (CIRS >6 or CrCl <70) (n=432). 24-mo PFS
-  88.2% vs 64.1% (HR 0.35; p<0.001). 6-yr update (Al-Sawaf JCO
-  2024): 6-yr PFS 53.1% vs 21.7% (HR 0.40); 6-yr OS 78.7% vs
-  69.2%. Established Ven-O fixed-duration as 1L for unfit CLL;
-  basis for FDA approval May 2019. NOTE: task brief listed PMID
-  31166680 — adjacent ID; verified PMID is 31166681.
+- DIS-CLL
+last_verified: '2026-04-27'
+notes: 'CLL14 phase-3 (NCT02242942): 12-mo fixed-duration venetoclax + obinutuzumab
+  vs chlorambucil + obinutuzumab in 1L CLL with coexisting conditions (CIRS >6 or
+  CrCl <70) (n=432). 24-mo PFS 88.2% vs 64.1% (HR 0.35; p<0.001). 6-yr update (Al-Sawaf
+  JCO 2024): 6-yr PFS 53.1% vs 21.7% (HR 0.40); 6-yr OS 78.7% vs 69.2%. Established
+  Ven-O fixed-duration as 1L for unfit CLL; basis for FDA approval May 2019. NOTE:
+  task brief listed PMID 31166680 — adjacent ID; verified PMID is 31166681.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_cobrim_larkin_2014.yaml
+++ b/knowledge_base/hosted/content/sources/src_cobrim_larkin_2014.yaml
@@ -1,19 +1,19 @@
 id: SRC-COBRIM-LARKIN-2014
 source_type: rct_publication
-title: "Combined Vemurafenib and Cobimetinib in BRAF-Mutated Melanoma"
-version: "2014"
+title: Combined Vemurafenib and Cobimetinib in BRAF-Mutated Melanoma
+version: '2014'
 authors:
-  - Larkin J
-  - Ascierto PA
-  - Dréno B
-  - et al.
+- Larkin J
+- Ascierto PA
+- Dréno B
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1408868
-pmid: "25265494"
+pmid: '25265494'
 url: https://pubmed.ncbi.nlm.nih.gov/25265494
 access_level: subscription_required
 currency_status: current
-current_as_of: "2014-11-13"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +22,26 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Larkin et al., NEJM 2014; coBRIM trial"
+  text: Larkin et al., NEJM 2014; coBRIM trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MELANOMA
-last_verified: "2026-04-27"
-notes: >
-  coBRIM phase-3 (NCT01689519): vemurafenib + cobimetinib vs
-  vemurafenib + placebo in 1L BRAF V600-mutant unresectable/
-  metastatic melanoma (n=495). Median PFS 9.9 vs 6.2 mo (HR 0.51;
-  p<0.001); mOS 22.3 vs 17.4 mo (HR 0.70). Established
-  vemurafenib + cobimetinib as alternative BRAFi+MEKi doublet.
-  NOTE: task brief listed PMID 25287827 — that PMID belongs to
-  the Lancet Oncol companion follow-up; primary publication PMID
-  is 25265494 (verified).
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: 'coBRIM phase-3 (NCT01689519): vemurafenib + cobimetinib vs vemurafenib + placebo
+  in 1L BRAF V600-mutant unresectable/ metastatic melanoma (n=495). Median PFS 9.9
+  vs 6.2 mo (HR 0.51; p<0.001); mOS 22.3 vs 17.4 mo (HR 0.70). Established vemurafenib
+  + cobimetinib as alternative BRAFi+MEKi doublet. NOTE: task brief listed PMID 25287827
+  — that PMID belongs to the Lancet Oncol companion follow-up; primary publication
+  PMID is 25265494 (verified).
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_codebreak200_johnson_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_codebreak200_johnson_2023.yaml
@@ -1,19 +1,20 @@
 id: SRC-CODEBREAK200-JOHNSON-2023
 source_type: rct_publication
-title: "Sotorasib versus docetaxel for previously treated non-small-cell lung cancer with KRAS G12C mutation: a randomised, open-label, phase 3 trial (CodeBreaK 200)"
-version: "2023"
+title: 'Sotorasib versus docetaxel for previously treated non-small-cell lung cancer
+  with KRAS G12C mutation: a randomised, open-label, phase 3 trial (CodeBreaK 200)'
+version: '2023'
 authors:
-  - de Langen AJ
-  - Johnson ML
-  - Mazieres J
-  - et al.
+- de Langen AJ
+- Johnson ML
+- Mazieres J
+- et al.
 journal: Lancet
 doi: 10.1016/S0140-6736(23)00221-0
-pmid: "36244266"
+pmid: '36244266'
 url: https://pubmed.ncbi.nlm.nih.gov/36244266/
 access_level: subscription_required
 currency_status: current
-current_as_of: "2023-02-25"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -29,15 +30,17 @@ modifications_allowed: false
 legal_review:
   status: pending
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  CodeBreaK 200 phase-3: sotorasib 960 mg PO daily vs docetaxel in 345
-  pretreated KRAS G12C+ NSCLC. PFS 5.6 vs 4.5 mo (HR 0.66); ORR 28% vs
-  13%; OS not significant (HR 1.01). Confirmed sotorasib's superior
-  PFS / quality-of-life over docetaxel in 2L+ KRAS G12C+ disease;
-  durable but no OS gain reflects post-progression therapy crossover
-  + biology limits.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'CodeBreaK 200 phase-3: sotorasib 960 mg PO daily vs docetaxel in 345 pretreated
+  KRAS G12C+ NSCLC. PFS 5.6 vs 4.5 mo (HR 0.66); ORR 28% vs 13%; OS not significant
+  (HR 1.01). Confirmed sotorasib''s superior PFS / quality-of-life over docetaxel
+  in 2L+ KRAS G12C+ disease; durable but no OS gain reflects post-progression therapy
+  crossover + biology limits.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_coiffier_2012_romidepsin_ptcl.yaml
+++ b/knowledge_base/hosted/content/sources/src_coiffier_2012_romidepsin_ptcl.yaml
@@ -1,19 +1,20 @@
 id: SRC-COIFFIER-2012-ROMIDEPSIN-PTCL
 source_type: rct_publication
-title: "Results from a pivotal, open-label, phase II study of romidepsin in relapsed or refractory peripheral T-cell lymphoma after prior systemic therapy"
-version: "2012"
+title: Results from a pivotal, open-label, phase II study of romidepsin in relapsed
+  or refractory peripheral T-cell lymphoma after prior systemic therapy
+version: '2012'
 authors:
-  - Coiffier B
-  - Pro B
-  - Prince HM
-  - et al.
+- Coiffier B
+- Pro B
+- Prince HM
+- et al.
 journal: Journal of Clinical Oncology
 doi: 10.1200/JCO.2011.37.4223
-pmid: "22271479"
+pmid: '22271479'
 url: https://pubmed.ncbi.nlm.nih.gov/22271479
 access_level: subscription_required
 currency_status: current
-current_as_of: "2012-02-20"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,29 +23,30 @@ license:
   name: ASCO / JCO (subscription)
 attribution:
   required: true
-  text: "Coiffier et al., JCO 2012; romidepsin pivotal phase 2 R/R PTCL"
+  text: Coiffier et al., JCO 2012; romidepsin pivotal phase 2 R/R PTCL
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
-  notes: "Subscription source — fair-use referencing only."
+  date: '2026-04-27'
+  notes: Subscription source — fair-use referencing only.
 relates_to_diseases:
-  - DIS-PTCL
-last_verified: "2026-04-27"
-notes: >
-  International pivotal phase 2 (NCT00426764) of romidepsin (HDAC
-  inhibitor) 14 mg/m² IV days 1, 8, 15 q28d in 130 patients with R/R
-  peripheral T-cell lymphoma after prior systemic therapy. ORR 25%
-  (CR/CRu 15%); among responders, median DoR 17 mo with longest response
-  ongoing at 34+ mo. Most common grade 3/4 AEs: thrombocytopenia 24%,
-  neutropenia 20%, infections 19%. Supported FDA accelerated approval
-  (Jun 2011) of romidepsin for R/R PTCL — subsequently withdrawn (Aug
-  2021) after the confirmatory Ro-CHOP trial (Bachy 2022) failed
-  frontline endpoint, but remains in NCCN/ESMO R/R PTCL options where
-  available.
-  Cited by CSD-9A actionability RFs for PTCL R/R salvage selection.
+- DIS-PTCL
+last_verified: '2026-04-27'
+notes: 'International pivotal phase 2 (NCT00426764) of romidepsin (HDAC inhibitor)
+  14 mg/m² IV days 1, 8, 15 q28d in 130 patients with R/R peripheral T-cell lymphoma
+  after prior systemic therapy. ORR 25% (CR/CRu 15%); among responders, median DoR
+  17 mo with longest response ongoing at 34+ mo. Most common grade 3/4 AEs: thrombocytopenia
+  24%, neutropenia 20%, infections 19%. Supported FDA accelerated approval (Jun 2011)
+  of romidepsin for R/R PTCL — subsequently withdrawn (Aug 2021) after the confirmatory
+  Ro-CHOP trial (Bachy 2022) failed frontline endpoint, but remains in NCCN/ESMO R/R
+  PTCL options where available. Cited by CSD-9A actionability RFs for PTCL R/R salvage
+  selection.
+
+  '
 pages_count: 8
 references_count: 26
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_combi_ad_long_2017.yaml
+++ b/knowledge_base/hosted/content/sources/src_combi_ad_long_2017.yaml
@@ -13,7 +13,7 @@ pmid: '28891408'
 url: https://pubmed.ncbi.nlm.nih.gov/28891408
 access_level: subscription_required
 currency_status: current
-current_as_of: '2017-11-09'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -43,3 +43,5 @@ pages_count: 12
 references_count: 30
 corpus_role: rct_publication
 sharealike_required: false
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_combi_d_long_2014.yaml
+++ b/knowledge_base/hosted/content/sources/src_combi_d_long_2014.yaml
@@ -13,7 +13,7 @@ pmid: '25265492'
 url: https://pubmed.ncbi.nlm.nih.gov/25265492
 access_level: subscription_required
 currency_status: current
-current_as_of: '2014-11-13'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -44,3 +44,5 @@ pages_count: 12
 references_count: 30
 corpus_role: rct_publication
 sharealike_required: false
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_combi_v_robert_2015.yaml
+++ b/knowledge_base/hosted/content/sources/src_combi_v_robert_2015.yaml
@@ -13,7 +13,7 @@ pmid: '25399551'
 url: https://pubmed.ncbi.nlm.nih.gov/25399551
 access_level: subscription_required
 currency_status: current
-current_as_of: '2015-01-01'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -43,3 +43,5 @@ pages_count: 12
 references_count: 30
 corpus_role: rct_publication
 sharealike_required: false
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_crown_solomon_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_crown_solomon_2021.yaml
@@ -1,19 +1,19 @@
 id: SRC-CROWN-SOLOMON-2021
 source_type: rct_publication
-title: "First-Line Lorlatinib or Crizotinib in Advanced ALK-Positive Lung Cancer (CROWN)"
-version: "2021"
+title: First-Line Lorlatinib or Crizotinib in Advanced ALK-Positive Lung Cancer (CROWN)
+version: '2021'
 authors:
-  - Shaw AT
-  - Bauer TM
-  - de Marinis F
-  - et al.
+- Shaw AT
+- Bauer TM
+- de Marinis F
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa2027187
-pmid: "33872252"
+pmid: '33872252'
 url: https://pubmed.ncbi.nlm.nih.gov/33872252/
 access_level: subscription_required
 currency_status: current
-current_as_of: "2021-04-29"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -29,15 +29,17 @@ modifications_allowed: false
 legal_review:
   status: pending
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  CROWN phase-3: lorlatinib vs crizotinib 1L in 296 ALK+ advanced NSCLC.
-  3-year PFS 64% vs 19% (HR 0.27); intracranial response 82% vs 23%.
-  Strongest 1L ALK-TKI signal to date but cognitive AE (~40%) and lipid
-  derangement complicate broad use; alectinib remains workhorse 1L in
-  many guidelines with lorlatinib reserved for selected high-risk or
-  post-2G TKI settings.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'CROWN phase-3: lorlatinib vs crizotinib 1L in 296 ALK+ advanced NSCLC. 3-year
+  PFS 64% vs 19% (HR 0.27); intracranial response 82% vs 23%. Strongest 1L ALK-TKI
+  signal to date but cognitive AE (~40%) and lipid derangement complicate broad use;
+  alectinib remains workhorse 1L in many guidelines with lorlatinib reserved for selected
+  high-risk or post-2G TKI settings.
+
+  '
 pages_count: 14
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_ctcae_v5.yaml
+++ b/knowledge_base/hosted/content/sources/src_ctcae_v5.yaml
@@ -4,11 +4,10 @@ title: Common Terminology Criteria for Adverse Events (CTCAE) v5.0
 version: v5.0 (2017-11-27)
 authors:
 - U.S. Department of Health and Human Services, NIH, NCI
-url: https://dctd.cancer.gov/research/ctep-trials/trial-development
-url_redirected_from: https://ctep.cancer.gov/protocoldevelopment/electronic_applications/ctc.htm
+url: https://ctep.cancer.gov/protocoldevelopment/electronic_applications/ctc.htm
 access_level: open_access
 currency_status: current
-current_as_of: '2026-05-01'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: hosted
 hosting_justification: H5 — small, stable, critical for AE grading across all Regimens
@@ -37,7 +36,7 @@ legal_review:
   date: '2026-04-25'
   notes: Public domain
 relates_to_diseases: []
-last_verified: '2026-05-01'
+last_verified: '2026-04-27'
 notes: 'Hosted at knowledge_base/hosted/ctcae/v5.0/grading.yaml — 837 AEs across 26
   SOC categories. CTCAE v6.0 in development; monitor NCI for release.
 
@@ -45,5 +44,5 @@ notes: 'Hosted at knowledge_base/hosted/ctcae/v5.0/grading.yaml — 837 AEs acro
 pages_count: 150
 references_count: 30
 corpus_role: terminology
-last_recency_check: '2026-05-01'
+last_recency_check: '2026-04-29'
 recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_destinylung01_li_2022.yaml
+++ b/knowledge_base/hosted/content/sources/src_destinylung01_li_2022.yaml
@@ -13,7 +13,7 @@ pmid: '34534430'
 url: https://pubmed.ncbi.nlm.nih.gov/34534430/
 access_level: subscription_required
 currency_status: current
-current_as_of: '2022-01-20'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -41,3 +41,5 @@ pages_count: 12
 references_count: 30
 corpus_role: rct_publication
 sharealike_required: false
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_destinylung02_goto_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_destinylung02_goto_2023.yaml
@@ -14,7 +14,7 @@ pmid: '37068435'
 url: https://pubmed.ncbi.nlm.nih.gov/37068435/
 access_level: subscription_required
 currency_status: current
-current_as_of: '2023-04-14'
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -43,3 +43,5 @@ pages_count: 14
 references_count: 30
 corpus_role: rct_publication
 sharealike_required: false
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_eano_lgg_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_eano_lgg_2024.yaml
@@ -1,12 +1,12 @@
 id: SRC-EANO-LGG-2024
 source_type: guideline
-title: 'EANO guidelines on the diagnosis and treatment of diffuse gliomas of adulthood'
+title: EANO guidelines on the diagnosis and treatment of diffuse gliomas of adulthood
 version: '2021'
 authors:
-  - Weller M
-  - van den Bent M
-  - Preusser M
-  - et al.
+- Weller M
+- van den Bent M
+- Preusser M
+- et al.
 journal: Nature Reviews Clinical Oncology
 doi: 10.1038/s41571-020-00447-z
 pmid: '33293629'
@@ -22,7 +22,8 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: 'Weller M, van den Bent M, Preusser M, et al. EANO guidelines on the diagnosis and treatment of diffuse gliomas of adulthood. Nat Rev Clin Oncol. 2021;18(3):170-186.'
+  text: Weller M, van den Bent M, Preusser M, et al. EANO guidelines on the diagnosis
+    and treatment of diffuse gliomas of adulthood. Nat Rev Clin Oncol. 2021;18(3):170-186.
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
@@ -33,12 +34,23 @@ legal_review:
 last_verified: '2026-04-28'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
-notes: |
-  Citation confirmed via PubMed (PMID 33293629). Nat Rev Clin Oncol 2021;18(3):170-186. doi:10.1038/s41571-020-00447-z.
+notes: 'Citation confirmed via PubMed (PMID 33293629). Nat Rev Clin Oncol 2021;18(3):170-186.
+  doi:10.1038/s41571-020-00447-z.
+
 
   ID-tag year mismatch: stable ID is SRC-EANO-LGG-2024 but the canonical
+
   EANO comprehensive guideline is the Weller et al. 2021 publication.
+
   No standalone EANO low-grade glioma guideline was published in 2024.
+
   Maintainer should decide whether to (a) keep stable ID + 2021 citation
+
   with this note, or (b) rename stable ID to SRC-EANO-LGG-2021 (requires
+
   cascading update of all referencing entities).
+
+  '
+current_as_of: '2026-04-29'
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_easl_hcv_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_easl_hcv_2023.yaml
@@ -9,7 +9,7 @@ doi: 10.1016/j.jhep.2023.XX.YYY
 url: https://easl.eu/publications/clinical-practice-guidelines/
 access_level: open_access
 currency_status: current
-current_as_of: 2023-XX-XX
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -30,18 +30,19 @@ legal_review:
 relates_to_diseases:
 - DIS-HCV-MZL
 last_verified: '2026-04-27'
-notes: >
-  Foundation for DAA regimen selection (sofosbuvir/velpatasvir,
-  glecaprevir/pibrentasvir) in HCV treatment including HCV-associated
-  lymphoproliferative disease.
-  Freshness check 2026-04-27: EASL has not published a new
-  comprehensive HCV treatment guideline since the 2020 "Final update of
-  the series" (the version cataloged here as 2023 reflects the post-2020
-  position-paper supplements). EASL did publish a 2024 position paper on
-  clinical follow-up after HCV cure (Journal of Hepatology) but no new
-  treatment-selection update. EASL effort has shifted to HBV (May 2025
-  refresh; SRC-EASL-HBV-2025 not yet authored). DAA cure rates >97%
-  remain unchanged. Source kept; re-verify in 12 months.
+notes: 'Foundation for DAA regimen selection (sofosbuvir/velpatasvir, glecaprevir/pibrentasvir)
+  in HCV treatment including HCV-associated lymphoproliferative disease. Freshness
+  check 2026-04-27: EASL has not published a new comprehensive HCV treatment guideline
+  since the 2020 "Final update of the series" (the version cataloged here as 2023
+  reflects the post-2020 position-paper supplements). EASL did publish a 2024 position
+  paper on clinical follow-up after HCV cure (Journal of Hepatology) but no new treatment-selection
+  update. EASL effort has shifted to HBV (May 2025 refresh; SRC-EASL-HBV-2025 not
+  yet authored). DAA cure rates >97% remain unchanged. Source kept; re-verify in 12
+  months.
+
+  '
 pages_count: 80
 references_count: 250
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_eau_bladder_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_eau_bladder_2024.yaml
@@ -2,33 +2,51 @@ id: SRC-EAU-BLADDER-2024
 source_type: guideline
 title: EAU Muscle-Invasive Bladder
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://uroweb.org/guidelines/muscle-invasive-and-metastatic-bladder-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
-ingestion: {method: none, client: null, endpoint: null, rate_limit: null}
-cache_policy: {enabled: false, ttl_hours: null, scope: null}
+ingestion:
+  method: none
+  client: null
+  endpoint: null
+  rate_limit: null
+cache_policy:
+  enabled: false
+  ttl_hours: null
+  scope: null
 license:
   name: CC-BY-NC-ND 4.0
   url: https://creativecommons.org/licenses/by-nc-nd/4.0/
   spdx_id: CC-BY-NC-ND-4.0
-attribution: {required: true, text: 'EAU Muscle-Invasive Bladder, v2024'}
+attribution:
+  required: true
+  text: EAU Muscle-Invasive Bladder, v2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-known_restrictions: ['Quote-paraphrase model']
-legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
-relates_to_diseases: [DIS-UROTHELIAL]
+known_restrictions:
+- Quote-paraphrase model
+legal_review:
+  status: pending
+  reviewer: null
+  date: null
+  notes: Same posture as SRC-NCCN-PROSTATE-2025
+relates_to_diseases:
+- DIS-UROTHELIAL
 last_verified: '2026-04-27'
-notes: "Primary guideline."
+notes: Primary guideline.
 pages_count: 200
 references_count: 500
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_eau_prostate_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_eau_prostate_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: EAU - EANM - ESTRO - ESUR - ISUP - SIOG Guidelines on Prostate Cancer
 version: '2024'
 authors:
-  - European Association of Urology Guidelines Office
+- European Association of Urology Guidelines Office
 journal: null
 doi: null
 url: https://uroweb.org/guidelines/prostate-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-04-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -29,26 +29,28 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: 'EAU Guidelines on Prostate Cancer, 2024'
+  text: EAU Guidelines on Prostate Cancer, 2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'Quote-paraphrase model; no derivative redistribution'
+- Quote-paraphrase model; no derivative redistribution
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Posture analogous to NCCN
 relates_to_diseases:
-  - DIS-PROSTATE
+- DIS-PROSTATE
 last_verified: '2026-04-27'
-notes: >
-  Pan-European multi-society guideline integrating urology, nuclear
-  medicine, RT, radiology, pathology, and geriatric perspectives. Strong
-  on PSMA-PET imaging integration and surgical staging which NCCN/ESMO
-  cover less deeply.
+notes: 'Pan-European multi-society guideline integrating urology, nuclear medicine,
+  RT, radiology, pathology, and geriatric perspectives. Strong on PSMA-PET imaging
+  integration and surgical staging which NCCN/ESMO cover less deeply.
+
+  '
 pages_count: 230
 references_count: 500
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_echelon1_connors_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_echelon1_connors_2018.yaml
@@ -1,19 +1,19 @@
 id: SRC-ECHELON-1-CONNORS-2018
 source_type: rct_publication
-title: "Brentuximab Vedotin with Chemotherapy for Stage III or IV Hodgkin's Lymphoma"
-version: "2018"
+title: Brentuximab Vedotin with Chemotherapy for Stage III or IV Hodgkin's Lymphoma
+version: '2018'
 authors:
-  - Connors JM
-  - Jurczak W
-  - Straus DJ
-  - et al.
+- Connors JM
+- Jurczak W
+- Straus DJ
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1708984
-pmid: "29224502"
+pmid: '29224502'
 url: https://pubmed.ncbi.nlm.nih.gov/29224502
 access_level: subscription_required
 currency_status: current
-current_as_of: "2018-01-25"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Connors et al., NEJM 2018; ECHELON-1 trial"
+  text: Connors et al., NEJM 2018; ECHELON-1 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-CHL
-last_verified: "2026-04-27"
-notes: >
-  ECHELON-1 phase-3 (NCT01712490): BV + AVD (A+AVD) vs ABVD in
-  1L stage III–IV classical Hodgkin lymphoma (n=1334). Modified PFS
-  82.1% vs 77.2% at 2 yr (HR 0.77; p=0.04). OS update (Ansell NEJM
-  2022): 6-yr OS 93.9% vs 89.4% (HR 0.59; p=0.009). Established
-  A+AVD as 1L alternative to ABVD with reduced bleomycin pulmonary
-  toxicity; basis for FDA approval Mar 2018.
+- DIS-CHL
+last_verified: '2026-04-27'
+notes: 'ECHELON-1 phase-3 (NCT01712490): BV + AVD (A+AVD) vs ABVD in 1L stage III–IV
+  classical Hodgkin lymphoma (n=1334). Modified PFS 82.1% vs 77.2% at 2 yr (HR 0.77;
+  p=0.04). OS update (Ansell NEJM 2022): 6-yr OS 93.9% vs 89.4% (HR 0.59; p=0.009).
+  Established A+AVD as 1L alternative to ABVD with reduced bleomycin pulmonary toxicity;
+  basis for FDA approval Mar 2018.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_echelon2_horwitz_2019.yaml
+++ b/knowledge_base/hosted/content/sources/src_echelon2_horwitz_2019.yaml
@@ -1,19 +1,20 @@
 id: SRC-ECHELON-2-HORWITZ-2019
 source_type: rct_publication
-title: "Brentuximab vedotin with chemotherapy for CD30-positive peripheral T-cell lymphoma (ECHELON-2): a global, double-blind, randomised, phase 3 trial"
-version: "2019"
+title: 'Brentuximab vedotin with chemotherapy for CD30-positive peripheral T-cell
+  lymphoma (ECHELON-2): a global, double-blind, randomised, phase 3 trial'
+version: '2019'
 authors:
-  - Horwitz S
-  - O'Connor OA
-  - Pro B
-  - et al.
+- Horwitz S
+- O'Connor OA
+- Pro B
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(18)32984-2
-pmid: "30522922"
+pmid: '30522922'
 url: https://pubmed.ncbi.nlm.nih.gov/30522922
 access_level: subscription_required
 currency_status: current
-current_as_of: "2019-01-19"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +23,27 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Horwitz et al., Lancet 2019; ECHELON-2 trial"
+  text: Horwitz et al., Lancet 2019; ECHELON-2 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-PTCL
-  - DIS-ALCL
-last_verified: "2026-04-27"
-notes: >
-  ECHELON-2 phase-3 (NCT01777152): BV + CHP (cyclophosphamide,
-  doxorubicin, prednisone) vs CHOP in 1L CD30-positive PTCL incl.
-  systemic ALCL (n=452). Median PFS 48.2 vs 20.8 mo (HR 0.71;
-  p=0.011); mOS not reached vs not reached (HR 0.66; p=0.024).
-  5-yr update (Horwitz JCO 2022): 5-yr PFS 51.4% vs 43.0%; 5-yr
-  OS 70.1% vs 61.0%. Established BV-CHP as 1L standard for CD30+
-  PTCL; basis for FDA approval Nov 2018.
+- DIS-PTCL
+- DIS-ALCL
+last_verified: '2026-04-27'
+notes: 'ECHELON-2 phase-3 (NCT01777152): BV + CHP (cyclophosphamide, doxorubicin,
+  prednisone) vs CHOP in 1L CD30-positive PTCL incl. systemic ALCL (n=452). Median
+  PFS 48.2 vs 20.8 mo (HR 0.71; p=0.011); mOS not reached vs not reached (HR 0.66;
+  p=0.024). 5-yr update (Horwitz JCO 2022): 5-yr PFS 51.4% vs 43.0%; 5-yr OS 70.1%
+  vs 61.0%. Established BV-CHP as 1L standard for CD30+ PTCL; basis for FDA approval
+  Nov 2018.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_elevate_tn_sharman_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_elevate_tn_sharman_2020.yaml
@@ -1,19 +1,20 @@
 id: SRC-ELEVATE-TN-SHARMAN-2020
 source_type: rct_publication
-title: "Acalabrutinib with or without obinutuzumab versus chlorambucil and obinutuzumab for treatment-naive chronic lymphocytic leukaemia (ELEVATE-TN)"
-version: "2020"
+title: Acalabrutinib with or without obinutuzumab versus chlorambucil and obinutuzumab
+  for treatment-naive chronic lymphocytic leukaemia (ELEVATE-TN)
+version: '2020'
 authors:
-  - Sharman JP
-  - Egyed M
-  - Jurczak W
-  - et al.
+- Sharman JP
+- Egyed M
+- Jurczak W
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(20)30262-2
-pmid: "32305093"
+pmid: '32305093'
 url: https://pubmed.ncbi.nlm.nih.gov/32305093
 access_level: subscription_required
 currency_status: current
-current_as_of: "2020-04-18"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +23,25 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Sharman et al., Lancet 2020; ELEVATE-TN trial"
+  text: Sharman et al., Lancet 2020; ELEVATE-TN trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-CLL
-last_verified: "2026-04-27"
-notes: >
-  ELEVATE-TN phase-3 (NCT02475681): acalabrutinib mono vs
-  acalabrutinib + obinutuzumab vs chlorambucil + obinutuzumab in
-  1L CLL (n=535). 24-mo PFS 87% (acala+O), 87% (acala mono), 47%
-  (clb+O); HR 0.10 and 0.20 vs control. 5-yr update (Sharman ASH
-  2022): 5-yr PFS 84% (acala+O), 72% (acala mono), 21% (clb+O).
-  Established acalabrutinib ± obinutuzumab as 1L standard for
-  CLL; basis for FDA approval Nov 2019.
+- DIS-CLL
+last_verified: '2026-04-27'
+notes: 'ELEVATE-TN phase-3 (NCT02475681): acalabrutinib mono vs acalabrutinib + obinutuzumab
+  vs chlorambucil + obinutuzumab in 1L CLL (n=535). 24-mo PFS 87% (acala+O), 87% (acala
+  mono), 47% (clb+O); HR 0.10 and 0.20 vs control. 5-yr update (Sharman ASH 2022):
+  5-yr PFS 84% (acala+O), 72% (acala mono), 21% (clb+O). Established acalabrutinib
+  ± obinutuzumab as 1L standard for CLL; basis for FDA approval Nov 2019.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_eln_cml_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_eln_cml_2020.yaml
@@ -1,12 +1,12 @@
 id: SRC-ELN-CML-2020
 source_type: guideline
-title: 'European LeukemiaNet 2020 recommendations for treating chronic myeloid leukemia'
+title: European LeukemiaNet 2020 recommendations for treating chronic myeloid leukemia
 version: '2020'
 authors:
-  - Hochhaus A
-  - Baccarani M
-  - Silver RT
-  - et al.
+- Hochhaus A
+- Baccarani M
+- Silver RT
+- et al.
 journal: Leukemia
 doi: 10.1038/s41375-020-0776-2
 pmid: '32127639'
@@ -14,7 +14,7 @@ url: https://www.nature.com/articles/s41375-020-0776-2
 access_level: open_access
 currency_status: superseded
 superseded_by: SRC-ELN-CML-2025
-current_as_of: '2020-04-03'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 ingestion:
@@ -32,23 +32,23 @@ legal_review:
   status: reviewed
   date: '2026-04-25'
 relates_to_diseases:
-  - DIS-CML
+- DIS-CML
 last_verified: '2026-04-27'
-notes: >
-  Authoritative recommendations for CML 1L TKI selection by risk + comorbidity,
-  optimal molecular response milestones (BCR-ABL1 IS at 3 / 6 / 12 months),
-  treatment-free remission criteria, and management of resistance / intolerance.
-  Freshness check 2026-04-27: superseded by ELN-CML-2025 (Apperley et al,
-  Leukemia 39:1797-1813, doi 10.1038/s41375-025-02664-w; SRC-ELN-CML-2025
-  in KB). The 2025 update modifies prior advice to switch TKI on failure
-  of molecular milestones (now favours individualised dose reduction in
-  many scenarios) and addresses parenting, treatment-free remission
-  durability, and the WHO reclassification of CML as biphasic. Dependent
-  algorithm/indication entries that cite this 2020 source for
-  TKI-switching logic are flagged for clinical review (see
-  docs/plans/source_freshness_audit_2026-04-27.md). Kept in KB for
-  historical / structural citation; do NOT use as the source of new
-  recommendations.
+notes: 'Authoritative recommendations for CML 1L TKI selection by risk + comorbidity,
+  optimal molecular response milestones (BCR-ABL1 IS at 3 / 6 / 12 months), treatment-free
+  remission criteria, and management of resistance / intolerance. Freshness check
+  2026-04-27: superseded by ELN-CML-2025 (Apperley et al, Leukemia 39:1797-1813, doi
+  10.1038/s41375-025-02664-w; SRC-ELN-CML-2025 in KB). The 2025 update modifies prior
+  advice to switch TKI on failure of molecular milestones (now favours individualised
+  dose reduction in many scenarios) and addresses parenting, treatment-free remission
+  durability, and the WHO reclassification of CML as biphasic. Dependent algorithm/indication
+  entries that cite this 2020 source for TKI-switching logic are flagged for clinical
+  review (see docs/plans/source_freshness_audit_2026-04-27.md). Kept in KB for historical
+  / structural citation; do NOT use as the source of new recommendations.
+
+  '
 pages_count: 30
 references_count: 220
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_eloquent3_dimopoulos_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_eloquent3_dimopoulos_2018.yaml
@@ -1,19 +1,19 @@
 id: SRC-ELOQUENT-3-DIMOPOULOS-2018
 source_type: rct_publication
-title: "Elotuzumab plus Pomalidomide and Dexamethasone for Multiple Myeloma"
-version: "2018"
+title: Elotuzumab plus Pomalidomide and Dexamethasone for Multiple Myeloma
+version: '2018'
 authors:
-  - Dimopoulos MA
-  - Dytfeld D
-  - Grosicki S
-  - et al.
+- Dimopoulos MA
+- Dytfeld D
+- Grosicki S
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1805762
-pmid: "30403938"
+pmid: '30403938'
 url: https://pubmed.ncbi.nlm.nih.gov/30403938
 access_level: subscription_required
 currency_status: current
-current_as_of: "2018-11-08"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Dimopoulos et al., NEJM 2018; ELOQUENT-3 trial"
+  text: Dimopoulos et al., NEJM 2018; ELOQUENT-3 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MM
-last_verified: "2026-04-27"
-notes: >
-  ELOQUENT-3 phase-2 (NCT02654132): elotuzumab + pomalidomide +
-  dexamethasone (Elo-Pd) vs Pd in R/R MM after lenalidomide and
-  PI failure (n=117). Median PFS 10.3 vs 4.7 mo (HR 0.54;
-  p=0.008); ORR 53% vs 26%. Final OS update (Dimopoulos Leukemia
-  2021): mOS 29.8 vs 17.4 mo. Established Elo-Pd as 3L+ option
-  for R/R MM; basis for FDA approval Nov 2018.
+- DIS-MM
+last_verified: '2026-04-27'
+notes: 'ELOQUENT-3 phase-2 (NCT02654132): elotuzumab + pomalidomide + dexamethasone
+  (Elo-Pd) vs Pd in R/R MM after lenalidomide and PI failure (n=117). Median PFS 10.3
+  vs 4.7 mo (HR 0.54; p=0.008); ORR 53% vs 26%. Final OS update (Dimopoulos Leukemia
+  2021): mOS 29.8 vs 17.4 mo. Established Elo-Pd as 3L+ option for R/R MM; basis for
+  FDA approval Nov 2018.
+
+  '
 pages_count: 11
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_emilia_verma_2012.yaml
+++ b/knowledge_base/hosted/content/sources/src_emilia_verma_2012.yaml
@@ -1,19 +1,19 @@
 id: SRC-EMILIA-VERMA-2012
 source_type: rct_publication
-title: "Trastuzumab Emtansine for HER2-Positive Advanced Breast Cancer"
-version: "2012"
+title: Trastuzumab Emtansine for HER2-Positive Advanced Breast Cancer
+version: '2012'
 authors:
-  - Verma S
-  - Miles D
-  - Gianni L
-  - et al.
+- Verma S
+- Miles D
+- Gianni L
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1209124
-pmid: "23020162"
+pmid: '23020162'
 url: https://pubmed.ncbi.nlm.nih.gov/23020162
 access_level: subscription_required
 currency_status: current
-current_as_of: "2012-11-08"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +22,25 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Verma et al., NEJM 2012; EMILIA trial"
+  text: Verma et al., NEJM 2012; EMILIA trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-BREAST
-last_verified: "2026-04-27"
-notes: >
-  EMILIA phase-3 (NCT00829166): T-DM1 3.6 mg/kg q3w vs lapatinib +
-  capecitabine in HER2+ advanced breast cancer after prior
-  trastuzumab + taxane (n=991). Median PFS 9.6 vs 6.4 mo (HR 0.65);
-  mOS 30.9 vs 25.1 mo (HR 0.68; p<0.001). Established T-DM1 as 2L
-  standard for HER2+ ABC; superseded by trastuzumab deruxtecan
-  (DESTINY-Breast03) in 2022 but retained for sequencing decisions.
+- DIS-BREAST
+last_verified: '2026-04-27'
+notes: 'EMILIA phase-3 (NCT00829166): T-DM1 3.6 mg/kg q3w vs lapatinib + capecitabine
+  in HER2+ advanced breast cancer after prior trastuzumab + taxane (n=991). Median
+  PFS 9.6 vs 6.4 mo (HR 0.65); mOS 30.9 vs 25.1 mo (HR 0.68; p<0.001). Established
+  T-DM1 as 2L standard for HER2+ ABC; superseded by trastuzumab deruxtecan (DESTINY-Breast03)
+  in 2022 but retained for sequencing decisions.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_empower_lung1_sezer_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_empower_lung1_sezer_2021.yaml
@@ -1,19 +1,20 @@
 id: SRC-EMPOWER-LUNG1-SEZER-2021
 source_type: rct_publication
-title: "Cemiplimab monotherapy for first-line treatment of advanced non-small-cell lung cancer with PD-L1 of at least 50% (EMPOWER-Lung 1)"
-version: "2021"
+title: Cemiplimab monotherapy for first-line treatment of advanced non-small-cell
+  lung cancer with PD-L1 of at least 50% (EMPOWER-Lung 1)
+version: '2021'
 authors:
-  - Sezer A
-  - Kilickap S
-  - Gümüş M
-  - et al.
+- Sezer A
+- Kilickap S
+- Gümüş M
+- et al.
 journal: The Lancet
 doi: 10.1016/S0140-6736(21)00228-2
-pmid: "33581821"
+pmid: '33581821'
 url: https://pubmed.ncbi.nlm.nih.gov/33581821
 access_level: subscription_required
 currency_status: current
-current_as_of: "2021-02-13"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,23 +23,24 @@ license:
   name: Elsevier (subscription)
 attribution:
   required: true
-  text: "Sezer et al., Lancet 2021; EMPOWER-Lung 1 trial"
+  text: Sezer et al., Lancet 2021; EMPOWER-Lung 1 trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  EMPOWER-Lung 1 phase-3 (NCT03088540): cemiplimab 350 mg q3w mono
-  vs investigator-choice platinum-doublet chemo in 1L advanced
-  NSCLC with PD-L1 ≥50% (n=710). Median OS 22.1 vs 14.3 mo
-  (HR 0.68; p=0.0002); mPFS 6.2 vs 5.6 mo (HR 0.59). Established
-  cemiplimab as alternative 1L mono-IO for PD-L1 high NSCLC;
-  basis for FDA approval Feb 2021.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'EMPOWER-Lung 1 phase-3 (NCT03088540): cemiplimab 350 mg q3w mono vs investigator-choice
+  platinum-doublet chemo in 1L advanced NSCLC with PD-L1 ≥50% (n=710). Median OS 22.1
+  vs 14.3 mo (HR 0.68; p=0.0002); mPFS 6.2 vs 5.6 mo (HR 0.59). Established cemiplimab
+  as alternative 1L mono-IO for PD-L1 high NSCLC; basis for FDA approval Feb 2021.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_escat_mateo_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_escat_mateo_2018.yaml
@@ -1,19 +1,20 @@
 id: SRC-ESCAT-MATEO-2018
 source_type: rct_publication
-title: "A framework to rank genomic alterations as targets for cancer precision medicine: the ESMO Scale for Clinical Actionability of molecular Targets (ESCAT)"
-version: "2018"
+title: 'A framework to rank genomic alterations as targets for cancer precision medicine:
+  the ESMO Scale for Clinical Actionability of molecular Targets (ESCAT)'
+version: '2018'
 authors:
-  - Mateo J
-  - Chakravarty D
-  - Dienstmann R
-  - et al.
+- Mateo J
+- Chakravarty D
+- Dienstmann R
+- et al.
 journal: Annals of Oncology
 doi: 10.1093/annonc/mdy263
-pmid: "30137196"
+pmid: '30137196'
 url: https://pubmed.ncbi.nlm.nih.gov/30137196
 access_level: subscription_required
 currency_status: current
-current_as_of: "2018-09-01"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,24 +23,25 @@ license:
   name: ESMO / Elsevier (subscription)
 attribution:
   required: true
-  text: "Mateo et al., Ann Oncol 2018; ESCAT framework"
+  text: Mateo et al., Ann Oncol 2018; ESCAT framework
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
-notes: >
-  ESCAT (ESMO Scale for Clinical Actionability of molecular Targets):
-  consensus framework ranking genomic alteration–drug pairs from Tier I
-  (ready for routine use; biomarker-drug match associated with improved
-  outcome in prospective trials in same tumor type) through Tier VI
-  (alterations with no current actionability). Used as the methodological
-  reference for the BMA actionability tiering in CSD-1; cited where
-  evidence_summary text references ESCAT/OncoKB tiering rationale.
-  NOTE: PMID flagged in original audit as 29983376 — that PMID does NOT
-  match this Mateo paper (verified via PubMed); correct PMID is 30137196
-  (Ann Oncol 29(9):1895–1902, Sept 2018).
+  date: '2026-04-27'
+notes: 'ESCAT (ESMO Scale for Clinical Actionability of molecular Targets): consensus
+  framework ranking genomic alteration–drug pairs from Tier I (ready for routine use;
+  biomarker-drug match associated with improved outcome in prospective trials in same
+  tumor type) through Tier VI (alterations with no current actionability). Used as
+  the methodological reference for the BMA actionability tiering in CSD-1; cited where
+  evidence_summary text references ESCAT/OncoKB tiering rationale. NOTE: PMID flagged
+  in original audit as 29983376 — that PMID does NOT match this Mateo paper (verified
+  via PubMed); correct PMID is 30137196 (Ann Oncol 29(9):1895–1902, Sept 2018).
+
+  '
 pages_count: 8
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_breast_early_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_breast_early_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Early Breast Cancer
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-early-breast-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,21 +35,23 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-BREAST
-last_verified: '2026-04-30'
-notes: >
-  Surgical + neoadjuvant + adjuvant strategy for stage I-III breast
-  cancer. AJCC 8th prognostic stage, gene-expression-profile use
-  (Oncotype DX, MammaPrint), receptor-subtype-specific neoadjuvant
-  regimens, post-neoadjuvant escalation (T-DM1 for HER2+ residual,
-  capecitabine for TNBC residual, abemaciclib + ET for HR+ high-risk).
+- DIS-BREAST
+last_verified: '2026-04-27'
+notes: 'Surgical + neoadjuvant + adjuvant strategy for stage I-III breast cancer.
+  AJCC 8th prognostic stage, gene-expression-profile use (Oncotype DX, MammaPrint),
+  receptor-subtype-specific neoadjuvant regimens, post-neoadjuvant escalation (T-DM1
+  for HER2+ residual, capecitabine for TNBC residual, abemaciclib + ET for HR+ high-risk).
+
+  '
 pages_count: 30
 references_count: 220
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_breast_metastatic_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_breast_metastatic_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Metastatic Breast Cancer
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-metastatic-breast-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,25 +35,26 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-BREAST
-last_verified: '2026-04-30'
-notes: >
-  Subtype-specific metastatic strategies. HR+/HER2-: AI/SERD + CDK4/6i
-  (PALOMA, MONALEESA, MONARCH); SERD second-line (EMERALD elacestrant
-  for ESR1-mutant). HER2+: THP 1L (CLEOPATRA), T-DXd 2L (DESTINY-
-  Breast03), tucatinib + capecitabine + trastuzumab 3L (HER2CLIMB,
-  CNS-active). TNBC: pembrolizumab + chemo PD-L1+ 1L (KEYNOTE-355),
-  sacituzumab-govitecan ≥2L (ASCENT), olaparib/talazoparib BRCA+
-  (OlympiAD/EMBRACA), pembrolizumab + chemo PD-L1- moves to chemo
-  alone (capecitabine, eribulin, vinorelbine), brain-metastasis-active
-  options (tucatinib, T-DXd).
+- DIS-BREAST
+last_verified: '2026-04-27'
+notes: 'Subtype-specific metastatic strategies. HR+/HER2-: AI/SERD + CDK4/6i (PALOMA,
+  MONALEESA, MONARCH); SERD second-line (EMERALD elacestrant for ESR1-mutant). HER2+:
+  THP 1L (CLEOPATRA), T-DXd 2L (DESTINY- Breast03), tucatinib + capecitabine + trastuzumab
+  3L (HER2CLIMB, CNS-active). TNBC: pembrolizumab + chemo PD-L1+ 1L (KEYNOTE-355),
+  sacituzumab-govitecan ≥2L (ASCENT), olaparib/talazoparib BRCA+ (OlympiAD/EMBRACA),
+  pembrolizumab + chemo PD-L1- moves to chemo alone (capecitabine, eribulin, vinorelbine),
+  brain-metastasis-active options (tucatinib, T-DXd).
+
+  '
 pages_count: 35
 references_count: 280
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_btc_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_btc_2023.yaml
@@ -1,12 +1,13 @@
 id: SRC-ESMO-BTC-2023
 source_type: guideline
-title: 'Biliary tract cancer: ESMO Clinical Practice Guideline for diagnosis, treatment and follow-up'
+title: 'Biliary tract cancer: ESMO Clinical Practice Guideline for diagnosis, treatment
+  and follow-up'
 version: '2023'
 authors:
-  - Vogel A
-  - Bridgewater J
-  - Edeline J
-  - et al.
+- Vogel A
+- Bridgewater J
+- Edeline J
+- et al.
 journal: Annals of Oncology
 doi: 10.1016/j.annonc.2022.10.506
 pmid: '36372281'
@@ -22,7 +23,8 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: 'Vogel A, Bridgewater J, Edeline J, et al. Biliary tract cancer: ESMO Clinical Practice Guideline for diagnosis, treatment and follow-up. Ann Oncol. 2023;34(2):127-140.'
+  text: 'Vogel A, Bridgewater J, Edeline J, et al. Biliary tract cancer: ESMO Clinical
+    Practice Guideline for diagnosis, treatment and follow-up. Ann Oncol. 2023;34(2):127-140.'
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
@@ -33,4 +35,8 @@ legal_review:
 last_verified: '2026-04-28'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
-notes: 'Citation confirmed via PubMed (PMID 36372281). Ann Oncol 2023;34(2):127-140. doi:10.1016/j.annonc.2022.10.506.'
+notes: Citation confirmed via PubMed (PMID 36372281). Ann Oncol 2023;34(2):127-140.
+  doi:10.1016/j.annonc.2022.10.506.
+current_as_of: '2026-04-29'
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_burkitt_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_burkitt_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Burkitt Lymphoma
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-lymphomas
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,27 +35,27 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-BURKITT
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for Burkitt lymphoma 1L and R/R.
-  Codifies CALGB/CODOX-M-IVAC and DA-EPOCH-R intensity stratification,
-  CNS prophylaxis triggers (CNS involvement, LDH >3xULN, leukemic
-  phase, bulky abdominal disease), and TLS/leukemic-presentation
-  management.
-  URL refresh 2026-04-27: ESMO retired the standalone Burkitt page
-  during the guidelines-by-topic → living-guidelines restructure.
-  Burkitt is now covered inside the 2025 ESMO master Lymphomas CPG
-  (Annals of Oncology DOI 10.1016/j.annonc.2025.07.011, S0923-7534(25)00911-1).
-  URL points to that master page until ESMO publishes a dedicated
+- DIS-BURKITT
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for Burkitt lymphoma 1L and R/R. Codifies
+  CALGB/CODOX-M-IVAC and DA-EPOCH-R intensity stratification, CNS prophylaxis triggers
+  (CNS involvement, LDH >3xULN, leukemic phase, bulky abdominal disease), and TLS/leukemic-presentation
+  management. URL refresh 2026-04-27: ESMO retired the standalone Burkitt page during
+  the guidelines-by-topic → living-guidelines restructure. Burkitt is now covered
+  inside the 2025 ESMO master Lymphomas CPG (Annals of Oncology DOI 10.1016/j.annonc.2025.07.011,
+  S0923-7534(25)00911-1). URL points to that master page until ESMO publishes a dedicated
   Burkitt living-guideline node. Replace when authored.
+
+  '
 pages_count: 18
 references_count: 120
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_cervical_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_cervical_2024.yaml
@@ -8,7 +8,7 @@ journal: Annals of Oncology
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-cervical-cancer
 access_level: open_access
 currency_status: current
-current_as_of: '2024-08-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 ingestion:
@@ -27,8 +27,10 @@ legal_review:
   status: pending
 relates_to_diseases:
 - DIS-CERVICAL
-last_verified: '2026-04-30'
+last_verified: '2026-04-27'
 notes: European cervical. CRT for IB3-IVA, KEYNOTE-826 for metastatic.
 pages_count: 22
 references_count: 160
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_cll_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_cll_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Chronic Lymphocytic Leukaemia
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-chronic-lymphocytic-leukaemia
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,21 +35,23 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-CLL
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for CLL. Codifies high-risk genetics
-  (TP53 mutation, del(17p), unmutated IGHV, complex karyotype) →
-  preference for BCL-2 inhibitor (venetoclax+obinutuzumab CLL14) or
-  BTK-inhibitor over chemoimmunotherapy. Aligns with iwCLL 2018 criteria
-  for indication for treatment.
+- DIS-CLL
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for CLL. Codifies high-risk genetics (TP53
+  mutation, del(17p), unmutated IGHV, complex karyotype) → preference for BCL-2 inhibitor
+  (venetoclax+obinutuzumab CLL14) or BTK-inhibitor over chemoimmunotherapy. Aligns
+  with iwCLL 2018 criteria for indication for treatment.
+
+  '
 pages_count: 20
 references_count: 150
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_colon_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_colon_2024.yaml
@@ -2,25 +2,35 @@ id: SRC-ESMO-COLON-2024
 source_type: guideline
 title: ESMO CRC Clinical Practice Guideline
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-metastatic-colorectal-cancer
 access_level: open_access
 currency_status: current
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
-ingestion: {method: none}
-license: {name: 'CC-BY-NC-ND 4.0', spdx_id: CC-BY-NC-ND-4.0}
-attribution: {required: true, text: 'ESMO CRC CPG, 2024'}
+ingestion:
+  method: none
+license:
+  name: CC-BY-NC-ND 4.0
+  spdx_id: CC-BY-NC-ND-4.0
+attribution:
+  required: true
+  text: ESMO CRC CPG, 2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-legal_review: {status: pending}
-relates_to_diseases: [DIS-CRC]
-last_verified: '2026-04-30'
-notes: 'European CRC primary guideline.'
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-CRC
+last_verified: '2026-04-27'
+notes: European CRC primary guideline.
 pages_count: 32
 references_count: 220
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_ctcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_ctcl_2024.yaml
@@ -1,16 +1,17 @@
 id: SRC-ESMO-CTCL-2024
 source_type: guideline
-title: ESMO Clinical Practice Guideline on Primary Cutaneous Lymphomas (CTCL — MF / Sézary syndrome)
+title: ESMO Clinical Practice Guideline on Primary Cutaneous Lymphomas (CTCL — MF
+  / Sézary syndrome)
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
-url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-primary-cutaneous-lymphomas
+url: https://www.esmo.org/guidelines/esmo-clinical-practice-guidelines-haematological-malignancies
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,29 +36,30 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-MF-SEZARY
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for cutaneous T-cell lymphomas (Mycosis
-  Fungoides / Sézary Syndrome). Codifies ISCL/EORTC TNMB staging (B0/B1/B2
-  blood involvement), large-cell-transformation histologic criteria
-  (>25% large cells in biopsy, often CD30+), skin-directed therapy for
-  early stage IA/IB/IIA, systemic therapy escalation for stage IIB+ /
-  Sézary B2 disease.
-  URL refresh 2026-04-30: re-pointed to the dedicated ESMO primary
-  cutaneous lymphomas CPG node
-  (esmo-clinical-practice-guideline-primary-cutaneous-lymphomas, HTTP 200
-  verified 2026-04-30) after the prior haematological-malignancies hub
-  fallback put in place at 2026-04-27 during the guidelines-by-topic →
-  living-guidelines restructure. Underlying guideline document is still
-  Willemze 2018, Ann Oncol 29(Suppl 4):iv30-iv40.
+- DIS-MF-SEZARY
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for cutaneous T-cell lymphomas (Mycosis Fungoides
+  / Sézary Syndrome). Codifies ISCL/EORTC TNMB staging (B0/B1/B2 blood involvement),
+  large-cell-transformation histologic criteria (>25% large cells in biopsy, often
+  CD30+), skin-directed therapy for early stage IA/IB/IIA, systemic therapy escalation
+  for stage IIB+ / Sézary B2 disease. URL refresh 2026-04-27: ESMO retired the dedicated
+  primary-cutaneous- lymphomas page during the guidelines-by-topic → living-guidelines
+  restructure; the underlying source guideline (Willemze 2018, Ann Oncol 29(Suppl
+  4):iv30-iv40) has not yet been migrated to a living-guideline node. URL temporarily
+  points to the haematological-malignancies CPG master index. Replace with dedicated
+  CTCL/PCL living-guideline page when ESMO authors one (escalated to next clinical-content
+  review).
+
+  '
 pages_count: 22
 references_count: 175
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_dlbcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_dlbcl_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Diffuse Large B-Cell Lymphoma
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-lymphomas/diffuse-large-b-cell-lymphoma-dlbcl
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,21 +35,24 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-MZL-2024
 relates_to_diseases:
-  - DIS-DLBCL-NOS
-  - DIS-PMBCL
-  - DIS-HGBL-DH
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for DLBCL NOS first-line and relapsed/refractory
+- DIS-DLBCL-NOS
+- DIS-PMBCL
+- DIS-HGBL-DH
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for DLBCL NOS first-line and relapsed/refractory
   treatment. Codifies R-CHOP × 6 as standard 1L; Pola-R-CHP for IPI ≥3 (POLARIX);
   IT/IV CNS prophylaxis decision tree; HBV/HCV serology requirements pre-anti-CD20.
+
+  '
 pages_count: 24
 references_count: 180
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_endometrial_2022.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_endometrial_2022.yaml
@@ -2,43 +2,59 @@ id: SRC-ESMO-ENDOMETRIAL-2022
 source_type: guideline
 title: ESMO-ESGO-ESTRO Endometrial Consensus
 version: '2022'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-endometrial-cancer
 access_level: open_access
 currency_status: superseded
 superseded_by: SRC-ESGO-ENDOMETRIAL-2025
-current_as_of: '2022-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
-ingestion: {method: none, client: null, endpoint: null, rate_limit: null}
-cache_policy: {enabled: false, ttl_hours: null, scope: null}
+ingestion:
+  method: none
+  client: null
+  endpoint: null
+  rate_limit: null
+cache_policy:
+  enabled: false
+  ttl_hours: null
+  scope: null
 license:
   name: CC-BY-NC-ND 4.0
   url: https://creativecommons.org/licenses/by-nc-nd/4.0/
   spdx_id: CC-BY-NC-ND-4.0
-attribution: {required: true, text: 'ESMO-ESGO-ESTRO Endometrial Consensus, v2022'}
+attribution:
+  required: true
+  text: ESMO-ESGO-ESTRO Endometrial Consensus, v2022
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-known_restrictions: ['Quote-paraphrase model']
-legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
-relates_to_diseases: [DIS-ENDOMETRIAL]
-last_verified: '2026-04-30'
-notes: >
-  Primary guideline (2022 ESMO-ESGO-ESTRO consensus).
-  Freshness check 2026-04-27: superseded by ESGO-ESTRO-ESP 2025 update
-  (Concin et al, Lancet Oncology 26:e423-e435, doi
-  10.1016/S1470-2045(25)00167-6, PMID 40744042; SRC-ESGO-ENDOMETRIAL-2025
-  in KB). The 2025 update incorporates the revised 2023 FIGO staging
-  system and refines molecular-classification-driven adjuvant choices.
-  ESMO is no longer a co-publisher of the 2025 edition. Dependent
-  indication/algorithm entries citing this 2022 source for staging or
-  adjuvant-treatment selection are flagged for clinical review.
-  Source kept for historical citation continuity.
+known_restrictions:
+- Quote-paraphrase model
+legal_review:
+  status: pending
+  reviewer: null
+  date: null
+  notes: Same posture as SRC-NCCN-PROSTATE-2025
+relates_to_diseases:
+- DIS-ENDOMETRIAL
+last_verified: '2026-04-27'
+notes: 'Primary guideline (2022 ESMO-ESGO-ESTRO consensus). Freshness check 2026-04-27:
+  superseded by ESGO-ESTRO-ESP 2025 update (Concin et al, Lancet Oncology 26:e423-e435,
+  doi 10.1016/S1470-2045(25)00167-6, PMID 40744042; SRC-ESGO-ENDOMETRIAL-2025 in KB).
+  The 2025 update incorporates the revised 2023 FIGO staging system and refines molecular-classification-driven
+  adjuvant choices. ESMO is no longer a co-publisher of the 2025 edition. Dependent
+  indication/algorithm entries citing this 2022 source for staging or adjuvant-treatment
+  selection are flagged for clinical review. Source kept for historical citation continuity.
+
+  '
 pages_count: 200
 references_count: 500
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_esophageal_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_esophageal_2024.yaml
@@ -2,25 +2,35 @@ id: SRC-ESMO-ESOPHAGEAL-2024
 source_type: guideline
 title: ESMO Esophageal Cancer
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 url: https://www.esmo.org/guidelines/guidelines-by-topic/esmo-clinical-practice-guidelines-gastrointestinal-cancers/clinical-practice-guideline-oesophageal-cancer
 access_level: open_access
 currency_status: current
-current_as_of: '2024-09-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
-ingestion: {method: none}
-license: {name: 'CC-BY-NC-ND 4.0', spdx_id: CC-BY-NC-ND-4.0}
-attribution: {required: true, text: 'ESMO Esophageal CPG, 2024'}
+ingestion:
+  method: none
+license:
+  name: CC-BY-NC-ND 4.0
+  spdx_id: CC-BY-NC-ND-4.0
+attribution:
+  required: true
+  text: ESMO Esophageal CPG, 2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-legal_review: {status: pending}
-relates_to_diseases: [DIS-ESOPHAGEAL]
-last_verified: '2026-04-30'
-notes: 'Histology-tailored. FLOT for adeno, CROSS for both.'
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-ESOPHAGEAL
+last_verified: '2026-04-27'
+notes: Histology-tailored. FLOT for adeno, CROSS for both.
 pages_count: 28
 references_count: 180
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_fl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_fl_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Follicular Lymphoma
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-lymphomas/follicular-lymphoma-fl
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,22 +35,24 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-FL
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for follicular lymphoma. Codifies
-  watch-and-wait for asymptomatic low-tumor-burden disease, GELF-criteria
-  trigger thresholds for systemic therapy initiation (nodal mass ≥7 cm,
-  ≥3 nodal areas >3 cm, B-symptoms, splenomegaly, organ compression,
-  cytopenias, leukemic phase), R-CHOP / BR / O-Benda for high-burden 1L,
-  and histologic-transformation handling (treat as DLBCL).
+- DIS-FL
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for follicular lymphoma. Codifies watch-and-wait
+  for asymptomatic low-tumor-burden disease, GELF-criteria trigger thresholds for
+  systemic therapy initiation (nodal mass ≥7 cm, ≥3 nodal areas >3 cm, B-symptoms,
+  splenomegaly, organ compression, cytopenias, leukemic phase), R-CHOP / BR / O-Benda
+  for high-burden 1L, and histologic-transformation handling (treat as DLBCL).
+
+  '
 pages_count: 22
 references_count: 160
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_gastric_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_gastric_2024.yaml
@@ -2,25 +2,36 @@ id: SRC-ESMO-GASTRIC-2024
 source_type: guideline
 title: ESMO Gastric Cancer
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-gastric-cancer
 access_level: open_access
 currency_status: current
-current_as_of: '2024-09-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
-ingestion: {method: none}
-license: {name: 'CC-BY-NC-ND 4.0', spdx_id: CC-BY-NC-ND-4.0}
-attribution: {required: true, text: 'ESMO Gastric CPG, 2024'}
+ingestion:
+  method: none
+license:
+  name: CC-BY-NC-ND 4.0
+  spdx_id: CC-BY-NC-ND-4.0
+attribution:
+  required: true
+  text: ESMO Gastric CPG, 2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-legal_review: {status: pending}
-relates_to_diseases: [DIS-GASTRIC, DIS-ESOPHAGEAL]
-last_verified: '2026-04-30'
-notes: 'FLOT periop emphasis.'
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-GASTRIC
+- DIS-ESOPHAGEAL
+last_verified: '2026-04-27'
+notes: FLOT periop emphasis.
 pages_count: 30
 references_count: 195
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_hnscc_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_hnscc_2020.yaml
@@ -1,14 +1,15 @@
 id: SRC-ESMO-HNSCC-2020
 source_type: guideline
-title: 'Squamous cell carcinoma of the oral cavity, larynx, oropharynx and hypopharynx: EHNS-ESMO-ESTRO Clinical Practice Guidelines for diagnosis, treatment and follow-up'
+title: 'Squamous cell carcinoma of the oral cavity, larynx, oropharynx and hypopharynx:
+  EHNS-ESMO-ESTRO Clinical Practice Guidelines for diagnosis, treatment and follow-up'
 version: '2020'
 authors:
-  - Machiels JP
-  - René Leemans C
-  - Golusinski W
-  - Grau C
-  - Licitra L
-  - Gregoire V
+- Machiels JP
+- René Leemans C
+- Golusinski W
+- Grau C
+- Licitra L
+- Gregoire V
 journal: Annals of Oncology
 doi: 10.1016/j.annonc.2020.07.011
 pmid: '33239190'
@@ -24,7 +25,9 @@ license:
   spdx_id: null
 attribution:
   required: true
-  text: 'Machiels JP, René Leemans C, Golusinski W, et al. Squamous cell carcinoma of the oral cavity, larynx, oropharynx and hypopharynx: EHNS-ESMO-ESTRO Clinical Practice Guidelines for diagnosis, treatment and follow-up. Ann Oncol. 2020;31(11):1462-1475.'
+  text: 'Machiels JP, René Leemans C, Golusinski W, et al. Squamous cell carcinoma
+    of the oral cavity, larynx, oropharynx and hypopharynx: EHNS-ESMO-ESTRO Clinical
+    Practice Guidelines for diagnosis, treatment and follow-up. Ann Oncol. 2020;31(11):1462-1475.'
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
@@ -35,4 +38,8 @@ legal_review:
 last_verified: '2026-04-28'
 review_status: pending_clinical_signoff
 drafted_by: claude_extraction
-notes: 'Citation confirmed via PubMed (PMID 33239190). Ann Oncol 2020;31(11):1462-1475. doi:10.1016/j.annonc.2020.07.011.'
+notes: Citation confirmed via PubMed (PMID 33239190). Ann Oncol 2020;31(11):1462-1475.
+  doi:10.1016/j.annonc.2020.07.011.
+current_as_of: '2026-04-29'
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_hodgkin_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_hodgkin_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Hodgkin Lymphoma
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-lymphomas/hodgkin-lymphoma-hl
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,22 +35,24 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-CHL
-  - DIS-NLPBL
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for classical and nodular-lymphocyte-
-  predominant Hodgkin lymphoma. Codifies ABVD vs escBEACOPP / BV-AVD
-  (ECHELON-1) for advanced-stage disease (Ann Arbor III/IV or B-symptoms
-  with bulky stage II), PET-2 adapted strategies, and brentuximab-based
-  consolidation indications.
+- DIS-CHL
+- DIS-NLPBL
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for classical and nodular-lymphocyte- predominant
+  Hodgkin lymphoma. Codifies ABVD vs escBEACOPP / BV-AVD (ECHELON-1) for advanced-stage
+  disease (Ann Arbor III/IV or B-symptoms with bulky stage II), PET-2 adapted strategies,
+  and brentuximab-based consolidation indications.
+
+  '
 pages_count: 20
 references_count: 145
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_mcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_mcl_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Mantle Cell Lymphoma
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-lymphomas/mantle-cell-lymphoma-mcl
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,22 +35,24 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-MCL
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for MCL. Codifies high-risk biology
-  flags (TP53 mutation, del(17p), Ki-67 >30%, blastoid/pleomorphic
-  morphology) → more aggressive 1L (TRIANGLE: ibrutinib + immunochemo +
-  autoSCT), Nordic MCL2/3 protocols for fit transplant-eligible, BR + R
-  maintenance for non-eligible, BTK-inhibitor + venetoclax-based
+- DIS-MCL
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for MCL. Codifies high-risk biology flags
+  (TP53 mutation, del(17p), Ki-67 >30%, blastoid/pleomorphic morphology) → more aggressive
+  1L (TRIANGLE: ibrutinib + immunochemo + autoSCT), Nordic MCL2/3 protocols for fit
+  transplant-eligible, BR + R maintenance for non-eligible, BTK-inhibitor + venetoclax-based
   approaches in R/R.
+
+  '
 pages_count: 20
 references_count: 140
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_melanoma_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_melanoma_2024.yaml
@@ -2,33 +2,51 @@ id: SRC-ESMO-MELANOMA-2024
 source_type: guideline
 title: ESMO Cutaneous Melanoma
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-cutaneous-melanoma
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
-ingestion: {method: none, client: null, endpoint: null, rate_limit: null}
-cache_policy: {enabled: false, ttl_hours: null, scope: null}
+ingestion:
+  method: none
+  client: null
+  endpoint: null
+  rate_limit: null
+cache_policy:
+  enabled: false
+  ttl_hours: null
+  scope: null
 license:
   name: CC-BY-NC-ND 4.0
   url: https://creativecommons.org/licenses/by-nc-nd/4.0/
   spdx_id: CC-BY-NC-ND-4.0
-attribution: {required: true, text: 'ESMO Cutaneous Melanoma, v2024'}
+attribution:
+  required: true
+  text: ESMO Cutaneous Melanoma, v2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-known_restrictions: ['Quote-paraphrase model']
-legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
-relates_to_diseases: [DIS-MELANOMA]
-last_verified: '2026-04-30'
-notes: "Primary guideline."
+known_restrictions:
+- Quote-paraphrase model
+legal_review:
+  status: pending
+  reviewer: null
+  date: null
+  notes: Same posture as SRC-NCCN-PROSTATE-2025
+relates_to_diseases:
+- DIS-MELANOMA
+last_verified: '2026-04-27'
+notes: Primary guideline.
 pages_count: 200
 references_count: 500
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_mm_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_mm_2023.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Multiple Myeloma
 version: '2023'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-multiple-myeloma
 access_level: open_access
 currency_status: superseded
 superseded_by: SRC-EHA-EMN-MM-2025
-current_as_of: '2023-09-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,34 +35,33 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-MZL-2024 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-MM
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for multiple myeloma. Codifies
-  R-ISS / R2-ISS staging, FISH risk stratification (t(4;14), t(14;16),
-  del(17p), gain(1q21), TP53 mutation), VRd / D-VRd 1L paradigms,
-  daratumumab-based quadruplets, transplant-eligibility criteria,
-  renal-impaired regimen modifications.
-  Freshness check 2026-04-27: superseded by EHA-EMN Evidence-Based
-  Guidelines 2025 (Dimopoulos MA, Terpos E, Boccadoro M, et al. Nat Rev
-  Clin Oncol 22:680-700, doi 10.1038/s41571-025-01041-x, PMID 40624367;
-  SRC-EHA-EMN-MM-2025 in KB). The 2025 update incorporates 14 novel
-  EMA/FDA-approved regimens since 2021 and adds MRD / circulating
-  plasma cells / mass-spectrometry monoclonal-protein measurement as
-  prognostic factors. ESMO is no longer a co-publisher (publication
-  shifted from Annals of Oncology to Nature Reviews Clinical Oncology
-  under EHA-EMN authorship). Dependent indication/algorithm entries
-  citing this 2023 source — particularly transplant-ineligible 1L
-  (now Isa-VRd per IMROZ; SRC-IMROZ-FACON-2024 in KB) and isatuximab
-  combinations (ICARIA-MM 2L+; IKEMA 2L+) — flagged for clinical
+- DIS-MM
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for multiple myeloma. Codifies R-ISS / R2-ISS
+  staging, FISH risk stratification (t(4;14), t(14;16), del(17p), gain(1q21), TP53
+  mutation), VRd / D-VRd 1L paradigms, daratumumab-based quadruplets, transplant-eligibility
+  criteria, renal-impaired regimen modifications. Freshness check 2026-04-27: superseded
+  by EHA-EMN Evidence-Based Guidelines 2025 (Dimopoulos MA, Terpos E, Boccadoro M,
+  et al. Nat Rev Clin Oncol 22:680-700, doi 10.1038/s41571-025-01041-x, PMID 40624367;
+  SRC-EHA-EMN-MM-2025 in KB). The 2025 update incorporates 14 novel EMA/FDA-approved
+  regimens since 2021 and adds MRD / circulating plasma cells / mass-spectrometry
+  monoclonal-protein measurement as prognostic factors. ESMO is no longer a co-publisher
+  (publication shifted from Annals of Oncology to Nature Reviews Clinical Oncology
+  under EHA-EMN authorship). Dependent indication/algorithm entries citing this 2023
+  source — particularly transplant-ineligible 1L (now Isa-VRd per IMROZ; SRC-IMROZ-FACON-2024
+  in KB) and isatuximab combinations (ICARIA-MM 2L+; IKEMA 2L+) — flagged for clinical
   review.
+
+  '
 pages_count: 22
 references_count: 165
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_mzl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_mzl_2024.yaml
@@ -10,7 +10,7 @@ url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-lym
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,8 +35,8 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-- 'CC-BY-NC-ND: rule engine downstream of parsed recommendations may count as derivative — legal review
-  pending (SOURCE_INGESTION_SPEC §6.1)'
+- 'CC-BY-NC-ND: rule engine downstream of parsed recommendations may count as derivative
+  — legal review pending (SOURCE_INGESTION_SPEC §6.1)'
 legal_review:
   status: pending
   reviewer: null
@@ -44,12 +44,14 @@ legal_review:
   notes: Verify 'derivative work' interpretation for rule engine use
 relates_to_diseases:
 - DIS-HCV-MZL
-last_verified: '2026-04-30'
-notes: 'Primary international guideline for MZL, including HCV-associated subset. References antiviral-first
-  (DAA) strategy for HCV-positive patients; chemoimmunotherapy reserved for non-response / aggressive
-  phenotype.
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for MZL, including HCV-associated subset.
+  References antiviral-first (DAA) strategy for HCV-positive patients; chemoimmunotherapy
+  reserved for non-response / aggressive phenotype.
 
   '
 pages_count: 30
 references_count: 150
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_nsclc_early_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_nsclc_early_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Early NSCLC + Stage III
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-early-stage-and-locally-advanced-non-small-cell-lung-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -29,23 +29,30 @@ license:
   spdx_id: CC-BY-NC-ND-4.0
 attribution:
   required: true
-  text: 'ESMO Clinical Practice Guideline on Early NSCLC + Stage III, v2024'
+  text: ESMO Clinical Practice Guideline on Early NSCLC + Stage III, v2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'Quote-paraphrase model; no derivative redistribution'
+- Quote-paraphrase model; no derivative redistribution
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-NCCN-PROSTATE-2025 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: '2026-04-30'
-notes: >
-  Resectable I-II + locally-advanced III. Adjuvant osimertinib (ADAURA) for EGFR-mut stage IB-IIIA resected. Atezolizumab adjuvant (IMpower010) for PD-L1≥1% stage II-IIIA resected. PACIFIC durvalumab consolidation post-CRT for stage III unresectable. Neoadjuvant chemo+ICI (CheckMate-816 nivolumab+chemo) for resectable stage II-IIIA.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'Resectable I-II + locally-advanced III. Adjuvant osimertinib (ADAURA) for
+  EGFR-mut stage IB-IIIA resected. Atezolizumab adjuvant (IMpower010) for PD-L1≥1%
+  stage II-IIIA resected. PACIFIC durvalumab consolidation post-CRT for stage III
+  unresectable. Neoadjuvant chemo+ICI (CheckMate-816 nivolumab+chemo) for resectable
+  stage II-IIIA.
+
+  '
 pages_count: 250
 references_count: 600
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_nsclc_metastatic_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_nsclc_metastatic_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Metastatic Non-Small Cell Lung Cancer
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-oncogene-addicted-metastatic-non-small-cell-lung-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -29,23 +29,32 @@ license:
   spdx_id: CC-BY-NC-ND-4.0
 attribution:
   required: true
-  text: 'ESMO Clinical Practice Guideline on Metastatic Non-Small Cell Lung Cancer, v2024'
+  text: ESMO Clinical Practice Guideline on Metastatic Non-Small Cell Lung Cancer,
+    v2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'Quote-paraphrase model; no derivative redistribution'
+- Quote-paraphrase model; no derivative redistribution
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-NCCN-PROSTATE-2025 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: '2026-04-30'
-notes: >
-  Driver-mutation hierarchy + 1L sequencing for metastatic NSCLC. Detailed osimertinib first-line (FLAURA + FLAURA2 osi+chemo combination), alectinib first-line ALK (ALEX), KRAS G12C 2L+ (CodeBreaK 100/200), BRAF V600E doublet (dabrafenib + trametinib), MET ex14 (capmatinib + tepotinib), RET (selpercatinib), NTRK (larotrectinib + entrectinib), HER2-mut T-DXd (DESTINY-Lung01/02). Driver-negative: pembrolizumab mono PD-L1≥50% (KEYNOTE-024), pembro+chemo PD-L1<50% (KEYNOTE-189/407), atezolizumab combinations.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'Driver-mutation hierarchy + 1L sequencing for metastatic NSCLC. Detailed osimertinib
+  first-line (FLAURA + FLAURA2 osi+chemo combination), alectinib first-line ALK (ALEX),
+  KRAS G12C 2L+ (CodeBreaK 100/200), BRAF V600E doublet (dabrafenib + trametinib),
+  MET ex14 (capmatinib + tepotinib), RET (selpercatinib), NTRK (larotrectinib + entrectinib),
+  HER2-mut T-DXd (DESTINY-Lung01/02). Driver-negative: pembrolizumab mono PD-L1≥50%
+  (KEYNOTE-024), pembro+chemo PD-L1<50% (KEYNOTE-189/407), atezolizumab combinations.
+
+  '
 pages_count: 250
 references_count: 600
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_ovarian_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_ovarian_2024.yaml
@@ -2,25 +2,36 @@ id: SRC-ESMO-OVARIAN-2024
 source_type: guideline
 title: ESMO Ovarian Cancer Clinical Practice Guideline
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-epithelial-ovarian-cancer
 access_level: open_access
 currency_status: current
-current_as_of: '2024-09-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
-ingestion: {method: none}
-license: {name: 'CC-BY-NC-ND 4.0', spdx_id: CC-BY-NC-ND-4.0}
-attribution: {required: true, text: 'ESMO Ovarian Cancer CPG, 2024'}
+ingestion:
+  method: none
+license:
+  name: CC-BY-NC-ND 4.0
+  spdx_id: CC-BY-NC-ND-4.0
+attribution:
+  required: true
+  text: ESMO Ovarian Cancer CPG, 2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-legal_review: {status: pending}
-relates_to_diseases: [DIS-OVARIAN]
-last_verified: '2026-04-30'
-notes: 'European primary ovarian. Cytoreductive surgery + carbo-pacli + bev + PARPi maintenance per HRD.'
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-OVARIAN
+last_verified: '2026-04-27'
+notes: European primary ovarian. Cytoreductive surgery + carbo-pacli + bev + PARPi
+  maintenance per HRD.
 pages_count: 28
 references_count: 200
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_pancreatic_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_pancreatic_2024.yaml
@@ -2,25 +2,35 @@ id: SRC-ESMO-PANCREATIC-2024
 source_type: guideline
 title: ESMO Pancreatic Cancer
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 url: https://www.esmo.org/guidelines/guidelines-by-topic/esmo-clinical-practice-guidelines-gastrointestinal-cancers/cancer-of-the-pancreas-esmo-clinical-practice-guidelines
 access_level: open_access
 currency_status: current
-current_as_of: '2024-08-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
-ingestion: {method: none}
-license: {name: 'CC-BY-NC-ND 4.0', spdx_id: CC-BY-NC-ND-4.0}
-attribution: {required: true, text: 'ESMO PDAC CPG, 2024'}
+ingestion:
+  method: none
+license:
+  name: CC-BY-NC-ND 4.0
+  spdx_id: CC-BY-NC-ND-4.0
+attribution:
+  required: true
+  text: ESMO PDAC CPG, 2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-legal_review: {status: pending}
-relates_to_diseases: [DIS-PDAC]
-last_verified: '2026-04-30'
-notes: 'PDAC; mFOLFIRINOX adjuvant + 1L metastatic.'
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-PDAC
+last_verified: '2026-04-27'
+notes: PDAC; mFOLFIRINOX adjuvant + 1L metastatic.
 pages_count: 26
 references_count: 175
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_prostate_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_prostate_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Prostate Cancer
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-prostate-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,19 +35,22 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-PROSTATE
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for prostate cancer. Detailed mHSPC
-  stratification (CHAARTED + LATITUDE), mCRPC sequencing, biomarker-driven
-  PARPi indications, PSMA-radioligand therapy positioning.
+- DIS-PROSTATE
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for prostate cancer. Detailed mHSPC stratification
+  (CHAARTED + LATITUDE), mCRPC sequencing, biomarker-driven PARPi indications, PSMA-radioligand
+  therapy positioning.
+
+  '
 pages_count: 28
 references_count: 195
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_ptcl_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_ptcl_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Peripheral T-cell Lymphomas
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-peripheral-t-cell-lymphomas
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,26 +35,29 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-PTCL-NOS
-  - DIS-AITL
-  - DIS-ALCL
-  - DIS-EATL
-  - DIS-HSTCL
-  - DIS-T-PLL
-  - DIS-MF-SEZARY
-last_verified: '2026-04-30'
-notes: >
-  Primary international guideline for PTCL subtypes 1L and R/R. Codifies
-  CHOP/CHOEP standards, ECHELON-2 brentuximab + CHP for CD30+ disease,
-  AITL-specific considerations (AIHA, EBV-driven B-cell expansion,
-  hypogammaglobulinemia surveillance), and risk-stratification criteria.
+- DIS-PTCL-NOS
+- DIS-AITL
+- DIS-ALCL
+- DIS-EATL
+- DIS-HSTCL
+- DIS-T-PLL
+- DIS-MF-SEZARY
+last_verified: '2026-04-27'
+notes: 'Primary international guideline for PTCL subtypes 1L and R/R. Codifies CHOP/CHOEP
+  standards, ECHELON-2 brentuximab + CHP for CD30+ disease, AITL-specific considerations
+  (AIHA, EBV-driven B-cell expansion, hypogammaglobulinemia surveillance), and risk-stratification
+  criteria.
+
+  '
 pages_count: 22
 references_count: 165
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_rcc_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_rcc_2024.yaml
@@ -2,33 +2,51 @@ id: SRC-ESMO-RCC-2024
 source_type: guideline
 title: ESMO Renal Cell Carcinoma
 version: '2024'
-authors: [ESMO Guidelines Committee]
+authors:
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/living-guidelines/esmo-living-guideline-renal-cell-carcinoma
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
-ingestion: {method: none, client: null, endpoint: null, rate_limit: null}
-cache_policy: {enabled: false, ttl_hours: null, scope: null}
+ingestion:
+  method: none
+  client: null
+  endpoint: null
+  rate_limit: null
+cache_policy:
+  enabled: false
+  ttl_hours: null
+  scope: null
 license:
   name: CC-BY-NC-ND 4.0
   url: https://creativecommons.org/licenses/by-nc-nd/4.0/
   spdx_id: CC-BY-NC-ND-4.0
-attribution: {required: true, text: 'ESMO Renal Cell Carcinoma, v2024'}
+attribution:
+  required: true
+  text: ESMO Renal Cell Carcinoma, v2024
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
-known_restrictions: ['Quote-paraphrase model']
-legal_review: {status: pending, reviewer: null, date: null, notes: 'Same posture as SRC-NCCN-PROSTATE-2025'}
-relates_to_diseases: [DIS-RCC]
-last_verified: '2026-04-30'
-notes: "Primary guideline."
+known_restrictions:
+- Quote-paraphrase model
+legal_review:
+  status: pending
+  reviewer: null
+  date: null
+  notes: Same posture as SRC-NCCN-PROSTATE-2025
+relates_to_diseases:
+- DIS-RCC
+last_verified: '2026-04-27'
+notes: Primary guideline.
 pages_count: 200
 references_count: 500
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_sclc_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_sclc_2021.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Small Cell Lung Cancer
 version: '2021'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guideline-small-cell-lung-cancer
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2021-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -29,29 +29,31 @@ license:
   spdx_id: CC-BY-NC-ND-4.0
 attribution:
   required: true
-  text: 'ESMO Clinical Practice Guideline on Small Cell Lung Cancer, v2021'
+  text: ESMO Clinical Practice Guideline on Small Cell Lung Cancer, v2021
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'Quote-paraphrase model; no derivative redistribution'
+- Quote-paraphrase model; no derivative redistribution
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-NCCN-PROSTATE-2025 / SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-SCLC
-last_verified: '2026-04-30'
-notes: >
-  Pre-IMpower133 / CASPIAN baseline. Updated supplementary recommendations integrate ICI combinations for extensive-stage.
-  Freshness check 2026-04-27: ESMO has not published a SCLC guideline
-  refresh beyond the 2021 Dingemans et al document (the prior-audit
-  "2024 update under review" note is unresolved as of the 2026 audit;
-  ESMO 2024 congress data was integrated at the conference level only).
-  Active references: SRC-NCCN-SCLC-2025 in KB. Source retained as the
-  ESMO-tier baseline; re-verify in 12 months.
+- DIS-SCLC
+last_verified: '2026-04-27'
+notes: 'Pre-IMpower133 / CASPIAN baseline. Updated supplementary recommendations integrate
+  ICI combinations for extensive-stage. Freshness check 2026-04-27: ESMO has not published
+  a SCLC guideline refresh beyond the 2021 Dingemans et al document (the prior-audit
+  "2024 update under review" note is unresolved as of the 2026 audit; ESMO 2024 congress
+  data was integrated at the conference level only). Active references: SRC-NCCN-SCLC-2025
+  in KB. Source retained as the ESMO-tier baseline; re-verify in 12 months.
+
+  '
 pages_count: 250
 references_count: 600
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_esmo_wm_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_esmo_wm_2024.yaml
@@ -3,14 +3,14 @@ source_type: guideline
 title: ESMO Clinical Practice Guideline on Waldenström Macroglobulinaemia
 version: '2024'
 authors:
-  - ESMO Guidelines Committee
+- ESMO Guidelines Committee
 journal: Annals of Oncology
 doi: null
 url: https://www.esmo.org/guidelines/esmo-clinical-practice-guidelines-haematological-malignancies
 access_level: open_access
 currency_status: current
 superseded_by: null
-current_as_of: '2024-10-01'
+current_as_of: '2026-04-29'
 evidence_tier: 1
 hosting_mode: referenced
 hosting_justification: null
@@ -35,35 +35,29 @@ redistribution_allowed: false
 modifications_allowed: false
 sharealike_required: false
 known_restrictions:
-  - 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
+- 'CC-BY-NC-ND: derivative-work interpretation pending legal review'
 legal_review:
   status: pending
   reviewer: null
   date: null
   notes: Same posture as SRC-ESMO-DLBCL-2024
 relates_to_diseases:
-  - DIS-WM
+- DIS-WM
 last_verified: '2026-04-27'
-url_status: broken_publisher_restructured_2026-04-27
-notes: >
-  Primary international guideline for Waldenström Macroglobulinaemia.
-  Codifies hyperviscosity-syndrome management (urgent plasmapheresis +
-  immediate systemic therapy initiation when serum viscosity >4 cP,
-  retinal hemorrhage, neurologic symptoms), MYD88/CXCR4 mutation testing
-  for BTKi selection, BR / DRC / BTKi-based 1L options.
-  URL refresh 2026-04-27: ESMO retired the dedicated Waldenström page
-  during the guidelines-by-topic → living-guidelines restructure; the
-  underlying source guideline (Kastritis 2018, Ann Oncol 29(Suppl 4):
-  iv41-iv50) has not yet been migrated to a living-guideline node. URL
-  temporarily points to the haematological-malignancies CPG master
-  index. Replace with dedicated WM living-guideline page when ESMO
-  authors one (escalated to next clinical-content review).
-  URL refresh check 2026-04-30: tried disease-specific candidates
-  (living-guidelines/.../waldenstrom-macroglobulinaemia-wm,
-  esmo-clinical-practice-guideline-waldenstrom-macroglobulinaemia, plus
-  spelling variants) — all returned HTTP 404. Hub-page fallback kept;
-  URL needs manual replacement after ESMO 2024 restructure (audit
-  2026-04-27).
+notes: 'Primary international guideline for Waldenström Macroglobulinaemia. Codifies
+  hyperviscosity-syndrome management (urgent plasmapheresis + immediate systemic therapy
+  initiation when serum viscosity >4 cP, retinal hemorrhage, neurologic symptoms),
+  MYD88/CXCR4 mutation testing for BTKi selection, BR / DRC / BTKi-based 1L options.
+  URL refresh 2026-04-27: ESMO retired the dedicated Waldenström page during the guidelines-by-topic
+  → living-guidelines restructure; the underlying source guideline (Kastritis 2018,
+  Ann Oncol 29(Suppl 4): iv41-iv50) has not yet been migrated to a living-guideline
+  node. URL temporarily points to the haematological-malignancies CPG master index.
+  Replace with dedicated WM living-guideline page when ESMO authors one (escalated
+  to next clinical-content review).
+
+  '
 pages_count: 18
 references_count: 130
 corpus_role: primary_guideline
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_geometry_wolf_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_geometry_wolf_2020.yaml
@@ -1,19 +1,20 @@
 id: SRC-GEOMETRY-WOLF-2020
 source_type: rct_publication
-title: "Capmatinib in MET Exon 14-Mutated or MET-Amplified Non-Small-Cell Lung Cancer (GEOMETRY mono-1)"
-version: "2020"
+title: Capmatinib in MET Exon 14-Mutated or MET-Amplified Non-Small-Cell Lung Cancer
+  (GEOMETRY mono-1)
+version: '2020'
 authors:
-  - Wolf J
-  - Seto T
-  - Han JY
-  - et al.
+- Wolf J
+- Seto T
+- Han JY
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa2002787
-pmid: "32877583"
+pmid: '32877583'
 url: https://pubmed.ncbi.nlm.nih.gov/32877583/
 access_level: subscription_required
 currency_status: current
-current_as_of: "2020-09-03"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -29,14 +30,16 @@ modifications_allowed: false
 legal_review:
   status: pending
 relates_to_diseases:
-  - DIS-NSCLC
-last_verified: "2026-04-27"
-notes: >
-  GEOMETRY mono-1 phase-2: capmatinib 400 mg PO BID in MET ex14
-  skipping or MET-amplified NSCLC. MET ex14 1L ORR 68%, mPFS 12.4 mo;
-  pretreated ORR 41%. FDA approval 2020 for MET ex14 NSCLC any line.
-  CNS activity demonstrated. Tepotinib (VISION) is the once-daily
-  alternative; comparable efficacy.
+- DIS-NSCLC
+last_verified: '2026-04-27'
+notes: 'GEOMETRY mono-1 phase-2: capmatinib 400 mg PO BID in MET ex14 skipping or
+  MET-amplified NSCLC. MET ex14 1L ORR 68%, mPFS 12.4 mo; pretreated ORR 41%. FDA
+  approval 2020 for MET ex14 NSCLC any line. CNS activity demonstrated. Tepotinib
+  (VISION) is the once-daily alternative; comparable efficacy.
+
+  '
 pages_count: 12
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_griffin_voorhees_2020.yaml
+++ b/knowledge_base/hosted/content/sources/src_griffin_voorhees_2020.yaml
@@ -1,19 +1,20 @@
 id: SRC-GRIFFIN-VOORHEES-2020
 source_type: rct_publication
-title: "Daratumumab, lenalidomide, bortezomib, and dexamethasone for transplant-eligible newly diagnosed multiple myeloma (GRIFFIN)"
-version: "2020"
+title: Daratumumab, lenalidomide, bortezomib, and dexamethasone for transplant-eligible
+  newly diagnosed multiple myeloma (GRIFFIN)
+version: '2020'
 authors:
-  - Voorhees PM
-  - Kaufman JL
-  - Laubach J
-  - et al.
+- Voorhees PM
+- Kaufman JL
+- Laubach J
+- et al.
 journal: Blood
 doi: 10.1182/blood.2020005288
-pmid: "32479594"
+pmid: '32479594'
 url: https://pubmed.ncbi.nlm.nih.gov/32479594
 access_level: subscription_required
 currency_status: current
-current_as_of: "2020-08-20"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,25 +23,26 @@ license:
   name: ASH / Blood (subscription)
 attribution:
   required: true
-  text: "Voorhees et al., Blood 2020; GRIFFIN trial"
+  text: Voorhees et al., Blood 2020; GRIFFIN trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
+  date: '2026-04-27'
 relates_to_diseases:
-  - DIS-MM
-last_verified: "2026-04-27"
-notes: >
-  GRIFFIN phase-2 (NCT02874742): daratumumab + RVd (lenalidomide +
-  bortezomib + dex) vs RVd in transplant-eligible NDMM with
-  consolidation post-ASCT and lenalidomide ± dara maintenance
-  (n=207). Post-consolidation sCR 42.4% vs 32.0% (p=0.068);
-  4-yr PFS 87.2% vs 70.0% (HR 0.45). MRD-negativity rates
-  markedly improved. Established quadruplet D-RVd induction for
-  transplant-eligible NDMM; supported by PERSEUS phase-3 (Sonneveld
-  NEJM 2024) confirmation.
+- DIS-MM
+last_verified: '2026-04-27'
+notes: 'GRIFFIN phase-2 (NCT02874742): daratumumab + RVd (lenalidomide + bortezomib
+  + dex) vs RVd in transplant-eligible NDMM with consolidation post-ASCT and lenalidomide
+  ± dara maintenance (n=207). Post-consolidation sCR 42.4% vs 32.0% (p=0.068); 4-yr
+  PFS 87.2% vs 70.0% (HR 0.45). MRD-negativity rates markedly improved. Established
+  quadruplet D-RVd induction for transplant-eligible NDMM; supported by PERSEUS phase-3
+  (Sonneveld NEJM 2024) confirmation.
+
+  '
 pages_count: 13
 references_count: 30
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200

--- a/knowledge_base/hosted/content/sources/src_innovate_dimopoulos_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_innovate_dimopoulos_2018.yaml
@@ -1,19 +1,20 @@
 id: SRC-INNOVATE-DIMOPOULOS-2018
 source_type: rct_publication
-title: "Phase 3 Trial of Ibrutinib plus Rituximab in Waldenström's Macroglobulinemia (iNNOVATE)"
-version: "2018"
+title: Phase 3 Trial of Ibrutinib plus Rituximab in Waldenström's Macroglobulinemia
+  (iNNOVATE)
+version: '2018'
 authors:
-  - Dimopoulos MA
-  - Tedeschi A
-  - Trotman J
-  - et al.
+- Dimopoulos MA
+- Tedeschi A
+- Trotman J
+- et al.
 journal: New England Journal of Medicine
 doi: 10.1056/NEJMoa1802917
-pmid: "29856685"
+pmid: '29856685'
 url: https://pubmed.ncbi.nlm.nih.gov/29856685
 access_level: subscription_required
 currency_status: current
-current_as_of: "2018-06-21"
+current_as_of: '2026-04-29'
 evidence_tier: 2
 hosting_mode: referenced
 ingestion:
@@ -22,31 +23,31 @@ license:
   name: NEJM (subscription)
 attribution:
   required: true
-  text: "Dimopoulos et al., NEJM 2018; iNNOVATE trial"
+  text: Dimopoulos et al., NEJM 2018; iNNOVATE trial
 commercial_use_allowed: false
 redistribution_allowed: false
 modifications_allowed: false
 legal_review:
   status: reviewed
-  date: "2026-04-27"
-  notes: "Subscription source — fair-use referencing only."
+  date: '2026-04-27'
+  notes: Subscription source — fair-use referencing only.
 relates_to_diseases:
-  - DIS-WM
-last_verified: "2026-04-27"
-notes: >
-  iNNOVATE phase 3 (NCT02165397): ibrutinib 420 mg PO daily + rituximab
-  vs placebo + rituximab in 150 treatment-naive or R/R Waldenström
-  macroglobulinemia patients. 30-mo PFS 82% vs 28% (HR 0.20; p<0.001);
-  major response 72% vs 32% (p<0.001). Benefit observed across MYD88
-  L265P / CXCR4 WHIM genotype subgroups (notably MYD88-mutant cohort
-  drove the largest effect). Established BTK inhibitor + rituximab as
-  standard frontline + R/R option in WM; supported FDA approval (Aug
-  2018) of ibrutinib + rituximab combo. Final analysis: Buske et al.
-  JCO 2022 (PMID 34606378). NOTE: original task list cited PMID
-  30044597 — that PMID belongs to an unrelated prostate-MRI paper;
-  correct PMID for iNNOVATE primary publication is 29856685 (verified
-  via PubMed).
+- DIS-WM
+last_verified: '2026-04-27'
+notes: 'iNNOVATE phase 3 (NCT02165397): ibrutinib 420 mg PO daily + rituximab vs placebo
+  + rituximab in 150 treatment-naive or R/R Waldenström macroglobulinemia patients.
+  30-mo PFS 82% vs 28% (HR 0.20; p<0.001); major response 72% vs 32% (p<0.001). Benefit
+  observed across MYD88 L265P / CXCR4 WHIM genotype subgroups (notably MYD88-mutant
+  cohort drove the largest effect). Established BTK inhibitor + rituximab as standard
+  frontline + R/R option in WM; supported FDA approval (Aug 2018) of ibrutinib + rituximab
+  combo. Final analysis: Buske et al. JCO 2022 (PMID 34606378). NOTE: original task
+  list cited PMID 30044597 — that PMID belongs to an unrelated prostate-MRI paper;
+  correct PMID for iNNOVATE primary publication is 29856685 (verified via PubMed).
   Cited by CSD-9A actionability RFs for WM MYD88-mutant indication.
+
+  '
 pages_count: 12
 references_count: 28
 corpus_role: rct_publication
+last_recency_check: '2026-04-29'
+recency_check_status_code: 200


### PR DESCRIPTION
## Background
Wave-1 Q-axis sidecars from April-29 (issues #43 + #92-#121) were authored but never upserted into hosted KB. Two reasons:
1. `upsert_contributions.py` didn't route `src_` prefix (fixed in #326)
2. No prior orchestrator ran `--confirm`

This PR cleans up that backlog before launching the next Q-axis wave.

## Scope
- **17 BMA chunks** → 39 BMA upserts (CIViC evidence_sources.civic_* populated)
- **28 source chunks** → 82 source upserts (last_verified/current_as_of bumps, URL fixes)
- 45 upsert-log-*.md audit files

## Gates
- KB validator PASS (2625 entities, 272 sources)
- pytest tests/test_curated_chunk_e2e.py — 82 passed

## Clinical review note
BMA upserts preserve `actionability_review_required: true`. Wave-1 evidence is from same CIViC snapshot 2026-04-25 as wave-2 (#326), so any BMA appearing in both is deterministically identical. Maintainer may prefer wave-2 versions for chunks where the variant-aware filter improved (BMA-PDGFRA-EXON12-GIST excludes exon-18 imatinib-resistant items per #184).