### PR TITLE
fix(kb): GI-2 B1 reconcile gastric 1L PD-L1 CPS threshold + canonical CheckMate-649 dose

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_gastric_metastatic_1l_pdl1_chemo_ici.yaml
+++ b/knowledge_base/hosted/content/indications/ind_gastric_metastatic_1l_pdl1_chemo_ici.yaml
@@ -7,7 +7,7 @@ applicable_to:
   stage_requirements: ["Stage IV (metastatic)", "Unresectable locally advanced not eligible for periop"]
   biomarker_requirements_required:
     - biomarker_id: BIO-PDL1-CPS
-      value_constraint: "CPS ≥5"
+      value_constraint: "CPS ≥1"
   biomarker_requirements_excluded:
     - biomarker_id: BIO-HER2-SOLID
       value_constraint: "positive"
@@ -23,10 +23,21 @@ strength_of_recommendation: strong
 nccn_category: "1"
 
 expected_outcomes:
-  overall_response_rate: "~60% (CheckMate-649 CPS ≥5)"
+  overall_response_rate: "~60% (CheckMate-649 CPS ≥5); preserved benefit at CPS 1-4"
   complete_response: "~10%"
-  progression_free_survival: "Median ~7.7 mo"
+  progression_free_survival: "Median ~7.7 mo (CPS ≥5)"
   overall_survival_5y: "mOS 14.4 mo (vs 11.1 chemo alone, CheckMate-649 CPS ≥5)"
+  # Stratified magnitude-of-benefit per CheckMate-649 (Janjigian 2022) — stronger
+  # OS benefit at CPS ≥5 (HR 0.71) but preserved benefit at CPS 1-4 (HR 0.78).
+  # Engine renders both strata so clinicians can weigh CPS-stratum benefit when
+  # CPS=1-4 patients are routed (algorithm gates via RF-GASTRIC-PDL1-CPS-1-PLUS).
+  # Disease-specific OutcomeValue fields (admitted via Pydantic extra='allow').
+  overall_survival_hr_cps_5plus:
+    value: "OS HR 0.71 (CPS ≥5; CheckMate-649)"
+    source: SRC-CHECKMATE-649-JANJIGIAN-2022
+  overall_survival_hr_cps_1_to_4:
+    value: "OS HR 0.78 (CPS 1-4; preserved benefit, smaller magnitude than CPS ≥5)"
+    source: SRC-CHECKMATE-649-JANJIGIAN-2022
 
 hard_contraindications:
   - CI-PEMBROLIZUMAB-AUTOIMMUNE  # Same autoimmune block applies to nivo
@@ -41,11 +52,21 @@ required_tests:
 desired_tests: []
 
 rationale: >
-  CheckMate-649: FOLFOX + nivo for HER2-negative advanced gastric/GEJ
-  with PD-L1 CPS ≥5 — OS benefit. NCCN category 1.
+  CheckMate-649: FOLFOX + nivo for HER2-negative advanced gastric/GEJ.
+  Stratified OS benefit — HR 0.71 at CPS ≥5 (primary endpoint, EMA cutoff)
+  and HR 0.78 at CPS 1-4 (preserved benefit, smaller magnitude). NCCN
+  v3.2025 + ESMO 2024 favour adding nivolumab at CPS ≥1; FDA approval
+  is regardless of CPS. Indication value_constraint set to CPS ≥1 to
+  match RF-GASTRIC-PDL1-CPS-1-PLUS (algorithm-gating threshold) and
+  NCCN/ESMO authoring; magnitude-of-benefit difference surfaced via
+  expected_outcomes stratum fields and known_controversies.
 
 rationale_ua: >
