### PR TITLE
feat(kb): patient watchpoints — Wave 3I (21 regimens)

### DIFF
--- a/knowledge_base/hosted/content/regimens/atra_ato_ida_apl.yaml
+++ b/knowledge_base/hosted/content/regimens/atra_ato_ida_apl.yaml
@@ -62,6 +62,50 @@ sources:
   - SRC-ELN-APL-2019
   - SRC-APL0406-LOCOCO-2013
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# ATRA + ATO + idarubicin for high-risk APL induction. Differentiation
+# syndrome + DIC + QT prolongation are early-induction killers; cytopenia
+# from idarubicin + cardio overlay. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-ELN-APL-2019
+  - trigger_ua: "Сухість шкіри, тріщини на губах, головний біль (ATRA)"
+    action_ua: "Очікувано від ATRA — зволожувач, занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-ELN-APL-2019
+  - trigger_ua: "Раптовий набір ваги, набряки, задишка, лихоманка під час перших 2 тижнів"
+    action_ua: "Звертайтесь у лікарню негайно — синдром диференціації, потенційно фатальний без лікування"
+    urgency: er_now
+    cycle_day_window: "Day 1-14"
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-ELN-APL-2019
+  - trigger_ua: "Кровотеча з ясен, з носа, синці без причини"
+    action_ua: "Звертайтесь у лікарню негайно — ДВЗ-синдром, потрібна термінова трансфузія"
+    urgency: er_now
+    cycle_day_window: "Day 1-14"
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Серцебиття, запаморочення, втрата свідомості"
+    action_ua: "Подзвоніть у клініку того ж дня — ATO може подовжувати QT"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Задишка при підйомі сходами або в стані спокою, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — антрацикліни впливають на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   1L for high-risk APL (Sanz WBC >10) per ELN 2019. ATRA + ATO + idarubicin

--- a/knowledge_base/hosted/content/regimens/azt_ifn_a.yaml
+++ b/knowledge_base/hosted/content/regimens/azt_ifn_a.yaml
@@ -36,6 +36,43 @@ ukraine_availability:
   notes: "AZT — широко доступний як HIV antiretroviral. IFN-α — обмежено доступний; pegylated form (PEG-IFN-α-2a/2b) альтернативна."
 
 sources: [SRC-NCCN-BCELL-2025]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# AZT + IFN-α for ATLL — continuous oral + injectable. Cytopenia from
+# AZT; flu-like + depression + thyroid + hepatitis from IFN. Slow onset.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Грипоподібні симптоми (озноб, біль у м'язах) у перші тижні"
+    action_ua: "Очікувано від інтерферону — парацетамол, занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна втома, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Стійкий смуток, втрата інтересу, думки про самопошкодження"
+    action_ua: "Подзвоніть у клініку того ж дня — інтерферон може спричиняти депресію"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C, що триває довше 24 годин"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія від AZT"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Виражена слабкість, постійне відчуття холоду, набір ваги"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — гепатотоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   STUB. AZT inhibits HTLV-1 reverse transcriptase; IFN — immune

--- a/knowledge_base/hosted/content/regimens/durvalumab_tremelimumab_stride.yaml
+++ b/knowledge_base/hosted/content/regimens/durvalumab_tremelimumab_stride.yaml
@@ -36,6 +36,47 @@ ukraine_availability:
   notes: "Tremelimumab not registered in Ukraine; access via clinical-trial / off-label pathway only."
 
 sources: [SRC-NCCN-HCC-2025]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Durvalumab + tremelimumab (STRIDE) for HCC. CTLA-4 + PD-L1 — colitis +
