### PR TITLE
feat(kb): GI-2 D1 algorithm extensions (4 routing branches, all engine-smoke green)

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_esoph_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_esoph_2l.yaml
@@ -5,11 +5,38 @@ purpose: 'Select 2L+ metastatic esophageal carcinoma Indication. Two ICI tracks 
 
   '
 output_indications:
+- IND-ESOPH-METASTATIC-2L-HER2-POSITIVE-T-DXD
 - IND-ESOPH-METASTATIC-2L-NIVO-SQUAMOUS
 - IND-ESOPH-METASTATIC-2L-PEMBRO-CPS10
 default_indication: IND-ESOPH-METASTATIC-2L-NIVO-SQUAMOUS
 alternative_indication: IND-ESOPH-METASTATIC-2L-PEMBRO-CPS10
 decision_tree:
+- step: 10
+  # D1 chunk (gi2-d1-algo-extensions-2026-05-07-2030) — Adenocarcinoma + HER2+
+  # + post-trastuzumab progression → trastuzumab deruxtecan (T-DXd). Extrapolation
+  # from DESTINY-Gastric01/04 (gastric/GEJ adeno, post-trastuzumab; mOS 14.7 vs
+  # 11.4 mo, HR 0.70 in DG-04). Excludes squamous-cell esoph carcinoma — DG-01/04
+  # enrolled adeno only and HER2 amplification is rare in ESCC. Falls through to
+  # existing step 1 (CPS≥10 pembro) when HER2-/SCC/no prior trastuzumab.
+  evaluate:
+    all_of:
+    - finding: "histology"
+      value: "adeno"
+    - finding: "her2_status"
+      value: "positive"
+    - finding: "prior_trastuzumab_progression"
+      value: true
+  if_true:
+    result: IND-ESOPH-METASTATIC-2L-HER2-POSITIVE-T-DXD
+    notes: >
+      EAC / GEJ Siewert I + HER2+ + progression on 1L trastuzumab-containing
+      regimen → T-DXd 6.4 mg/kg q3w (REG-TDXD-GASTRIC reused). Extrapolation
+      from DESTINY-Gastric01/04 (gastric/GEJ adeno, post-trastuzumab). NCCN-
+      Esophageal/EGJ 2025 + ESMO-Esophageal 2024 endorse via biological
+      contiguity with GEJ adeno. Confidence: moderate.
+  if_false:
+    next_step: 1
+  notes: "D1 chunk new branch — routes HER2+ esoph adeno post 1L trastuzumab to T-DXd before generic ICI logic."
 - step: 1
   evaluate:
     all_of:

--- a/knowledge_base/hosted/content/algorithms/algo_esoph_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_esoph_metastatic_1l.yaml
@@ -8,6 +8,8 @@ purpose: >
   RESECTABLE-1L (neoadjuvant CROSS) and ALGO-ESOPHAGEAL-ADJUVANT-1L.
 
 output_indications:
+  - IND-ESOPH-METASTATIC-1L-SCC-IPI-NIVO
+  - IND-ESOPH-METASTATIC-1L-HER2-TRASTUZUMAB-CHEMO
   - IND-ESOPH-METASTATIC-1L-NIVO-CHEMO-SCC
   - IND-ESOPH-METASTATIC-1L-PEMBRO-CHEMO
 
@@ -15,6 +17,55 @@ default_indication: IND-ESOPH-METASTATIC-1L-NIVO-CHEMO-SCC
 alternative_indication: IND-ESOPH-METASTATIC-1L-PEMBRO-CHEMO
 
 decision_tree:
