### PR TITLE
feat(schema): §17 ratification — Surgery + RadiationCourse + Indication.phases

### DIFF
--- a/knowledge_base/hosted/content/diseases/crc.yaml
+++ b/knowledge_base/hosted/content/diseases/crc.yaml
@@ -38,8 +38,7 @@ last_reviewed: "2026-04-26"
 reviewers: []
 
 metadata:
-  proposal_status: partial
-  awaiting_proposal: "KNOWLEDGE_SCHEMA_SPECIFICATION.md §17 Solid-tumor extensions — full neoadjuvant→surgery→adjuvant phasing for rectum + periop chemoradiation modeling"
+  proposal_status: full
 
 notes: >
   Combined colon + rectum scope. The two share most systemic-therapy

--- a/knowledge_base/hosted/content/diseases/esophageal.yaml
+++ b/knowledge_base/hosted/content/diseases/esophageal.yaml
@@ -39,8 +39,7 @@ last_reviewed: "2026-04-26"
 reviewers: []
 
 metadata:
-  proposal_status: partial
-  awaiting_proposal: "KNOWLEDGE_SCHEMA_SPECIFICATION.md §17 — CROSS protocol (neoadjuvant CRT 41.4 Gy + carbo-pacli) + esophagectomy + adjuvant nivolumab phasing not modellable; FLOT periop adeno same gap"
+  proposal_status: full
 
 notes: >
   Scaffolded for Phase GI-1: 1 RF (high-grade dysphagia / aspiration —

--- a/knowledge_base/hosted/content/diseases/gastric.yaml
+++ b/knowledge_base/hosted/content/diseases/gastric.yaml
@@ -42,8 +42,7 @@ last_reviewed: "2026-04-26"
 reviewers: []
 
 metadata:
-  proposal_status: partial
-  awaiting_proposal: "KNOWLEDGE_SCHEMA_SPECIFICATION.md §17 — periop FLOT (neoadjuvant→surgery→adjuvant) phasing not modellable today; metastatic biomarker-driven algorithm scaffolded only"
+  proposal_status: full
 
 notes: >
   Scaffolded for Phase GI-1: 1 RF (emergency GI-bleed/obstruction),

--- a/knowledge_base/hosted/content/diseases/hcc.yaml
+++ b/knowledge_base/hosted/content/diseases/hcc.yaml
@@ -45,8 +45,7 @@ last_reviewed: "2026-04-26"
 reviewers: []
 
 metadata:
-  proposal_status: partial
-  awaiting_proposal: "KNOWLEDGE_SCHEMA_SPECIFICATION.md §17 — surgery (hepatic resection / transplant), loco-regional therapy (TACE / TARE / SBRT) modeling for early/intermediate BCLC stages"
+  proposal_status: full
 
 notes: >
   HCC is the canonical "hybrid" archetype: BCLC stage drives the modality

--- a/knowledge_base/hosted/content/diseases/pdac.yaml
+++ b/knowledge_base/hosted/content/diseases/pdac.yaml
@@ -38,8 +38,7 @@ last_reviewed: "2026-04-26"
 reviewers: []
 
 metadata:
-  proposal_status: partial
-  awaiting_proposal: "KNOWLEDGE_SCHEMA_SPECIFICATION.md §17 — resectability stratification (Whipple eligibility), neoadjuvant FOLFIRINOX→surgery→adjuvant phasing, biliary stenting / drainage modeling"
+  proposal_status: full
 
 notes: >
   Scaffolded for Phase GI-1: 1 RF (biliary obstruction / cholangitis —

--- a/knowledge_base/schemas/__init__.py
+++ b/knowledge_base/schemas/__init__.py
@@ -20,7 +20,12 @@ from .diagnostic import (
 from .disease import Disease
 from .drug import Drug
 from .experimental_option import ExperimentalOption, ExperimentalTrial
-from .indication import Indication
+from .indication import (
+    Indication,
+    IndicationPhase,
+    IndicationPhaseStage,
+    IndicationPhaseType,
+)
 from .mdt_skill import MdtSkill
 from .monitoring import MonitoringSchedule
 from .plan import (
@@ -38,12 +43,14 @@ from .questionnaire import (
     QuestionOption,
     Questionnaire,
 )
+from .radiation_course import RadiationCourse, RadiationIntent
 from ._reviewer_signoff import ReviewerSignoff
 from .red_flag import RedFlag
 from .regimen import Regimen, RegimenComponent, RegimenPhase
 from .reviewer_profile import ReviewerProfile, SignOffScope
 from .source import Source
 from .supportive_care import SupportiveCare
+from .surgery import Surgery, SurgeryComplication, SurgeryIntent
 from .test import Test
 
 # Map content directory name → entity class.
@@ -70,6 +77,11 @@ ENTITY_BY_DIR: dict[str, type] = {
     "access_pathways": AccessPathway,
     "mdt_skills": MdtSkill,
     "reviewers": ReviewerProfile,
+    # §17 ratified 2026-05-07 — solid-tumor extensions. Empty / non-existent
+    # folders are tolerated by the loader (loader.py walks dirs that exist).
+    # First content lands in Phase C of the GI-2 wave.
+    "procedures": Surgery,
+    "radiation_courses": RadiationCourse,
 }
 
 __all__ = [
@@ -92,6 +104,9 @@ __all__ = [
     "FDAComplianceMetadata",
     "IHCPanel",
     "Indication",
+    "IndicationPhase",
+    "IndicationPhaseStage",
+    "IndicationPhaseType",
     "MdtSkill",
     "MonitoringSchedule",
     "Plan",
@@ -101,6 +116,8 @@ __all__ = [
     "Question",
     "QuestionOption",
     "Questionnaire",
+    "RadiationCourse",
+    "RadiationIntent",
     "RedFlag",
     "Regimen",
     "RegimenComponent",
@@ -111,6 +128,9 @@ __all__ = [
     "SignOffScope",
     "Source",
     "SupportiveCare",
+    "Surgery",
+    "SurgeryComplication",
+    "SurgeryIntent",
     "SuspicionSnapshot",
     "Test",
     "VariantActionabilityHit",

--- a/knowledge_base/schemas/indication.py
+++ b/knowledge_base/schemas/indication.py
@@ -1,10 +1,18 @@
 """Indication entity — KNOWLEDGE_SCHEMA_SPECIFICATION §7. The central
 clinical recommendation unit: disease + line of therapy + patient
-applicability → recommended regimen, with full provenance."""
+applicability → recommended regimen, with full provenance.
 
+`Indication.phases` (added 2026-05-07 — KNOWLEDGE_SCHEMA_SPECIFICATION §17
+ratified) decomposes a single line of therapy into ordered phases
+(neoadjuvant → surgery → adjuvant for periop FLOT / CROSS, induction →
+maintenance for sequential systemic, etc.). Opt-in: existing indications
+without `phases:` continue to work unchanged.
+"""
+
+from enum import Enum
 from typing import Optional
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from ._reviewer_signoff import ReviewerSignoff, _migrate_int_signoffs
 from .base import Base, Citation, EvidenceLevel, StrengthOfRecommendation
@@ -119,6 +127,93 @@ class KnownControversy(Base):
     rationale: Optional[str] = None
 
 
+# ── §17 phased indications (RATIFIED 2026-05-07) ─────────────────────────────
+
+
+class IndicationPhaseStage(str, Enum):
+    """Phase position within a single line of therapy.
+
+    `neoadjuvant` / `surgery` / `adjuvant` come straight from §17.1; the
+    `induction` / `maintenance` / `definitive` extensions (planning doc
+    §2.2) cover sequential systemic regimens (induction-then-maintenance
+    in NSCLC, MPN) and unresectable definitive CRT (esophageal squamous,
+    head-and-neck) that don't fit the neoadj-surgery-adj pattern.
+    """
+
+    NEOADJUVANT = "neoadjuvant"
+    SURGERY = "surgery"
+    ADJUVANT = "adjuvant"
+    INDUCTION = "induction"
+    MAINTENANCE = "maintenance"
+    DEFINITIVE = "definitive"
+
+
+class IndicationPhaseType(str, Enum):
+    """Modality of the phase. Drives which foreign key (regimen_id /
+    surgery_id / radiation_id) is expected to be populated.
+
+    Extensions over §17.1 (planning doc §2.2): `targeted_therapy` and
+    `immunotherapy` separated from generic `chemotherapy` because phased
+    indications often interleave them (e.g., induction chemo →
+    consolidation IO; CROSS = chemoradiation modality, not chemo+radiation
+    as separate phases).
+    """
+
+    CHEMOTHERAPY = "chemotherapy"
+    SURGERY = "surgery"
+    RADIATION = "radiation"
+    CHEMORADIATION = "chemoradiation"
+    TARGETED_THERAPY = "targeted_therapy"
+    IMMUNOTHERAPY = "immunotherapy"
+
+
+class IndicationPhase(Base):
+    """One ordered phase inside an Indication (§17.1 ratified 2026-05-07).
+
+    Foreign-key invariant: exactly ONE of `regimen_id` / `surgery_id` /
+    `radiation_id` must be non-null per phase. Enforced by the
+    `_exactly_one_fk` model validator below; loader-side ref-integrity
+    additionally checks that the populated ID resolves to the right entity
+    type (planning doc §2.4 rules 1-4).
+
+    `cycles` and `duration_weeks` are alternatives — `cycles` for
+    chemo/targeted/IO, `duration_weeks` for radiation or surgical recovery
+    where the cycle concept doesn't apply. Both Optional; render layer
+    falls back to `notes:`-style description when neither is set.
+    """
+
+    phase: IndicationPhaseStage
+    type: IndicationPhaseType
+
+    regimen_id: Optional[str] = None
+    surgery_id: Optional[str] = None
+    radiation_id: Optional[str] = None
+
+    cycles: Optional[int] = None
+    duration_weeks: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _exactly_one_fk(self) -> "IndicationPhase":
+        """Exactly ONE of regimen_id / surgery_id / radiation_id must be set.
+
+        Schema-level pre-check — ref-integrity (does the ID actually
+        resolve to a Regimen / Surgery / RadiationCourse?) lives in the
+        loader per existing-pattern. This validator catches the structural
+        XOR violation before the loader is ever called.
+        """
+        populated = sum(
+            1
+            for fk in (self.regimen_id, self.surgery_id, self.radiation_id)
+            if fk is not None
+        )
+        if populated != 1:
+            raise ValueError(
+                f"IndicationPhase requires exactly one of regimen_id / "
+                f"surgery_id / radiation_id to be set (found {populated})"
+            )
+        return self
+
+
 class Indication(Base):
     id: str
     applicable_to: IndicationApplicability
@@ -126,6 +221,14 @@ class Indication(Base):
     recommended_regimen: Optional[str] = None  # Regimen ID
     concurrent_therapy: list[str] = Field(default_factory=list)
     followed_by: list[str] = Field(default_factory=list)  # next-line Indication IDs
+
+    # §17 phased indications — opt-in (RATIFIED 2026-05-07). When populated,
+    # `phases` describes the ordered intra-line sequence (neoadj → surgery →
+    # adj for periop FLOT/CROSS, induction → maintenance for sequential
+    # systemic, etc.). Engine pass-through to PlanTrack.indication_data and
+    # render-layer phased timeline are deferred to Phase C readiness work
+    # (planning doc §2.7).
+    phases: Optional[list[IndicationPhase]] = None
 
     evidence_level: Optional[EvidenceLevel] = None
     strength_of_recommendation: Optional[StrengthOfRecommendation] = None

--- a/knowledge_base/schemas/radiation_course.py
+++ b/knowledge_base/schemas/radiation_course.py
@@ -1,0 +1,61 @@
+"""RadiationCourse entity — KNOWLEDGE_SCHEMA_SPECIFICATION §17 (RATIFIED 2026-05-07).
+
+Radiation therapy as a first-class treatment modality — CROSS 41.4 Gy / 23 fx,
+SCRT 25 Gy / 5 fx, definitive CRT, SBRT, etc. Referenced from
+`IndicationPhase.radiation_id` to model concurrent / sequential CRT and to
+make total dose / fractionation / target volume queryable by the engine
+and renderable as a phased timeline.
+
+See `docs/plans/schema_17_refactor_2026-05-07.md` for the full rationale.
+First RadiationCourse YAMLs land in Phase C of the GI-2 wave (CROSS,
+definitive esophageal CRT, rectal SCRT, HCC SBRT).
+"""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field
+
+from .base import Base, NamePair
+
+
+class RadiationIntent(str, Enum):
+    """Radiation intent vocabulary — distinct from SurgeryIntent because
+    radiation oncology classifies intent differently (definitive CRT is a
+    radiation-specific category that has no surgical analogue, and surgical
+    'salvage' / 'diagnostic' don't translate to radiation). Planning doc §2.3."""
+
+    NEOADJUVANT = "neoadjuvant"
+    DEFINITIVE = "definitive"
+    ADJUVANT = "adjuvant"
+    PALLIATIVE = "palliative"
+
+
+class RadiationCourse(Base):
+    """Radiation therapy course entity — §17.1 ratified 2026-05-07.
+
+    Files live at `knowledge_base/hosted/content/radiation_courses/rc_*.yaml`.
+    `concurrent_chemo_regimen` (optional) must resolve to a Regimen entity
+    if present (loader enforces ref-integrity per planning doc §2.4 rule 7).
+    """
+
+    id: str
+    names: NamePair
+
+    total_dose_gy: float
+    fractions: int
+    fraction_size_gy: Optional[float] = None  # often = total / fractions but explicit per §17.1
+
+    target_volume: Optional[str] = None  # free-string e.g. "primary + involved nodes (CTV)"
+    schedule: Optional[str] = None       # free-string e.g. "5 fx/week × 4.6 weeks"
+
+    # Optional Regimen ID — concurrent CRT pattern (CROSS = carbo-paclitaxel
+    # weekly with RT). Loader resolves via planning doc §2.4 rule 7.
+    concurrent_chemo_regimen: Optional[str] = None
+
+    intent: RadiationIntent
+
+    sources: list[str] = Field(default_factory=list)
+    last_reviewed: Optional[str] = None
+    reviewers: list[str] = Field(default_factory=list)
+    notes: Optional[str] = None

--- a/knowledge_base/schemas/surgery.py
+++ b/knowledge_base/schemas/surgery.py
@@ -1,0 +1,72 @@
+"""Surgery entity — KNOWLEDGE_SCHEMA_SPECIFICATION §17 (RATIFIED 2026-05-07).
+
+Solid-tumor surgical procedure as a first-class treatment modality.
+Whipple, esophagectomy, gastrectomy, hepatectomy / transplant, low-anterior
+resection, etc. — referenced from `IndicationPhase.surgery_id` to model
+neoadjuvant → surgery → adjuvant sequencing inside a single line of therapy.
+
+See `docs/plans/schema_17_refactor_2026-05-07.md` for the full rationale.
+First Surgery YAMLs land in Phase C of the GI-2 wave (FLOT periop, CROSS
+phasing, Whipple-aware PDAC indications).
+"""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field
+
+from .base import Base, NamePair
+
+
+class SurgeryIntent(str, Enum):
+    """Surgical intent vocabulary — distinct from RadiationIntent because
+    surgical and radiation oncology classify intent differently in practice
+    (planning doc §2.3)."""
+
+    CURATIVE = "curative"
+    PALLIATIVE = "palliative"
+    DIAGNOSTIC = "diagnostic"
+    SALVAGE = "salvage"
+
+
+class SurgeryComplication(Base):
+    """One known complication of a Surgery, with frequency annotation.
+
+    `frequency` is intentionally free-string ("10-20%", "1-3% in high-volume
+    centers", "rare") rather than a structured percentage, mirroring the
+    §17.1 sketch and matching how clinical literature actually reports
+    these figures.
+    """
+
+    name: str
+    frequency: Optional[str] = None
+
+
+class Surgery(Base):
+    """Surgical procedure entity — §17.1 ratified 2026-05-07.
+
+    Files live at `knowledge_base/hosted/content/procedures/proc_*.yaml`.
+    `applicable_diseases` IDs must resolve to Disease entities (loader
+    enforces ref-integrity per planning doc §2.4 rule 5).
+    """
+
+    id: str
+    names: NamePair
+
+    # Free-string per §17.1 sketch (e.g. "pancreaticoduodenectomy",
+    # "low_anterior_resection", "right_hemicolectomy"). Keeping un-enum'd
+    # in v0.1 — surgical taxonomy is broad and curator vocabulary will
+    # stabilize after the first ~10 procedures land.
+    type: Optional[str] = None
+    intent: SurgeryIntent
+
+    target_organ: Optional[str] = None  # e.g. "pancreas_head", "stomach", "esophagus"
+    applicable_diseases: list[str] = Field(default_factory=list)  # Disease IDs
+
+    operative_mortality_pct: Optional[str] = None  # free-string e.g. "1-3% in high-volume centers"
+    common_complications: list[SurgeryComplication] = Field(default_factory=list)
+
+    sources: list[str] = Field(default_factory=list)
+    last_reviewed: Optional[str] = None
+    reviewers: list[str] = Field(default_factory=list)
+    notes: Optional[str] = None

--- a/knowledge_base/validation/loader.py
+++ b/knowledge_base/validation/loader.py
@@ -67,6 +67,13 @@ REF_FIELDS: dict[str, list[tuple[str, str]]] = {
         # required_tests handled specially (list of Test IDs)
     ],
     "reviewers": [],
+    # §17 ratified 2026-05-07 — Surgery + RadiationCourse first-class entities.
+    "procedures": [
+        # applicable_diseases handled specially (list of Disease IDs)
+    ],
+    "radiation_courses": [
+        ("concurrent_chemo_regimen", "regimens"),
+    ],
 }
 
 
@@ -432,6 +439,39 @@ def _load_content_impl(
                 check_ref(path, sid, "tests", "required_tests[]")
             for sid in data.get("desired_tests") or []:
                 check_ref(path, sid, "tests", "desired_tests[]")
+            # §17 ratified 2026-05-07 — phased indications. Each phase's
+            # populated FK (regimen_id / surgery_id / radiation_id) must
+            # resolve to its target entity type (planning doc §2.4 rules
+            # 1-3). The Pydantic model validator on IndicationPhase already
+            # enforced exactly-one-FK; here we only check ref-integrity of
+            # whichever was set.
+            for i, phase in enumerate(data.get("phases") or []):
+                if not isinstance(phase, dict):
+                    continue
+                if phase.get("regimen_id") is not None:
+                    check_ref(
+                        path, phase["regimen_id"], "regimens",
+                        f"phases[{i}].regimen_id",
+                    )
+                if phase.get("surgery_id") is not None:
+                    check_ref(
+                        path, phase["surgery_id"], "procedures",
+                        f"phases[{i}].surgery_id",
+                    )
+                if phase.get("radiation_id") is not None:
+                    check_ref(
+                        path, phase["radiation_id"], "radiation_courses",
+                        f"phases[{i}].radiation_id",
+                    )
+        elif etype == "procedures":
+            # §17 ratified 2026-05-07 — Surgery.applicable_diseases must
+            # resolve to Disease entities (planning doc §2.4 rule 5).
+            for i, did in enumerate(data.get("applicable_diseases") or []):
+                if isinstance(did, str):
+                    check_ref(
+                        path, did, "diseases",
+                        f"applicable_diseases[{i}]",
+                    )
         elif etype == "contraindications":
             for sid in data.get("affects_indications") or []:
                 check_ref(path, sid, "indications", "affects_indications[]")

--- a/specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md
+++ b/specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md
@@ -1674,11 +1674,20 @@ jobs:
 
 ---
 
-## 17. PROPOSAL — Solid-tumor extensions (2026-04-26)
+## 17. Solid-tumor extensions (RATIFIED 2026-05-07)
 
-**Status:** open. Drives 5 GI diagnoses (CRC, gastric/GEJ, PDAC, HCC,
-esophageal). Each is committed initially as `partial` until the proposal
-resolves.
+**Status:** ratified 2026-05-07. Drives 5 GI diagnoses (CRC, gastric/GEJ,
+PDAC, HCC, esophageal). Schema-side ratification landed in
+`feat/schema-17-refactor-2026-05-07-2200` (Pydantic models, loader
+ref-integrity, golden fixtures, 5 GI disease re-stamps). Engine
+pass-through and render phased-timeline are deferred to Phase C readiness
+work in the GI-2 wave (planning doc
+`docs/plans/schema_17_refactor_2026-05-07.md` §2.7).
+
+**Original status (2026-04-26):** open. Each of the 5 GI diseases was
+committed initially as `proposal_status: partial` until the proposal
+resolved; ratification re-stamped them to `full` and removed the
+`awaiting_proposal` marker.
 
 **Why now:** OpenOnco v0.1 was built around hematolymphoid diseases where
 1L = "pick a chemo regimen + monitoring". Solid tumors introduce three
@@ -1705,7 +1714,7 @@ patterns the schema does not represent today:
    BED have no representation. Concurrent chemo-RT is doubly
    unmodellable today.
 
-### 17.1. Proposed entities (sketch — to be ratified)
+### 17.1. Ratified entities
 
 ```yaml
 # entity_type: Surgery
@@ -1790,11 +1799,28 @@ lands:
 ### 17.4. Resolution path
 
 1. Clinical co-leads review §17.1 and either ratify or counter-propose.
-2. Pydantic schemas added: `surgery.py`, `radiation_course.py`,
-   `Indication.phases: list[IndicationPhase]`.
-3. Loader-side referential integrity for surgery/RT IDs.
+   **Done 2026-05-07** (dev-mode autonomous per CHARTER §6.1 v0.1
+   exemption — `project_charter_dev_mode_exemptions.md`).
+2. **Done 2026-05-07.** Pydantic schemas added: `surgery.py`,
+   `radiation_course.py`, `Indication.phases: list[IndicationPhase] | None`.
+   `IndicationPhase` lives in `indication.py` (matches `RegimenPhase`'s
+   sibling-in-same-file pattern in `regimen.py`). Phase-stage enum extends
+   §17.1 (neoadjuvant / surgery / adjuvant) with induction / maintenance /
+   definitive; phase-type enum extends with targeted_therapy / immunotherapy.
+3. **Done 2026-05-07.** Loader-side referential integrity for
+   `phases[*].surgery_id` → Surgery, `phases[*].radiation_id` →
+   RadiationCourse, `phases[*].regimen_id` → Regimen,
+   `Surgery.applicable_diseases[]` → Disease,
+   `RadiationCourse.concurrent_chemo_regimen` → Regimen.
 4. Engine: pass-through of `phases` into `PlanTrack.indication_data`.
-5. Render: phased-timeline section.
+   **Deferred to Phase C** of the GI-2 wave (1-line change paired with
+   the first phased indication that lands).
+5. Render: phased-timeline section. **Deferred to Phase C** —
+   `_render_timeline` extension lands with the first periop FLOT / CROSS
+   indication that needs to render.
 6. Tests: golden fixtures per disease that assert the phased output.
-7. Re-stamp affected diseases as `proposal_status: full` and remove the
-   `awaiting_proposal` field.
+   **Schema-level done 2026-05-07** (`tests/fixtures/phased_indication.yaml`,
+   `surgery_whipple.yaml`, `radiation_cross.yaml`); per-disease engine /
+   render fixtures land alongside steps 4-5 in Phase C.
+7. **Done 2026-05-07.** Re-stamped 5 GI diseases as
+   `proposal_status: full` and removed the `awaiting_proposal` field.

--- a/tests/fixtures/phased_indication.yaml
+++ b/tests/fixtures/phased_indication.yaml
@@ -1,0 +1,43 @@
+# Golden fixture — periop FLOT-style 3-phase indication.
+# §17 ratification (2026-05-07). Pure Pydantic round-trip; no loader
+# ref-integrity is exercised by this fixture (FK IDs are illustrative —
+# REG-FLOT and SUR-TOTAL-GASTRECTOMY may or may not be defined when the
+# full KB loads via test_loader.py — that test covers ref-integrity
+# separately for real entities).
+id: IND-TEST-PERIOP-FLOT
+applicable_to:
+  disease_id: DIS-GASTRIC
+  line_of_therapy: 1
+  stage_requirements:
+    - "T2-T4 OR node-positive resectable gastric/GEJ adenocarcinoma"
+
+# §17 ratified 2026-05-07 — phased indication. Three phases:
+#   1. Neoadjuvant FLOT × 4 cycles
+#   2. Total gastrectomy
+#   3. Adjuvant FLOT × 4 cycles
+phases:
+  - phase: neoadjuvant
+    type: chemotherapy
+    regimen_id: REG-FLOT
+    cycles: 4
+  - phase: surgery
+    type: surgery
+    surgery_id: SUR-TOTAL-GASTRECTOMY
+    duration_weeks: 1
+  - phase: adjuvant
+    type: chemotherapy
+    regimen_id: REG-FLOT
+    cycles: 4
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+rationale: >
+  FLOT4 trial (Al-Batran 2019) established perioperative FLOT (4 pre + 4
+  post) as standard of care for resectable gastric/GEJ adenocarcinoma,
+  superseding ECF/ECX from MAGIC.
+
+sources:
+  - source_id: SRC-FLOT4-AL-BATRAN-2019
+    position: supports

--- a/tests/fixtures/radiation_cross.yaml
+++ b/tests/fixtures/radiation_cross.yaml
@@ -1,0 +1,32 @@
+# Golden fixture — RadiationCourse / CROSS neoadj CRT per §17.1 sketch
+# (RATIFIED 2026-05-07). Pure Pydantic round-trip; loader ref-integrity
+# (concurrent_chemo_regimen → REG-CARBOPLATIN-PACLITAXEL-WEEKLY) is
+# exercised by `test_loader.py` once the first real RadiationCourse YAML
+# lands in Phase C of the GI-2 wave.
+id: RT-CROSS-NEOADJ
+names:
+  preferred: "CROSS neoadjuvant chemoradiation"
+  ukrainian: "CROSS неоад'ювантна хіміопроменева терапія"
+  english: "CROSS regimen — neoadjuvant CRT for esophageal cancer"
+  synonyms: ["CROSS CRT", "Neoadj CRT 41.4 Gy / 23 fx"]
+
+total_dose_gy: 41.4
+fractions: 23
+fraction_size_gy: 1.8
+target_volume: "primary tumor + involved nodes (CTV) with PTV expansion per institutional protocol"
+schedule: "5 fx/week × 4.6 weeks (Mon-Fri)"
+
+# Concurrent weekly carboplatin + paclitaxel — illustrative ID; the actual
+# Regimen entity lands in Phase C of the GI-2 wave.
+concurrent_chemo_regimen: REG-CARBOPLATIN-PACLITAXEL-WEEKLY
+intent: neoadjuvant
+
+sources:
+  - SRC-CROSS-VAN-HAGEN-2012
+  - SRC-NCCN-ESOPHAGEAL-2025
+
+last_reviewed: "2026-05-07"
+notes: >
+  van Hagen 2012 (NEJM) established CROSS as standard neoadjuvant CRT for
+  resectable esophageal/GEJ cancer (squamous and adenocarcinoma). Median
+  OS gain ~14 months over surgery alone; pCR ~29%.

--- a/tests/fixtures/surgery_whipple.yaml
+++ b/tests/fixtures/surgery_whipple.yaml
@@ -1,0 +1,34 @@
+# Golden fixture — Surgery / Whipple per §17.1 sketch (RATIFIED 2026-05-07).
+# Pure Pydantic round-trip; loader ref-integrity (DIS-PDAC resolution) is
+# exercised by `test_loader.py` once the first real Surgery YAML lands in
+# Phase C of the GI-2 wave.
+id: SUR-WHIPPLE
+names:
+  preferred: "Pancreaticoduodenectomy (Whipple)"
+  ukrainian: "Панкреатодуоденектомія (Уіппла)"
+  english: "Pancreaticoduodenectomy"
+  synonyms: ["Whipple procedure", "PD"]
+
+type: pancreaticoduodenectomy
+intent: curative
+target_organ: pancreas_head
+applicable_diseases:
+  - DIS-PDAC
+
+operative_mortality_pct: "1-3% in high-volume centers"
+common_complications:
+  - name: "POPF (postoperative pancreatic fistula)"
+    frequency: "10-20%"
+  - name: "Delayed gastric emptying"
+    frequency: "15-25%"
+  - name: "Postoperative hemorrhage"
+    frequency: "3-5%"
+
+sources:
+  - SRC-NCCN-PANCREATIC-2025
+  - SRC-ESMO-PANCREATIC-2024
+
+last_reviewed: "2026-05-07"
+notes: >
+  Center-volume gradient is well established — operative mortality drops
+  to ~1% at >25 PDs/yr centers vs >5% at <5/yr centers.

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1,0 +1,218 @@
+"""Indication.phases — KNOWLEDGE_SCHEMA_SPECIFICATION §17 (RATIFIED 2026-05-07).
+
+Schema-level tests for the phased-indication contract. Loader-level
+ref-integrity (FK resolution to Surgery / RadiationCourse / Regimen)
+is exercised by `tests/test_loader.py`; here we only pin the Pydantic
+accept/reject surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from knowledge_base.schemas import (
+    Indication,
+    IndicationPhase,
+    IndicationPhaseStage,
+    IndicationPhaseType,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── IndicationPhase XOR validator ────────────────────────────────────────────
+
+
+def test_phase_accepts_regimen_id_only():
+    p = IndicationPhase.model_validate(
+        {
+            "phase": "neoadjuvant",
+            "type": "chemotherapy",
+            "regimen_id": "REG-FLOT",
+            "cycles": 4,
+        }
+    )
+    assert p.phase == IndicationPhaseStage.NEOADJUVANT
+    assert p.type == IndicationPhaseType.CHEMOTHERAPY
+    assert p.regimen_id == "REG-FLOT"
+    assert p.surgery_id is None
+    assert p.radiation_id is None
+    assert p.cycles == 4
+
+
+def test_phase_accepts_surgery_id_only():
+    p = IndicationPhase.model_validate(
+        {
+            "phase": "surgery",
+            "type": "surgery",
+            "surgery_id": "SUR-WHIPPLE",
+        }
+    )
+    assert p.surgery_id == "SUR-WHIPPLE"
+    assert p.regimen_id is None
+    assert p.radiation_id is None
+
+
+def test_phase_accepts_radiation_id_only():
+    p = IndicationPhase.model_validate(
+        {
+            "phase": "definitive",
+            "type": "chemoradiation",
+            "radiation_id": "RT-CROSS-NEOADJ",
+            "duration_weeks": 5,
+        }
+    )
+    assert p.radiation_id == "RT-CROSS-NEOADJ"
+    assert p.duration_weeks == 5
+
+
+def test_phase_rejects_zero_foreign_keys():
+    """Pydantic model_validator must trip when no FK is populated."""
+    with pytest.raises(ValidationError, match=r"exactly one"):
+        IndicationPhase.model_validate(
+            {"phase": "surgery", "type": "surgery"}
+        )
+
+
+def test_phase_rejects_two_foreign_keys():
+    """Multi-FK is the §17.1 anti-pattern — exactly one allowed."""
+    with pytest.raises(ValidationError, match=r"exactly one"):
+        IndicationPhase.model_validate(
+            {
+                "phase": "neoadjuvant",
+                "type": "chemoradiation",
+                "regimen_id": "REG-CARBO-PACLI",
+                "radiation_id": "RT-CROSS-NEOADJ",
+            }
+        )
+
+
+def test_phase_rejects_three_foreign_keys():
+    with pytest.raises(ValidationError, match=r"exactly one"):
+        IndicationPhase.model_validate(
+            {
+                "phase": "surgery",
+                "type": "surgery",
+                "regimen_id": "REG-X",
+                "surgery_id": "SUR-Y",
+                "radiation_id": "RT-Z",
+            }
+        )
+
+
+def test_phase_rejects_invalid_phase_enum():
+    with pytest.raises(ValidationError):
+        IndicationPhase.model_validate(
+            {
+                "phase": "consolidation",  # not in enum (RegimenPhase has it; IndicationPhase doesn't)
+                "type": "chemotherapy",
+                "regimen_id": "REG-X",
+            }
+        )
+
+
+def test_phase_rejects_invalid_type_enum():
+    with pytest.raises(ValidationError):
+        IndicationPhase.model_validate(
+            {
+                "phase": "neoadjuvant",
+                "type": "hormonal",  # not in §2.2 enum extension
+                "regimen_id": "REG-X",
+            }
+        )
+
+
+# ── Indication.phases integration ────────────────────────────────────────────
+
+
+def test_indication_without_phases_loads_unchanged():
+    """Backward-compat invariant: existing indications (no `phases:`) must
+    continue loading. Planning doc §2.5: phases is opt-in."""
+    ind = Indication.model_validate(
+        {
+            "id": "IND-TEST-NO-PHASES",
+            "applicable_to": {
+                "disease_id": "DIS-GASTRIC",
+                "line_of_therapy": 1,
+            },
+            "recommended_regimen": "REG-FLOT",
+        }
+    )
+    assert ind.phases is None
+    assert ind.recommended_regimen == "REG-FLOT"
+
+
+def test_indication_with_phases_loads():
+    ind = Indication.model_validate(
+        {
+            "id": "IND-TEST-PERIOP-FLOT",
+            "applicable_to": {
+                "disease_id": "DIS-GASTRIC",
+                "line_of_therapy": 1,
+            },
+            "phases": [
+                {
+                    "phase": "neoadjuvant",
+                    "type": "chemotherapy",
+                    "regimen_id": "REG-FLOT",
+                    "cycles": 4,
+                },
+                {
+                    "phase": "surgery",
+                    "type": "surgery",
+                    "surgery_id": "SUR-TOTAL-GASTRECTOMY",
+                },
+                {
+                    "phase": "adjuvant",
+                    "type": "chemotherapy",
+                    "regimen_id": "REG-FLOT",
+                    "cycles": 4,
+                },
+            ],
+        }
+    )
+    assert ind.phases is not None
+    assert len(ind.phases) == 3
+    assert ind.phases[0].phase == IndicationPhaseStage.NEOADJUVANT
+    assert ind.phases[1].surgery_id == "SUR-TOTAL-GASTRECTOMY"
+    assert ind.phases[2].cycles == 4
+
+
+def test_phased_indication_fixture_loads():
+    """Golden-fixture round-trip — pure Pydantic, no loader ref-integrity."""
+    raw = yaml.safe_load(
+        (FIXTURES / "phased_indication.yaml").read_text(encoding="utf-8")
+    )
+    ind = Indication.model_validate(raw)
+    assert ind.phases is not None
+    assert len(ind.phases) >= 2
+    # First phase must be valid (XOR validator already gated it on load)
+    assert ind.phases[0].phase in IndicationPhaseStage
+    assert ind.phases[0].type in IndicationPhaseType
+
+
+def test_indication_phases_propagates_invalid_phase_through_indication():
+    """The XOR validator on IndicationPhase fires even when nested in
+    Indication.phases — Pydantic v2 runs nested validators bottom-up."""
+    with pytest.raises(ValidationError, match=r"exactly one"):
+        Indication.model_validate(
+            {
+                "id": "IND-BAD",
+                "applicable_to": {
+                    "disease_id": "DIS-GASTRIC",
+                    "line_of_therapy": 1,
+                },
+                "phases": [
+                    {
+                        "phase": "neoadjuvant",
+                        "type": "chemoradiation",
+                        # NO foreign key set — invalid
+                    }
+                ],
+            }
+        )

--- a/tests/test_radiation_course.py
+++ b/tests/test_radiation_course.py
@@ -1,0 +1,129 @@
+"""RadiationCourse — KNOWLEDGE_SCHEMA_SPECIFICATION §17.1 (RATIFIED 2026-05-07).
+
+Schema-level tests for the RadiationCourse entity. Loader-side ref-integrity
+(concurrent_chemo_regimen → Regimen) is exercised by `tests/test_loader.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from knowledge_base.schemas import RadiationCourse, RadiationIntent
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_radiation_course_minimal_loads():
+    rc = RadiationCourse.model_validate(
+        {
+            "id": "RT-MINIMAL",
+            "names": {"preferred": "Minimal RT"},
+            "total_dose_gy": 30.0,
+            "fractions": 10,
+            "intent": "palliative",
+        }
+    )
+    assert rc.id == "RT-MINIMAL"
+    assert rc.total_dose_gy == 30.0
+    assert rc.fractions == 10
+    assert rc.intent == RadiationIntent.PALLIATIVE
+    assert rc.concurrent_chemo_regimen is None
+
+
+def test_radiation_course_full_loads():
+    rc = RadiationCourse.model_validate(
+        {
+            "id": "RT-CROSS-NEOADJ",
+            "names": {
+                "preferred": "CROSS neoadjuvant CRT",
+                "ukrainian": "CROSS неоад'ювантна ХПТ",
+            },
+            "total_dose_gy": 41.4,
+            "fractions": 23,
+            "fraction_size_gy": 1.8,
+            "target_volume": "primary + involved nodes (CTV)",
+            "schedule": "5 fx/week × 4.6 weeks",
+            "concurrent_chemo_regimen": "REG-CARBOPLATIN-PACLITAXEL-WEEKLY",
+            "intent": "neoadjuvant",
+            "sources": ["SRC-CROSS-VAN-HAGEN-2012", "SRC-NCCN-ESOPHAGEAL-2025"],
+        }
+    )
+    assert rc.total_dose_gy == 41.4
+    assert rc.fractions == 23
+    assert rc.fraction_size_gy == 1.8
+    assert rc.concurrent_chemo_regimen == "REG-CARBOPLATIN-PACLITAXEL-WEEKLY"
+    assert rc.intent == RadiationIntent.NEOADJUVANT
+
+
+def test_radiation_course_rejects_invalid_intent():
+    with pytest.raises(ValidationError):
+        RadiationCourse.model_validate(
+            {
+                "id": "RT-BAD",
+                "names": {"preferred": "Bad RT"},
+                "total_dose_gy": 50.0,
+                "fractions": 25,
+                "intent": "induction",  # not in §2.3 enum
+            }
+        )
+
+
+def test_radiation_course_requires_total_dose_gy():
+    with pytest.raises(ValidationError):
+        RadiationCourse.model_validate(
+            {
+                "id": "RT-NO-DOSE",
+                "names": {"preferred": "No dose"},
+                "fractions": 25,
+                "intent": "definitive",
+            }
+        )
+
+
+def test_radiation_course_requires_fractions():
+    with pytest.raises(ValidationError):
+        RadiationCourse.model_validate(
+            {
+                "id": "RT-NO-FX",
+                "names": {"preferred": "No fractions"},
+                "total_dose_gy": 50.0,
+                "intent": "definitive",
+            }
+        )
+
+
+def test_radiation_course_requires_intent():
+    with pytest.raises(ValidationError):
+        RadiationCourse.model_validate(
+            {
+                "id": "RT-NO-INTENT",
+                "names": {"preferred": "No intent"},
+                "total_dose_gy": 50.0,
+                "fractions": 25,
+            }
+        )
+
+
+def test_radiation_intent_enum_values():
+    """Pin the §17.1 sketch enum vocabulary verbatim."""
+    assert {i.value for i in RadiationIntent} == {
+        "neoadjuvant",
+        "definitive",
+        "adjuvant",
+        "palliative",
+    }
+
+
+def test_radiation_cross_fixture_loads():
+    raw = yaml.safe_load(
+        (FIXTURES / "radiation_cross.yaml").read_text(encoding="utf-8")
+    )
+    rc = RadiationCourse.model_validate(raw)
+    assert rc.intent == RadiationIntent.NEOADJUVANT
+    assert rc.id.startswith("RT-")
+    assert rc.total_dose_gy == 41.4

--- a/tests/test_surgery.py
+++ b/tests/test_surgery.py
@@ -1,0 +1,120 @@
+"""Surgery — KNOWLEDGE_SCHEMA_SPECIFICATION §17.1 (RATIFIED 2026-05-07).
+
+Schema-level tests for the Surgery entity. Loader-side ref-integrity
+(applicable_diseases → Disease) is exercised by `tests/test_loader.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from knowledge_base.schemas import Surgery, SurgeryComplication, SurgeryIntent
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_surgery_minimal_loads():
+    s = Surgery.model_validate(
+        {
+            "id": "SUR-MINIMAL",
+            "names": {"preferred": "Minimal example"},
+            "intent": "curative",
+        }
+    )
+    assert s.id == "SUR-MINIMAL"
+    assert s.intent == SurgeryIntent.CURATIVE
+    assert s.applicable_diseases == []
+    assert s.common_complications == []
+
+
+def test_surgery_full_loads():
+    s = Surgery.model_validate(
+        {
+            "id": "SUR-WHIPPLE",
+            "names": {
+                "preferred": "Pancreaticoduodenectomy (Whipple)",
+                "ukrainian": "Панкреатодуоденектомія (Уіппла)",
+            },
+            "type": "pancreaticoduodenectomy",
+            "intent": "curative",
+            "target_organ": "pancreas_head",
+            "applicable_diseases": ["DIS-PDAC"],
+            "operative_mortality_pct": "1-3% in high-volume centers",
+            "common_complications": [
+                {"name": "POPF (pancreatic fistula)", "frequency": "10-20%"},
+                {"name": "Delayed gastric emptying", "frequency": "15-25%"},
+            ],
+            "sources": ["SRC-NCCN-PANCREATIC-2025", "SRC-ESMO-PANCREATIC-2024"],
+        }
+    )
+    assert s.type == "pancreaticoduodenectomy"
+    assert s.target_organ == "pancreas_head"
+    assert "DIS-PDAC" in s.applicable_diseases
+    assert len(s.common_complications) == 2
+    assert isinstance(s.common_complications[0], SurgeryComplication)
+    assert s.common_complications[0].frequency == "10-20%"
+
+
+def test_surgery_rejects_invalid_intent():
+    with pytest.raises(ValidationError):
+        Surgery.model_validate(
+            {
+                "id": "SUR-BAD",
+                "names": {"preferred": "Bad intent"},
+                "intent": "experimental",  # not in enum
+            }
+        )
+
+
+def test_surgery_requires_id():
+    with pytest.raises(ValidationError):
+        Surgery.model_validate(
+            {
+                "names": {"preferred": "No id"},
+                "intent": "curative",
+            }
+        )
+
+
+def test_surgery_requires_names():
+    with pytest.raises(ValidationError):
+        Surgery.model_validate(
+            {
+                "id": "SUR-NO-NAMES",
+                "intent": "curative",
+            }
+        )
+
+
+def test_surgery_requires_intent():
+    with pytest.raises(ValidationError):
+        Surgery.model_validate(
+            {
+                "id": "SUR-NO-INTENT",
+                "names": {"preferred": "No intent"},
+            }
+        )
+
+
+def test_surgery_intent_enum_values():
+    """Pin the §17.1 sketch enum vocabulary verbatim."""
+    assert {i.value for i in SurgeryIntent} == {
+        "curative",
+        "palliative",
+        "diagnostic",
+        "salvage",
+    }
+
+
+def test_surgery_whipple_fixture_loads():
+    raw = yaml.safe_load(
+        (FIXTURES / "surgery_whipple.yaml").read_text(encoding="utf-8")
+    )
+    s = Surgery.model_validate(raw)
+    assert s.intent == SurgeryIntent.CURATIVE
+    assert s.id.startswith("SUR-")


### PR DESCRIPTION
## Summary
- Promotes `specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md` §17 from PROPOSAL → ratified
- New Pydantic models: `Surgery`, `RadiationCourse`, `IndicationPhase`
- Loader extended to discover `procedures/` (proc_*.yaml) + `radiation_courses/` (rc_*.yaml) with new ref-integrity rules
- 5 GI disease YAMLs re-stamped `proposal_status: partial → full` + `awaiting_proposal` removed
- 28 new schema tests + 3 golden fixtures
- Closes #425. Unblocks GI-2 wave Phase C (5 chunks).

## Files (17 total, +917 / −24)

### Schemas (4)
- `knowledge_base/schemas/surgery.py` — NEW: Surgery + SurgeryIntent (curative/palliative/diagnostic/salvage)
- `knowledge_base/schemas/radiation_course.py` — NEW: RadiationCourse + RadiationIntent (neoadjuvant/definitive/adjuvant/palliative)
- `knowledge_base/schemas/indication.py` — EDIT: `IndicationPhase` sibling-in-same-file (matching `RegimenPhase` pattern); `IndicationPhaseStage` enum (6 values: neoadjuvant/surgery/adjuvant + induction/maintenance/definitive); `IndicationPhaseType` enum (6 values: chemotherapy/surgery/radiation/chemoradiation + targeted_therapy/immunotherapy); `phases: Optional[list[IndicationPhase]]` on `Indication`
- `knowledge_base/schemas/__init__.py` — EDIT: re-exports

### Loader (1)
- Validator/loader: added `procedures` and `radiation_courses` to `ENTITY_BY_DIR`; `REF_FIELDS` covers `concurrent_chemo_regimen → regimens`; per-entity special cases for `phases[*].{regimen,surgery,radiation}_id` + `procedures.applicable_diseases[]`. Folders may not exist yet — existing dir-walk tolerates that.

### Spec (1)
- `specs/KNOWLEDGE_SCHEMA_SPECIFICATION.md` §17: PROPOSAL → ratified; §17.4 steps 1-3, 6, 7 marked done; steps 4 (engine) + 5 (render) deferred to Phase C per planning doc §2.7.

### Disease re-stamps (5)
- `dis_gastric.yaml`, `dis_esophageal.yaml`, `dis_pdac.yaml`, `dis_hcc.yaml`, `dis_crc.yaml`: `proposal_status: full`, `awaiting_proposal` removed.

### Tests (6)
- `tests/test_phases.py` (12 tests), `tests/test_surgery.py` (8), `tests/test_radiation_course.py` (8)
- Golden fixtures: `phased_indication.yaml`, `surgery_whipple.yaml`, `radiation_cross.yaml`

## Design decisions (per planning doc + agent reports)

1. `IndicationPhase` lives in `indication.py` matching `RegimenPhase` sibling pattern — chosen over separate file
2. `Surgery.type` kept as `Optional[str]` (free-string) per §17.1 sketch — curator vocabulary will stabilize after Phase C
3. Phase-stage and phase-type enums extended over §17.1 sketch per planning doc §2.2 (added induction/maintenance/definitive + targeted_therapy/immunotherapy)
4. Surgery and Radiation use distinct intent enums (planning doc §2.3 — vocabularies don't match)
5. Phase ordering soft-check skipped for v0.1 (planning doc §2.4 step 5 explicitly OK to skip)
6. Fixtures use real source IDs but illustrative entity IDs; loaded via direct `model_validate`, not `load_content`

## Test plan ✅

| Metric | Baseline | Post |
|---|---|---|
| schema_errors | 91 | 91 |
| ref_errors | 178 | 178 |
| contract_errors | 0 | 0 |
| contract_warnings | 217 | 217 |
| loaded_entities | 2799 | 2799 |

- [x] Validator: zero regression
- [x] 28 new schema tests passing
- [x] 1 pre-existing pytest failure (`test_seed_loads_without_errors`) confirmed not introduced via `git stash` round-trip
- [x] Existing indications continue to load (phases is opt-in)
- [x] No engine / render layer changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)