+# hypophysitis come earlier and harder than PD-1 mono. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Шкірний свербіж, помірна втома"
+    action_ua: "Очікувано — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-HCC-2025
+  - trigger_ua: "Помірна діарея або кров у стільці"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт від CTLA-4"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HCC-2025
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит на тлі вже хворої печінки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HCC-2025
+  - trigger_ua: "Сильний головний біль, нудота, проблеми з зором"
+    action_ua: "Подзвоніть у клініку того ж дня — гіпофізит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HCC-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага, потемніння шкіри"
+    action_ua: "Подзвоніть у клініку того ж дня — наднирникова недостатність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HCC-2025
+  - trigger_ua: "Нова задишка, сухий кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — пневмоніт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HCC-2025
+  - trigger_ua: "Тяжка діарея, сильний біль у животі або сильна задишка"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-HCC-2025
+
 last_reviewed: "2026-04-26"
 
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_allohct_mds_hr.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_allohct_mds_hr.yaml
@@ -92,6 +92,49 @@ sources:
   - SRC-ESMO-MDS-2021
   - SRC-IPSS-M-BERNARD-2022
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Allo-HCT for high-risk MDS. Multi-month inpatient pathway. Toxicity
+# dominated by GVHD + infection during prolonged neutropenia + organ
+# toxicity from conditioning. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена втома, що триває тижнями після виписки"
+    action_ua: "Очікувано — кістковий мозок відновлюється повільно; відпочивайте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Лихоманка вище 38°C — у будь-який час після кондиціонування"
+    action_ua: "Звертайтесь у лікарню негайно — інфекція на тлі тривалої нейтропенії"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Висип на шкірі (особливо долоні, стопи), діарея, жовтяниця"
+    action_ua: "Подзвоніть у клініку того ж дня — реакція трансплантат-проти-господаря"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Сухість у роті, очах, ускладнене ковтання, що не минає"
+    action_ua: "Занотовуйте — хронічна РТПХ; обговоримо на наступному візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Жовтяниця, набір ваги, біль у правому підребер'ї перші 30 днів"
+    action_ua: "Звертайтесь у лікарню негайно — вено-оклюзивне ускладнення"
+    urgency: er_now
+    cycle_day_window: "Day 1-30"
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Сильний біль у животі, нудота, кров у стільці"
+    action_ua: "Звертайтесь у лікарню негайно — РТПХ кишечника або інфекція"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Сплутаність свідомості, висока лихоманка з ознобом"
+    action_ua: "Звертайтесь у лікарню негайно — ознаки можливого сепсису"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-25"
 notes: >
   AlloHCT remains the ONLY curative option for MDS-HR. Mandatory

--- a/knowledge_base/hosted/content/regimens/reg_allohct_pmf.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_allohct_pmf.yaml
@@ -91,6 +91,49 @@ sources:
   - SRC-NCCN-MPN-2025
   - SRC-DIPSS-PLUS-GANGAT-2011
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Allo-HCT for high-risk PMF with JAKi bridging. Same allo-HCT toxicity
+# pattern (GVHD + infection + VOD); during JAKi bridging — cytopenia +
+# rebound on taper. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Виражена втома, що триває тижнями після виписки"
+    action_ua: "Очікувано — кістковий мозок відновлюється повільно; відпочивайте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Лихоманка вище 38°C — у будь-який час після кондиціонування"
+    action_ua: "Звертайтесь у лікарню негайно — інфекція на тлі тривалої нейтропенії"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MPN-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Висип на шкірі (особливо долоні, стопи), діарея, жовтяниця"
+    action_ua: "Подзвоніть у клініку того ж дня — реакція трансплантат-проти-господаря"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Жовтяниця, набір ваги, біль у правому підребер'ї перші 30 днів"
+    action_ua: "Звертайтесь у лікарню негайно — вено-оклюзивне ускладнення"
+    urgency: er_now
+    cycle_day_window: "Day 1-30"
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Раптове повернення симптомів селезінки (біль, набряк живота, лихоманка) під час відміни руксолітинібу"
+    action_ua: "Подзвоніть у клініку того ж дня — синдром відміни JAKi"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Сильний біль у животі, нудота, кров у стільці"
+    action_ua: "Звертайтесь у лікарню негайно — РТПХ кишечника або інфекція"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Сплутаність свідомості, висока лихоманка з ознобом"
+    action_ua: "Звертайтесь у лікарню негайно — ознаки можливого сепсису"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-25"
 notes: >
   AlloHCT remains the ONLY curative option for PMF. Mandatory

