### PR TITLE
fix(kb): GI-2 W0-3 propagate SRC-CHECKMATE-649-JANJIGIAN-2022 citations

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_gastric_metastatic_1l_pdl1_chemo_ici.yaml
+++ b/knowledge_base/hosted/content/indications/ind_gastric_metastatic_1l_pdl1_chemo_ici.yaml
@@ -49,6 +49,8 @@ rationale_ua: >
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
+  - source_id: SRC-CHECKMATE-649-JANJIGIAN-2022
+    position: supports
   - source_id: SRC-NCCN-GASTRIC-2025
     position: supports
   - source_id: SRC-ESMO-GASTRIC-2024

--- a/knowledge_base/hosted/content/redflags/rf_gastric_pdl1_cps_1_plus.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_gastric_pdl1_cps_1_plus.yaml
@@ -44,6 +44,7 @@ shifts_algorithm:
   - ALGO-GASTRIC-METASTATIC-1L
 
 sources:
+  - SRC-CHECKMATE-649-JANJIGIAN-2022
   - SRC-NCCN-GASTRIC-2025
   - SRC-ESMO-GASTRIC-2024
 
@@ -76,5 +77,3 @@ notes_ua: >
   встановлено. Виявлення: 22C3 IHC центральна або локальна лабораторія;
   Dako 28-8 (використано в CheckMate-649) і 22C3 — взаємозамінні для
   гастро CPS на практиці.
-
-# MISSING SOURCE: SRC-CHECKMATE-649-JANJIGIAN-2021 — phase-3 RCT.

--- a/knowledge_base/hosted/content/regimens/folfox_nivolumab.yaml
+++ b/knowledge_base/hosted/content/regimens/folfox_nivolumab.yaml
@@ -40,7 +40,7 @@ ukraine_availability:
   all_components_reimbursed: false
   notes: "Nivolumab out-of-pocket; chemo backbone NSZU-funded."
 
-sources: [SRC-NCCN-GASTRIC-2025, SRC-ESMO-GASTRIC-2024]
+sources: [SRC-CHECKMATE-649-JANJIGIAN-2022, SRC-NCCN-GASTRIC-2025, SRC-ESMO-GASTRIC-2024]
 
 # Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
 # FOLFOX + nivolumab for gastric/GEJ adeno 1L (CheckMate-649).


### PR DESCRIPTION
## Summary
- CheckMate-649 source file existed in `sources/` but was orphaned (no indication, regimen, or RF cited it) — engine output for HER2-neg CPS≥5 metastatic gastric (FOLFOX + nivolumab) cited only NCCN/ESMO secondary, missing the primary RCT
- Propagated citation to 3 files: indication, regimen, red-flag
- Resolved stale TODO in RF (referenced wrong year `2021`; actual source is `2022`)
- ZERO new files (all `M` modified, +4/-3 lines)
- Closes #393

## Files modified

| File | Action |
|---|---|
| `indications/ind_gastric_metastatic_1l_pdl1_chemo_ici.yaml` | citation prepended before NCCN/ESMO |
| `regimens/folfox_nivolumab.yaml` | citation prepended in flow-style `sources:` list |
| `redflags/rf_gastric_pdl1_cps_1_plus.yaml` | citation prepended + stale TODO line 80 removed |

## Additional grep hits — correctly scoped out

Grep surfaced ~12 other files mentioning CheckMate-649. All skipped per chunk's "only this single source ID added" rejection criterion:
- 7 files with narrative/comparator references (algo, drugs/nivolumab, reg_nivolumab_mono, reg_zolbetuximab_chemo, ind_cldn18_2_zolbetuximab, bio_pdl1_cps, bio_cldn18_2)
- 8 MSI/Lynch BMAs (different evidence point — KEYNOTE-158 pan-tumor, not CPS≥5 primary endpoint)

## Test plan
- [x] KB validator no regressions (91 errors pre/post, all pre-existing in unrelated regimens/)
- [x] pytest 11/117 fail/pass identical pre/post (baseline failures unrelated)
- [x] Idempotency check: none of the 3 files cited SRC-CHECKMATE-649-JANJIGIAN-2022 before
- [x] Diff scope: 3 files (`M` flag), zero new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)