### PR TITLE
feat(kb): GI-2 drug-stubs DRUG-BEMARITUZUMAB + DRUG-PAZOPANIB (-2 ref errors)

### DIFF
--- a/knowledge_base/hosted/content/drugs/drug_bemarituzumab.yaml
+++ b/knowledge_base/hosted/content/drugs/drug_bemarituzumab.yaml
@@ -1,0 +1,143 @@
+id: DRUG-BEMARITUZUMAB
+names:
+  preferred: "Bemarituzumab"
+  ukrainian: "Бемаритузумаб"
+  english: "Bemarituzumab"
+  brand_names: []
+atc_code: null
+rxnorm_id: null
+drug_class: "Anti-FGFR2b Fc-engineered (afucosylated) humanized IgG1 monoclonal antibody"
+
+mechanism: >
+  Humanized IgG1 monoclonal antibody (development name FPA144) selective
+  for the IIIb splice isoform of fibroblast growth factor receptor 2
+  (FGFR2b) extracellular domain. Two complementary modes of action:
+  (1) competitive blockade of FGF7 / FGF10 / FGF22 ligand binding to
+  FGFR2b, suppressing downstream MAPK/PI3K signaling in tumor cells
+  that overexpress FGFR2b; (2) Fc engineering — afucosylated IgG1
+  glycoform with enhanced FcγRIIIa binding — produces amplified
+  antibody-dependent cellular cytotoxicity (ADCC) by NK cells against
+  FGFR2b-expressing tumor cells. Selectivity for the IIIb splice
+  isoform avoids broader pan-FGFR receptor blockade and reduces the
+  hyperphosphatemia / nail / mucosal toxicities characteristic of
+  small-molecule pan-FGFR inhibitors. FGFR2b overexpression occurs in
+  ~30% of HER2-non-positive gastric/GEJ adenocarcinoma; the validated
+  companion diagnostic (Ventana FGFR2b RxDx, IIIb-selective IHC)
+  defines eligibility as 2+/3+ membranous staining in ≥10% of tumor
+  cells.
+
+regulatory_status:
+  fda:
+    approved: false
+    year_first_approval: null
+    indications_brief: []
+  ema:
+    approved: false
+    year_first_approval: null
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-07"
+    notes: |
+      Не зареєстровано в UA (drlz.com.ua станом на 2026-05-07).
+      Не FDA / EMA-схвалений станом на 2026-05-07. FDA Breakthrough
+      Therapy Designation (квітень 2021). Phase 3 FORTITUDE-101
+      первинний readout позитивний (ESMO 2025 LBA10) — регуляторне
+      подання очікується. Шляхи доступу:
+      - Named-patient import (DEC спецдозвіл) — за рахунок пацієнта;
+      - Amgen compassionate use / EAP — обмежено;
+      - Cross-border (EU): EU онкоцентр (наказ МОЗ 988);
+      - Trial-only: FORTITUDE-102 (perioperative) / FORTITUDE-103
+        (1L з PD-1 інгібітором).
+
+typical_dosing: >
+  FORTITUDE-101 / FORTITUDE-102 protocol: 15 mg/kg IV q2w with an
+  additional 7.5 mg/kg loading dose on cycle 1 day 8 (administered
+  with mFOLFOX6 backbone for FGFR2b-overexpressing 1L gastric/GEJ).
+  Infusion over ≥30 minutes; subsequent infusions may shorten if
+  first cycle tolerated. Treatment continued until disease progression,
+  unacceptable toxicity (most commonly grade ≥3 corneal events), or
+  patient withdrawal. No FDA / EMA labelled dose as of 2026-05-07
+  (investigational).
+
+formulations:
+  - "IV concentrate (FORTITUDE programme; commercial formulation pending regulatory approval)"
+
+absolute_contraindications:
+  - "Severe hypersensitivity / anaphylaxis to bemarituzumab"
+  - "Pre-existing severe corneal disease (relative — high baseline ocular toxicity risk)"
+  - "Pregnancy (no human data; animal class effect concerns)"
+  - "FGFR2b-non-overexpressing tumor (no efficacy demonstrated; companion diagnostic IHC 2+/3+ ≥10% required)"
+
+black_box_warnings: []
+
+common_adverse_events:
+  - "Corneal events / keratopathy (~70% any-grade — punctate keratitis, dry eye, reduced visual acuity, corneal epithelium defect)"
+  - "Dry eye (~30-40%)"
+  - "Hypoalbuminemia (~30%)"
+  - "Nausea (~30%; combination with mFOLFOX6 backbone)"
+  - "Decreased appetite (~20%)"
+  - "Fatigue"
+  - "Stomatitis"
+  - "Mild infusion reactions (~5%, mostly grade 1-2)"
+  - "Diarrhea (combination with chemo backbone)"
+  - "Peripheral neuropathy (chemo backbone)"
+
+serious_adverse_events:
+  - "Grade ≥3 corneal events (~25%; typical onset ~6 months) — dose-defining toxicity; 28% withdrew from FORTITUDE-101 due to ocular toxicity"
+  - "Severe infusion reactions / anaphylaxis (rare but reported)"
+  - "Severe hypoalbuminemia (rare; clinically significant edema)"
+  - "Corneal ulceration / persistent visual acuity loss (rare; usually reversible after discontinuation but may persist months)"
+
+major_interactions:
+  - "Concurrent emetogenic chemotherapy (mFOLFOX6) — additive nausea, fatigue, mucositis"
+  - "Live vaccines — avoid (general mAb-class precaution)"
+
+pharmacology:
+  half_life_hours: null
+  half_life_notes: "Antibody PK; steady state by ~3-4 cycles. Specific t½ not yet published in peer-reviewed full text as of 2026-05-07."
+  clearance: "non-specific catabolism (proteolysis); target-mediated drug disposition expected"
+  protein_binding_pct: null
+  metabolism: "non-CYP; antibody catabolism"
+  volume_of_distribution_l: null
+
+sources:
+  - SRC-FORTITUDE-101
+  - SRC-FIGHT
+  - SRC-NCCN-GASTRIC-2025
+
+last_reviewed: "2026-05-07"
+reviewers: []
+notes: >
+  First-in-class IIIb-selective afucosylated anti-FGFR2b mAb (Amgen;
+  development name FPA144). FDA Breakthrough Therapy Designation
+  awarded April 2021 for FGFR2b-overexpressing 1L gastric/GEJ.
+  Pivotal evidence: FIGHT phase 2 (Wainberg et al. Lancet Oncol 2022;
+  bemarituzumab + mFOLFOX6 vs placebo + mFOLFOX6 in FGFR2b ≥10%
+  2+/3+ subgroup — mPFS 9.5 vs 7.4 mo, HR 0.68); FORTITUDE-101
+  phase 3 (Rha et al. ESMO 2025 LBA10; NCT05052801) — primary
+  analysis (median follow-up 11.8 mo): mOS 17.9 vs 12.5 mo (HR 0.61,
+  p=0.005); mPFS 8.6 vs 6.7 mo. Updated descriptive analysis (median
+  follow-up 19.4 mo) showed mOS 14.5 vs 13.2 mo (HR 0.82) — early
+  survival gain attenuated, raising practice-changing controversy at
+  ESMO 2025 (one discussant flagged absence of PD-1 backbone in
+  control arm and shrinking median OS difference). Ocular toxicity is
+  the dose-defining AE (~70% any-grade corneal events, ~25% G≥3,
+  typical onset ~6 months) — mandatory baseline + serial slit-lamp
+  ophthalmology REQUIRED before each cycle. Companion diagnostic
+  (Ventana FGFR2b RxDx, IIIb-selective IHC) defines eligibility as
+  2+/3+ membranous staining ≥10% of tumor cells; FGFR2b high-positive
+  (≥10% 2+/3+) ~30% of HER2-non-positive gastric/GEJ. Hierarchy when
+  multiple actionable signals co-occur in HER2-non-positive 1L
+  gastric/GEJ: HER2+ trastuzumab supersedes; MSI-H pembrolizumab
+  supersedes; CLDN18.2 ≥75% zolbetuximab supersedes (phase 3 OS
+  established Oct 2024 vs FORTITUDE-101 attenuated benefit);
+  bemarituzumab reserved for FGFR2b ≥10% with CLDN18.2 <75%. STUB
+  pending Clinical Co-Lead sign-off (CHARTER §6.1: ≥2 reviewers for
+  clinical content). Drug-stub created to resolve transient ref-error
+  introduced by REG-BEMARITUZUMAB-MFOLFOX6 (issue #413 bemfill).
+
+notes_patient: >
+  Експериментальний препарат-мітка (анти-FGFR2b моноклональне антитіло) для пухлин шлунка з підвищеним FGFR2b. Ще не схвалений FDA/EMA — доступний лише через клінічні дослідження або named-patient import. Головний неприємний ефект — проблеми з рогівкою ока (потрібен регулярний огляд офтальмолога перед кожним циклом).

--- a/knowledge_base/hosted/content/drugs/drug_pazopanib.yaml
+++ b/knowledge_base/hosted/content/drugs/drug_pazopanib.yaml
@@ -1,0 +1,165 @@
+id: DRUG-PAZOPANIB
+names:
+  preferred: "Pazopanib"
+  ukrainian: "Пазопаніб"
+  english: "Pazopanib"
+  brand_names: ["Votrient"]
+atc_code: L01EK02
+rxnorm_id: "718771"
+drug_class: "Multi-targeted oral tyrosine kinase inhibitor (VEGFR-1/2/3, PDGFR-α/β, c-KIT)"
+
+mechanism: >
+  Orally bioavailable small-molecule multi-kinase inhibitor of vascular
+  endothelial growth factor receptors VEGFR-1, VEGFR-2, and VEGFR-3,
+  platelet-derived growth factor receptors PDGFR-α and PDGFR-β, and
+  stem-cell factor receptor c-KIT. Antiangiogenic mechanism: inhibition
+  of VEGFR-driven endothelial proliferation, migration, and tube formation
+  starves the tumor microvasculature; PDGFR blockade additionally targets
+  pericyte recruitment and stromal support. Activity in clear-cell renal
+  cell carcinoma (driven by VHL-loss / HIF-2α / VEGF axis) and in soft
+  tissue sarcoma (with VEGFR / PDGFR / c-KIT signaling contributing to
+  tumor angiogenesis and proliferation). Significant CYP3A4 substrate
+  with substantial drug-drug-interaction potential; requires fasting
+  administration (food roughly doubles AUC).
+
+regulatory_status:
+  fda:
+    approved: true
+    year_first_approval: 2009
+    indications_brief:
+      - "Advanced renal cell carcinoma (RCC) — FDA approved October 2009 (VEG105192 phase 3)"
+      - "Advanced soft tissue sarcoma (STS) after prior chemotherapy — FDA approved April 2012 (PALETTE phase 3); excluding GIST and adipocytic sarcoma"
+  ema:
+    approved: true
+    year_first_approval: 2010
+  ukraine_registration:
+    registered: true
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-07"
+    notes: |
+      Зареєстрований в UA (drlz.com.ua, бренд Votrient — GSK / Novartis
+      transfer). НСЗУ: реімбурсація обмежена / відсутня станом на
+      2026-05-07 — потребує підтвердження за поточним переліком
+      «Реімбурсаційний пакет Онкологія». Альтернативи 1L ccRCC при
+      недоступному pazopanib: sunitinib (НСЗУ-покритий за програмою
+      Доступні ліки), або ICI-комбо (pembrolizumab+axitinib, nivolumab+
+      cabozantinib) — за окремими програмами.
+
+typical_dosing: >
+  Standard adult dose: 800 mg PO once daily continuous, taken on an
+  empty stomach (≥1 hour before or ≥2 hours after a meal — food
+  significantly increases exposure and toxicity risk). Dose
+  reductions to 400 mg then 200 mg for grade 3-4 toxicity or
+  hepatic AE per labelling. Treatment continued until disease
+  progression or unacceptable toxicity. Hepatic monitoring schedule
+  (per FDA boxed warning): LFTs at baseline, weeks 3, 5, 7, 9, then
+  monthly through month 4, then periodically. Hold for ALT >3× ULN;
+  permanently discontinue for ALT >8× ULN or concurrent ALT >3× ULN
+  with bilirubin >2× ULN. Dose reduction to 200 mg recommended for
+  moderate hepatic impairment; not recommended in severe hepatic
+  impairment. Avoid concomitant strong CYP3A4 inhibitors / inducers;
+  if unavoidable, dose adjust per labelling (reduce to 400 mg with
+  strong inhibitors).
+
+formulations:
+  - "Oral tablet 200 mg (Votrient)"
+  - "Oral tablet 400 mg (legacy formulation; not all markets)"
+
+absolute_contraindications:
+  - "Severe hypersensitivity to pazopanib"
+  - "Severe pre-existing hepatic impairment (Child-Pugh C; not recommended)"
+  - "Pregnancy (Category D — embryo-fetal toxicity)"
+  - "Uncontrolled hypertension (manage before initiation)"
+  - "Recent serious arterial thromboembolic event (within 6 months — relative)"
+
+black_box_warnings:
+  - "Severe and fatal hepatotoxicity — ALT elevations >3× ULN in ~20%, >8× ULN in ~10%; rare fatal hepatic failure has occurred. LFT monitoring schedule (baseline, weeks 3/5/7/9, monthly through month 4, then periodically) MANDATORY"
+
+common_adverse_events:
+  - "Diarrhea (~50-60% any grade)"
+  - "Hypertension (~40-50%; new-onset or worsening)"
+  - "Hair color change / depigmentation (~30-40%)"
+  - "Nausea (~25-30%)"
+  - "Fatigue (~20-25%; less than sunitinib per COMPARZ)"
+  - "Anorexia (~20%)"
+  - "Vomiting"
+  - "Hand-foot syndrome / palmar-plantar erythrodysesthesia (~15%; less than sunitinib)"
+  - "Headache"
+  - "Hypothyroidism (~10-15%; class effect)"
+  - "Proteinuria"
+  - "Stomatitis / mucositis"
+  - "Asymptomatic ALT / AST elevation (~50%; G≥3 ~10-20%)"
+
+serious_adverse_events:
+  - "Grade 3-4 hepatotoxicity (~10-20%) — boxed warning; monitor LFTs per schedule"
+  - "Severe / fatal hepatic failure (rare)"
+  - "QT prolongation / torsades de pointes (rare; baseline + periodic ECG in at-risk patients)"
+  - "Arterial thromboembolism — MI, stroke, TIA (~3%)"
+  - "Venous thromboembolism — DVT, PE"
+  - "Hemorrhagic events — GI, pulmonary, intracranial (~5% any-grade; G≥3 ~1-2%)"
+  - "GI perforation / fistula (rare; ~1%)"
+  - "Wound healing impairment (hold pazopanib ≥7 days before elective surgery; resume after adequate healing)"
+  - "Posterior reversible encephalopathy syndrome (PRES; rare)"
+  - "Thrombotic microangiopathy (rare)"
+  - "Pneumothorax (sarcoma population — ~3%)"
+  - "Hypothyroidism progressing to severe / myxedema (rare)"
+  - "Severe hypertensive crisis"
+  - "Cardiac dysfunction / decreased LVEF (~7-11%)"
+
+major_interactions:
+  - "Strong CYP3A4 inhibitors (ketoconazole, itraconazole, ritonavir, clarithromycin) — increase pazopanib AUC; reduce pazopanib to 400 mg or avoid"
+  - "Strong CYP3A4 inducers (rifampin, carbamazepine, phenytoin, St. John's wort) — decrease pazopanib AUC; avoid combination"
+  - "CYP3A4 substrates with narrow therapeutic index (simvastatin) — pazopanib increases simvastatin exposure; avoid >20 mg/d"
+  - "QT-prolonging drugs (ondansetron, methadone, fluoroquinolones) — additive QT prolongation"
+  - "Acid-suppressive therapy (PPI, H2-blocker) — may reduce pazopanib absorption (pH-dependent solubility); separate dosing"
+  - "P-glycoprotein and BCRP inhibitors / substrates — pazopanib inhibits both; concomitant substrates (paclitaxel, irinotecan, lapatinib) at increased exposure"
+  - "Anticoagulants (warfarin, DOACs) — additive bleeding risk; close INR / clinical monitoring"
+  - "Live vaccines — avoid during therapy"
+
+pharmacology:
+  half_life_hours: 31
+  half_life_notes: "Mean t½ ~30-31 hours; steady state by day 7-14 of continuous daily dosing."
+  clearance: "Hepatic (primarily CYP3A4-mediated oxidation; minor CYP1A2, CYP2C8); fecal elimination predominant"
+  protein_binding_pct: 99
+  metabolism: "CYP3A4 (major), CYP1A2 / CYP2C8 (minor); pazopanib also inhibits CYP3A4, CYP2C8, UGT1A1, BCRP, P-gp"
+  volume_of_distribution_l: null
+
+sources:
+  - SRC-NCCN-KIDNEY-2025
+  - SRC-ESMO-RCC-2024
+
+last_reviewed: "2026-05-07"
+reviewers: []
+notes: >
+  First-generation multi-kinase TKI (originally GlaxoSmithKline,
+  development code GW786034; transferred to Novartis 2015 acquisition
+  of GSK oncology portfolio). FDA-approved Oct 2009 for advanced RCC
+  on the basis of VEG105192 (Sternberg et al. JCO 2010 — pazopanib vs
+  placebo in treatment-naive or cytokine-pretreated mRCC: mPFS 9.2 vs
+  4.2 mo, HR 0.46). Subsequently FDA-approved April 2012 for advanced
+  STS (excluding GIST and adipocytic sarcoma) post-chemo on the basis
+  of PALETTE phase 3 (van der Graaf et al. Lancet 2012 — pazopanib vs
+  placebo: mPFS 4.6 vs 1.6 mo, HR 0.35). COMPARZ phase 3 (Motzer et al.
+  NEJM 2013) demonstrated non-inferiority of pazopanib vs sunitinib
+  for mPFS in 1L mRCC (8.4 vs 9.5 mo) with a different toxicity profile
+  — less fatigue and hand-foot syndrome with pazopanib but more
+  hepatotoxicity. PISCES patient-preference study (Escudier et al.
+  JCO 2014) showed 70% of patients preferred pazopanib vs sunitinib
+  on QoL grounds. Pazopanib remains an acceptable NCCN single-agent
+  TKI option in 1L mRCC favorable-risk and as a chemo-free alternative
+  in poor-PS patients where ICI combination is contraindicated. Modern
+  1L ccRCC standard is ICI-based combination (pembrolizumab+axitinib,
+  nivolumab+cabozantinib, nivolumab+ipilimumab for intermediate/poor
+  risk) — pazopanib reserved for ICI-ineligible patients or as a
+  later-line monotherapy. STUB pending Clinical Co-Lead sign-off
+  (CHARTER §6.1: ≥2 reviewers for clinical content). Drug-stub
+  created to resolve pre-existing ref-error from REG-PAZOPANIB-RCC.
+  Primary RCT citations (VEG105192, PALETTE, COMPARZ) not yet
+  ingested as Source entities — flagged for source ingestion in a
+  future chunk; current sources are NCCN + ESMO guidelines as
+  fallback, both of which cite the primary trials.
+
+notes_patient: >
+  Пазопаніб — щоденна таблетка для нирково-клітинного раку та саркоми м'яких тканин. Приймати натще (за 1 годину до або 2 години після їжі). Контролюємо печінкові ферменти регулярно (перші місяці часто), артеріальний тиск, та функцію щитоподібної залози. Можливе знебарвлення волосся — це очікувано, не потребує дій.


### PR DESCRIPTION
## Summary
- 2 NEW drug stubs resolve 2 pre-existing orphan-ref errors
- `REG-BEMARITUZUMAB-MFOLFOX6` (introduced bemfill #413) → `DRUG-BEMARITUZUMAB` now resolves
- `REG-PAZOPANIB-RCC` (pre-existing pattern from before GI-2) → `DRUG-PAZOPANIB` now resolves
- Closes #420

## Files (2 NEW)

| Drug | Approval | Primary trials cited |
|---|---|---|
| `drug_bemarituzumab.yaml` | FDA Breakthrough 2021 (investigational) | SRC-FORTITUDE-101 (ESMO 2025 LBA10) + SRC-FIGHT (Wainberg Lancet Oncol 2022) |
| `drug_pazopanib.yaml` | FDA 2009 (RCC), 2012 (STS) | Fallback to NCCN-Kidney-2025 + ESMO-RCC-2024; primary RCTs (VEG105192/PALETTE/COMPARZ) flagged for future source-stub chunk |

## Validator delta (verified locally with `--strict-source-refs`)

- **Entities:** 2797 → 2799 (+2)
- **Ref-errors:** 354 → 352 (Δ −2, exactly as required)
- **Schema errors:** 354 → 354 (unchanged; pre-existing pattern in regimen files)

## Test plan
- [x] Diff scope: 2 NEW files under `drugs/`
- [x] No banned sources (OncoKB / SNOMED / MedDRA / CIViC-as-primary)
- [x] Schema fields canonical (Drug schema only; free-text in `notes:` where needed)
- [x] Both stubs marked `pending_clinical_signoff` per CHARTER §6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)