--- a/knowledge_base/hosted/content/regimens/reg_asciminib_cml.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_asciminib_cml.yaml
@@ -51,6 +51,42 @@ sources:
   - SRC-ELN-CML-2020
   - SRC-ASCEMBL-REA-2021
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Asciminib (STAMP allosteric BCR-ABL inhibitor) for 3L+ CML-CP.
+# Better cardiovascular safety than ponatinib; cytopenia + pancreatitis
+# are dominant signals. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, помірний головний біль"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Висип на шкірі"
+    action_ua: "Очікувано — зволожувач; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Сильний біль у верхній частині живота, що віддає в спину"
+    action_ua: "Подзвоніть у клініку того ж дня — підозра на панкреатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-ASCEMBL-REA-2021
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кровотеча з ясен, з носа, синці без причини"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Раптовий біль у грудях, задишка, слабкість в одній руці чи нозі"
+    action_ua: "Звертайтесь у лікарню негайно — судинна подія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MPN-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   STAMP allosteric inhibitor — mechanism distinct from all ATP-site

--- a/knowledge_base/hosted/content/regimens/reg_av_hepatic_modified.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_av_hepatic_modified.yaml
@@ -54,6 +54,43 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-HODGKIN-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Modified ABVD (doxorubicin + vinblastine only) for HL with severe
+# hepatic impairment. Anthracycline cardio + cytopenia + vinca neuropathy.
+# Hepatic decompensation overlay critical. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Поколювання у пальцях рук і ніг"
+    action_ua: "Очікувано від вінбластину — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Закреп на 3+ дні, біль у животі"
+    action_ua: "Подзвоніть у клініку того ж дня — кишкова непрохідність від вінбластину"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Поглиблення жовтяниці, набряки живота, сплутаність"
+    action_ua: "Звертайтесь у лікарню негайно — погіршення печінкової недостатності"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Задишка при підйомі сходами або в стані спокою, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — антрацикліни впливають на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_avapritinib_advsm_1l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_avapritinib_advsm_1l.yaml
@@ -50,6 +50,42 @@ sources:
   - SRC-NCCN-SM-2025
   - SRC-ONCOKB
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Avapritinib for advanced systemic mastocytosis (KIT D816V+).
+# Boxed warning: intracranial hemorrhage at low platelets; cognitive
+# AEs and cerebral microbleeds dominant signals. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, помірна втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Періорбітальні набряки (опухлі повіки)"
+    action_ua: "Очікувано від аваприніб — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Зміни пам'яті, концентрації, настрою, сплутаність"
+    action_ua: "Подзвоніть у клініку того ж дня — когнітивний побічний ефект, можлива пауза в препараті"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Раптовий сильний головний біль, проблеми із зором, слабкість в одній стороні тіла"
+    action_ua: "Звертайтесь у лікарню негайно — підозра на внутрішньомозковий крововилив"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Кровотеча з ясен, з носа, синці без причини"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія підвищує ризик крововиливу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SM-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-27"
 notes: >
   EXPLORER (Gotlib NEJM 2023) + PATHFINDER (DeAngelo Nat Med 2023):

--- a/knowledge_base/hosted/content/regimens/reg_azacitidine_aitl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_azacitidine_aitl.yaml
@@ -46,6 +46,42 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-PTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Azacitidine SC/IV monotherapy for r/r AITL (off-label epigenetic).
+# Cytopenia + SC site reactions + slow-onset response (≥6 cycles).
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Почервоніння, болючість, свербіж у місцях ін'єкцій"
+    action_ua: "Очікувано — холодні компреси, чергуйте місця ін'єкцій"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна нудота в дні ін'єкцій"
+    action_ua: "Очікувано — приймайте призначені протиблювотні"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кровотеча з ясен, з носа, синці без причини"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Зменшення сечі, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — нефротоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   RUYUAN-2 / Lemonnier 2018-2023: emerging epigenetic therapy