-  CheckMate-649: FOLFOX + nivo for HER2-negative поширений gastric/GEJ with PD-L1 CPS ≥5 — OS виграш. NCCN категорія 1.
+  CheckMate-649: FOLFOX + nivo for HER2-negative поширений gastric/GEJ.
+  Стратифікована користь OS — HR 0.71 при CPS ≥5 (первинна кінцева точка,
+  EMA cutoff) та HR 0.78 при CPS 1-4 (збережена користь, менший magnitude).
+  NCCN v3.2025 + ESMO 2024 підтримують додавання ніволумабу при CPS ≥1;
+  FDA схвалення — незалежно від CPS.
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
@@ -55,6 +76,28 @@ sources:
     position: supports
   - source_id: SRC-ESMO-GASTRIC-2024
     position: supports
+
+known_controversies:
+  - topic: PD-L1 CPS threshold for adding nivolumab to FOLFOX/XELOX (HER2-neg gastric/GEJ 1L) — jurisdictional split
+    positions:
+      - position: FDA — approved regardless of CPS (no biomarker gate on label)
+        sources:
+          - SRC-CHECKMATE-649-JANJIGIAN-2022
+        evidence_note: "FDA label permits use across CPS range; rests on overall CheckMate-649 ITT benefit"
+      - position: EMA — restricts to CPS ≥5 (label-gated to primary-endpoint stratum)
+        sources:
+          - SRC-CHECKMATE-649-JANJIGIAN-2022
+        evidence_note: "Aligned with CheckMate-649 primary-endpoint pre-specified CPS ≥5 stratum (HR 0.71)"
+      - position: NCCN v3.2025 — favours adding nivolumab at CPS ≥1 with magnitude-of-benefit note for CPS ≥5
+        sources:
+          - SRC-NCCN-GASTRIC-2025
+        evidence_note: "Acknowledges preserved benefit at CPS 1-4 (HR 0.78) while flagging stronger magnitude at CPS ≥5"
+      - position: ESMO 2024 — supports CPS ≥1 with stronger preference at CPS ≥5
+        sources:
+          - SRC-ESMO-GASTRIC-2024
+        evidence_note: "Treatment guideline aligns with NCCN; CPS ≥5 preferred when access constrained"
+    our_default: "Add nivolumab to FOLFOX/XELOX at CPS ≥1 (matches NCCN/ESMO + RF-GASTRIC-PDL1-CPS-1-PLUS); document stronger magnitude expected at CPS ≥5 in MDT note"
+    rationale: "CheckMate-649 CPS 1-4 subgroup retains OS benefit (HR 0.78) although the primary-endpoint analysis was at CPS ≥5; NCCN/ESMO consensus favours the broader cohort. EMA-only sites should follow EMA cutoff; jurisdictional notes surfaced for transparency."
 
 do_not_do:
   - "Do NOT use without HER2 testing — HER2+ patients get trastuzumab+chemo instead"
@@ -66,4 +109,11 @@ do_not_do_en:
   - "Do NOT continue through Grade 3+ irAE without permanent ICI discontinuation consideration"
   - "Do NOT initiate during ongoing GI bleed / obstruction"
 last_reviewed: "2026-04-26"
-notes: "Scaffold entry — gastric metastatic 1L PD-L1 CPS ≥5 / HER2- track only."
+notes: >
+  Gastric metastatic 1L HER2-neg PD-L1 CPS ≥1 track. Indication threshold
+  reconciled with RF-GASTRIC-PDL1-CPS-1-PLUS (CPS ≥1) and NCCN/ESMO 2024-2025
+  consensus (GI-2 B1 chunk gi2-cps-recon-nivo-dose-2026-05-04-2030).
+  Algorithm ALGO-GASTRIC-METASTATIC-1L step 3 gates ICI add-on via the
+  ≥1 RedFlag; magnitude-of-benefit difference between CPS ≥5 (HR 0.71)
+  and CPS 1-4 (HR 0.78) per CheckMate-649 captured in expected_outcomes
+  stratum fields and known_controversies.

--- a/knowledge_base/hosted/content/redflags/rf_gastric_pdl1_cps_1_plus.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_gastric_pdl1_cps_1_plus.yaml
@@ -64,6 +64,21 @@ notes: >
   threshold established. Detection: 22C3 IHC, central or local
   laboratory; Dako 28-8 (used in CheckMate-649) and 22C3 are
   interchangeable for gastric CPS in clinical practice.
