### PR TITLE
hotfix(site): /en/* 404 → redirect to root (urgent)

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenOnco — page not found</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link href="/style.css" rel="stylesheet">
+<script>
+(function () {
+  try {
+    var p = window.location.pathname || "";
+    var s = window.location.search || "";
+    var h = window.location.hash || "";
+    // Legacy /en/* paths were retired 2026-04-30 (English moved to root).
+    // Strip the /en prefix and redirect so old links / search results still work.
+    if (p === "/en" || p === "/en/") {
+      window.location.replace("/" + s + h);
+      return;
+    }
+    if (p.indexOf("/en/") === 0) {
+      window.location.replace(p.substring(3) + s + h);
+      return;
+    }
+  } catch (e) { /* fall through to static 404 below */ }
+})();
+</script>
+</head>
+<body>
+<header class="top-bar">
+  <div class="brand-line">
+    <a href="/" class="brand-mini">OpenOnco</a>
+  </div>
+  <nav class="top-nav">
+    <a href="/">Home</a>
+    <a href="/diseases.html">Diseases</a>
+    <a href="/capabilities.html">Capabilities</a>
+    <a href="/contribute.html">Contribute</a>
+    <a href="/gallery.html">Examples</a>
+  </nav>
+  <div class="top-right">
+    <div class="lang-switch" role="group" aria-label="Language">
+      <a class="lang-other" href="/ukr/"><span class="lang-flag flag-ua" aria-hidden="true"></span>UA</a>
+      <span class="lang-current"><span class="lang-flag flag-en" aria-hidden="true"></span>EN</span>
+    </div>
+  </div>
+</header>
+<main style="max-width:720px;margin:6rem auto;padding:0 1.5rem;text-align:center;">
+  <h1 style="font-family:'Playfair Display',serif;font-size:3rem;margin-bottom:0.5rem;">404</h1>
+  <p style="font-size:1.25rem;color:#555;">This page has moved or no longer exists.</p>
+  <p style="margin-top:2rem;">
+    <a href="/" style="display:inline-block;padding:0.75rem 1.5rem;border:1px solid #333;border-radius:4px;text-decoration:none;color:#333;">Go to OpenOnco home →</a>
+  </p>
+  <p style="margin-top:3rem;color:#888;font-size:0.9rem;">
+    Looking for the Ukrainian version? <a href="/ukr/">Open /ukr/</a>.
+  </p>
+</main>
+</body>
+</html>

--- a/docs/en/capabilities.html
+++ b/docs/en/capabilities.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Capabilities</title>
+<link rel="canonical" href="https://openonco.info/capabilities.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/capabilities.html">
+<script>window.location.replace("/capabilities.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/capabilities.html">https://openonco.info/capabilities.html</a>.</p>
+</body>
+</html>

--- a/docs/en/contribute.html
+++ b/docs/en/contribute.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Contribute</title>
+<link rel="canonical" href="https://openonco.info/contribute.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/contribute.html">
+<script>window.location.replace("/contribute.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/contribute.html">https://openonco.info/contribute.html</a>.</p>
+</body>
+</html>

--- a/docs/en/diseases.html
+++ b/docs/en/diseases.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Disease coverage</title>
+<link rel="canonical" href="https://openonco.info/diseases.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/diseases.html">
+<script>window.location.replace("/diseases.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/diseases.html">https://openonco.info/diseases.html</a>.</p>
+</body>
+</html>

--- a/docs/en/gallery.html
+++ b/docs/en/gallery.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Examples</title>
+<link rel="canonical" href="https://openonco.info/gallery.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/gallery.html">
+<script>window.location.replace("/gallery.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/gallery.html">https://openonco.info/gallery.html</a>.</p>
+</body>
+</html>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Open-source CDS for oncology</title>
+<link rel="canonical" href="https://openonco.info/">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/">
+<script>window.location.replace("/" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/">https://openonco.info/</a>.</p>
+</body>
+</html>

--- a/docs/en/limitations.html
+++ b/docs/en/limitations.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Limitations</title>
+<link rel="canonical" href="https://openonco.info/limitations.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/limitations.html">
+<script>window.location.replace("/limitations.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/limitations.html">https://openonco.info/limitations.html</a>.</p>
+</body>
+</html>

--- a/docs/en/specs.html
+++ b/docs/en/specs.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Specifications</title>
+<link rel="canonical" href="https://openonco.info/specs.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/specs.html">
+<script>window.location.replace("/specs.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/specs.html">https://openonco.info/specs.html</a>.</p>
+</body>
+</html>

--- a/docs/en/try.html
+++ b/docs/en/try.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenOnco — Try it</title>
+<link rel="canonical" href="https://openonco.info/try.html">
+<meta name="robots" content="noindex,follow">
+<meta http-equiv="refresh" content="0; url=/try.html">
+<script>window.location.replace("/try.html" + (window.location.search || "") + (window.location.hash || ""));</script>
+</head>
+<body>
+<p>This page has moved to <a href="/try.html">https://openonco.info/try.html</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Google has stale `/en/*` URLs indexed from before the 2026-04-30 EN-promotion (commit 48eb804e moved English from `/en/` to `/`).
- Live site returns **404** for `https://openonco.info/en/` — user reported externally, urgent.
- Fix: add `docs/404.html` with JS redirect that strips `/en/` prefix; add static stubs at the eight main `/en/*` paths with `rel=canonical` + meta-refresh + JS redirect so search engines see the canonical root URL on first crawl. Per-case `/en/cases/<id>.html` handled by 404.html.

## Test plan

- [ ] Merge → wait for Pages deploy.
- [ ] `curl -I https://openonco.info/en/` returns 200 (was 404).
- [ ] Visit `https://openonco.info/en/` in browser → redirects to `https://openonco.info/`.
- [ ] Visit `https://openonco.info/en/capabilities.html` → redirects to `/capabilities.html`.
- [ ] Visit `https://openonco.info/en/cases/somerandomid.html` → 404.html JS redirects to `/cases/somerandomid.html` (then 404 if id is fake — expected).