### PR TITLE
fix(bundle): recover 345 KB from core by fixing two split misses

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -108,6 +108,7 @@ _DISEASE_SCOPED_DIRS = {
     "regimens",
     "redflags",
     "biomarker_actionability",
+    "questionnaires",  # disease_id present in every questionnaire; moves ~155 KB compressed out of core
 }
 
 
@@ -144,6 +145,16 @@ def _disease_id_for_yaml(yaml_text: str, arc_path: str) -> str | None:
         return m.group(1).upper()
     # redflags: relevant_diseases — only attribute when it pins to a
     # single concrete disease. Universal / multi-disease RFs stay in core.
+    # Handles both inline list `[DIS-X]` and block-list format.
+    m = _re.search(
+        r"^relevant_diseases\s*:\s*\[([^\]]+)\]",
+        yaml_text, _re.MULTILINE,
+    )
+    if m:
+        items = [t.strip() for t in m.group(1).split(",") if t.strip()]
+        dis = [t.upper() for t in items if t.upper().startswith("DIS-")]
+        if len(dis) == 1:
+            return dis[0]
     m = _re.search(
         r"^relevant_diseases\s*:\s*\n((?:\s*-\s*\S+\s*\n)+)",
         yaml_text, _re.MULTILINE,
@@ -244,9 +255,9 @@ def bundle_engine(output_dir: Path) -> dict:
 
       1. `openonco-engine-core.zip` — code + schemas + validation +
          shared content (drugs, sources, biomarkers, tests,
-         supportive_care, monitoring, workups, questionnaires,
-         contraindications, mdt_skills, diseases, plus universal
-         redflags and any indications/algorithms/regimens/RFs/BMA cells
+         supportive_care, monitoring, workups, contraindications,
+         mdt_skills, diseases, plus universal redflags and any
+         indications/algorithms/regimens/RFs/BMAs/questionnaires
          that don't pin to a single disease). /try.html fetches this
          first — small enough to make the page interactive quickly.
 

--- a/scripts/profile_engine_bundle.py
+++ b/scripts/profile_engine_bundle.py
@@ -88,7 +88,14 @@ def _disease_id_from_yaml(zf: zipfile.ZipFile, info: zipfile.ZipInfo) -> str | N
     m = re.search(r"applicable_to\s*:\s*\n[\s\S]{0,200}?disease_id\s*:\s*(DIS-[A-Z0-9_-]+)", head)
     if m:
         return m.group(1).upper()
-    # relevant_diseases for redflags — pick first listed disease (skip "*")
+    # relevant_diseases for redflags — pick first listed disease (skip "*").
+    # Handles inline [DIS-X] and block-list format.
+    m = re.search(r"relevant_diseases\s*:\s*\[([^\]]+)\]", head)
+    if m:
+        for tok in m.group(1).split(","):
+            tok = tok.strip()
+            if tok.upper().startswith("DIS-"):
+                return tok.upper()
     m = re.search(r"relevant_diseases\s*:\s*\n((?:\s*-\s*\S+\s*\n)+)", head)
     if m:
         block = m.group(1)

--- a/tests/test_engine_bundle_optimization.py
+++ b/tests/test_engine_bundle_optimization.py
@@ -61,15 +61,17 @@ def test_core_and_index_and_disease_dir_present(bundle_out: dict):
 
 
 def test_core_bundle_under_size_ceiling(bundle_out: dict):
-    """Core bundle target: ≤2.95 MB compressed today (~2.89 MB observed
-    2026-05-01 after EN-render translation overrides + do_not_do JSON
-    sidecar (~72 KB compressed) and four Waves of patient-watchpoints
-    authoring: Wave 1 (11 anchor regimens, ~12 KB), Wave 2 (15 disease
-    anchors, ~90 KB), Wave 2B (16 disease anchors, ~70 KB), Wave 2C
-    (17 disease anchors, ~90 KB). Eventual goal ≤1.5 MB once more
-    disease-scoped content (drugs, regimens, indications) is moved out
-    of core into per-disease modules. Ceiling sized for headroom;
-    tighten as the split matures."""
+    """Core bundle target: ≤2.95 MB compressed (~2.63 MB observed
+    2026-05-07 after two split fixes that recovered 345 KB):
+      - All 78 questionnaires moved to per-disease bundles (each already
+        had disease_id but questionnaires wasn't in _DISEASE_SCOPED_DIRS).
+      - 154 single-disease redflags that used inline `[DIS-X]` format
+        for relevant_diseases were being mis-classified as core content;
+        fixed by extending the regex to handle inline lists.
+    Watchpoints Waves 3D–3J and tier2-reg PRs added ~222 KB of regimens
+    to core between 2026-05-01 and 2026-05-07, driving the breach.
+    Eventual goal ≤1.5 MB once regimens/drugs are split further.
+    Ceiling sized for headroom; tighten as the split matures."""
     core_zip = Path(bundle_out["_dir"]) / "openonco-engine-core.zip"
     size = core_zip.stat().st_size
     assert size < 3_000_000, (


### PR DESCRIPTION
## Summary

- **Bug 1**: `questionnaires/` was missing from `_DISEASE_SCOPED_DIRS` in `scripts/build_site.py`. All 78 questionnaire YAMLs (each with a `disease_id` field) were landing in core instead of their per-disease bundles. Adding `"questionnaires"` to the set moves ~155 KB compressed out of core.
- **Bug 2**: `_disease_id_for_yaml()` only matched block-list `relevant_diseases` YAML (multi-line `- DIS-X` format). 154 single-disease redflag files used inline list format `relevant_diseases: [DIS-X]` and fell through to core. Added an inline-list regex check before the existing block-list check (~190 KB recovered).
- `scripts/profile_engine_bundle.py` mirrored the same inline-list fix so the profiler's attribution stays consistent with the build.

**Net effect**: Core bundle drops from 3.11 MB → 2.63 MB (345 KB saved). `test_core_bundle_under_size_ceiling` (3 MB ceiling) now passes.

## Test plan

- [x] `test_core_bundle_under_size_ceiling` — was FAILING (3,111,908 bytes > 3,000,000), now PASSES (2,758,393 bytes)
- [x] `test_per_disease_bundles_under_size_ceiling` — passes; questionnaire bundles land correctly in per-disease zips
- [x] `test_core_bundle_excludes_disease_specific_indications` — unaffected, still passes
- [x] `test_bundle_index_is_valid_and_lists_existing_bundles` — unaffected, still passes
- [ ] `test_lazy_load_disease_merges_into_core` — **pre-existing failure**, 54 schema errors from 26 invalid regimen files; confirmed unchanged before/after this fix; tracked separately in spawned investigation task

🤖 Generated with [Claude Code](https://claude.com/claude-code)