+  # Step 10 (D1 chunk gi2-d1-algo-extensions-2026-05-07-2030) — SCC + PD-L1 CPS≥1
+  # + chemo-spare preference → nivolumab + ipilimumab (CheckMate-648 nivo+ipi arm).
+  # CM-648 enrolled ESCC only; chemo-sparing arm benefits from avoiding cytotoxic
+  # chemo (renal dysfunction, frailty, patient preference). Falls through to
+  # existing step 1 (chemo+nivo SCC arm) when chemo_spare_preference is not set.
+  - step: 10
+    evaluate:
+      all_of:
+        - finding: "histology"
+          value: "squamous"
+        - finding: "pdl1_cps"
+          threshold: 1
+          comparator: ">="
+        - finding: "chemo_spare_preference"
+          value: true
+    if_true:
+      result: IND-ESOPH-METASTATIC-1L-SCC-IPI-NIVO
+      notes: >
+        ESCC + PD-L1 CPS≥1 + chemo-spare preference: nivo+ipi (CheckMate-648
+        nivo+ipi arm). Chosen over chemo+nivo when avoiding cytotoxic chemo
+        is preferred (frailty, renal dysfunction, patient preference). mOS
+        13.7 vs 9.1 mo CPS≥1 (HR 0.64).
+    if_false:
+      next_step: 11
+    notes: "D1 chunk new branch — routes chemo-sparing CPS≥1 ESCC to ipi+nivo arm of CheckMate-648."
+
+  # Step 11 (D1 chunk) — Adenocarcinoma + HER2-positive → trastuzumab + chemo
+  # (ToGA backbone extrapolation per NCCN-Esophageal/EGJ 2025). HER2 testing in
+  # metastatic adeno is recommended; trastuzumab + cisplatin/cape (or 5-FU)
+  # supersedes chemo+pembro for the HER2+ subset.
+  - step: 11
+    evaluate:
+      all_of:
+        - finding: "histology"
+          value: "adeno"
+        - finding: "her2_status"
+          value: "positive"
+    if_true:
+      result: IND-ESOPH-METASTATIC-1L-HER2-TRASTUZUMAB-CHEMO
+      notes: >
+        EAC / GEJ Siewert I + HER2+ (IHC 3+ or IHC 2+/ISH+): trastuzumab +
+        cisplatin + capecitabine/5-FU (ToGA backbone). Extrapolation from
+        gastric/GEJ ToGA pivotal trial (mOS 13.8 vs 11.1 mo, HR 0.74; IHC3+
+        or IHC2+/FISH+ subgroup mOS 16.0 vs 11.8 mo). NCCN-Esophageal/EGJ
+        2025 endorses extrapolation. Confidence: moderate.
+    if_false:
+      next_step: 1
+    notes: "D1 chunk new branch — routes HER2+ esoph adeno to ToGA-backbone trastuzumab+chemo before generic CPS gating."
+
   # Step 1 — Staging confirmation. Algorithm applies to metastatic (stage IV)
   # or unresectable locally advanced esophageal carcinoma only.
   # Resectable disease → ALGO-ESOPH-RESECTABLE-1L (CROSS neoadjuvant).

--- a/knowledge_base/hosted/content/algorithms/algo_gastric_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gastric_metastatic_1l.yaml
@@ -11,6 +11,7 @@ purpose: >
 output_indications:
   - IND-GASTRIC-METASTATIC-1L-HER2-TOGA
   - IND-GASTRIC-METASTATIC-1L-CLDN18-2-ZOLBETUXIMAB
+  - IND-GASTRIC-METASTATIC-1L-FGFR2B-BEMARITUZUMAB
   - IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI
 
 default_indication: IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI
@@ -41,8 +42,33 @@ decision_tree:
     if_true:
       result: IND-GASTRIC-METASTATIC-1L-CLDN18-2-ZOLBETUXIMAB
     if_false:
-      next_step: 3
+      next_step: 10
     notes: "CLDN18.2 branch added W1.B2 (2026-04-30). MSI-H pembrolizumab branch still pending — surfaces via known_controversies in indication."
