### PR TITLE
feat(kb): GI-2 A1-redux esoph 1L gaps — 2 indications + 1 regimen (3rd deferred)

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_esoph_metastatic_1l_her2_trastuzumab_chemo.yaml
+++ b/knowledge_base/hosted/content/indications/ind_esoph_metastatic_1l_her2_trastuzumab_chemo.yaml
@@ -1,0 +1,115 @@
+id: IND-ESOPH-METASTATIC-1L-HER2-TRASTUZUMAB-CHEMO
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-ESOPHAGEAL
+  line_of_therapy: 1
+  stage_requirements:
+    - "Stage IV (metastatic) OR unresectable locally advanced esophageal carcinoma"
+    - "Adenocarcinoma histology (EAC) OR GEJ adenocarcinoma (Siewert I)"
+    - "Treatment-naive (no prior systemic therapy for advanced disease)"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-HER2-SOLID
+      required: true
+      value_constraint: "HER2-positive (IHC 3+ OR IHC 2+/ISH-amplified). ToGA showed greatest benefit in IHC 3+ or IHC 2+/FISH+ subgroup."
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+    histology_excluded: "Squamous-cell — HER2 amplification rare in ESCC; trial data (ToGA) is gastric/GEJ adenocarcinoma; extrapolation valid only for esoph adeno"
+
+recommended_regimen: REG-TRASTUZUMAB-CHEMO-TOGA
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: moderate
+strength_of_recommendation: conditional
+nccn_category: "2A"
+
+expected_outcomes:
+  overall_response_rate: "~47% (ToGA HER2 IHC3+ subgroup; gastric/GEJ population — esoph adeno extrapolation)"
+  progression_free_survival: "Median ~7 mo (ToGA all-HER2-positive)"
+  overall_survival_median: "mOS 13.8 vs 11.1 mo (ToGA all-HER2-positive vs chemo, HR 0.74); 16.0 vs 11.8 mo in IHC3+ or IHC2+/FISH+ subgroup"
+  notes: >
+    ToGA enrolled gastric + GEJ adenocarcinoma (Siewert I-III). Esoph
+    adenocarcinoma was not enrolled but is biologically grouped with
+    GEJ/gastric adeno; NCCN-Esophageal/EGJ 2025 endorses extrapolation
+    when distal-third esoph adeno is HER2+. Confidence: moderate
+    (extrapolation from anatomically adjacent disease site enrolled in
+    the pivotal trial).
+
+hard_contraindications: []
+
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-HER2-IHC-FISH
+  - TEST-ECHO
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+
+desired_tests:
+  - TEST-PDL1-IHC
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+
+rationale: >
+  ToGA (Bang 2010 Lancet, NCT01041404): trastuzumab 8 mg/kg loading then
+  6 mg/kg q3w + capecitabine 1000 mg/m² PO BID D1-14 OR 5-FU 800 mg/m²/d D1-5 +
+  cisplatin 80 mg/m² q3w vs chemo alone in HER2-positive (IHC3+ or FISH+)
+  advanced gastric/GEJ adenocarcinoma (n=594). Median OS 13.8 vs 11.1 mo
+  (HR 0.74, p=0.0046); IHC3+ or IHC2+/FISH+ subgroup mOS 16.0 vs 11.8 mo.
+  Established trastuzumab + chemo as 1L standard for HER2+ advanced gastric/
+  GEJ adeno. NCCN/ESMO category 1 for gastric/GEJ.
+
+  Extrapolation rationale for esoph adenocarcinoma: ToGA enrolled GEJ adeno
+  (Siewert I-III); distal-third esoph adenocarcinoma is biologically
+  contiguous with GEJ adeno (shared chronic GERD / Barrett pathogenesis).
+  NCCN-Esophageal/EGJ 2025 endorses HER2 testing in metastatic adeno and
+  trastuzumab + chemo when HER2+ — same backbone as gastric. Pure
+  esoph-confined adeno was not enrolled in ToGA; benefit magnitude is
+  inferred. Confidence: moderate.
+
+rationale_ua: >
+  ToGA (Bang 2010): трастузумаб + цисплатин + капецитабін/5-ФУ для HER2+
+  метастатичної аденокарциноми шлунка/ВГП. mOS 13.8 vs 11.1 міс (HR 0.74).
+  Екстраполяція на аденокарциному стравоходу обґрунтована анатомічною
+  суміжністю з ВГП-аденокарциномою; NCCN-Esophageal 2025 підтримує. Рівень
+  достовірності: помірний.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-TOGA-BANG-2010
+    position: supports
+    relevant_quote_paraphrase: "ToGA: trastuzumab + cisplatin + 5-FU/cape vs chemo in HER2+ advanced gastric/GEJ adeno (n=594); mOS 13.8 vs 11.1 mo (HR 0.74). IHC3+ or IHC2+/FISH+ subgroup mOS 16.0 vs 11.8 mo. Established 1L standard for HER2+ gastric/GEJ. Extrapolated to HER2+ esoph adeno per NCCN."
+  - source_id: SRC-NCCN-ESOPHAGEAL-2025
+    position: supports
+  - source_id: SRC-ESMO-ESOPHAGEAL-2024
+    position: supports
+
+do_not_do:
+  - "Do NOT use in squamous-cell histology — HER2 amplification rare in ESCC; trial enrolled adeno only"
+  - "Do NOT use without baseline LVEF — trastuzumab cardiotoxicity (q3-mo echo monitoring)"
+  - "Do NOT combine with anthracycline (cumulative cardiotoxicity)"
+  - "Do NOT skip HER2 reflex ISH on IHC 2+ — IHC 2+ alone is NOT a treatment indication"
+  - "Do NOT initiate during ongoing GI bleed / luminal obstruction without first-line stabilization"
+  - "Do NOT extrapolate to ESCC even with rare HER2 amplification — out of scope of ToGA"
+
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  Extrapolation indication — confidence: moderate. ToGA was gastric + GEJ
+  (Siewert I-III). Esoph adenocarcinoma was not formally enrolled but NCCN
+  2025 recommends HER2 testing + trastuzumab + chemo for HER2+ metastatic
+  esoph adeno based on biological continuity with GEJ. KEYNOTE-811
+  (pembro + trastuzumab + chemo for HER2+ gastric/GEJ + CPS≥1) further
+  supports this backbone but is a separate indication scope.
+
+  Reuses REG-TRASTUZUMAB-CHEMO-TOGA (gastric ToGA regimen) — same dose,
+  schedule, components for esoph adeno extrapolation. No new regimen
+  authored; reuse audit confirmed identical backbone.
+
+  Algorithm extension required: ALGO-ESOPH-METASTATIC-1L should add a
+  HER2-positive adeno branch routing to this indication. Out of scope for
+  A1 (algorithm chunk D1 will handle).

