### PR TITLE
feat(kb): GI-2 W0-2 esophageal trial source backfill (5 sources)

### DIFF
--- a/knowledge_base/hosted/content/sources/src_checkmate_577_kelly_2021.yaml
+++ b/knowledge_base/hosted/content/sources/src_checkmate_577_kelly_2021.yaml
@@ -1,0 +1,50 @@
+id: SRC-CHECKMATE-577-KELLY-2021
+source_type: rct_publication
+title: Adjuvant Nivolumab in Resected Esophageal or Gastroesophageal Junction Cancer
+version: '2021'
+authors:
+- Kelly RJ
+- Ajani JA
+- Kuzdzal J
+- et al.
+journal: New England Journal of Medicine
+doi: 10.1056/NEJMoa2032125
+pmid: '33789008'
+url: https://pubmed.ncbi.nlm.nih.gov/33789008/
+access_level: subscription_required
+currency_status: current
+current_as_of: '2026-05-04'
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: NEJM (subscription)
+attribution:
+  required: true
+  text: Kelly et al., NEJM 2021; CheckMate-577 trial
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-ESOPHAGEAL
+- DIS-GASTRIC
+last_verified: '2026-05-04'
+notes: 'CheckMate-577 phase-3 (NCT02743494; n=794): adjuvant nivolumab 240 mg q2w
+  x 16 wk then 480 mg q4w (up to 1 year total) vs placebo in patients with
+  resected (R0) stage II/III esophageal or gastroesophageal-junction (EGJ) cancer
+  with residual pathologic disease (ypT1-4 or ypN1-3) after neoadjuvant
+  chemoradiotherapy. Both adenocarcinoma (71%) and squamous-cell carcinoma (29%)
+  histology eligible. Median DFS 22.4 vs 11.0 mo (HR 0.69; 96.4% CI 0.56-0.86;
+  p<0.001). Distant-recurrence-free survival HR 0.74. Treatment-related grade
+  3-4 AEs 13% vs 6%; discontinuation due to AE 9% vs 3%. Established adjuvant
+  nivolumab as standard of care for resected esophageal/EGJ cancer with
+  residual pathologic disease after neoadjuvant CRT; basis for FDA approval
+  May 2021.
+
+  '
+pages_count: 13
+references_count: 30
+corpus_role: rct_publication

--- a/knowledge_base/hosted/content/sources/src_cross_van_hagen_2012.yaml
+++ b/knowledge_base/hosted/content/sources/src_cross_van_hagen_2012.yaml
@@ -1,0 +1,47 @@
+id: SRC-CROSS-VAN-HAGEN-2012
+source_type: rct_publication
+title: Preoperative chemoradiotherapy for esophageal or junctional cancer
+version: '2012'
+authors:
+- van Hagen P
+- Hulshof MCCM
+- van Lanschot JJB
+- et al.
+journal: New England Journal of Medicine
+doi: 10.1056/NEJMoa1112088
+pmid: '22646630'
+url: https://pubmed.ncbi.nlm.nih.gov/22646630/
+access_level: subscription_required
+currency_status: current
+current_as_of: '2026-05-04'
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: NEJM (subscription)
+attribution:
+  required: true
+  text: van Hagen et al., NEJM 2012; CROSS trial (CROSS Group)
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-ESOPHAGEAL
+last_verified: '2026-05-04'
+notes: 'CROSS phase-3 (Netherlands Trial Register NTR487; n=366): preoperative
+  chemoradiotherapy (carboplatin AUC 2 + paclitaxel 50 mg/m^2 weekly x 5 with
+  concurrent 41.4 Gy in 23 fractions) followed by surgery vs surgery alone for
+  resectable esophageal or esophagogastric junction (EGJ) cancer (squamous-cell
+  carcinoma 23%, adenocarcinoma 75%). Median OS 49.4 vs 24.0 mo (HR 0.657; 95%
+  CI 0.495-0.871; p=0.003). pCR 29% in the CRT arm (49% SCC, 23% adenoca). R0
+  resection 92% vs 69%. Established neoadjuvant CROSS regimen as a standard of
+  care for resectable esophageal/EGJ cancer; long-term follow-up (Shapiro Lancet
+  Oncol 2015) confirmed sustained OS benefit at 84 months.
+
+  '
+pages_count: 11
+references_count: 30
+corpus_role: rct_publication