+
+  # Step 10 (D1 chunk gi2-d1-algo-extensions-2026-05-07-2030) — FGFR2b+ HER2-
+  # non-positive → bemarituzumab + mFOLFOX6 (FORTITUDE-101 phase 3 / FIGHT phase
+  # 2). FGFR2b IHC 2+/3+ ≥10% threshold. Positioned between CLDN18.2 (step 2)
+  # and PD-L1 CPS (step 3) per indication-level hierarchy: HER2+ TOGA → CLDN18.2+
+  # zolbetuximab (phase 3 FDA-approved) → FGFR2b+ bemarituzumab (phase 3 emerging,
+  # FORTITUDE-101 ESMO 2025 LBA10) → PD-L1 CPS+ chemo+nivo (CheckMate-649). Falls
+  # through to step 3 (PD-L1 CPS) when FGFR2b-negative.
+  - step: 10
+    evaluate:
+      all_of:
+        - finding: "fgfr2b_status"
+          value: "positive"
+        - {finding: her2_status, value: negative}
+    if_true:
+      result: IND-GASTRIC-METASTATIC-1L-FGFR2B-BEMARITUZUMAB
+    if_false:
+      next_step: 3
+    notes: >
+      D1 chunk new branch — FGFR2b+ (IHC 2+/3+ ≥10%) HER2-non-positive routes to
+      bemarituzumab + mFOLFOX6 (FORTITUDE-101 phase 3 mOS 17.9 vs 12.5 mo at
+      primary analysis HR 0.61, attenuated to HR 0.82 at descriptive follow-up;
+      FIGHT phase 2 mOS 19.2 vs 13.5 mo HR 0.60). HER2+ pre-routed at step 1
+      (TOGA supersedes); CLDN18.2+ pre-routed at step 2 (zolbetuximab supersedes
+      until FORTITUDE-101 vs SPOTLIGHT/GLOW head-to-head data emerges).
 
   # Step 3 — HER2- + PD-L1 CPS ≥1 → FOLFOX+nivo (CheckMate-649). Note:
   # FDA strict label is CPS ≥5; EMA broader label is CPS ≥1.


### PR DESCRIPTION
## Summary
- 4 NEW routing branches across 3 algorithm files
- All 4 new GI-2 indications now route end-to-end (indication + regimen resolved)
- No regression on existing routes (`auto_esophageal.json`, `auto_gastric.json` route unchanged)
- Closes #419

## Engine smoke 4/4 PASS

| Patient profile | Algorithm | → Indication | → Regimen |
|---|---|---|---|
| Esoph SCC + CPS=5 + chemo-spare | ALGO-ESOPH-METASTATIC-1L | IND-ESOPH-METASTATIC-1L-SCC-IPI-NIVO | REG-IPI-NIVO-ESOPH-SCC |
| Esoph adeno + HER2 IHC3+ 1L | ALGO-ESOPH-METASTATIC-1L | IND-ESOPH-METASTATIC-1L-HER2-TRASTUZUMAB-CHEMO | REG-TRASTUZUMAB-CHEMO-TOGA |
| Esoph adeno + HER2 IHC3+ 2L post-tras | ALGO-ESOPH-2L | IND-ESOPH-METASTATIC-2L-HER2-POSITIVE-T-DXD | REG-TDXD-GASTRIC |
| Gastric FGFR2b+ HER2-neg 1L | ALGO-GASTRIC-METASTATIC-1L | IND-GASTRIC-METASTATIC-1L-FGFR2B-BEMARITUZUMAB | REG-BEMARITUZUMAB-MFOLFOX6 |

## Structural changes

- `algo_esoph_metastatic_1l.yaml`: +2 entries to `output_indications`, +2 new steps (10, 11) prepended to decision_tree, falling through to existing step 1
- `algo_esoph_2l.yaml`: +1 entry to `output_indications`, +1 new step (10) prepended
- `algo_gastric_metastatic_1l.yaml`: +1 entry to `output_indications`, +1 new step (10) inserted between CLDN18.2 (step 2) and PD-L1 (step 3); step 2 reroute preserved hierarchy: **HER2 → CLDN18.2 → FGFR2b → PD-L1**

## Decision predicates

All new clauses use real finding-keyed lookups: `histology`, `her2_status`, `pdl1_cps`, `fgfr2b_status`, `chemo_spare_preference`, `prior_trastuzumab_progression`.

**Note (out of scope but flagged):** existing English-string `condition:` clauses in `algo_esoph_metastatic_1l.yaml` steps 1-4 functionally never fire — `default_indication` fallback handles routing. Preserved untouched per allowlist; latent bug for future cleanup.

## Test plan
- [x] Engine smoke: 4/4 pass (this is the primary D1 acceptance criterion)
- [x] Existing-patient regression: auto_esophageal.json + auto_gastric.json route unchanged
- [x] KB validator: 91 schema baseline → 91 (no regression)
- [x] Engine + render tests: 40 pass / 2 pre-existing failures (verified unrelated)
- [x] Diff scope: 3 files, all `M`, all under `algorithms/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)