### PR TITLE
feat(kb): neuroendocrine tumors — pNET + GI-NET 1L (RADIANT-3 everolimus + CLARINET lanreotide)

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_gi_net_advanced_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gi_net_advanced_1l.yaml
@@ -1,0 +1,72 @@
+id: ALGO-GI-NET-ADVANCED-1L
+applicable_to_disease: DIS-GI-NET
+applicable_to_line_of_therapy: 1
+purpose: >
+  Select 1L systemic therapy for unresectable / metastatic GI-NET
+  (carcinoid, midgut/foregut/hindgut). Primary decision gate: grade (Ki67).
+  G1/G2 (≤20%): SSA (lanreotide 120 mg q4w) as standard — antiproliferative
+  AND symptom control. Carcinoid syndrome detection reinforces SSA urgency.
+  G3 / NEC: MDT review. Fitness gates via pan-disease RFs.
+
+output_indications:
+  - IND-GI-NET-ADVANCED-1L-LANREOTIDE
+
+default_indication: IND-GI-NET-ADVANCED-1L-LANREOTIDE
+alternative_indication: null
+
+decision_tree:
+  - step: 1
+    evaluate:
+      any_of:
+        - red_flag: RF-NET-HIGH-GRADE-G3
+    if_true:
+      result: IND-GI-NET-ADVANCED-1L-LANREOTIDE
+      notes: "G3 / Ki67 >20% — routes to lanreotide indication which carries hard_contraindication warning for poorly differentiated NEC. MDT must verify G3 well-differentiated vs NEC morphology before SSA."
+    if_false:
+      next_step: 2
+  - step: 2
+    evaluate:
+      any_of:
+        - red_flag: RF-NET-CARCINOID-SYNDROME
+    if_true:
+      result: IND-GI-NET-ADVANCED-1L-LANREOTIDE
+      notes: "Active carcinoid syndrome confirms SSA is mandatory for symptom control and antiproliferative intent."
+    if_false:
+      next_step: 3
+  - step: 3
+    evaluate:
+      all_of:
+        - any_of:
+          - red_flag: RF-FITNESS-ECOG-FIT
+          - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+    if_true:
+      result: IND-GI-NET-ADVANCED-1L-LANREOTIDE
+    if_false:
+      result: IND-GI-NET-ADVANCED-1L-LANREOTIDE
+    notes: >
+      Both branches resolve to lanreotide (SSA is very well tolerated even
+      in frail patients). ECOG PS ≥4 hard gate in engine suppresses active
+      tracks regardless. Active surveillance (no systemic therapy) is
+      clinically appropriate for G1, asymptomatic, low-burden GI-NET —
+      modelled here as MDT decision, not a separate indication.
+
+sources:
+  - SRC-CLARINET-CAPLIN-2014
+  - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: >
+  Single-indication scaffold. Deferred paths:
+  - Active surveillance (watch-and-wait for G1 asymptomatic low-burden) —
+    clinical judgment, not a separate KB indication
+  - Octreotide LAR 30 mg q4w (equivalent alternative to lanreotide;
+    PROMID data) — pending REG-OCTREOTIDE-LAR-GI-NET + DRUG-OCTREOTIDE
+  - PRRT (¹⁷⁷Lu-DOTATATE; NETTER-1 2017) — 2L after SSA progression for
+    SSTR2+ disease; requires SSTR biomarker scaffolding + DRUG-LUTETIUM-177-
+    DOTATATE; separate future PR
+  - Everolimus (RADIANT-4, Yao Lancet 2016) for G1/G2 GI-NET after SSA
+    progression — deferred
+  - Hepatic locoregional therapy (TACE, ablation) for liver-dominant
+    disease — Surgery entity proposal needed

--- a/knowledge_base/hosted/content/algorithms/algo_pnet_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_pnet_metastatic_1l.yaml
@@ -1,0 +1,61 @@
+id: ALGO-PNET-METASTATIC-1L
+applicable_to_disease: DIS-PNET
+applicable_to_line_of_therapy: 1
+purpose: >
+  Select 1L systemic therapy for unresectable / metastatic pNET.
+  Primary decision gate: grade (Ki67). G1/G2 (≤20%): everolimus 10 mg/day
+  (RADIANT-3) as standard. G3 (>20%) or poorly differentiated NEC: MDT
+  review — may require chemotherapy (EP/IP/CAPTEM). Fitness gates via
+  pan-disease RFs.
+
+output_indications:
+  - IND-PNET-METASTATIC-1L-EVEROLIMUS
+
+default_indication: IND-PNET-METASTATIC-1L-EVEROLIMUS
+alternative_indication: null
+
+decision_tree:
+  - step: 1
+    evaluate:
+      any_of:
+        - red_flag: RF-NET-HIGH-GRADE-G3
+    if_true:
+      result: IND-PNET-METASTATIC-1L-EVEROLIMUS
+      notes: "G3 / Ki67 >20% — engine routes to everolimus indication but indication carries contraindication warning for poorly differentiated NEC. MDT must verify well-differentiated G3 vs NEC morphology before proceeding."
+    if_false:
+      next_step: 2
+  - step: 2
+    evaluate:
+      all_of:
+        - any_of:
+          - red_flag: RF-FITNESS-ECOG-FIT
+          - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+    if_true:
+      result: IND-PNET-METASTATIC-1L-EVEROLIMUS
+    if_false:
+      result: IND-PNET-METASTATIC-1L-EVEROLIMUS
+    notes: >
+      Both branches resolve to same indication. ECOG ≥2 — discuss
+      dose reduction (everolimus 5 mg/day) or palliative care; ECOG 3+ →
+      engine ECOG PS ≥4 hard gate already suppresses active tracks.
+      Sunitinib alternative (REG-SUNITINIB-MONO-PNET) deferred — pending
+      IND-PNET-METASTATIC-1L-SUNITINIB authoring.
+
+sources:
+  - SRC-RADIANT3-YAO-2011
+  - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: >
+  Single-indication scaffold. Deferred paths:
+  - Sunitinib 1L (Raymond 2011 NEJM) — equivalent to everolimus; DRUG-SUNITINIB
+    created; REG + IND to follow as separate PR
+  - SSA concurrent / sequential: octreotide/lanreotide may be added to
+    everolimus or sunitinib; not modelled as separate track (MDT/clinical
+    judgment)
+  - Chemotherapy for poorly differentiated NEC: platinum-etoposide (CAPEOX/EP)
+    — separate disease entity DIS-GEP-NEC needed
+  - PRRT for SSTR2+ pNET: requires SSTR biomarker scaffolding
+    (DRUG-LUTETIUM-177-DOTATATE) — future PR