--- a/knowledge_base/hosted/content/regimens/reg_bev_maintenance_ovarian.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_bev_maintenance_ovarian.yaml
@@ -41,6 +41,47 @@ sources:
   - SRC-NCCN-OVARIAN-2025
   - SRC-ESMO-OVARIAN-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Bevacizumab maintenance after carbo-paclitaxel for ovarian. Anti-VEGF
+# signature: HTN + proteinuria + GI perforation + thrombosis. STUB
+# pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+  - trigger_ua: "Підвищений тиск на домашньому тонометрі"
+    action_ua: "Бевацизумаб може підвищувати тиск; занотовуйте показники для лікаря"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+  - trigger_ua: "Кров у сечі, піна в сечі"
+    action_ua: "Подзвоніть у клініку того ж дня — бевацизумаб впливає на нирки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+  - trigger_ua: "Тиск стійко >160/100 попри ліки"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна корекція терапії"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+  - trigger_ua: "Кровотеча з носа, що довго не зупиняється"
+    action_ua: "Подзвоніть у клініку того ж дня"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+  - trigger_ua: "Раптовий гострий біль у животі"
+    action_ua: "Звертайтесь у лікарню негайно — можлива перфорація кишечника"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+  - trigger_ua: "Раптова сильна задишка, біль у грудях, набряк ноги"
+    action_ua: "Звертайтесь у лікарню негайно — тромбоемболія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-OVARIAN-2025
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_bexarotene_maintenance_ctcl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_bexarotene_maintenance_ctcl.yaml
@@ -42,6 +42,37 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-CTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Bexarotene low-dose maintenance for CTCL responders. RXR retinoid;
+# central hypothyroidism + hypertriglyceridemia signature. Maintenance
+# is lower-grade. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна сухість шкіри, помірна втома"
+    action_ua: "Очікувано — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Постійне відчуття холоду, набір ваги, виражена слабкість"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Сильний біль у верхній частині живота, що віддає в спину"
+    action_ua: "Подзвоніть у клініку того ж дня — підвищені тригліцериди можуть спричиняти панкреатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — лейкопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця"
+    action_ua: "Подзвоніть у клініку того ж дня — гепатотоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   Maintenance dosing extends responses beyond induction. Same toxicity

--- a/knowledge_base/hosted/content/regimens/reg_bexarotene_mono_ctcl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_bexarotene_mono_ctcl.yaml
@@ -45,6 +45,37 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-CTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Bexarotene full-dose monotherapy for r/r CTCL. RXR retinoid;
+# hypertriglyceridemia (frequently >400) + central hypothyroidism +
+# pancreatitis risk dominant. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Сухість шкіри, помірна втома, головний біль"
+    action_ua: "Очікувано — зволожувач, питний режим"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Постійне відчуття холоду, набір ваги, виражена слабкість"
+    action_ua: "Подзвоніть у клініку того ж дня — щитоподібна реакція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Сильний біль у верхній частині живота, що віддає в спину, нудота"
+    action_ua: "Звертайтесь у лікарню негайно — підозра на панкреатит від тригліцеридів"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — лейкопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — гепатотоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   Duvic 2001 (Arch Dermatol) — ORR 45-55% in r/r CTCL. Triglyceride

--- a/knowledge_base/hosted/content/regimens/reg_brentuximab_maintenance_alcl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_brentuximab_maintenance_alcl.yaml
@@ -41,6 +41,42 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-PTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Brentuximab vedotin maintenance post-ASCT for ALCL. CD30 ADC;
+# peripheral neuropathy signature + neutropenia + rare PML/pancreatitis.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Поколювання у пальцях рук і ніг"
+    action_ua: "Занотовуйте інтенсивність — вираженість має бути обговорена з лікарем"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Помірна втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Виражене оніміння або слабкість у руках чи ногах, що погіршується"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна корекція дози або пауза"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сильний біль у верхній частині живота, що віддає в спину"
+    action_ua: "Подзвоніть у клініку того ж дня — рідкісний побічний — панкреатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Сплутаність свідомості, проблеми з мовою, рухами"
+    action_ua: "Звертайтесь у лікарню негайно — рідкісний неврологічний побічний"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-BCELL-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   Adapted from AETHERA (Moskowitz 2015 cHL) — extrapolated to systemic