+
+  Jurisdictional split (canonical home: known_controversies block on
+  IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI; RedFlag schema does not
+  define a known_controversies field — recorded here in notes for
+  cross-reference):
+    - FDA: nivolumab + chemo approved regardless of CPS (overall
+      CheckMate-649 ITT benefit basis).
+    - EMA: restricts to CPS ≥5 (primary-endpoint stratum, HR 0.71).
+    - NCCN v3.2025: favours adding nivolumab at CPS ≥1; flags stronger
+      magnitude expected at CPS ≥5.
+    - ESMO 2024: supports CPS ≥1 with stronger preference at CPS ≥5.
+  RF threshold = 1 matches NCCN/ESMO; engine routes CPS 1-4 patients to
+  the indication where the magnitude-of-benefit difference (HR 0.71 at
+  CPS ≥5 vs HR 0.78 at CPS 1-4) is documented in expected_outcomes
+  stratum fields. GI-2 B1 chunk gi2-cps-recon-nivo-dose-2026-05-04-2030.
 notes_ua: >
   Двоступеневий CPS-підхід: CPS ≥5 — сильні докази (CheckMate-649
   primary endpoint, EMA-схвалений cutoff); CPS 1-4 — secondary subgroup,

--- a/knowledge_base/hosted/content/regimens/folfox_nivolumab.yaml
+++ b/knowledge_base/hosted/content/regimens/folfox_nivolumab.yaml
@@ -17,8 +17,8 @@ components:
     schedule: "Day 1 bolus, day 1-2 CIV"
     route: IV
   - drug_id: DRUG-NIVOLUMAB
-    dose: "240 mg IV q2w (alternatively 480 mg IV q4w)"
-    schedule: "IV day 1 of each 14-d cycle"
+    dose: "360 mg IV q3w (CheckMate-649 primary protocol; FDA-approved flat-dose alternatives 240 mg IV q2w or 480 mg IV q4w)"
+    schedule: "Primary: 360 mg q3w aligned with XELOX 21-d cycle. Alternatives: 240 mg q2w aligned with FOLFOX 14-d cycle (day 1) or 480 mg q4w (every other FOLFOX cycle)"
     route: IV
 
 cycle_length_days: 14
@@ -88,11 +88,24 @@ between_visit_watchpoints:
 last_reviewed: "2026-04-26"
 
 notes: >
-  CheckMate-649: FOLFOX + nivo in PD-L1 CPS ≥5 (per FDA label) — mOS
-  benefit. Pembrolizumab + chemo (KEYNOTE-859) is a label-equivalent
-  alternative without strict CPS gating but practical CPS ≥1 cutoff.
-  HER2+ patients route to trastuzumab + chemo instead.
+  CheckMate-649: FOLFOX/XELOX + nivolumab. Canonical trial protocol used
+  nivolumab 360 mg IV q3w (aligned with XELOX 21-d cycle); FDA-approved
+  flat-dose alternatives 240 mg q2w (aligned with FOLFOX 14-d cycle) or
+  480 mg q4w (every other FOLFOX cycle). Primary endpoint at CPS ≥5 (mOS
+  14.4 vs 11.1, HR 0.71); preserved benefit at CPS 1-4 (HR 0.78).
+  Indication value_constraint reconciled to CPS ≥1 in GI-2 B1 chunk
+  (2026-05-04-2030); jurisdictional split (FDA: any CPS; EMA: ≥5;
+  NCCN v3.2025 + ESMO 2024: ≥1) surfaced via indication's
+  known_controversies block. Pembrolizumab + chemo (KEYNOTE-859) is a
+  label-equivalent alternative. HER2+ patients route to trastuzumab + chemo.
 notes_ua: >
