### PR TITLE
feat(kb): cervical recurrent/metastatic 1L — KEYNOTE-826 regimen + algorithm

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_cervical_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_cervical_metastatic_1l.yaml
@@ -1,0 +1,62 @@
+id: ALGO-CERVICAL-METASTATIC-1L
+applicable_to_disease: DIS-CERVICAL
+applicable_to_line_of_therapy: 1
+purpose: >
+  Select 1L regimen for metastatic / persistent / recurrent cervical cancer
+  (FIGO IVB or R/M not amenable to curative-intent therapy). Primary path:
+  pembrolizumab + paclitaxel + carboplatin ± bevacizumab for PD-L1 CPS ≥1
+  (KEYNOTE-826). Fitness gates via pan-disease RFs. Pembro-ineligible
+  (CPS <1 or autoimmune contraindication) → chemo ± bev (pending
+  separate indication authoring).
+
+output_indications:
+  - IND-CERVICAL-METASTATIC-1L-PEMBRO-CHEMO-BEV
+
+default_indication: IND-CERVICAL-METASTATIC-1L-PEMBRO-CHEMO-BEV
+alternative_indication: null
+
+decision_tree:
+  - step: 1
+    evaluate:
+      all_of:
+        - condition: "FIGO IVB (metastatic) OR persistent / recurrent cervical cancer not amenable to curative-intent therapy"
+        - any_of:
+          - red_flag: RF-FITNESS-ECOG-FIT
+          - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+    if_true:
+      next_step: 2
+    if_false:
+      result: IND-CERVICAL-METASTATIC-1L-PEMBRO-CHEMO-BEV
+    notes: "Fitness gate via CSD-7A pan-disease RFs. ECOG 2 (intermediate) eligible per KEYNOTE-826 enrolment criteria — not excluded."
+  - step: 2
+    evaluate:
+      any_of:
+        - red_flag: RF-CERVICAL-PDL1-CPS-1-PLUS
+    if_true:
+      result: IND-CERVICAL-METASTATIC-1L-PEMBRO-CHEMO-BEV
+    if_false:
+      result: IND-CERVICAL-METASTATIC-1L-PEMBRO-CHEMO-BEV
+    notes: >
+      Both branches resolve to the same Indication for now (the Indication itself
+      carries the CPS ≥1 requirement in biomarker_requirements_required).
+      CPS-negative or autoimmune-contraindication pembro-ineligible path
+      (chemo ± bev only) deferred — separate Indication to be authored.
+      Engine/MDT will flag the biomarker constraint at render time.
+
+sources:
+  - SRC-NCCN-CERVICAL-2025
+  - SRC-ESMO-CERVICAL-2024
+
+last_reviewed: "2026-05-03"
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: >
+  Single-indication scaffold for metastatic/recurrent cervical 1L.
+  Closes the gap noted in algo_cervical_locally_advanced_1l.yaml.
+  Deferred paths:
+  - CPS <1 / pembro-contraindicated: chemo ± bev only (no ICI) — needs
+    separate IND-CERVICAL-METASTATIC-1L-CHEMO-BEV-ONLY
+  - KEYNOTE-A18: pembro + concurrent CRT for high-risk locally advanced
+    FIGO IIIB-IVA — belongs in ALGO-CERVICAL-LOCALLY-ADVANCED-1L update
+  - 2L+: tisotumab vedotin (innovaTV-204); cemiplimab (EMPOWER-Cervical-1)
+    — deferred to algo_cervical_metastatic_2l (not yet authored)

--- a/knowledge_base/hosted/content/indications/ind_cervical_metastatic_1l_pembro_chemo_bev.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cervical_metastatic_1l_pembro_chemo_bev.yaml
@@ -13,7 +13,7 @@ applicable_to:
   demographic_constraints:
     ecog_max: 1
 
-recommended_regimen:
+recommended_regimen: REG-PEMBRO-PACLI-CARBO-BEV-CERVICAL
 concurrent_therapy: []
 followed_by: []
 