--- a/knowledge_base/hosted/content/sources/src_omec_1_kroese_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_omec_1_kroese_2018.yaml
@@ -1,0 +1,59 @@
+id: SRC-OMEC-1-KROESE-2018
+source_type: guideline
+title: 'Definition, diagnosis and treatment of oligometastatic oesophagogastric cancer:
+  A Delphi consensus study in Europe'
+version: '2023'
+authors:
+- Kroese TE
+- van Laarhoven HWM
+- Schoppman SF
+- et al.
+journal: European Journal of Cancer
+doi: 10.1016/j.ejca.2023.02.015
+pmid: '36947929'
+url: https://pubmed.ncbi.nlm.nih.gov/36947929/
+access_level: subscription_required
+currency_status: current
+current_as_of: '2026-05-04'
+evidence_tier: 3
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Elsevier / European Journal of Cancer (subscription)
+attribution:
+  required: true
+  text: Kroese et al., Eur J Cancer 2023; OMEC-1 European Delphi consensus
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-ESOPHAGEAL
+- DIS-GASTRIC
+last_verified: '2026-05-04'
+notes: 'OMEC-1 (OligoMetastatic Esophagogastric Cancer) project: multidisciplinary
+  European Delphi consensus on the definition, diagnosis, and treatment of
+  oligometastatic esophagogastric cancer. 65 European experts (medical
+  oncologists, surgeons, radiation oncologists, gastroenterologists,
+  radiologists, nuclear-medicine physicians) across 5 stages reaching consensus
+  on (a) definition: 1-3 metastatic lesions or metachronous oligo-recurrence
+  >=6 mo after curative-intent treatment, (b) diagnostic workup: PET/CT, EUS,
+  brain MRI for symptomatic patients, (c) local-therapy thresholds: surgery or
+  radiotherapy for de-novo or progressive oligometastatic disease alongside
+  systemic therapy. Provides reference framework for oligometastatic
+  esophagogastric scenarios where RCT evidence is sparse. Companion protocol
+  paper: Kroese TE et al., Eur J Surg Oncol 2023;49(1):21-28 (PMID 36184420).
+  Successor RCT (OMEC-4 / SOPRANO) ongoing.
+
+  NOTE on ID year: manifest assigned 2018 in the chunk-spec ID, but the
+  OMEC project did not exist in 2018 - protocol was published 2022 (PMID
+  36184420), Delphi consensus paper 2023 (PMID 36947929). Manifest ID
+  preserved verbatim per chunk brief; future renormalisation chunk should
+  consider rename to align ID year with publication year (2023).
+
+  '
+pages_count: 12
+references_count: 30
+corpus_role: primary_guideline

--- a/knowledge_base/hosted/content/sources/src_robot_van_der_sluis_2019.yaml
+++ b/knowledge_base/hosted/content/sources/src_robot_van_der_sluis_2019.yaml
@@ -1,0 +1,53 @@
+id: SRC-ROBOT-VAN-DER-SLUIS-2019
+source_type: rct_publication
+title: 'Robot-assisted Minimally Invasive Thoracolaparoscopic Esophagectomy Versus
+  Open Transthoracic Esophagectomy for Resectable Esophageal Cancer: A Randomized
+  Controlled Trial'
+version: '2019'
+authors:
+- van der Sluis PC
+- van der Horst S
+- May AM
+- et al.
+journal: Annals of Surgery
+doi: 10.1097/SLA.0000000000003031
+pmid: '30308612'
+url: https://pubmed.ncbi.nlm.nih.gov/30308612/
+access_level: subscription_required
+currency_status: current
+current_as_of: '2026-05-04'
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Wolters Kluwer / Annals of Surgery (subscription)
+attribution:
+  required: true
+  text: van der Sluis et al., Ann Surg 2019; ROBOT trial
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-ESOPHAGEAL
+last_verified: '2026-05-04'
+notes: 'ROBOT (Robot-assisted thoracOlaparoscopic esophagectomy vs Open
+  Transthoracic esophagectomy) single-centre phase-3 RCT (NCT01544790; n=112;
+  University Medical Center Utrecht, 2012-2016): robot-assisted minimally
+  invasive thoracolaparoscopic esophagectomy (RAMIE) vs open transthoracic
+  esophagectomy (OTE) for resectable intrathoracic esophageal cancer (cT1-4a,
+  cN0-3). Primary endpoint overall postoperative complications (modified Clavien-
+  Dindo >= grade 2): 59% (RAMIE) vs 80% (OTE) (RR 0.74; 95% CI 0.57-0.96;
+  p=0.02). Pulmonary complications 32% vs 58% (p=0.005); cardiac complications
+  22% vs 47% (p=0.006). Functional recovery superior in RAMIE arm; oncologic
+  outcomes (R0 resection 93% vs 96%; lymph-node yield 27 vs 25; 2-yr
+  disease-free survival 60% vs 47%) similar between arms. Established RAMIE as
+  a viable surgical option for resectable esophageal cancer with reduced short-
+  term morbidity vs open transthoracic approach.
+
+  '
+pages_count: 10
+references_count: 30
+corpus_role: rct_publication