-  CheckMate-649: FOLFOX + nivo in PD-L1 CPS ≥5 (per FDA label) — mOS виграш. пембролізумаб + chemo (KEYNOTE-859) is a label-еквівалентний alternative without strict CPS gating but practical CPS ≥1 cutoff. HER2+ patients route to трастузумаб + chemo instead.
+  CheckMate-649: FOLFOX/XELOX + ніволумаб. Канонічний протокол трайлу —
+  ніволумаб 360 мг в/в q3w (узгоджено з XELOX 21-денним циклом); FDA-схвалені
+  альтернативи фіксованої дози 240 мг q2w (узгоджено з FOLFOX 14-денним
+  циклом) або 480 мг q4w (кожен другий цикл FOLFOX). Первинна кінцева точка
+  при CPS ≥5 (мОВ 14.4 проти 11.1, HR 0.71); збережена користь при CPS 1-4
+  (HR 0.78). Поріг indication узгоджено до CPS ≥1 (chunk GI-2 B1, 2026-05-04-2030).
+  Пембролізумаб + хіміо (KEYNOTE-859) — альтернатива з еквівалентним лейблом.
+  HER2+ маршрутизуються на трастузумаб + хіміо.
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- Reconcile authoring inconsistency between indication (required CPS ≥5) and RF / NCCN / ESMO (≥1)
- Add stratified magnitude-of-benefit per CheckMate-649 (HR 0.71 at ≥5 vs HR 0.78 at 1-4)
- Add canonical CheckMate-649 nivo dose (360 mg q3w); preserve FDA flat-dose alternatives
- Surface FDA / EMA / NCCN / ESMO jurisdictional split via `known_controversies`
- Closes #399

## Important: routing was already correct

Investigation showed `value_constraint: "CPS ≥5"` on the indication was **metadata-only**, not a routing predicate. The algorithm `ALGO-GASTRIC-METASTATIC-1L` is RF-driven, and the RF (`RF-GASTRIC-PDL1-CPS-1-PLUS`) threshold was already `≥1` — so a CPS=3 patient was already routing to FOLFOX+nivolumab pre-edit.

This PR fixes the **authoring inconsistency** (indication metadata didn't match routing reality), adds previously-missing magnitude-of-benefit stratification, jurisdictional split documentation, and canonical CheckMate-649 nivo q3w dose. **No engine routing change.** Honestly recorded in commit message.

## Files

| File | Δ | Change |
|---|---|---|
| `ind_gastric_metastatic_1l_pdl1_chemo_ici.yaml` | +59 / -5 | value_constraint ≥5→≥1; stratified `ExpectedOutcomes` (HR 0.71 vs 0.78); `known_controversies` block (canonical schema field) |
| `folfox_nivolumab.yaml` | +20 / -7 | 360 mg q3w added as CheckMate-649 primary; FDA 240 q2w / 480 q4w preserved as alternatives |
| `rf_gastric_pdl1_cps_1_plus.yaml` | +13 / -2 | jurisdictional split in `notes:` (RF schema has no `known_controversies` field — authorized free-text fallback per brief) |

## Schema-field choices

- **Indication `known_controversies`**: canonical schema field (`KnownControversy` in `schemas/indication.py`); used as-is, matching convention from `ind_mm_rr_2l_ciltacel` etc.
- **Magnitude-of-benefit stratification**: no canonical top-level field exists; used `ExpectedOutcomes.extra='allow'` (Pydantic config) to add stratum-specific `OutcomeValue` dicts with `SRC-CHECKMATE-649-JANJIGIAN-2022` citations. Did NOT invent a new top-level field.
- **RedFlag `known_controversies`**: schema has no such field; recorded in `notes:` free-text per brief's authorized fallback, with explicit cross-reference to the canonical block on the indication.

## Test plan
- [x] KB validator: 91 schema errors / 217 contract warnings / 2785 entities (identical pre/post)
- [x] pytest: 119 passed / 12 failed (all pre-existing baseline failures)
- [x] Engine smoke: CPS=3 → ALGO step 3 → RF-GASTRIC-PDL1-CPS-1-PLUS fires → IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI selected ✓
- [x] Diff scope: 3 files, all `M` flag, all under allowlist
- [x] No banned sources cited

🤖 Generated with [Claude Code](https://claude.com/claude-code)