--- a/knowledge_base/hosted/content/indications/ind_esoph_metastatic_1l_scc_ipi_nivo.yaml
+++ b/knowledge_base/hosted/content/indications/ind_esoph_metastatic_1l_scc_ipi_nivo.yaml
@@ -1,0 +1,103 @@
+id: IND-ESOPH-METASTATIC-1L-SCC-IPI-NIVO
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-ESOPHAGEAL
+  line_of_therapy: 1
+  stage_requirements:
+    - "Stage IV (metastatic) OR unresectable locally advanced esophageal carcinoma"
+    - "Squamous-cell histology (ESCC)"
+    - "Treatment-naive (no prior systemic therapy for advanced disease)"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-PDL1-CPS
+      required: false
+      value_constraint: "PD-L1 CPS ≥1 preferred (CheckMate-648 primary endpoint stratum; OS HR 0.64). All-randomized benefit smaller (HR 0.78). Test required for decision-making."
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+    histology_excluded: "Adenocarcinoma — CheckMate-648 enrolled ESCC only; use pembro+chemo (KEYNOTE-590) or chemo alone for adeno"
+
+recommended_regimen: REG-IPI-NIVO-ESOPH-SCC
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "35.4% vs 27.3% (CPS≥1 nivo+ipi vs chemo; CheckMate-648). Lower than chemo+nivo arm ORR (47.0%)."
+  progression_free_survival: "mPFS 4.0 vs 4.4 mo (CPS≥1, HR 1.02). PFS benefit not significant in CPS≥1; OS benefit driven by long-term tail."
+  overall_survival_median: "mOS 13.7 vs 9.1 mo (CPS≥1, HR 0.64, p=0.001). All-randomized: 12.7 vs 10.7 mo (HR 0.78)."
+  notes: >
+    CheckMate-648, N=970 ESCC. Nivo+ipi arm chosen over nivo+chemo when chemo-sparing
+    is preferred (renal dysfunction, frailty, patient preference). Higher rate of
+    immune-related AEs vs chemo+nivo. Use chemo+nivo if rapid response priority
+    (higher ORR vs nivo+ipi).
+
+hard_contraindications: []
+
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-PDL1-IHC
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-ECHO
+
+desired_tests:
+  - TEST-HER2-IHC-FISH
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+
+rationale: >
+  CheckMate-648 (NCT03143153, Doki 2022): nivolumab 3 mg/kg q2w + ipilimumab
+  1 mg/kg q6w vs chemo alone in untreated advanced ESCC (n=970). PD-L1 CPS≥1
+  primary endpoint: mOS 13.7 vs 9.1 mo (HR 0.64, p=0.001). All-randomized:
+  mOS 12.7 vs 10.7 mo (HR 0.78, p=0.011). ORR 35.4% (CPS≥1) — lower than the
+  chemo+nivo arm (47.0%) but with chemo-sparing benefit. Choice between
+  nivo+ipi and chemo+nivo is patient-specific: nivo+ipi preferred when avoiding
+  cytotoxic chemo (frailty, renal dysfunction, patient preference); chemo+nivo
+  preferred for rapid disease control / high tumor burden. FDA-approved May 2022
+  for ESCC 1L. NCCN category 1.
+
+rationale_ua: >
+  CheckMate-648: ніволумаб + іпілімумаб для ПКРС стравоходу 1L (chemo-free режим).
+  mOS 13.7 vs 9.1 міс при CPS≥1 (HR 0.64). Категорія 1 NCCN. Альтернатива
+  nivo+chemo при бажанні уникнути цитотоксичної хіміотерапії (вікова крихкість,
+  ниркова дисфункція, вибір пацієнта).
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-CHECKMATE648-DOKI-2022
+    position: supports
+    relevant_quote_paraphrase: "CheckMate-648 nivo+ipi arm vs chemo: mOS 13.7 vs 9.1 mo (CPS≥1, HR 0.64); 12.7 vs 10.7 mo (all-randomized, HR 0.78)"
+  - source_id: SRC-NCCN-ESOPHAGEAL-2025
+    position: supports
+  - source_id: SRC-ESMO-ESOPHAGEAL-2024
+    position: supports
+
+do_not_do:
+  - "Do NOT use in adenocarcinoma — CheckMate-648 enrolled ESCC only"
+  - "Do NOT use in patients with prior ICI exposure"
+  - "Do NOT use in active autoimmune disease requiring systemic immunosuppression (high irAE risk on combination ICI)"
+  - "Do NOT use in patients with prior solid organ transplant (rejection risk)"
+  - "Do NOT continue ipilimumab beyond cycle 4 equivalent if irAEs are escalating — switch to nivo monotherapy"
+  - "Do NOT skip baseline endocrine + cardiac panels (combination ICI has ~30%+ irAE rate)"
+  - "Do NOT use if ECOG ≥2 (trial enrolled 0-1; safety in poor PS unestablished)"
+
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  Sister indication to IND-ESOPH-METASTATIC-1L-NIVO-CHEMO-SCC (chemo+nivo arm,
+  same trial). Choice between arms is clinical: nivo+ipi favored when avoiding
+  cytotoxic chemo; chemo+nivo favored when rapid response is priority. Regimen
+  REG-IPI-NIVO-ESOPH-SCC uses CM-648-specific dosing (nivo 3 mg/kg q2w +
+  ipi 1 mg/kg q6w) — distinct from melanoma (1+3 mg/kg) and RCC (3+1 q3w);
+  hence new ESCC-specific regimen file rather than reuse.
+
+  Algorithm extension required: ALGO-ESOPH-METASTATIC-1L should add a
+  branch routing CPS≥1 ESCC patients with chemo-spare preference to this
+  indication. Out of scope for A1 (algorithm chunk D1 will handle).

