### PR TITLE
feat(kb): patient watchpoints — Wave 3H (17 regimens)

### DIFF
--- a/knowledge_base/hosted/content/regimens/reg_doxorubicin_ifosfamide_mpnst.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_doxorubicin_ifosfamide_mpnst.yaml
@@ -27,5 +27,43 @@ sources:
   - SRC-NCCN-SARCOMA
 
 reviewer_signoffs: 0
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Doxorubicin + ifosfamide for advanced MPNST. Toxicity = anthracycline
+# (cardio + cytopenia + alopecia) + ifosfamide (encephalopathy +
+# hemorrhagic cystitis even with mesna). STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кров у сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — геморагічний цистит від іфосфаміду"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Сплутаність свідомості, надмірна сонливість"
+    action_ua: "Подзвоніть у клініку того ж дня — енцефалопатія від іфосфаміду"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Задишка при підйомі сходами або в стані спокою, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — антрацикліни впливають на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Сильна задишка або біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-SARCOMA
+
 notes: >
   STUB scaffold. Dosing summary only.

--- a/knowledge_base/hosted/content/regimens/reg_folfiri_bev.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_folfiri_bev.yaml
@@ -73,6 +73,49 @@ sources:
   - SRC-NCCN-COLON-2025
   - SRC-ESMO-COLON-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# FOLFIRI + bevacizumab for mCRC 2L+. Irinotecan diarrhea + cytopenia