--- a/knowledge_base/hosted/content/regimens/reg_capecitabine_palliative.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_capecitabine_palliative.yaml
@@ -48,6 +48,42 @@ sources:
   - SRC-NCCN-COLON-2025
   - SRC-ESMO-COLON-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Capecitabine palliative monotherapy for frail mCRC. Oral 5-FU prodrug;
+# HFS + diarrhea + DPYD risk dominant; goal is symptom balance.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Почервоніння, лущення, легка болючість на долонях і стопах"
+    action_ua: "HFS — крем з сечовиною; уникайте тертя і гарячої води"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Помірна втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Виражений біль на долонях / стопах, що заважає ходити"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна пауза в препараті"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Більше 4-5 рідких випорожнень на день"
+    action_ua: "Подзвоніть у клініку того ж дня — почніть лоперамід, питний режим"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-COLON-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Біль у грудях, серцебиття під час прийому препарату"
+    action_ua: "Звертайтесь у лікарню негайно — рідкісний кардіотоксичний побічний 5-ФУ-проліків"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-COLON-2025
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_carbo_pem_mod_elderly.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_carbo_pem_mod_elderly.yaml
@@ -54,6 +54,43 @@ sources:
   - SRC-NCCN-NSCLC-2025
   - SRC-ESMO-NSCLC-METASTATIC-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Attenuated carbo-pem for elderly NSCLC ≥75y. Same toxicities as
+# standard dose but lower-grade; ototoxicity + cytopenia + fatigue
+# dominate. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Висип, помірна сухість шкіри"
+    action_ua: "Зволожувач; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Шум у вухах, зниження слуху"
+    action_ua: "Подзвоніть у клініку того ж дня — карбоплатин впливає на слух"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Поколювання у пальцях, що погіршується"
+    action_ua: "Занотовуйте — обговоримо корекцію дози"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Виражена слабкість, неможливість підвестися"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик падінь у похилому віці"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+
 last_reviewed: "2026-04-27"
 reviewers: []
 notes: >

--- a/knowledge_base/hosted/content/regimens/reg_choep_allosct_consolidation.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_choep_allosct_consolidation.yaml
@@ -102,6 +102,48 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-PTCL-2024
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# CHOEP × 6 induction → allo-HCT consolidation for fit transplant-eligible
+# PTCL NOS in CR1. Induction has CHOP toxicities + etoposide cytopenia;
+# transplant phase has GVHD + infection signature. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Поколювання у пальцях рук і ніг"
+    action_ua: "Очікувано від вінкристину — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Закреп на 3+ дні, біль у животі під час циклу"
+    action_ua: "Подзвоніть у клініку того ж дня — кишкова непрохідність від вінкристину"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Висип на шкірі (особливо долоні, стопи), діарея, жовтяниця після трансплантації"
+    action_ua: "Подзвоніть у клініку того ж дня — реакція трансплантат-проти-господаря"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Задишка при підйомі сходами, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — антрацикліни впливають на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Сплутаність свідомості, висока лихоманка з ознобом"
+    action_ua: "Звертайтесь у лікарню негайно — ознаки сепсису"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-25"
 notes: >
   Standard intensification for fit younger transplant-eligible PTCL

--- a/knowledge_base/hosted/content/regimens/reg_dostarlimab_carbo_pacli_endom.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_dostarlimab_carbo_pacli_endom.yaml
@@ -15,6 +15,49 @@ monitoring_schedule_id:
 dose_adjustments: [{condition: "Peripheral neuropathy", modification: "Reduce paclitaxel"}, {condition: "Immune AE", modification: "Hold dostarlimab"}]
 ukraine_availability: {all_components_registered: false, all_components_reimbursed: false, notes: "Dostarlimab not registered in Ukraine"}
 sources: [SRC-NCCN-UTERINE-2025, SRC-ESMO-ENDOMETRIAL-2022]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Dostarlimab + carbo + paclitaxel for endometrial dMMR (RUBY).