--- a/knowledge_base/hosted/content/regimens/reg_ipi_nivo_esoph_scc.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_ipi_nivo_esoph_scc.yaml
@@ -1,0 +1,80 @@
+id: REG-IPI-NIVO-ESOPH-SCC
+name: "Nivolumab + ipilimumab (ESCC, 1L metastatic; CheckMate-648)"
+name_ua: "Ніволумаб + іпілімумаб (ПКРС стравоходу, 1L метастаз; CheckMate-648)"
+alternate_names: ["CheckMate-648 nivo+ipi arm", "Nivo 3 mg/kg q2w + ipi 1 mg/kg q6w"]
+
+components:
+  - drug_id: DRUG-NIVOLUMAB
+    dose: "3 mg/kg IV (CheckMate-648 ESCC dose)"
+    schedule: "Day 1 every 2 weeks"
+    route: IV
+  - drug_id: DRUG-IPILIMUMAB
+    dose: "1 mg/kg IV (CheckMate-648 ESCC dose)"
+    schedule: "Day 1 every 6 weeks"
+    route: IV
+
+cycle_length_days: 14
+total_cycles: "Until progression / unacceptable toxicity / 2 years (per CheckMate-648 protocol)"
+
+toxicity_profile: severe
+
+premedication: []
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Grade 2 immune-related AE (irAE)"
+    modification: "Hold both agents; corticosteroids (prednisone 0.5-1 mg/kg) until ≤Grade 1; resume if benefit > risk"
+    rationale: "Combination ICI has higher irAE rate than monotherapy; early intervention prevents Grade 3-4 escalation"
+    source_refs: [SRC-CHECKMATE648-DOKI-2022, SRC-NCCN-ESOPHAGEAL-2025]
+  - condition: "Grade ≥3 immune-related AE"
+    modification: "Permanently discontinue ipilimumab; high-dose corticosteroids (prednisone 1-2 mg/kg) + organ-specific specialist; nivolumab may resume if irAE resolves to ≤Grade 1 and not endocrine/neurologic"
+    source_refs: [SRC-CHECKMATE648-DOKI-2022]
+  - condition: "Immune-mediated pneumonitis (any grade)"
+    modification: "Hold immediately; HRCT chest + pulmonology; Grade 1 — consider hold + observation; Grade ≥2 — corticosteroids + permanent ipilimumab discontinuation"
+    source_refs: [SRC-NCCN-ESOPHAGEAL-2025]
+  - condition: "Immune-mediated colitis Grade ≥3"
+    modification: "Permanent discontinuation of both agents; high-dose IV methylprednisolone; consider infliximab if steroid-refractory"
+    source_refs: [SRC-NCCN-ESOPHAGEAL-2025]
+  - condition: "Immune-mediated hepatitis (AST/ALT > 5× ULN)"
+    modification: "Hold both agents; hepatology consult; corticosteroids; ipilimumab permanently discontinued at Grade 3+"
+    source_refs: [SRC-NCCN-ESOPHAGEAL-2025]
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Nivolumab + ipilimumab: both registered in Ukraine. NSZU 2026 onco package
+    does NOT cover ipilimumab for esophageal indication; combination is
+    out-of-pocket / charitable pathway. Single-agent nivolumab (CheckMate-577
+    adjuvant) is reimbursed but not the ipi combo. Realistic funded alternative
+    is REG-NIVO-CHEMO-ESCC (chemo+nivo) which has higher ORR but adds chemo
+    toxicity.
+
+sources:
+  - SRC-CHECKMATE648-DOKI-2022
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-07"
+notes: >
+  CheckMate-648 (Doki 2022 NEJM): nivolumab 3 mg/kg q2w + ipilimumab 1 mg/kg q6w
+  in untreated advanced ESCC. mOS 13.7 vs 9.1 mo (CPS≥1, HR 0.64); 12.7 vs 10.7 mo
+  (all-randomized, HR 0.78). ORR 35.4% (lower than chemo+nivo arm 47%) but
+  chemo-sparing. FDA-approved May 2022 for ESCC 1L. NCCN category 1.
+
+  Dose distinct from melanoma (REG-NIVO-IPI-MELANOMA: nivo 1 + ipi 3 induction)
+  and RCC (REG-NIVO-IPI-RCC: nivo 3 + ipi 1 q3w induction). CheckMate-648 ESCC
+  uses extended-interval schedule (q2w nivo + q6w ipi) without distinct
+  induction/maintenance phases — both agents continue concurrently until
+  progression / 2-year cap.
+
+  Watchpoints (PATIENT_MODE_SPEC §3.4) deferred — to be authored alongside
+  REG-NIVO-CHEMO-ESCC sister regimen in a coordinated patient-mode pass.
+
+notes_ua: >
+  CheckMate-648 (Doki 2022): ніволумаб 3 mg/kg q2w + іпілімумаб 1 mg/kg q6w для
+  нелікованого розвиненого ПКРС стравоходу. mOS 13.7 vs 9.1 міс (CPS≥1, HR 0.64).
+  Хімі-зберігаюча схема. Доза відрізняється від меланоми та НКР.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- Adds 2 new esoph 1L metastatic indications + 1 new regimen
- Partially addresses #406 — third indication deferred due to clinical inconsistency surfaced by agent (see below)