--- a/knowledge_base/hosted/content/sources/src_time_biere_2012.yaml
+++ b/knowledge_base/hosted/content/sources/src_time_biere_2012.yaml
@@ -1,0 +1,49 @@
+id: SRC-TIME-BIERE-2012
+source_type: rct_publication
+title: 'Minimally invasive versus open oesophagectomy for patients with oesophageal
+  cancer: a multicentre, open-label, randomised controlled trial'
+version: '2012'
+authors:
+- Biere SSAY
+- van Berge Henegouwen MI
+- Maas KW
+- et al.
+journal: Lancet
+doi: 10.1016/S0140-6736(12)60516-9
+pmid: '22552194'
+url: https://pubmed.ncbi.nlm.nih.gov/22552194/
+access_level: subscription_required
+currency_status: current
+current_as_of: '2026-05-04'
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Elsevier / Lancet (subscription)
+attribution:
+  required: true
+  text: Biere et al., Lancet 2012; TIME trial
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: pending
+relates_to_diseases:
+- DIS-ESOPHAGEAL
+last_verified: '2026-05-04'
+notes: 'TIME (Traditional Invasive vs Minimally invasive Esophagectomy) phase-3
+  multicentre RCT (NCT01184469; n=115; 5 European centres, 2009-2011): open
+  transthoracic esophagectomy vs minimally invasive transthoracic esophagectomy
+  (MIE) for resectable intrathoracic or EGJ cancer. Primary endpoint pulmonary
+  infection in the first 2 weeks: 29% (open) vs 9% (MIE) (RR 0.30; 95% CI
+  0.12-0.76; p=0.005). In-hospital pulmonary infection 34% vs 12% (p=0.005).
+  Hospital stay 14 vs 11 days (p=0.044). Quality of life favoured MIE at 6
+  weeks. Established MIE as a viable alternative to open transthoracic
+  esophagectomy with reduced short-term pulmonary morbidity; cited by NCCN /
+  ESMO esophageal-cancer surgical guidelines as supporting evidence.
+
+  '
+pages_count: 6
+references_count: 30
+corpus_role: rct_publication


### PR DESCRIPTION
## Summary
- 5 new primary-trial source YAMLs for esophageal cancer per GI-2 wave plan §4.1
- Revised manifest after orchestrator collision-resolution decision (2 IDs dropped — already exist as `SRC-CHECKMATE648` / `SRC-KEYNOTE590` non-hyphenated)
- Closes #392

## Sources added

| Source ID | Trial | PMID | Year |
|---|---|---|---|
| SRC-CROSS-VAN-HAGEN-2012 | CROSS (neoadjuvant CRT esoph) | 22646630 | 2012 |
| SRC-CHECKMATE-577-KELLY-2021 | CheckMate-577 (adjuvant nivo post-CROSS) | 33789008 | 2021 |
| SRC-TIME-BIERE-2012 | TIME (open vs MIE esophagectomy) | 22552194 | 2012 |
| SRC-ROBOT-VAN-DER-SLUIS-2019 | ROBOT (open vs RAMIE esophagectomy) | 30308612 | 2019 |
| SRC-OMEC-1-KROESE-2018 | OMEC-1 oligometastatic Delphi consensus | 36947929 | **2023** (see note) |

## Known manifest defects (deferred to renormalisation chunk)

1. **OMEC-1 year mismatch.** Manifest ID says `KROESE-2018` but actual OMEC-1 Delphi consensus paper is Kroese 2023 (PMID 36947929). The 2018 paper does not exist. Agent preserved manifest ID verbatim per brief; year-mismatch flagged in `notes` field. Future renormalisation chunk should rename `SRC-OMEC-1-KROESE-2018` → `SRC-OMEC-1-KROESE-2023` and update any future references.

2. **Schema field naming.** Original chunk brief used `kind` / `clinical_trial_registration` which don't exist in `knowledge_base/schemas/source.py`. Agent correctly used the actual schema convention (`source_type: rct_publication` for trials / `source_type: guideline` for consensus; NCT IDs embedded in `notes` prose) matching existing `src_keynote189_gandhi_2018.yaml`, `src_adaura_wu_2020.yaml` patterns. Plan doc to be updated.

## Test plan
- [x] KB validator (loader --strict) exits 0; no schema errors on 5 new files
- [x] pytest test_loader.py + test_source_ref_integrity.py: 1 fail / 17 pass (1 fail is pre-existing baseline failure on regimen schema, unrelated)
- [x] All 5 PubMed canonical pages return HTTP 200; DOI fallback not needed
- [x] Diff scope: 5 paths, all under `knowledge_base/hosted/content/sources/`
- [x] No collisions on revised manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)