--- a/knowledge_base/hosted/content/redflags/rf_cervical_pdl1_cps_1_plus.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_cervical_pdl1_cps_1_plus.yaml
@@ -41,6 +41,7 @@ relevant_diseases:
   - DIS-CERVICAL
 shifts_algorithm:
   - ALGO-CERVICAL-LOCALLY-ADVANCED-1L
+  - ALGO-CERVICAL-METASTATIC-1L
 
 sources:
   - SRC-NCCN-CERVICAL-2025

--- a/knowledge_base/hosted/content/regimens/reg_pembro_pacli_carbo_bev_cervical.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_pacli_carbo_bev_cervical.yaml
@@ -1,0 +1,163 @@
+id: REG-PEMBRO-PACLI-CARBO-BEV-CERVICAL
+name: "Pembrolizumab + paclitaxel + carboplatin ± bevacizumab (metastatic/recurrent cervical cancer 1L; KEYNOTE-826)"
+name_ua: "Пембролізумаб + паклітаксел + карбоплатин ± бевацизумаб (метастатичний/рецидивний РШМ, 1L; KEYNOTE-826)"
+alternate_names:
+  - "KEYNOTE-826 regimen"
+  - "Pembro + paclitaxel + carboplatin ± bevacizumab cervical"
+  - "Pembro + paclitaxel + cisplatin ± bevacizumab cervical"
+
+components:
+  - drug_id: DRUG-PEMBROLIZUMAB
+    dose: "200 mg IV q3w"
+    schedule: "Day 1 every 3 weeks, up to 35 cycles (~2 years) or until progression / unacceptable toxicity"
+    route: IV
+  - drug_id: DRUG-PACLITAXEL
+    dose: "175 mg/m² IV over 3 hours"
+    schedule: "Day 1 every 3 weeks, for up to 6 cycles of chemotherapy"
+    route: IV
+  - drug_id: DRUG-CARBOPLATIN
+    dose: "AUC 5 IV (alternative: cisplatin 50 mg/m² IV for cisplatin-naïve fit patients)"
+    schedule: "Day 1 every 3 weeks, for up to 6 cycles of chemotherapy"
+    route: IV
+  - drug_id: DRUG-BEVACIZUMAB
+    dose: "15 mg/kg IV (optional — add when no contraindications: no fistula history, BP controlled, proteinuria <2+)"
+    schedule: "Day 1 every 3 weeks; may continue beyond chemotherapy cycles at MDT discretion"
+    route: IV
+    optional: true
+
+cycle_length_days: 21
+total_cycles: "Up to 6 cycles platinum-based chemotherapy + pembrolizumab up to 35 cycles (~2 years) or until progression"
+toxicity_profile: severe
+
+premedication:
+  - "Dexamethasone 20 mg IV (or PO) ~30 min before paclitaxel — hypersensitivity prophylaxis"
+  - "Diphenhydramine 50 mg IV ~30 min before paclitaxel"
+  - "Ranitidine 50 mg IV (or famotidine) ~30 min before paclitaxel"
+  - "Antiemetics — moderate-to-high emetogenic prophylaxis (5-HT3 antagonist + NK1 antagonist + dex day 1; metoclopramide days 2-3)"
+
+mandatory_supportive_care:
+  - SUP-HBV-PROPHYLAXIS
+  - SUP-PJP-PROPHYLAXIS
+
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Severe immune-related adverse event (irAE gr ≥3: colitis, pneumonitis, hepatitis, nephritis, adrenal insufficiency)"
+    modification: "Hold pembrolizumab; high-dose corticosteroids (1-2 mg/kg prednisone equiv); permanent discontinuation for recurrent gr ≥3 or any gr 4 (except endocrinopathy on replacement)"
+    rationale: "irAE management per ASCO / ESMO IO toxicity guidelines"
+    source_refs:
+      - SRC-NCCN-CERVICAL-2025
+  - condition: "Grade ≥2 peripheral neuropathy (paclitaxel)"
+    modification: "Hold paclitaxel until ≤gr 1; reduce 20% on resumption; discontinue if gr 3 persists >7 days"
+    rationale: "Paclitaxel cumulative neurotoxicity"
+    source_refs:
+      - SRC-NCCN-CERVICAL-2025
+  - condition: "Proteinuria ≥2+ on dipstick / ≥2 g/24h urine protein (bevacizumab)"
+    modification: "Hold bevacizumab; re-check; discontinue if >3 g/24h or nephrotic syndrome"
+    rationale: "Bevacizumab-related proteinuria / nephrotic syndrome"
+    source_refs:
+      - SRC-NCCN-CERVICAL-2025
+  - condition: "Hypertension grade 3 not controlled on oral antihypertensives (bevacizumab)"
+    modification: "Hold bevacizumab; optimize BP control; permanent discontinuation if gr 4 or hypertensive crisis"
+    rationale: "Bevacizumab anti-VEGF hypertensive risk"
+    source_refs:
+      - SRC-NCCN-CERVICAL-2025
+  - condition: "ANC <1.0 × 10⁹/L or platelets <75 × 10⁹/L on day 1"
+    modification: "Delay cycle 1 week; consider dose reduction 20% if recurrent; G-CSF prophylaxis not routinely required but may be added after febrile neutropenia"
+    rationale: "Chemotherapy myelosuppression"
+    source_refs:
+      - SRC-NCCN-CERVICAL-2025
+  - condition: "CrCl <50 mL/min"
+    modification: "Prefer carboplatin AUC 5 over cisplatin; re-calculate Calvert AUC with current GFR"
+    rationale: "Cisplatin is nephrotoxic and requires CrCl ≥50 mL/min; carboplatin dose-adjusts via Calvert formula"
+    source_refs:
+      - SRC-NCCN-CERVICAL-2025
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: >
+    Pembrolizumab registered in Ukraine and НСЗУ-listed for cervical CPS ≥1 (2025 — major
+    improvement). Paclitaxel + carboplatin НСЗУ-reimbursed. Bevacizumab registered but
+    limited reimbursement. Cisplatin alternative fully available and reimbursed. Overall
+    regimen partially accessible; pembrolizumab access for eligible patients significantly
+    improved since 2025 НСЗУ listing.
+
+sources:
+  - SRC-NCCN-CERVICAL-2025
+  - SRC-ESMO-CERVICAL-2024
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# KEYNOTE-826 pembro + paclitaxel + carboplatin ± bev. Key risks:
+# paclitaxel neurotoxicity/HSR, carboplatin myelosuppression,
+# bevacizumab hypertension/fistula, pembro irAEs.
+between_visit_watchpoints:
+  - trigger_ua: "Оніміння або поколювання в руках/ногах після курсу"
+    action_ua: "Занотовуйте — повідомте лікаря при наступному візиті; при посиленні — дзвоніть раніше"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+  - trigger_ua: "Підвищений артеріальний тиск (>140/90 мм рт ст) при самоконтролі"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик гіпертонії від бевацизумабу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія на фоні хіміотерапії"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Нова задишка або кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний пневмоніт від пембролізумабу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+  - trigger_ua: "Помірна діарея (3-4 рідких випорожнення на день)"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+  - trigger_ua: "Жовтяниця або виражена слабкість"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+  - trigger_ua: "Поява піхвового / ректального свища або незвичних виділень після початку бевацизумабу"
+    action_ua: "Звертайтесь у лікарню негайно — перфорація / свищ від бевацизумабу"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+  - trigger_ua: "Раптовий сильний біль у животі"
+    action_ua: "Звертайтесь у лікарню негайно — перфорація кишківника (рідкісне ускладнення бевацизумабу)"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-CERVICAL-2025
+
+last_reviewed: "2026-05-03"
+reviewer_signoffs: []
+notes: >
+  KEYNOTE-826 (Colombo NEJM 2021 + Lancet 2023 final OS): pembrolizumab +
+  paclitaxel + carboplatin (or cisplatin) ± bevacizumab vs placebo + chemo ±
+  bev for 1L metastatic / persistent / recurrent cervical cancer (n=617).
+  CPS ≥1 subgroup (n=548): mOS 28.6 vs 16.5 mo (HR 0.64, p<0.001);
+  mPFS 10.4 vs 8.2 mo (HR 0.62). All-comers: mOS 24.4 vs 16.5 mo
+  (HR 0.67, p<0.001). Bevacizumab was used in ~63% of patients;
+  bevacizumab-containing arm showed numerically better outcomes.
+  FDA approval Jan 2021 for CPS ≥1; EMA approved. Carboplatin AUC 5
+  preferred over cisplatin for patients with prior platinum (e.g. post-CRT)
+  or renal dysfunction (JCOG 0505 equivalence data). STUB — pending
+  Co-Lead sign-off (CHARTER §6.1 dev-mode exemption).
+notes_ua: >
+  KEYNOTE-826 (Colombo NEJM 2021 + Lancet 2023 фінальна ЗВ): пембролізумаб +
+  паклітаксел + карбоплатин (або цисплатин) ± бевацизумаб проти плацебо + хіміо ±
+  бев для 1L метастатичного / персистуючого / рецидивного РШМ (n=617).
+  CPS ≥1 підгрупа (n=548): мЗВ 28.6 vs 16.5 міс (HR 0.64, p<0.001);
+  мВБП 10.4 vs 8.2 міс (HR 0.62). Усі пацієнти: мЗВ 24.4 vs 16.5 міс
+  (HR 0.67, p<0.001). Бевацизумаб застосовано у ~63% пацієнтів;
+  рука з бевацизумабом показала чисельно кращі результати.
+  FDA схвалення: серп 2021 для CPS ≥1; EMA схвалено. Карбоплатин AUC 5
+  пріоритетний над цисплатином для пацієнтів із попереднім platinum
+  (наприклад, після ХПТ) або нирковою дисфункцією (дані JCOG 0505).
+  STUB — очікує підпис Co-Lead (CHARTER §6.1 exemption for dev-mode).
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary

- **New regimen** `REG-PEMBRO-PACLI-CARBO-BEV-CERVICAL` — KEYNOTE-826: pembrolizumab 200 mg q3w + paclitaxel 175 mg/m² + carboplatin AUC 5 (or cisplatin 50 mg/m²) ± bevacizumab 15 mg/kg; up to 35 cycles pembro. Full dose-adjustment table with bevacizumab contraindication guidance and between-visit watchpoints (fistula `er_now` gate, bev HTN, irAEs).
- **New algorithm** `ALGO-CERVICAL-METASTATIC-1L` — routes metastatic/persistent/recurrent cervical via PD-L1 CPS + fitness decision tree to the KEYNOTE-826 indication. Closes gap noted in `algo_cervical_locally_advanced_1l.yaml` STUB.
- **Edit** `ind_cervical_metastatic_1l_pembro_chemo_bev.yaml` — populates the empty `recommended_regimen:` field.
- **Edit** `rf_cervical_pdl1_cps_1_plus.yaml` — adds `ALGO-CERVICAL-METASTATIC-1L` to `shifts_algorithm` so the redflag routes both locally-advanced and metastatic paths.

Evidence basis: KEYNOTE-826 (Colombo NEJM 2021 + Lancet 2023 final OS) — mOS 28.6 vs 16.5 mo at CPS ≥1 (HR 0.64). FDA approved Jan 2021; НСЗУ-listed for cervical CPS ≥1 in Ukraine since 2025.

## Test plan

- [x] All 4 YAML files parse clean (`yaml.safe_load`)
- [x] `tests/test_patient_render.py` + `tests/test_engine_patient_render_smoke.py` — 68 passed, 1 skipped (no regressions)
- [x] 3 pre-existing failures unchanged: `test_no_regression_all_244_legacy_yamls_load`, `test_no_orphan_red_flag_decl`, `test_investigate_flags_do_not_shift`
- [ ] Clinical co-lead signoff required before merge to production (CHARTER §6.1 — STUB marking present on all entities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)