## What landed (3 new files, +298 lines)

| File | Source | Notes |
|---|---|---|
| `ind_esoph_metastatic_1l_scc_ipi_nivo.yaml` | `SRC-CHECKMATE648-DOKI-2022` | CM-648 ipi+nivo arm (sister to existing chemo+nivo arm) |
| `ind_esoph_metastatic_1l_her2_trastuzumab_chemo.yaml` | `SRC-TOGA-BANG-2010` | HER2-positive distal-third esoph adeno; ToGA extrapolation; reuses `REG-TRASTUZUMAB-CHEMO-TOGA` |
| `reg_ipi_nivo_esoph_scc.yaml` | `SRC-CHECKMATE648-DOKI-2022` | CM-648 ESCC dosing (nivo 3 q2w + ipi 1 q6w) — distinct from existing melanoma/RCC ipi+nivo regimens |

## Regimen reuse audit
- `REG-IPI-NIVO-ESOPH-SCC` NEW — CM-648 dose differs from melanoma (1+3) and RCC (3+1)
- `REG-TRASTUZUMAB-CHEMO-TOGA` REUSED — gastric ToGA backbone identical for esoph adeno extrapolation
- `REG-TDXD-GASTRIC` not exercised (tied to the deferred indication)

## Third indication deferred — clinical inconsistency in plan/issue spec