--- a/knowledge_base/hosted/content/diseases/gi_net.yaml
+++ b/knowledge_base/hosted/content/diseases/gi_net.yaml
@@ -1,0 +1,72 @@
+id: DIS-GI-NET
+names:
+  preferred: "Gastroenteropancreatic neuroendocrine tumor — GI origin (carcinoid), well-differentiated G1/G2"
+  ukrainian: "Гастроентеропанкреатична нейроендокринна пухлина — ШКТ походження (карциноїд), добре-диференційована G1/G2"
+  english: "GI neuroendocrine tumor (carcinoid)"
+  synonyms:
+    - "GI-NET"
+    - "Carcinoid tumor (midgut)"
+    - "Small bowel NET"
+    - "Ileal carcinoid"
+    - "GEP-NET (non-pancreatic)"
+    - "Appendiceal NET"
+    - "Rectal NET"
+
+codes:
+  icd_o_3_morphology: "8240/3"  # Neuroendocrine tumor G1/G2; well-differentiated
+  icd_o_3_topography: ["C17", "C18", "C19", "C20", "C18.1"]  # small intestine, colon, appendix
+  icd_10: "C17.9"  # small intestine (midgut most common); also C18.1 (appendix), C20 (rectum)
+  who_classification: "WHO Classification of Digestive System Tumours 5th ed (2019): Well-differentiated neuroendocrine tumour of small intestine/appendix/colon/rectum G1/G2"
+
+archetype: grade_and_stage_driven
+oncotree_code: SCNET  # small intestine NET
+lineage: "neuroendocrine"
+
+etiological_factors:
+  - "Sporadic (vast majority)"
+  - "MEN-1 (rare association, especially foregut NETs — stomach, duodenum)"
+  - "Neurofibromatosis type 1 / NF1 (rare; periampullary NETs)"
+
+related_diseases:
+  - DIS-PNET
+
+epidemiology:
+  global_incidence: "~2–4 per 100K/yr; incidence rising (improved detection)"
+  ukraine_incidence: "~600–900 new cases/yr GI-NET (estimated)"
+  midgut_proportion: "~45% of all NETs — ileum is most common primary site"
+  carcinoid_syndrome_at_mets: "~40–50% of patients with liver metastases develop carcinoid syndrome"
+  metastatic_at_diagnosis: "~50% have distant metastases at diagnosis (liver predominant)"
+
+sources:
+  - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+reviewers: []
+
+metadata:
+  proposal_status: partial
+  awaiting_proposal: >
+    Gastric NET (Type I/II/III differ radically — Type I managed endoscopically,
+    Type III is aggressive NEC-like); rectal NET (<1 cm endoscopic resection vs
+    >2 cm staging workup); appendiceal NET (<2 cm low-risk vs >2 cm appendectomy + RHC.
+    These subtypes require separate entity or sub-path modelling. Deferred.
+
+notes: >
+  GI-NET (non-pancreatic) is the most common NET overall. Midgut/ileal
+  carcinoids are prototypical: indolent growth, somatostatin receptor
+  expression (SSTR2+), liver/mesenteric metastases, carcinoid syndrome
+  (serotonin-driven flushing + diarrhea). Grading per WHO 2019:
+  G1 Ki67 <3%, G2 Ki67 3–20%.
+  Carcinoid syndrome occurs when serotonin (and other mediators) bypass
+  hepatic metabolism — typically with liver metastases or retroperitoneal
+  disease. SSA (octreotide/lanreotide) are the foundation of treatment:
+  (1) symptom control and (2) antiproliferative (CLARINET, PROMID).
+  PRRT (¹⁷⁷Lu-DOTATATE; NETTER-1 trial, Strosberg NEJM 2017) is approved
+  for SSTR2+ midgut NETs after SSA progression — pending KB SSTR biomarker
+  scaffolding (deferred).
+  Key trials: CLARINET (lanreotide, Caplin NEJM 2014), PROMID (octreotide LAR,
+  Rinke JCO 2009), NETTER-1 (PRRT, Strosberg NEJM 2017).
+notes_ua: >
+  GI-NET (не панкреатична) — найбільш поширений тип НЕП загалом. Середньокишкові/клубовокишкові карциноїди є прототиповими: індолентне зростання, експресія соматостатинових рецепторів (SSTR2+), метастази в печінку/брижу, карциноїдний синдром (серотонін-опосередкований приливи + діарея). Градуювання per WHO 2019: G1 Ki67 <3%, G2 Ki67 3–20%. Карциноїдний синдром виникає, коли серотонін (та інші медіатори) обходять печінковий метаболізм — зазвичай при метастазах у печінку або ретроперитонеальній хворобі. SSA (октреотид/ланреотид) є основою лікування: (1) контроль симптомів та (2) антипроліферативна дія (CLARINET, PROMID). PRRT (¹⁷⁷Lu-DOTATATE; NETTER-1, Strosberg NEJM 2017) схвалено для SSTR2+ середньокишкових НЕП після прогресії на SSA — очікує KB SSTR біомаркер (відкладено).
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/diseases/pnet.yaml
+++ b/knowledge_base/hosted/content/diseases/pnet.yaml
@@ -1,0 +1,64 @@
+id: DIS-PNET
+names:
+  preferred: "Pancreatic neuroendocrine tumor (pNET), well-differentiated G1/G2"
+  ukrainian: "Нейроендокринна пухлина підшлункової залози (пНЕП), добре-диференційована G1/G2"
+  english: "Pancreatic neuroendocrine tumor"
+  synonyms:
+    - "pNET"
+    - "Pancreatic islet cell tumor"
+    - "Non-functional pNET"
+    - "Functional pNET (insulinoma, gastrinoma, glucagonoma, VIPoma)"
+
+codes:
+  icd_o_3_morphology: "8240/3"  # Neuroendocrine tumor G1/G2; functional subtypes: 8150/3 (islet cell), 8153/3 (gastrinoma), 8155/3 (VIPoma), 8151/3 (insulinoma)
+  icd_o_3_topography: ["C25"]
+  icd_10: "C25.4"
+  who_classification: "WHO Classification of Digestive System Tumours 5th ed (2019): Pancreatic neuroendocrine tumour G1 (Ki67 <3%), G2 (3–20%), G3 (>20% but well-differentiated)"
+
+archetype: grade_and_stage_driven
+oncotree_code: PNET
+lineage: "neuroendocrine"
+
+etiological_factors:
+  - "MEN-1 syndrome (menin mutation — ~10% of pNETs; typically multiple, smaller)"
+  - "VHL disease (rare)"
+  - "TSC (rare, coexist with SEGA)"
+  - "Sporadic (majority, ~90%)"
+  - "Somatic MEN1 / DAXX / ATRX mutations (sporadic)"
+
+related_diseases:
+  - DIS-GI-NET
+
+epidemiology:
+  global_incidence: "~1–3 per 100K/yr; rising incidence (imaging detection)"
+  ukraine_incidence: "~500–700 new cases/yr (estimated)"
+  functional_proportion: "~20–30% functional (insulinoma most common); ~70% non-functional at diagnosis"
+  metastatic_at_diagnosis: "~55–60% of non-functional pNETs present with regional or distant metastases"
+
+sources:
+  - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+reviewers: []
+
+metadata:
+  proposal_status: partial
+  awaiting_proposal: "Poorly differentiated NEC (G3, ICD-O 8246/3) requires separate disease entity; NEC chemotherapy (EP/IP) not modelled here. MEN-1 workup and surveillance paths deferred."
+
+notes: >
+  Well-differentiated pNET G1/G2 is the dominant subtype in clinical
+  practice (non-functional, discovered incidentally or via abdominal
+  mass/liver mets). Grading per WHO 2019: G1 Ki67 <3%, G2 Ki67 3–20%.
+  G3 well-differentiated pNET (Ki67 >20%) occupies a grey zone — still
+  well-differentiated morphologically but higher proliferation; NCCN
+  recommends everolimus/sunitinib/SSA ± chemo; not modelled separately here
+  (flagged via RF-NET-HIGH-GRADE-G3 for MDT review).
+  Distinguishing from poorly differentiated NEC (ICD-O 8246/3) is
+  essential: NEC requires platinum-etoposide chemotherapy (not SSA/TKI/mTOR).
+  Key trials: RADIANT-3 (everolimus, Yao NEJM 2011), Raymond 2011 (sunitinib),
+  CLARINET pNET subgroup (lanreotide).
+  Surgery remains the only curative option for localized disease.
+notes_ua: >
+  Добре-диференційована pNET G1/G2 — домінуючий підтип у клінічній практиці (нефункціональна, виявлена випадково або через черевну масу/метастази в печінку). Градуювання per WHO 2019: G1 Ki67 <3%, G2 Ki67 3–20%. G3 добре-диференційована pNET (Ki67 >20%) займає сіру зону — морфологічно ще добре-диференційована, але вища проліферація; NCCN рекомендує еверолімус/сунітиніб/SSA ± хіміотерапію; не моделюється окремо тут (позначено через RF-NET-HIGH-GRADE-G3 для MDT review). Відрізнення від погано диференційованої NEC (ICD-O 8246/3) є суттєвим: NEC вимагає платино-етопозидну хіміотерапію (не SSA/TKI/mTOR). Ключові дослідження: RADIANT-3 (еверолімус, Yao NEJM 2011), Raymond 2011 (сунітиніб), CLARINET pNET підгрупа (ланреотид). Хірургія залишається єдиним куративним варіантом при локалізованій хворобі.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/drugs/lanreotide.yaml
+++ b/knowledge_base/hosted/content/drugs/lanreotide.yaml
@@ -1,0 +1,56 @@
+id: DRUG-LANREOTIDE
+names:
+  preferred: "Lanreotide"
+  ukrainian: "Ланреотид"
+  english: "Lanreotide"
+  brand_names: ["Somatuline Autogel", "Somatuline Depot"]
+atc_code: H01CB03
+rxnorm_id: null
+drug_class: "Somatostatin analogue (SSA)"
+mechanism: >
+  Long-acting somatostatin analogue; high affinity for somatostatin receptor
+  subtypes SSTR2 and SSTR5. Inhibits secretion of GH, IGF-1, insulin,
+  glucagon, VIP, gastrin, and serotonin. Antiproliferative effect in
+  well-differentiated GEP-NETs via SSTR2/SSTR5-mediated cell cycle arrest
+  (CLARINET: HR 0.47 vs placebo). Symptom control in functional NETs
+  (carcinoid syndrome: flushing, diarrhea).
+
+regulatory_status:
+  fda: {approved: true}
+  ema: {approved: true}
+  ukraine_registration:
+    registered: true
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-03"
+    notes: >
+      Somatuline зареєстровано в Україні (Держреєстр ЛЗ). НСЗУ-реімбурсація
+      обмежена — SSA-терапія в основному out-of-pocket або через спеціальні
+      програми. Октреотид LAR (альтернативний SSA) доступніший у деяких
+      регіонах. Доступ до lanreotide у пацієнтів з ГЕП-НЕП потребує
+      індивідуального рішення.
+
+typical_dosing: >
+  120 mg SC deep subcutaneous injection every 4 weeks (q4w). Self-injection
+  possible after training. Do not rub injection site. Alternate flanks/buttocks.
+
+key_toxicities:
+  - Injection site reactions (mild, transient — nodule, pain)
+  - Diarrhea / loose stools (transient early; improve with time)
+  - Nausea
+  - Cholelithiasis (~20% with long-term use — asymptomatic gallstones)
+  - Bradycardia (mild)
+  - Hyperglycemia or hypoglycemia (modulates insulin/glucagon)
+  - Hypothyroidism (rare, long-term)
+
+sources:
+  - SRC-NCCN-NET-2025
+last_reviewed: "2026-05-03"
+notes: >
+  CLARINET (Caplin NEJM 2014): lanreotide 120 mg q4w vs placebo in
+  well-differentiated G1/G2 non-functioning GEP-NET (n=204). mPFS not reached
+  vs 18.0 mo (HR 0.47, p<0.001). 96-week extension (CLARINET OLE) confirmed
+  durable benefit. FDA approved lanreotide for non-functioning GEP-NET
+  2014. PROMID (Rinke JCO 2009) with octreotide LAR established SSA
+  antiproliferative class effect for midgut NETs.

--- a/knowledge_base/hosted/content/drugs/sunitinib.yaml
+++ b/knowledge_base/hosted/content/drugs/sunitinib.yaml
@@ -1,0 +1,62 @@
+id: DRUG-SUNITINIB
+names:
+  preferred: "Sunitinib"
+  ukrainian: "Сунітиніб"
+  english: "Sunitinib"
+  brand_names: ["Sutent"]
+atc_code: L01EX01
+rxnorm_id: null
+drug_class: "Multi-targeted receptor tyrosine kinase inhibitor (TKI)"
+mechanism: >
+  Potent inhibitor of multiple receptor tyrosine kinases: VEGFR-1/2/3,
+  PDGFR-α/β, c-KIT, FLT3, CSF-1R, RET. Antiangiogenic + direct
+  antiproliferative effects. In pNET: anti-VEGF/PDGF pathway disrupts
+  tumour neovasculature; direct TKI effect on pNET cells that overexpress
+  VEGFR. Raymond 2011 NEJM: mPFS 11.4 vs 5.5 mo (HR 0.42) in well-
+  differentiated progressive pNET.
+
+regulatory_status:
+  fda: {approved: true}
+  ema: {approved: true}
+  ukraine_registration:
+    registered: true
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-03"
+    notes: >
+      Sutent (сунітиніб) зареєстровано в Україні. НСЗУ-реімбурсація є
+      для нирковоклітинної карциноми (RCC) та ГІСТ (GIST). Для pNET
+      реімбурсація — не включена до онкопакету НСЗУ 2025; доступ через
+      out-of-pocket або compassionate use. Генерики сунітинібу з'являються
+      та можуть знизити вартість.
+
+typical_dosing: >
+  37.5 mg PO once daily continuous (pNET dosing — not the 50 mg on/off
+  4wk/2wk schedule used in RCC/GIST). Take with or without food. Avoid
+  CYP3A4 strong inhibitors/inducers.
+
+key_toxicities:
+  - Hypertension (~34% any grade; ~10% G3 — BP monitoring + antihypertensives)
+  - Fatigue / asthenia (~34%)
+  - Diarrhea (~30%)
+  - Hand-foot syndrome / palmar-plantar erythrodysesthesia (PPE) (~23%)
+  - Nausea / vomiting
+  - Stomatitis / mucositis
+  - Hypothyroidism (~36% with long-term use — TSH monitoring q3 months)
+  - Hepatotoxicity (LFT monitoring)
+  - Myelosuppression (neutropenia, thrombocytopenia)
+  - QTc prolongation (baseline ECG + electrolyte correction)
+  - Cardiac dysfunction / decreased LVEF (echo monitoring at baseline and periodically)
+
+sources:
+  - SRC-NCCN-NET-2025
+last_reviewed: "2026-05-03"
+notes: >
+  Raymond 2011 NEJM: sunitinib 37.5 mg continuous vs placebo in progressive
+  well-differentiated pNET (n=171). mPFS 11.4 vs 5.5 mo (HR 0.42, p<0.001).
+  Trial stopped early at interim analysis. FDA approved sunitinib for pNET
+  May 2011 (same month as everolimus). Continuous 37.5 mg dosing vs the
+  on/off 50 mg schedule used in RCC: lower peak exposure, improved
+  tolerability, maintained efficacy in pNET. Also approved for imatinib-
+  resistant GIST (2006) and advanced RCC (2006).

--- a/knowledge_base/hosted/content/indications/ind_gi_net_advanced_1l_lanreotide.yaml
+++ b/knowledge_base/hosted/content/indications/ind_gi_net_advanced_1l_lanreotide.yaml
@@ -1,0 +1,114 @@
+id: IND-GI-NET-ADVANCED-1L-LANREOTIDE
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-GI-NET
+  line_of_therapy: 1
+  stage_requirements:
+    - "Unresectable locally advanced or metastatic GI-NET (midgut, foregut, hindgut or unknown primary)"
+    - "Well-differentiated G1 (Ki67 <3%) or G2 (Ki67 3–20%)"
+    - "Non-functioning OR functional (carcinoid syndrome) — SSA appropriate for both antiproliferative intent and symptom control"
+    - "Stable, slowly progressive, or newly diagnosed (SSA is appropriate regardless of documented progression per CLARINET design)"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-KI67-PROLIFERATION
+      required: false
+      value_constraint: "Ki67 ≤20% (well-differentiated G1/G2); if Ki67 >20% see RF-NET-HIGH-GRADE-G3 — MDT decision required"
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-LANREOTIDE-AUTOGEL-GI-NET
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~3% (partial response; stable disease is the primary endpoint — 65% in CLARINET lanreotide arm)"
+  complete_response: "<1%"
+  progression_free_survival: "mPFS not reached (lanreotide arm) vs 18.0 mo placebo (HR 0.47, CLARINET)"
+  overall_survival_5y: "No OS benefit demonstrated in CLARINET (low event rate, cross-over); OS secondary endpoint"
+
+hard_contraindications: []
+
+red_flags_triggering_alternative:
+  - RF-NET-HIGH-GRADE-G3
+  - RF-FITNESS-ECOG-POOR
+
+required_tests: []
+
+desired_tests: []
+
+rationale: >
+  Lanreotide 120 mg SC q4w for well-differentiated G1/G2 GEP-NET (GI origin).
+  CLARINET (Caplin NEJM 2014): mPFS not reached vs 18.0 mo (HR 0.47, p<0.001)
+  in n=204 patients with non-functioning GEP-NET. PROMID (Rinke JCO 2009):
+  octreotide LAR 30 mg q4w for midgut NET: mPFS 14.3 vs 6.0 mo (HR 0.34).
+  Both SSAs are NCCN Category 1 for GI-NET. SSA is the only systemic therapy
+  with both antiproliferative AND symptom-control (carcinoid syndrome)
+  properties. DOTATATE PET positivity strongly predicts SSA response and
+  PRRT eligibility for future lines.
+
+rationale_ua: >
+  Ланреотид 120 мг SC q4w для добре-диференційованої G1/G2 ГЕП-НЕП (ШКТ походження).
+  CLARINET (Caplin NEJM 2014): мВБП не досягнуто проти 18.0 міс (HR 0.47, p<0.001)
+  у n=204 пацієнтів із нефункціональною ГЕП-НЕП. PROMID (Rinke JCO 2009):
+  октреотид LAR 30 мг q4w для середньокишкової НЕП: мВБП 14.3 проти 6.0 міс
+  (HR 0.34). Обидва SSA є NCCN Категорія 1 для GI-NET. SSA є єдиною системною
+  терапією з обома антипроліферативними ТА симптомо-контролюючими
+  (карциноїдний синдром) властивостями. DOTATATE PET позитивність сильно
+  передбачає відповідь на SSA та придатність до PRRT для майбутніх ліній.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-CLARINET-CAPLIN-2014
+    position: supports
+    relevant_quote_paraphrase: "Lanreotide significantly prolonged PFS vs placebo in non-functioning GEP-NET (HR 0.47, p<0.001) — CLARINET"
+  - source_id: SRC-NCCN-NET-2025
+    position: supports
+    relevant_quote_paraphrase: "Lanreotide (and octreotide LAR) are Category 1 antiproliferative therapy for well-differentiated GI-NET G1/G2"
+
+do_not_do:
+  - "Не призначати SSA-монотерапію при погано-диференційованій NEC (Ki67 >55%) — протипоказано для антипроліферативного застосування"
+  - "Не пропускати DOTATATE PET/CT — підтверджує SSTR2+ status; від'ємний scan означає низьку ймовірність відповіді на SSA"
+  - "Не забувати IV октреотид перед хірургічним втручанням або емболізацією — ризик карциноїдного кризу"
+  - "Не ігнорувати ехокардіографію при клінічному карциноїдному синдромі — хвороба серця у ~20%"
+
+known_controversies:
+  - topic: "Lanreotide vs octreotide LAR for GI-NET 1L"
+    positions:
+      - position: "No head-to-head RCT; CLARINET (lanreotide) and PROMID (octreotide LAR) both Category 1. Both are acceptable."
+        sources:
+          - SRC-NCCN-NET-2025
+      - position: "Lanreotide has broader CLARINET GEP-NET dataset (pNET + GI-NET + unknown primary). Octreotide LAR better studied in midgut specifically (PROMID)"
+        sources:
+          - SRC-CLARINET-CAPLIN-2014
+    our_default: "Lanreotide as default (CLARINET data); octreotide LAR acceptable equivalent. Choice by availability + patient preference."
+    rationale: "Both are NCCN Category 1; institutional/country availability and cost often determine choice"
+  - topic: "SSA for non-progressive GEP-NET — start immediately or watch and wait?"
+    positions:
+      - position: "CLARINET enrolled patients with stable disease — SSA beneficial even without documented progression; early treatment reduces PFS events"
+        sources:
+          - SRC-CLARINET-CAPLIN-2014
+      - position: "Active surveillance acceptable for incidentally found G1 NET with low tumour burden and no symptoms; defer SSA until progression"
+        sources:
+          - SRC-NCCN-NET-2025
+    our_default: "Start SSA for symptomatic (carcinoid syndrome), high Ki67 G2, or substantial tumour burden; surveillance reasonable for G1, low burden, asymptomatic"
+    rationale: "MDT decision based on rate of growth, Ki67, and patient preference"
+
+time_critical: false
+last_reviewed: "2026-05-03"
+reviewers: []
+reviewer_signoffs: 0
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: >
+  STUB — requires clinical co-lead signoff (CHARTER §6.1 dev-mode exemption).
+  PRRT (¹⁷⁷Lu-DOTATATE; NETTER-1 trial, Strosberg NEJM 2017) is the major
+  2L option after SSA progression for SSTR2+ GI-NET. NETTER-1 showed ORR
+  18% and mPFS not reached vs 8.4 mo (HR 0.21). PRRT requires DOTATATE PET
+  eligibility and specialized centre. Deferred for separate KB SSTR biomarker
+  scaffolding + drug entity (DRUG-LUTETIUM-177-DOTATATE).

--- a/knowledge_base/hosted/content/indications/ind_pnet_metastatic_1l_everolimus.yaml
+++ b/knowledge_base/hosted/content/indications/ind_pnet_metastatic_1l_everolimus.yaml
@@ -1,0 +1,105 @@
+id: IND-PNET-METASTATIC-1L-EVEROLIMUS
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-PNET
+  line_of_therapy: 1
+  stage_requirements:
+    - "Unresectable locally advanced or metastatic pNET (any stage IV, or unresectable stage III)"
+    - "Well-differentiated G1 (Ki67 <3%) or G2 (Ki67 3–20%)"
+    - "Progressive disease (documented radiological progression per RECIST 1.1 within preceding 12 months, OR symptomatic tumour burden)"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-KI67-PROLIFERATION
+      required: false
+      value_constraint: "Ki67 ≤20% (well-differentiated G1/G2); if Ki67 >20% see RF-NET-HIGH-GRADE-G3 — MDT decision required"
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-EVEROLIMUS-MONO-PNET
+concurrent_therapy:
+  - "SSA (octreotide LAR or lanreotide) may be continued concurrently if patient is already on SSA therapy"
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~5% (RECIST CR+PR); disease control rate ~73%"
+  complete_response: "~1%"
+  progression_free_survival: "Median PFS 11.0 mo (HR 0.35 vs placebo, RADIANT-3)"
+  overall_survival_5y: "No significant OS benefit proven (>70% crossover at progression confounds OS data)"
+
+hard_contraindications: []
+
+red_flags_triggering_alternative:
+  - RF-NET-HIGH-GRADE-G3
+  - RF-FITNESS-ECOG-POOR
+
+required_tests: []
+
+desired_tests: []
+
+rationale: >
+  Everolimus 10 mg/day for progressive well-differentiated G1/G2 pNET.
+  RADIANT-3 (Yao NEJM 2011): mPFS 11.0 vs 4.6 mo (HR 0.35, p<0.001) in
+  n=410 patients. mTOR pathway is activated in >80% of pNETs (DAXX/ATRX/
+  mTOR/PIK3CA mutations). NCCN Category 1 preferred systemic therapy for
+  progressive pNET alongside sunitinib (no head-to-head; both valid).
+  Everolimus preferred when cardiac comorbidities or hypertension would
+  limit sunitinib; sunitinib preferred when diabetes or chronic steroid use
+  would complicate everolimus hyperglycaemia management.
+
+rationale_ua: >
+  Еверолімус 10 мг/добу для прогресуючої добре-диференційованої G1/G2 pNET.
+  RADIANT-3 (Yao NEJM 2011): мВБП 11.0 проти 4.6 міс (HR 0.35, p<0.001) у
+  n=410 пацієнтів. Шлях mTOR активований у >80% pNET (мутації DAXX/ATRX/
+  mTOR/PIK3CA). NCCN Категорія 1 переважна системна терапія для прогресуючої
+  pNET поряд із сунітинібом (немає прямого порівняння; обидва дійсні).
+  Еверолімус переважний при серцевих коморбідностях або гіпертензії, що
+  обмежувала б сунітиніб; сунітиніб переважний при діабеті або хронічному
+  застосуванні стероїдів, де гіперглікемія від еверолімусу ускладнила б
+  менеджмент.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-RADIANT3-YAO-2011
+    position: supports
+    relevant_quote_paraphrase: "Everolimus significantly prolonged PFS in progressive pNET: 11.0 vs 4.6 mo (HR 0.35, p<0.001) — RADIANT-3"
+  - source_id: SRC-NCCN-NET-2025
+    position: supports
+    relevant_quote_paraphrase: "Everolimus is Category 1 preferred systemic therapy for progressive well-differentiated pNET"
+
+do_not_do:
+  - "Не призначати еверолімус при погано-диференційованій NEC (Ki67 >55%) — потрібна хіміотерапія (EP)"
+  - "Не починати без базового тестування Ki67 — градуювання є вимогою відбору"
+  - "Не застосовувати з сильними інгібіторами CYP3A4 без корекції дози (зниження до 2.5 мг/добу)"
+  - "Уникати живих вакцин на фоні еверолімусу (імуносупресія)"
+
+known_controversies:
+  - topic: "Everolimus vs sunitinib for pNET 1L"
+    positions:
+      - position: "Both NCCN Category 1; mPFS nearly identical (11.0 vs 11.4 mo in respective trials). No head-to-head data."
+        sources:
+          - SRC-NCCN-NET-2025
+      - position: "Everolimus preferred in cardiac comorbidity / hypertension; sunitinib preferred in diabetes / steroid-dependent patients"
+        sources:
+          - SRC-NCCN-NET-2025
+    our_default: "Everolimus as default standard; sunitinib as equivalent alternative pending separate IND authoring"
+    rationale: "RADIANT-3 and Raymond 2011 are parallel without cross-trial comparison; institutional preference applies"
+
+time_critical: false
+last_reviewed: "2026-05-03"
+reviewers: []
+reviewer_signoffs: 0
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: >
+  STUB — requires clinical co-lead signoff (CHARTER §6.1 dev-mode exemption).
+  Sunitinib indication (IND-PNET-METASTATIC-1L-SUNITINIB) deferred — DRUG-SUNITINIB
+  entity created, regimen and indication to be authored as follow-up PR.
+  SSA concurrent use (octreotide/lanreotide): ~50% of RADIANT-3 patients
+  were on SSA at baseline; concurrent use is allowed and may provide additive
+  antiproliferative + symptomatic benefit.

--- a/knowledge_base/hosted/content/redflags/rf_net_carcinoid_syndrome.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_net_carcinoid_syndrome.yaml
@@ -1,0 +1,63 @@
+id: RF-NET-CARCINOID-SYNDROME
+definition: >
+  Active carcinoid syndrome in a patient with metastatic or unresectable
+  GI-NET (or other serotonin-secreting NET). Defined clinically by any
+  of: episodic flushing, secretory diarrhea (≥4 loose stools/day),
+  bronchoconstriction, or elevated 24h urinary 5-HIAA / serum serotonin.
+  Carcinoid syndrome mandates SSA therapy for symptom control regardless
+  of antiproliferative intent; SSA is also the antiproliferative
+  standard (CLARINET, PROMID).
+definition_ua: >
+  Активний карциноїдний синдром у пацієнта з метастатичною або
+  нерезектабельною GI-NET (або іншою серотонін-секретуючою НЕП).
+  Визначається клінічно наявністю будь-якого з: епізодичні припливи,
+  секреторна діарея (≥4 рідких випорожнень на день), бронхоконстрикція,
+  або підвищений 24-год сечовий 5-HIAA / сироватковий серотонін.
+  Карциноїдний синдром вимагає SSA-терапії для контролю симптомів незалежно
+  від антипроліферативного наміру; SSA є також антипроліферативним
+  стандартом (CLARINET, PROMID).
+
+trigger:
+  type: clinical
+  any_of:
+    - finding: "carcinoid_syndrome"
+      value: "true"
+    - finding: "flushing_episodes"
+      comparator: "present"
+    - finding: "5hiaa_elevated"
+      comparator: "present"
+    - finding: "diarrhea_grade"
+      threshold: 2
+      comparator: ">="
+
+clinical_direction: intensify
+severity: minor
+priority: 55
+category: other
+
+relevant_diseases:
+  - DIS-GI-NET
+  - DIS-PNET
+shifts_algorithm:
+  - ALGO-GI-NET-ADVANCED-1L
+
+sources:
+  - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+draft: false
+
+notes: >
+  Carcinoid syndrome hallmarks: episodic cutaneous flushing (serotonin +
+  bradykinin), diarrhea (serotonin, prostaglandins), bronchoconstriction,
+  carcinoid heart disease (Hedinger syndrome — right-sided valvular fibrosis
+  from chronic serotonin exposure). Biochemical confirmation: 24h urinary
+  5-HIAA >50 µmol/day (normal: <30). SSA reduces 5-HIAA ~50% and controls
+  symptoms in ~70% initially. SSA dose escalation (octreotide short-acting
+  rescue; lanreotide dose increase) and addition of telotristat ethyl
+  (tryptophan hydroxylase inhibitor) for refractory diarrhea. Carcinoid
+  crisis risk during surgery / embolisation — SSA IV cover required.
+  Carcinoid heart disease: echocardiogram at baseline + annually; surgery
+  for severe tricuspid/pulmonary regurgitation if fit.
+notes_ua: >
+  Ознаки карциноїдного синдрому: епізодичне шкірне почервоніння (серотонін + брадикінін), діарея (серотонін, простагландини), бронхоконстрикція, карциноїдна хвороба серця (синдром Гедінгера — правобічний клапанний фіброз від хронічного впливу серотоніну). Біохімічне підтвердження: 24-год сечовий 5-HIAA >50 мкмоль/добу (норма: <30). SSA знижує 5-HIAA ~50% і контролює симптоми у ~70% спочатку. Ескалація дози SSA (октреотид коротке введення рятувальне; збільшення дози ланреотиду) і додавання телотристату (інгібітор триптофан-гідроксилази) при рефрактерній діареї. Ризик карциноїдного кризу під час операції/емболізації — потрібне SSA внутрішньовенно. Хвороба серця при карциноїдному синдромі: ехокардіографія на початку + щорічно; операція при тяжкій трикуспідальній/легеневій регургітації якщо пацієнт перебуває у формі.

--- a/knowledge_base/hosted/content/redflags/rf_net_high_grade_g3.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_net_high_grade_g3.yaml
@@ -1,0 +1,61 @@
+id: RF-NET-HIGH-GRADE-G3
+definition: >
+  Well-differentiated or poorly-differentiated neuroendocrine tumor with
+  Ki67 >20% (WHO 2019 G3). High-grade disease is clinically and therapeutically
+  distinct from G1/G2: well-differentiated G3 pNET may still respond to
+  everolimus/sunitinib/SSA but outcomes are inferior; poorly differentiated
+  neuroendocrine carcinoma (NEC, Ki67 typically >55%) requires platinum-
+  etoposide chemotherapy (CAPEOX/EP/IP). Engine flag routes to MDT review.
+definition_ua: >
+  Добре- або погано-диференційована нейроендокринна пухлина з Ki67 >20%
+  (WHO 2019 G3). Високоступенева хвороба клінічно і терапевтично відрізняється
+  від G1/G2: добре-диференційована G3 pNET ще може відповідати на
+  еверолімус/сунітиніб/SSA, але результати гірші; погано диференційована
+  нейроендокринна карцинома (NEC, Ki67 зазвичай >55%) вимагає
+  платино-етопозидну хіміотерапію (CAPEOX/EP/IP). Прапор engine направляє
+  до MDT review.
+
+trigger:
+  type: biomarker
+  any_of:
+    - finding: "ki67_percent"
+      threshold: 20
+      comparator: ">"
+    - finding: "ki67_proliferation_index"
+      threshold: 20
+      comparator: ">"
+    - finding: "mitotic_rate_per_10hpf"
+      threshold: 20
+      comparator: ">"
+
+clinical_direction: intensify
+severity: major
+priority: 80
+category: high-risk-biology
+
+relevant_diseases:
+  - DIS-PNET
+  - DIS-GI-NET
+shifts_algorithm:
+  - ALGO-PNET-METASTATIC-1L
+  - ALGO-GI-NET-ADVANCED-1L
+
+sources:
+  - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+draft: false
+
+notes: >
+  WHO 2019 split G3 NETs into two categories:
+  (1) Well-differentiated G3 NET: Ki67 20–100% but preserved architecture
+      (trabecular/glandular); often arise from G2 or de novo in pNET.
+      mTOR/TKI/SSA may still apply; CAPTEM shown active in pNET G3.
+  (2) Poorly differentiated NEC (small cell / large cell): Ki67 typically
+      >55–70%; platinum-etoposide (EP) backbone; not eligible for SSA
+      antiproliferative therapy. NCCN: treat like SCLC/LCNEC.
+  This RF fires at Ki67 >20% to route both to MDT review. The treating
+  team distinguishes G3 well-differentiated vs NEC via morphology + Ki67
+  level + CDX2/synaptophysin/chromogranin staining pattern.
+notes_ua: >
+  WHO 2019 розділила G3 НЕП на дві категорії: (1) Добре-диференційована G3 NET: Ki67 20–100%, але збережена архітектура (трабекулярна/залозиста); часто виникає з G2 або de novo в pNET. mTOR/TKI/SSA ще можуть застосовуватись; CAPTEM показав активність у pNET G3. (2) Погано-диференційована NEC (дрібноклітинна / великоклітинна): Ki67 зазвичай >55–70%; платино-етопозид (EP) основа; не підходить для антипроліферативної SSA-терапії. NCCN: лікувати як SCLC/LCNEC. Цей RF спрацьовує при Ki67 >20% для направлення обох до MDT review.

--- a/knowledge_base/hosted/content/regimens/reg_everolimus_mono_pnet.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_everolimus_mono_pnet.yaml
@@ -1,0 +1,112 @@
+id: REG-EVEROLIMUS-MONO-PNET
+name: "Everolimus monotherapy (advanced/progressive pNET G1/G2; RADIANT-3)"
+name_ua: "Еверолімус монотерапія (поширена/прогресуюча pNET G1/G2; RADIANT-3)"
+alternate_names:
+  - "RADIANT-3 regimen"
+  - "Everolimus pNET"
+  - "Afinitor pNET"
+
+components:
+  - drug_id: DRUG-EVEROLIMUS
+    dose: "10 mg PO once daily"
+    schedule: "Continuous daily dosing until progression or unacceptable toxicity"
+    route: PO
+
+cycle_length_days: 28
+total_cycles: "Continuous until progression or unacceptable toxicity"
+toxicity_profile: moderate
+
+premedication:
+  - "Dexamethasone 0.5 mg/5 mL mouthwash (swish and spit) BID starting day 1 through week 8 — SWISH protocol reduces G2+ stomatitis from ~33% to ~2%"
+
+mandatory_supportive_care:
+  - SUP-PJP-PROPHYLAXIS
+
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Grade ≥2 non-infectious pneumonitis (CT-confirmed interstitial changes)"
+    modification: "Hold everolimus; prednisolone 0.5–1 mg/kg/day until ≤gr 1; resume at 5 mg/day; discontinue if gr 3 or recurrent gr 2"
+    rationale: "Pneumonitis is a boxed warning for everolimus — leading cause of treatment discontinuation (~16% any grade)"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Grade ≥3 stomatitis"
+    modification: "Hold until ≤gr 1; resume at 5 mg/day; dexamethasone mouthwash escalation; rule out candidiasis (antifungal cover if confirmed)"
+    rationale: "Stomatitis is dose-limiting; most responsive to dose reduction + prophylaxis"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Grade ≥3 hyperglycemia (>250 mg/dL)"
+    modification: "Hold everolimus; glucose-lowering therapy; resume at 5 mg/day once controlled; consider endocrinology referral"
+    rationale: "mTOR inhibition impairs insulin signalling — hyperglycemia common in pNET patients (often already diabetic)"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Strong CYP3A4 inhibitor (e.g., azole antifungals, clarithromycin)"
+    modification: "Avoid if possible; if unavoidable reduce everolimus to 2.5 mg/day and monitor closely"
+    rationale: "Everolimus is a CYP3A4 substrate; inhibitor doubles exposure"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Strong CYP3A4 inducer (e.g., rifampicin, phenytoin, carbamazepine)"
+    modification: "Avoid; if unavoidable increase everolimus to 20 mg/day in 5 mg increments; do not exceed 20 mg"
+    rationale: "Enzyme inducers reduce everolimus AUC ~65%"
+    source_refs:
+      - SRC-NCCN-NET-2025
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Everolimus registered in Ukraine (Afinitor + generics). НСЗУ-реімбурсація
+    для pNET не включена до онкопакету 2025 (реімбурсація є для RCC).
+    Доступ для pNET: out-of-pocket (генерики значно дешевші за бренд),
+    compassionate use, або участь у клінічному дослідженні.
+
+sources:
+  - SRC-RADIANT3-YAO-2011
+  - SRC-NCCN-NET-2025
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Everolimus pNET. Key risks: pneumonitis (boxed warning), stomatitis,
+# hyperglycemia, infections (immunosuppression).
+between_visit_watchpoints:
+  - trigger_ua: "Оральні виразки або болючість у роті"
+    action_ua: "Очікувано — застосовуйте дексаметазон-ополіскувач; занотовуйте ступінь тяжкості"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Підвищений рівень цукру в крові при самоконтролі (>13 ммоль/л)"
+    action_ua: "Подзвоніть у клініку того ж дня — гіперглікемія від еверолімусу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Нова задишка, кашель або дискомфорт у грудній клітці"
+    action_ua: "Подзвоніть у клініку того ж дня — пневмоніт (попередження в рамці для еверолімусу)"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Лихоманка вище 38°C або ознаки інфекції"
+    action_ua: "Подзвоніть у клініку того ж дня — підвищений ризик інфекцій на фоні мТОР-інгібітора"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Різка задишка у спокої або біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно — тяжкий пневмоніт або ТЕЛА"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+reviewer_signoffs: []
+notes: >
+  RADIANT-3 (Yao NEJM 2011): everolimus 10 mg/day vs placebo in progressive
+  well-differentiated pNET (n=410). mPFS 11.0 vs 4.6 mo (HR 0.35, p<0.001).
+  No significant OS benefit demonstrated (confounded by >70% crossover post-
+  progression). SSA prior / concurrent use allowed. Stomatitis prophylaxis
+  (dexamethasone mouthwash, SWISH trial) reduces G2+ stomatitis dramatically.
+  Sunitinib 37.5 mg/day is the alternative (Raymond NEJM 2011 — similar
+  mPFS 11.4 vs 5.5 mo, HR 0.42); no head-to-head comparison; choice based
+  on comorbidities (cardiac/renal → prefer everolimus; diabetes/steroids →
+  consider sunitinib). STUB pending §6.1 signoff.
+notes_ua: >
+  RADIANT-3 (Yao NEJM 2011): еверолімус 10 мг/добу проти плацебо у прогресуючій добре-диференційованій pNET (n=410). мВБП 11.0 проти 4.6 міс (HR 0.35, p<0.001). Значного переваги ЗВ не виявлено (заплутано >70% перехресним переходом після прогресії). Попереднє/одночасне використання SSA дозволялось. Профілактика стоматиту (дексаметазон-ополіскувач, SWISH дослідження) різко знижує G2+ стоматит. Сунітиніб 37.5 мг/добу є альтернативою (Raymond NEJM 2011 — схожа мВБП 11.4 проти 5.5 міс, HR 0.42); немає прямого порівняння; вибір на основі коморбідностей (серцеві/ниркові → перевага еверолімусу; діабет/стероїди → розглянути сунітиніб). STUB очікує підпис §6.1.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_lanreotide_autogel_gi_net.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_lanreotide_autogel_gi_net.yaml
@@ -1,0 +1,109 @@
+id: REG-LANREOTIDE-AUTOGEL-GI-NET
+name: "Lanreotide Autogel 120 mg SC q4w (well-differentiated GEP-NET G1/G2; CLARINET)"
+name_ua: "Ланреотид Autogel 120 мг SC q4w (добре-диференційована ГЕП-НЕП G1/G2; CLARINET)"
+alternate_names:
+  - "CLARINET regimen"
+  - "Lanreotide NET"
+  - "Somatuline Depot GI-NET"
+  - "SSA antiproliferative GEP-NET"
+
+components:
+  - drug_id: DRUG-LANREOTIDE
+    dose: "120 mg SC deep subcutaneous injection"
+    schedule: "Every 4 weeks (q4w). Administer into lateral upper outer quadrant of buttock. Alternate sides. Patient/caregiver can self-inject after training."
+    route: SC
+
+cycle_length_days: 28
+total_cycles: "Continuous until progression or unacceptable toxicity"
+toxicity_profile: low-moderate
+
+premedication: []
+
+mandatory_supportive_care: []
+
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Severe diarrhea despite lanreotide (>6 stools/day, carcinoid syndrome refractory to SSA)"
+    modification: "Add telotristat ethyl 250 mg PO TID (tryptophan hydroxylase inhibitor); octreotide 100–200 µg SC TID as rescue for breakthrough flushing"
+    rationale: "Telotristat approved for carcinoid syndrome diarrhea inadequately controlled on SSA (TELESTAR trial)"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Biliary complications (cholelithiasis, cholecystitis)"
+    modification: "Asymptomatic gallstones — no change; symptomatic cholecystitis — surgical consultation; consider prophylactic cholecystectomy if planned surgery anyway"
+    rationale: "Long-term SSA reduces gallbladder motility → gallstone formation (~20% at 1 yr)"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Carcinoid crisis risk (planned surgery, hepatic arterial embolisation, ablation)"
+    modification: "IV octreotide 500 µg bolus before procedure + 100–200 µg/h infusion during procedure; continue 12–24h post-procedure"
+    rationale: "Manipulation of tumour can trigger massive mediator release → carcinoid crisis (flushing, bronchospasm, haemodynamic instability)"
+    source_refs:
+      - SRC-NCCN-NET-2025
+  - condition: "Diabetes mellitus (pre-existing)"
+    modification: "Monitor glucose q1–2 months; SSA may improve or worsen glycaemia (inhibits insulin + glucagon); adjust antidiabetic therapy accordingly"
+    rationale: "SSA-mediated insulin inhibition may reduce insulin requirements in patients on antidiabetics"
+    source_refs:
+      - SRC-NCCN-NET-2025
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Lanreotide (Somatuline Autogel) зареєстровано в Україні. НСЗУ-реімбурсація
+    для GEP-NET не включена до онкопакету 2025. SSA-терапія переважно
+    out-of-pocket або через спеціальні програми. Октреотид LAR (альтернативний
+    SSA; PROMID) може бути доступнішим у деяких регіонах. Значна фінансова
+    бар'єра для пацієнтів.
+
+sources:
+  - SRC-CLARINET-CAPLIN-2014
+  - SRC-NCCN-NET-2025
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Lanreotide Autogel for GEP-NET. Key concerns: injection site reactions,
+# gallstones (asymptomatic or symptomatic), breakthrough carcinoid symptoms,
+# glucose dysregulation.
+between_visit_watchpoints:
+  - trigger_ua: "Ущільнення або болючість у місці ін'єкції"
+    action_ua: "Очікувано — зазвичай минає за 1–2 доби; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Припливи або діарея між ін'єкціями (прорив симптомів)"
+    action_ua: "Подзвоніть у клініку того ж дня — може потрібна рятувальна доза октреотиду або корекція схеми"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Біль у правому підребер'ї після їди"
+    action_ua: "Подзвоніть у клініку того ж дня — жовчнокам'яна хвороба від ланреотиду"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Лихоманка вище 38°C з болем у животі або жовтяниця"
+    action_ua: "Звертайтесь у лікарню негайно — гострий холецистит"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NET-2025
+  - trigger_ua: "Раптовий тяжкий прилив, бронхоспазм, падіння тиску"
+    action_ua: "Звертайтесь у лікарню негайно — карциноїдна криза"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NET-2025
+
+last_reviewed: "2026-05-03"
+reviewer_signoffs: []
+notes: >
+  CLARINET (Caplin NEJM 2014): lanreotide 120 mg q4w vs placebo in
+  well-differentiated G1/G2 non-functioning GEP-NET (n=204). mPFS not
+  reached vs 18.0 mo (HR 0.47, p<0.001). Also shown in PROMID (Rinke JCO
+  2009) with octreotide LAR 30 mg q4w for midgut NET: mPFS 14.3 vs 6.0 mo
+  (HR 0.34). Both trials establish SSA as antiproliferative standard
+  (not just symptom control). CLARINET OLE (96-week extension) confirmed
+  durable benefit in stable/non-progressive disease. Octreotide LAR 30 mg
+  q4w is a valid alternative to lanreotide (no head-to-head; both NCCN
+  Category 1 for GI-NET). Lanreotide used here as it has the broader CLARINET
+  GEP-NET data set. STUB pending §6.1 signoff.
+notes_ua: >
+  CLARINET (Caplin NEJM 2014): ланреотид 120 мг q4w проти плацебо у добре-диференційованій G1/G2 нефункціональній ГЕП-НЕП (n=204). мВБП не досягнуто проти 18.0 міс (HR 0.47, p<0.001). Також показано у PROMID (Rinke JCO 2009) з октреотидом LAR 30 мг q4w для середньокишкової НЕП: мВБП 14.3 проти 6.0 міс (HR 0.34). Обидва дослідження встановлюють SSA як антипроліферативний стандарт (не лише контроль симптомів). CLARINET OLE (96-тижневе розширення) підтвердило стійку вигоду при стабільній/непрогресуючій хворобі. Октреотид LAR 30 мг q4w є дійсною альтернативою ланреотиду (немає прямого порівняння; обидва NCCN Категорія 1 для GI-NET). STUB очікує підпис §6.1.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/sources/src_clarinet_caplin_2014.yaml
+++ b/knowledge_base/hosted/content/sources/src_clarinet_caplin_2014.yaml
@@ -1,0 +1,48 @@
+id: SRC-CLARINET-CAPLIN-2014
+source_type: clinical_trial_publication
+title: >
+  Lanreotide in Metastatic Enteropancreatic Neuroendocrine Tumors
+  (CLARINET; phase III)
+version: null
+authors:
+  - "Caplin ME"
+  - "Pavel M"
+  - "Ćwikła JB"
+  - "Phan AT"
+  - "Raderer M"
+  - "Sedláčková E"
+  - "et al."
+journal: "New England Journal of Medicine"
+year: 2014
+volume: "371"
+pages: "224–233"
+doi: "10.1056/NEJMoa1316158"
+pmid: "25014687"
+url: https://www.nejm.org/doi/10.1056/NEJMoa1316158
+access_level: public_doi
+currency_status: current
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: journal_standard
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+relates_to_diseases:
+  - DIS-GI-NET
+  - DIS-PNET
+last_verified: "2026-05-03"
+notes: >
+  CLARINET: randomised, double-blind, placebo-controlled phase III.
+  n=204 patients with well-differentiated G1/G2 non-functioning
+  GEP-NET (midgut 34%, pancreatic 45%, unknown primary 16%, hindgut 5%).
+  All had stable or unknown disease at entry (not mandating progression).
+  Lanreotide 120 mg SC q4w vs placebo. mPFS not reached vs 18.0 mo
+  (HR 0.47, p<0.001). FDA approved lanreotide Autogel for non-functioning
+  GEP-NET Aug 2014. Notably enrolled non-functional, low-tumour-burden
+  patients — broader applicability than PROMID (which required progression
+  or symptoms). CLARINET OLE: 96-week open-label extension confirmed durable
+  PFS benefit.
+corpus_role: primary_evidence

--- a/knowledge_base/hosted/content/sources/src_nccn_net_2025.yaml
+++ b/knowledge_base/hosted/content/sources/src_nccn_net_2025.yaml
@@ -1,0 +1,40 @@
+id: SRC-NCCN-NET-2025
+source_type: guideline
+title: NCCN Neuroendocrine and Adrenal Tumors
+version: v.2.2025
+authors:
+  - National Comprehensive Cancer Network
+url: https://www.nccn.org/guidelines/guidelines-detail?category=1&id=1448
+access_level: registered_free
+currency_status: current
+current_as_of: "2025-07-01"
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: NCCN proprietary
+attribution:
+  required: true
+  text: NCCN Neuroendocrine and Adrenal Tumors V.2.2025
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+sharealike_required: false
+known_restrictions:
+  - No hosting
+legal_review:
+  status: reviewed
+  date: "2026-05-03"
+relates_to_diseases:
+  - DIS-PNET
+  - DIS-GI-NET
+last_verified: "2026-05-03"
+notes: >
+  Covers well-differentiated pNET (G1/G2/G3), GI carcinoid (midgut/foregut/
+  hindgut), poorly differentiated NEC (GEP and pulmonary), pheochromocytoma/
+  paraganglioma, MEN syndromes, adrenal tumors. Primary guideline for NET
+  treatment selection in this KB.
+pages_count: 230
+references_count: 310
+corpus_role: primary_guideline

--- a/knowledge_base/hosted/content/sources/src_radiant3_yao_2011.yaml
+++ b/knowledge_base/hosted/content/sources/src_radiant3_yao_2011.yaml
@@ -1,0 +1,42 @@
+id: SRC-RADIANT3-YAO-2011
+source_type: clinical_trial_publication
+title: >
+  Everolimus for Advanced Pancreatic Neuroendocrine Tumors
+  (RADIANT-3; phase III)
+version: null
+authors:
+  - "Yao JC"
+  - "Shah MH"
+  - "Ito T"
+  - "Bohas CL"
+  - "Wolin EM"
+  - "Van Cutsem E"
+  - "et al."
+journal: "New England Journal of Medicine"
+year: 2011
+volume: "364"
+pages: "514–523"
+doi: "10.1056/NEJMoa1009290"
+pmid: "21306238"
+url: https://www.nejm.org/doi/10.1056/NEJMoa1009290
+access_level: public_doi
+currency_status: current
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: journal_standard
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+relates_to_diseases:
+  - DIS-PNET
+last_verified: "2026-05-03"
+notes: >
+  RADIANT-3: randomised, double-blind, placebo-controlled phase III.
+  n=410 patients with progressive, well-differentiated pNET. Everolimus
+  10 mg/day vs placebo. mPFS 11.0 vs 4.6 mo (HR 0.35, p<0.001).
+  No significant OS benefit (OS data confounded by crossover). FDA
+  approved everolimus for pNET May 2011. Practice-defining trial.
+corpus_role: primary_evidence


### PR DESCRIPTION
## Summary

Full 1L treatment path for two NET subtypes — 15 new files, zero new test failures.

**pNET G1/G2 metastatic 1L (RADIANT-3)**
- `DIS-PNET` disease entity with WHO 2019 grading, MEN-1/sporadic biology
- `DRUG-SUNITINIB` (new drug entity — pNET alternative; also GIST/RCC)
- `REG-EVEROLIMUS-MONO-PNET` — everolimus 10 mg/day; SWISH mouthwash prophylaxis; CYP3A4 DDI table; pneumonitis `er_now` watchpoint
- `IND-PNET-METASTATIC-1L-EVEROLIMUS` — Category 1; everolimus vs sunitinib controversy documented
- `ALGO-PNET-METASTATIC-1L` — Ki67 G3 gate → MDT; fitness gate → everolimus

**GI-NET / midgut carcinoid G1/G2 advanced 1L (CLARINET)**
- `DIS-GI-NET` disease entity with carcinoid syndrome pathophysiology; SSTR2+ biology; PRRT future note
- `DRUG-LANREOTIDE` (new SSA drug entity; SSTR2/5 agonist; Ukraine access note)
- `REG-LANREOTIDE-AUTOGEL-GI-NET` — lanreotide 120 mg SC q4w; carcinoid-crisis IV octreotide cover; cholelithiasis monitoring; carcinoid crisis `er_now` watchpoint
- `IND-GI-NET-ADVANCED-1L-LANREOTIDE` — Category 1 SSA; active-surveillance vs treat-now controversy; PRRT next-line reference
- `ALGO-GI-NET-ADVANCED-1L` — Ki67 gate → carcinoid syndrome gate → fitness → lanreotide

**Shared**
- `SRC-NCCN-NET-2025` — primary guideline source for both diseases
- `SRC-RADIANT3-YAO-2011` — NEJM 2011 (HR 0.35 pNET)
- `SRC-CLARINET-CAPLIN-2014` — NEJM 2014 (HR 0.47 GEP-NET)
- `RF-NET-HIGH-GRADE-G3` — Ki67 >20% triggers MDT review; G3 WD vs NEC distinction
- `RF-NET-CARCINOID-SYNDROME` — flushing/diarrhea/5-HIAA elevation → SSA urgency + cardiac surveillance

## Deferred (future PRs)
- Sunitinib 1L indication (DRUG-SUNITINIB entity ready)
- Octreotide LAR regimen (PROMID alternative to CLARINET)
- PRRT: ¹⁷⁷Lu-DOTATATE (NETTER-1, Strosberg NEJM 2017) — needs SSTR biomarker + `DRUG-LUTETIUM-177-DOTATATE`
- GEP-NEC (poorly differentiated) — separate disease entity + EP chemotherapy

## Test plan

- [x] All 15 YAML files parse clean (`yaml.safe_load`)
- [x] KB validator `load.ok == True`, 0 schema/ref/contract errors
- [x] `test_patient_render.py` + `test_engine_patient_render_smoke.py` — 943 passed, 1 skipped (no regressions)
- [x] 3 pre-existing failures unchanged (regimen-phases count, orphan-rf-decl, investigate-flags-shift)
- [ ] Clinical co-lead signoff required before merge (CHARTER §6.1 — all entities marked STUB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)