+# + bev HTN/proteinuria. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, втома"
+    action_ua: "Очікувано — приймайте призначені протиблювотні"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Раптовий приплив, виділення з носа, сльози (під час інфузії іринотекану)"
+    action_ua: "Очікувано — холінергічний синдром, минає за 30 хв; повідомте медсестру"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1"
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Підвищений тиск"
+    action_ua: "Бевацизумаб може підвищувати тиск"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Тяжка діарея >6 разів/день"
+    action_ua: "Подзвоніть у клініку того ж дня — іринотекан небезпечна діарея"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кров у сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — бев впливає на нирки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Раптовий гострий біль у животі або кровохаркання"
+    action_ua: "Звертайтесь у лікарню негайно — перфорація або кровотеча"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-COLON-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   Standard 2L mCRC after FOLFOX progression. Adding bevacizumab (TML

--- a/knowledge_base/hosted/content/regimens/reg_gemcitabine_cisplatin_cholangio.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_gemcitabine_cisplatin_cholangio.yaml
@@ -26,6 +26,45 @@ evidence_level: moderate
 sources:
   - SRC-NCCN-CNS-2025
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Gemcitabine + cisplatin for cholangiocarcinoma 1L (ABC-02).
+# Cisplatin nephro/oto + gem cytopenia/hepatic. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, втома"
+    action_ua: "Приймайте призначені протиблювотні; пийте багато води"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-3"
+    sources:
+      - SRC-NCCN-CNS-2025
+  - trigger_ua: "Шум у вухах, зниження слуху"
+    action_ua: "Подзвоніть у клініку того ж дня — цисплатин може впливати на слух"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CNS-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Зменшення кількості сечі, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — цисплатин впливає на нирки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CNS-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця, потемніння сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна оцінка функції печінки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CNS-2025
+  - trigger_ua: "Раптова сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно — рідко гем може спричиняти ушкодження легень"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-CNS-2025
+
 reviewer_signoffs: 0
 notes: >
   STUB scaffold. Dosing summary only.

--- a/knowledge_base/hosted/content/regimens/reg_gilteritinib_aml.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_gilteritinib_aml.yaml
@@ -55,6 +55,38 @@ sources:
   - SRC-ELN-AML-2022
   - SRC-ADMIRAL-PERL-2019
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Gilteritinib FLT3i for R/R FLT3-mutated AML (ADMIRAL). Tox:
+# differentiation syndrome (boxed), QT, hepatic, cytopenia.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, помірна діарея, втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Швидкий набір ваги, набряки, задишка"
+    action_ua: "Звертайтесь у лікарню негайно — синдром диференціювання"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-ADMIRAL-PERL-2019
+  - trigger_ua: "Жовтяниця, потемніння сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — гепатотоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова втрата свідомості, серцебиття ненормальне"
+    action_ua: "Звертайтесь у лікарню негайно — гілтеритиніб може подовжувати QT"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   Standard 2L+ for R/R FLT3-mutated AML per ADMIRAL. Bridge to

--- a/knowledge_base/hosted/content/regimens/reg_inotuzumab_b_all.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_inotuzumab_b_all.yaml
@@ -62,6 +62,39 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-INOVATE-KANTARJIAN-2016
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Inotuzumab CD22 ADC for R/R B-ALL (INO-VATE). Signature: VOD risk
+# (boxed warning, especially post-SCT), cytopenia, IRR.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Жовтяниця, набір ваги, біль у правому верхньому квадранті"
+    action_ua: "Звертайтесь у лікарню негайно — інотузумаб може спричиняти веноокклюзивну хворобу печінки (VOD); особливо при наступному alloHCT"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-INOVATE-KANTARJIAN-2016
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Звертайтесь у лікарню негайно — глибока нейтропенія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Незвичні синці, кровотеча"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Тяжка інфузійна реакція"
+    action_ua: "Інфузія в клініці — медперсонал реагує негайно"
+    urgency: er_now
+    cycle_day_window: "Day 1 of cycle 1"
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   Anti-CD22 ADC for R/R Ph- B-ALL. INO-VATE: CR/CRi 80.7% vs

--- a/knowledge_base/hosted/content/regimens/reg_larotrectinib_pantumor.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_larotrectinib_pantumor.yaml
@@ -45,6 +45,32 @@ sources:
   - SRC-NCCN-NSCLC-2025
   - SRC-ESMO-NSCLC-METASTATIC-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Larotrectinib for NTRK-fusion pan-tumor (NAVIGATE). Generally well-
+# tolerated TKI: GI, hepatic, dizziness. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, нудота, легке запаморочення"
+    action_ua: "Зустрічається — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Помірна діарея або запор"
+    action_ua: "Занотовуйте, обговоріть на візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця, потемніння сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — ларотректиніб може впливати на печінку"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Зміни поведінки, плутаність свідомості"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна оцінка нейротоксичності"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   Pooled NAVIGATE / SCOUT / phase-1: ORR 75% (IRC) across 17 tumor

--- a/knowledge_base/hosted/content/regimens/reg_lenalidomide_mds_del5q.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_lenalidomide_mds_del5q.yaml
@@ -64,6 +64,43 @@ sources:
   - SRC-ESMO-MDS-2021
   - SRC-MDS-004-FENAUX-2011
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Lenalidomide for MDS del(5q) (MDS-004). Cytopenia (especially
+# neutropenia + thrombocytopenia early on) + thrombosis.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, нудота"
+    action_ua: "Часто проходить — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Помірна діарея або висип"
+    action_ua: "Занотовуйте, обговоріть на візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія типова в перших циклах"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Незвичні синці, кровотеча"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Біль або припухлість в одній нозі"
+    action_ua: "Подзвоніть у клініку того ж дня — леналідомід підвищує ризик тромбозу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Раптова задишка, біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно — можлива легенева тромбоемболія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   Standard for transfusion-dependent del(5q) LR-MDS. ~56% achieve

--- a/knowledge_base/hosted/content/regimens/reg_midostaurin_advsm_1l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_midostaurin_advsm_1l.yaml
@@ -46,6 +46,36 @@ ukraine_availability:
 sources:
   - SRC-NCCN-SM-2025
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Midostaurin for advanced systemic mastocytosis 1L. Multi-kinase
+# inhibitor: GI dominates, hepatic, QT. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена нудота, блювота, діарея"
+    action_ua: "Часто на початку — приймайте призначені протиблювотні; занотовуйте інтенсивність"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Помірна втома, легке зниження апетиту"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Тяжка діарея або блювота"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик зневоднення"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця, потемніння сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — гепатотоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Раптова втрата свідомості, серцебиття ненормальне"
+    action_ua: "Звертайтесь у лікарню негайно — мідостаурин може подовжувати QT"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-SM-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   D-RIVE / CPKC412D2201 (Gotlib NEJM 2016): midostaurin 100 mg BID in

--- a/knowledge_base/hosted/content/regimens/reg_nelarabine_tcell.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_nelarabine_tcell.yaml
@@ -44,6 +44,38 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-PTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Nelarabine for relapsed T-ALL/T-LL. Boxed warning: severe
+# neurotoxicity (peripheral neuropathy + CNS — seizure, paralysis).
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Поколювання або оніміння в кистях/стопах — навіть легке"
+    action_ua: "Подзвоніть у клініку того ж дня — нелярабін має тяжку нейротоксичність як boxed warning"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Раптовий судомний напад або слабкість в одній стороні тіла"
+    action_ua: "Звертайтесь у лікарню негайно — нелярабін може спричиняти тяжку CNS-токсичність"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+      - SRC-ESMO-PTCL-2024
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Звертайтесь у лікарню негайно — глибока нейтропенія"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова сонливість, плутаність свідомості"
+    action_ua: "Звертайтесь у лікарню негайно — CNS-токсичність"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   Adult dosing per Gökbuget 2017 schema; pediatric dosing (650 mg/m²

--- a/knowledge_base/hosted/content/regimens/reg_nivo_maintenance_melanoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_nivo_maintenance_melanoma.yaml
@@ -43,6 +43,41 @@ sources:
   - SRC-ESMO-MELANOMA-2024
   - SRC-CHECKMATE-067-LARKIN-2019
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Nivolumab maintenance after combo induction for melanoma. Same
+# anti-PD-1 irAE pattern. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, шкірний свербіж"
+    action_ua: "Очікувано — використовуйте зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Жовтяниця"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Нова задишка"
+    action_ua: "Подзвоніть у клініку того ж дня — пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_nivo_mono_esoph_2l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_nivo_mono_esoph_2l.yaml
@@ -31,6 +31,37 @@ ukraine_availability:
   notes: "Nivolumab out-of-pocket / charitable / clinical-trial pathway in Ukraine; not NSZU-funded for esophageal."
 
 sources: [SRC-NCCN-ESOPHAGEAL-2025, SRC-ESMO-ESOPHAGEAL-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Nivolumab mono for esophageal 2L (ATTRACTION-3). Anti-PD-1 irAEs.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, свербіж шкіри"
+    action_ua: "Очікувано — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Нова задишка"
+    action_ua: "Подзвоніть у клініку того ж дня — пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Жовтяниця"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+
 last_reviewed: "2026-04-26"
 
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_olaparib_mono.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_olaparib_mono.yaml
@@ -34,6 +34,38 @@ ukraine_availability:
   notes: "Registered for ovarian/breast indications; prostate reimbursement under negotiation. Out-of-pocket for prostate use until formulary update."
 
 sources: [SRC-NCCN-PROSTATE-2025, SRC-ESMO-PROSTATE-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Olaparib mono for HRR-mutated mCRPC (PROfound). Same PARPi pattern.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, нудота"
+    action_ua: "Часто проходить за 2-3 місяці"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-PROSTATE-2025
+  - trigger_ua: "Виражена втома, задишка"
+    action_ua: "Подзвоніть у клініку того ж дня — олапариб може спричиняти анемію"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-PROSTATE-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Незвичні синці, кровотеча"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова задишка, новий сухий кашель"
+    action_ua: "Звертайтесь у лікарню негайно — рідко може спричиняти пневмоніт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-PROSTATE-2025
+
 last_reviewed:
 notes: >
   PROfound: olaparib superior to enzalutamide / abiraterone in HRR-mutant

--- a/knowledge_base/hosted/content/regimens/reg_paclitaxel_carboplatin_atc.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_paclitaxel_carboplatin_atc.yaml
@@ -27,5 +27,38 @@ sources:
   - SRC-NCCN-THYROID-2025
 
 reviewer_signoffs: 0
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Paclitaxel + carboplatin palliative 1L for anaplastic thyroid carcinoma.
+# Pacli neuropathy + hypersensitivity; carbo cytopenia + ototoxicity.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-THYROID-2025
+  - trigger_ua: "Поколювання у пальцях рук і ніг"
+    action_ua: "Очікувано від паклітакселу — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-THYROID-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Шум у вухах, зниження слуху"
+    action_ua: "Подзвоніть у клініку того ж дня — карбоплатин впливає на слух"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-THYROID-2025
+  - trigger_ua: "Сильна задишка, висип, набряк обличчя під час інфузії або одразу після"
+    action_ua: "Звертайтесь у лікарню негайно — гіперчутливість до паклітакселу"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-THYROID-2025
+
 notes: >
   STUB scaffold. Dosing summary only.

--- a/knowledge_base/hosted/content/regimens/reg_pembro_chemo_hnscc_1l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_chemo_hnscc_1l.yaml
@@ -60,6 +60,49 @@ ukraine_availability:
 sources:
   - SRC-NCCN-HNSCC-2025
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Pembro + 5-FU + cisplatin/carbo for HNSCC R/M 1L (KEYNOTE-048).
+# Combines IO irAEs with platinum nephro/oto + 5-FU GI.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, мукозит"
+    action_ua: "Полоскання порожнини рота, м'яка їжа"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Шкірний свербіж"
+    action_ua: "Очікувано — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Шум у вухах, зниження слуху"
+    action_ua: "Подзвоніть у клініку того ж дня — цисплатин впливає на слух"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Зменшення сечі, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — нефротоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт або 5-ФУ"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-HNSCC-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   KEYNOTE-048 (Burtness Lancet 2019): in PD-L1 CPS ≥1 R/M HNSCC,

--- a/knowledge_base/hosted/content/regimens/reg_pembro_chemo_tnbc_neoadjuvant.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_chemo_tnbc_neoadjuvant.yaml
@@ -49,6 +49,59 @@ ukraine_availability:
   notes: "Pembrolizumab registered; TNBC neoadjuvant indication reimbursement varies. Chemo backbone reimbursed. Out-of-pocket for pembro adds significant cost; clinical-review queue item."
 
 sources: [SRC-NCCN-BREAST-2025, SRC-ESMO-BREAST-EARLY-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# KEYNOTE-522 neoadjuvant: pembro + carbo/paclitaxel × 4 → pembro + AC × 4.
+# Mixes IO irAEs with platinum + anthracycline + cyclophosphamide.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Поколювання у пальцях рук і ніг"
+    action_ua: "Очікувано від паклітакселу — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Шкірний свербіж, помірна втома"
+    action_ua: "Очікувано від пембролізумабу — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Задишка при підйомі сходами або в стані спокою"
+    action_ua: "Подзвоніть у клініку того ж дня — антрацикліни впливають на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BREAST-2025
+  - trigger_ua: "Тяжка діарея, сильна задишка або біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BREAST-2025
+
 last_reviewed:
 notes: >
   KEYNOTE-522: pCR + EFS benefit in stage II-III TNBC (regardless of

--- a/knowledge_base/hosted/content/regimens/reg_pembro_mono_esoph_2l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_mono_esoph_2l.yaml
@@ -30,6 +30,42 @@ ukraine_availability:
   notes: "Pembrolizumab out-of-pocket / charitable / clinical-trial pathway in Ukraine; not NSZU-funded for esophageal."
 
 sources: [SRC-NCCN-ESOPHAGEAL-2025, SRC-ESMO-ESOPHAGEAL-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Pembrolizumab monotherapy 2L esophageal CPS ≥10. Single-agent IO —
+# irAE pattern only (no chemo overlay). STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Шкірний свербіж, помірна втома"
+    action_ua: "Очікувано — зволожувач, відпочивайте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Нова задишка, сухий кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-ESOPHAGEAL-2025
+
 last_reviewed: "2026-04-26"
 
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_pembro_mono_hnscc_1l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_mono_hnscc_1l.yaml
@@ -37,6 +37,41 @@ ukraine_availability:
 sources:
   - SRC-NCCN-HNSCC-2025
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Pembrolizumab monotherapy R/M HNSCC, CPS ≥20. Single-agent IO —
+# irAE pattern only. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Шкірний свербіж, помірна втома"
+    action_ua: "Очікувано — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Нова задишка, сухий кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HNSCC-2025
+  - trigger_ua: "Тяжка діарея або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-HNSCC-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   KEYNOTE-048 (Burtness Lancet 2019): in PD-L1 CPS ≥20 R/M HNSCC,


### PR DESCRIPTION
## Summary
- Wave 3H of patient between-visit watchpoints; 17 regimens covering mCRC 2L (FOLFIRI+bev), cholangio 1L, R/R AML FLT3, B-cell ALL ADC (VOD signature), NTRK pan-tumor, MDS del(5q), advSM, T-cell ALL (boxed CNS), melanoma maintenance, esoph 2L IO, HRR mCRPC, HNSCC R/M 1L (chemo-IO + IO mono), TNBC neoadj (KEYNOTE-522), MPNST sarcoma, ATC palliative 1L.
- Each regimen gets `between_visit_watchpoints` (trigger_ua / action_ua / urgency / sources) covering log/call/ER tiers.
- STUB pending §6.1 clinical sign-off (CHARTER dev-mode exemption).

## Test plan
- [x] `python -m knowledge_base.validation.loader knowledge_base/hosted/content` — 2613 entities, all references resolve
- [x] `pytest tests/test_patient_render.py` — 62 passed, 1 skipped
- [ ] Clinical reviewer signoff (deferred per §6.1 dev-mode exemption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)