Chunk spec and plan doc §4.2 line 201 cite `SRC-DESTINY-GASTRIC04-SHITARA-2025` as extrapolation source for **HER2-low** esoph adeno T-DXd. **DESTINY-Gastric04 is a HER2-POSITIVE 2L post-trastuzumab trial** (Shitara NEJM 2025), not HER2-low. HER2-positive and HER2-low are disjoint biomarker strata.

Reasonable next steps (maintainer decision):
1. Drop indication entirely — HER2-low gastric/esoph T-DXd lacks phase-3 evidence in 2026 (DESTINY-Breast04 is breast-only; no published gastric/esoph HER2-low primary RCT)
2. Repurpose as HER2-**positive** 2L esoph adeno T-DXd (DG-04 → esoph HER2+ 2L extrap; closer / better-supported)
3. Hold for DESTINY-Gastric02 (HER2-low gastric Western trial, not yet published as of 2026-05)

Issue #406 stays open with these options for triage. Agent honest reporting flagged the spec defect — not a delivery failure.

## Test plan
- [x] KB validator: 91 schema / 179 ref / 217 contract warnings — all identical pre/post
- [x] loaded_entities 2786 → 2789 (+2 indications + 1 regimen, as expected)
- [x] pytest: 4 pre-existing baseline failures, 85 passed, no regressions
- [x] All 3 entities load; regimen refs resolve

## Engine routing — algorithm extension recommendations for D1

`ALGO-ESOPH-METASTATIC-1L` doesn't yet route to these new indications (per A1 chunk spec, algorithm extension out of scope). Recommendations:
1. ESCC CPS≥1 + chemo-spare-preference branch → ipi+nivo indication
2. HER2-positive adeno branch (HER2 IHC 3+ or 2+/ISH+) → trastuzumab+chemo indication

## Schema-field choices
- `biomarker_requirements_excluded: []` empty — schema requires structured `BiomarkerRequirement` not strings; histology exclusion moved to `demographic_constraints.histology_excluded` (free-text, `extra='allow'`)
- `hard_contraindications: []` empty — no canonical CI-* IDs for ESCC autoimmune/transplant or trastuzumab-cardiotox; safety preserved in `do_not_do` field
- `required_tests` / `desired_tests` use canonical TEST-* IDs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)