+# IO + platinum + taxane combo: irAEs + neuropathy + cytopenia.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-UTERINE-2025
+  - trigger_ua: "Поколювання у пальцях рук і ніг"
+    action_ua: "Очікувано від паклітакселу — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-UTERINE-2025
+  - trigger_ua: "Шкірний свербіж"
+    action_ua: "Очікувано від достарлімабу — зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-UTERINE-2025
+  - trigger_ua: "Помірна діарея"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-UTERINE-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця, виражена слабкість"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит або тиреоїдит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-UTERINE-2025
+  - trigger_ua: "Сильна задишка, висип, набряк обличчя під час інфузії"
+    action_ua: "Звертайтесь у лікарню негайно — гіперчутливість до паклітакселу"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-UTERINE-2025
+
 last_reviewed:
 notes: "RUBY: dostarlimab+chemo PFS HR 0.30 dMMR, 0.64 pMMR."
 notes_ua: 'RUBY: dostarlimab+chemo PFS HR 0.30 dMMR, 0.64 pMMR.'

--- a/knowledge_base/hosted/content/regimens/reg_doxorubicin_chondrosarcoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_doxorubicin_chondrosarcoma.yaml
@@ -23,5 +23,43 @@ sources:
   - SRC-NCCN-SARCOMA
 
 reviewer_signoffs: 0
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Doxorubicin monotherapy palliative for advanced chondrosarcoma.
+# Anthracycline: cardio + cytopenia + alopecia + nausea + vesicant.
+# STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Випадіння волосся, помірна нудота"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Червоне забарвлення сечі 1-2 дні після інфузії"
+    action_ua: "Очікувано від доксорубіцину — нешкідливо"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Болючість, почервоніння або пухирі в місці інфузії"
+    action_ua: "Звертайтесь у лікарню негайно — підозра на екстравазацію (виток препарату)"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Задишка при підйомі сходами або в стані спокою, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — антрацикліни впливають на серце"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-SARCOMA
+  - trigger_ua: "Сильна задишка, біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-SARCOMA
+
 notes: >
   STUB scaffold. Dosing summary only.

--- a/knowledge_base/hosted/content/regimens/reg_fedratinib_pmf.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_fedratinib_pmf.yaml
@@ -60,6 +60,42 @@ sources:
   - SRC-NCCN-MPN-2025
   - SRC-JAKARTA2-HARRISON-2017
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Fedratinib for ruxolitinib-resistant PMF. Boxed warning: Wernicke
+# encephalopathy. GI toxicity + cytopenia dominant. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, помірна діарея — у перші тижні"
+    action_ua: "Приймайте призначені протиблювотні; лоперамід для діареї; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Помірна втома"
+    action_ua: "Очікувано — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MPN-2025
+  - trigger_ua: "Сплутаність свідомості, проблеми з координацією, рухи очей"
+    action_ua: "Звертайтесь у лікарню негайно — підозра на енцефалопатію Верніке (фатальна без лікування)"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MPN-2025
+      - SRC-JAKARTA2-HARRISON-2017
+  - trigger_ua: "Тяжка діарея або блювання, що не дозволяє пити"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик зневоднення, дефіциту тіаміну"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-JAKARTA2-HARRISON-2017
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Кровотеча з ясен, з носа, синці без причини"
+    action_ua: "Подзвоніть у клініку того ж дня — тромбоцитопенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MPN-2025
+
 last_reviewed: "2026-04-25"
 notes: >
   Selective JAK2 inhibitor for MF post-ruxolitinib failure or

--- a/knowledge_base/hosted/content/regimens/reg_gemtuzumab_apl.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_gemtuzumab_apl.yaml
@@ -71,6 +71,49 @@ sources:
   - SRC-MYLOFRANCE-ARIBI-2007
   - SRC-APL-RELAPSE-LENGFELDER-2017
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Gemtuzumab + ATRA + ATO for relapsed APL. CD33 ADC: VOD/SOS boxed
+# warning + DS + QT (ATO) + cytopenia overlay. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Сухість шкіри, тріщини на губах, головний біль"
+    action_ua: "Очікувано від ATRA — зволожувач, занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Помірна нудота"
+    action_ua: "Очікувано — приймайте призначені протиблювотні"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Жовтяниця, набір ваги, біль у правому підребер'ї"
+    action_ua: "Звертайтесь у лікарню негайно — вено-оклюзивне ускладнення від гемтузумабу (потенційно фатальне)"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-AML-2025
+      - SRC-MYLOFRANCE-ARIBI-2007
+  - trigger_ua: "Раптовий набір ваги, набряки, задишка, лихоманка"
+    action_ua: "Звертайтесь у лікарню негайно — синдром диференціації"
+    urgency: er_now
+    cycle_day_window: "Day 1-14"
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Кровотеча з ясен, з носа, синці без причини"
+    action_ua: "Звертайтесь у лікарню негайно — ДВЗ-синдром, потрібна термінова трансфузія"
+    urgency: er_now
+    cycle_day_window: "Day 1-14"
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Серцебиття, запаморочення"
+    action_ua: "Подзвоніть у клініку того ж дня — ATO може подовжувати QT"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-AML-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+
 last_reviewed: "2026-04-25"
 notes: >
   Gemtuzumab combined with ATRA + ATO for relapsed APL — APL is

--- a/knowledge_base/hosted/content/regimens/reg_imatinib_kit_melanoma.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_imatinib_kit_melanoma.yaml
@@ -39,6 +39,37 @@ sources:
   - SRC-ESMO-MELANOMA-2024
   - SRC-CARVAJAL-KIT-MELANOMA-2013
 
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Imatinib for KIT-mutant mucosal/acral melanoma (off-label). Same
+# imatinib pattern as CML/GIST: edema + fluid retention + GI + cytopenia
+# + rare hepatotoxicity. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Періорбітальні набряки (опухлі повіки) вранці"
+    action_ua: "Очікувано від іматинібу — занотовуйте; обмежте сіль"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Помірна нудота, спазми у м'язах"
+    action_ua: "Приймайте препарат з їжею; зволоження; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Швидкий набір ваги, виражені набряки ніг, задишка"
+    action_ua: "Подзвоніть у клініку того ж дня — затримка рідини"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Жовтяниця, темна сеча"
+    action_ua: "Подзвоніть у клініку того ж дня — гепатотоксичність"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MELANOMA-2025
+
 last_reviewed: "2026-04-27"
 notes: >
   Carvajal et al. JAMA 2011 (NCT00470470): imatinib 400 BID in


### PR DESCRIPTION
## Summary
- Wave 3I of patient between-visit watchpoints; 21 regimens (4 bonus over usual 17) covering high-risk APL induction, ATLL, HCC IO doublet (STRIDE), allo-HCT MDS-HR + PMF, 3L+ CML (asciminib), hepatic-modified ABVD, advSM 1L (avapritinib), r/r AITL azacitidine, ovarian bev maintenance, CTCL bexarotene mono + maintenance, ALCL post-ASCT BV maintenance, palliative cape mono, attenuated carbo-pem elderly NSCLC, CHOEP+alloSCT PTCL NOS, RUBY dostarlimab+chemo, palliative doxo chondrosarcoma, fedratinib JAKi (boxed Wernicke), relapsed APL gemtuzumab+ATRA+ATO, KIT-mutant melanoma imatinib.
- Each regimen gets `between_visit_watchpoints` (trigger_ua / action_ua / urgency / sources) covering log/call/ER tiers.
- STUB pending §6.1 clinical sign-off (CHARTER dev-mode exemption).

## Test plan
- [x] `python -m knowledge_base.validation.loader knowledge_base/hosted/content` — 2613 entities, all references resolve
- [x] `pytest tests/test_patient_render.py` — 62 passed, 1 skipped
- [ ] Clinical reviewer signoff (deferred per §6.1 dev-mode exemption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)