### PR TITLE
feat(kb): GI-2 C3 definitive CRT esoph SCC — first RadiationCourse §17 consumer

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_esoph_definitive_crt_scc.yaml
+++ b/knowledge_base/hosted/content/indications/ind_esoph_definitive_crt_scc.yaml
@@ -1,0 +1,102 @@
+id: IND-ESOPH-DEFINITIVE-CRT-SCC
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-ESOPHAGEAL
+  line_of_therapy: 1
+  stage_requirements:
+    - "cT4b any N M0 (unresectable due to invasion of adjacent structures)"
+    - "Medically inoperable (cardiopulmonary or comorbidity contraindications)"
+    - "Patient declines surgery"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+    histology: squamous_cell_carcinoma
+
+# §17 phased indication. Single-phase chemoradiation: the RadiationCourse
+# RC-DEFINITIVE-ESOPH-SCC owns the concurrent chemo regimen reference
+# (REG-CARBO-PACLI-CONCURRENT-RT-ESOPH) per planning doc §2.3 — XOR rule
+# permits exactly ONE of regimen_id / surgery_id / radiation_id per phase.
+phases:
+  - phase: definitive
+    type: chemoradiation
+    radiation_id: RC-DEFINITIVE-ESOPH-SCC
+    duration_weeks: 6
+
+# `recommended_regimen` left null — the concurrent chemo regimen is
+# discoverable via RadiationCourse.concurrent_chemo_regimen on
+# RC-DEFINITIVE-ESOPH-SCC (planning doc §2.3 design choice).
+recommended_regimen:
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_survival_median: "median OS ~14-21 mo (modern weekly carbo+pacli + 50.4 Gy series); RTOG 85-01 historical 12.5 mo"
+  overall_survival_5y: "5-yr OS ~20-25% squamous (modern definitive CRT cohorts)"
+  complete_response: "clinical CR ~60-70% post-CRT (squamous more responsive than adeno)"
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-ESOPH-SEVERE-DYSPHAGIA-ASPIRATION
+
+required_tests:
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+  - TEST-CT-PET
+
+desired_tests: []
+
+rationale: >
+  Definitive concurrent chemoradiation per RTOG 85-01 (Herskovic NEJM
+  1992) is standard of care for unresectable (T4b), M0, medically
+  inoperable, or surgery-declining esophageal squamous-cell carcinoma.
+  RTOG 85-01 established concurrent cisplatin + 5-FU + 50 Gy superior
+  to RT alone (2-yr OS 38% vs 10%). Modern NCCN/ESMO preferred regimen
+  is weekly carboplatin AUC 2 + paclitaxel 50 mg/m^2 with 50.4 Gy / 28
+  fx (1.8 Gy/fx) — same chemo backbone as CROSS neoadjuvant but extended
+  to 5-6 cycles paired with full-dose RT. NCCN category 1.
+
+rationale_ua: >
+  Радикальна одночасна хіміопроменева терапія за RTOG 85-01 (Herskovic
+  NEJM 1992) — стандарт лікування при нерезектабельному (T4b), M0,
+  медично неоперабельному або при відмові від хірургії плоскоклітинному
+  раку стравоходу. RTOG 85-01 показав перевагу одночасної ХПТ
+  (цисплатин + 5-ФУ + 50 Гр) над лише ПТ (2-річна ЗВ 38% vs 10%).
+  Сучасний NCCN/ESMO режим — щотижневий карбоплатин AUC 2 + паклітаксел
+  50 мг/м^2 разом із 50.4 Гр / 28 фракцій (1.8 Гр/фр). NCCN категорія 1.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-RTOG-8501-HERSKOVIC-1992
+    position: supports
+  - source_id: SRC-NCCN-ESOPHAGEAL-2025
+    position: supports
+  - source_id: SRC-ESMO-ESOPHAGEAL-2024
+    position: supports
+
+do_not_do:
+  - "Do NOT escalate RT dose beyond 50.4 Gy — INT-0123 / RTOG 94-05 showed no OS benefit and increased toxicity at 64.8 Gy"
+  - "Do NOT proceed with definitive CRT without addressing severe dysphagia / aspiration risk first (NG/PEG planning if needed)"
+  - "Do NOT omit nutritional + esophagitis supportive care — CRT esophagitis peaks weeks 3-5 and limits hydration / oral intake"
+  - "Do NOT switch to surgery-then-adjuvant pattern in a T4b unresectable patient — definitive CRT is the standard, not a bridge"
+
+do_not_do_en:
+  - "Do NOT escalate RT dose beyond 50.4 Gy — INT-0123 / RTOG 94-05 showed no OS benefit and increased toxicity at 64.8 Gy"
+  - "Do NOT proceed with definitive CRT without addressing severe dysphagia / aspiration risk first (NG/PEG planning if needed)"
+  - "Do NOT omit nutritional + esophagitis supportive care — CRT esophagitis peaks weeks 3-5 and limits hydration / oral intake"
+  - "Do NOT switch to surgery-then-adjuvant pattern in a T4b unresectable patient — definitive CRT is the standard, not a bridge"
+
+last_reviewed: "2026-05-08"
+notes: >
+  §17 phased indication using new RadiationCourse schema. Single phase
+  type=chemoradiation with radiation_id=RC-DEFINITIVE-ESOPH-SCC; the
+  RadiationCourse owns concurrent_chemo_regimen=REG-CARBO-PACLI-CONCURRENT-RT-ESOPH
+  per planning doc §2.3 (XOR rule on phase fields). Salvage esophagectomy
+  for persistent / recurrent disease post-definitive-CRT is a separate
+  indication path (not modeled here).

--- a/knowledge_base/hosted/content/radiation_courses/rc_definitive_esoph_scc.yaml
+++ b/knowledge_base/hosted/content/radiation_courses/rc_definitive_esoph_scc.yaml
@@ -1,0 +1,39 @@
+id: RC-DEFINITIVE-ESOPH-SCC
+names:
+  preferred: "Definitive concurrent chemoradiation for unresectable esophageal SCC"
+  ukrainian: "Радикальна одночасна хіміопроменева терапія при нерезектабельному плоскоклітинному раку стравоходу"
+  english: "Definitive CRT — esophageal SCC (T4b / M0 / medically inoperable)"
+  synonyms:
+    - "Definitive CRT esoph SCC"
+    - "RTOG 85-01-derived definitive CRT 50.4 Gy / 28 fx"
+
+total_dose_gy: 50.4
+fractions: 28
+fraction_size_gy: 1.8
+target_volume: "primary tumor + involved nodes (CTV) with PTV expansion per institutional protocol; elective nodal coverage per NCCN ESOPH-F"
+schedule: "5 fx/week (Mon-Fri) x ~5.6 weeks; concurrent with weekly carbo+pacli"
+
+# Concurrent weekly carboplatin + paclitaxel chemo backbone
+# (REG-CARBO-PACLI-CONCURRENT-RT-ESOPH, 5-6 weekly cycles paired with
+# this 28-fx course). NCCN-preferred regimen for definitive CRT in SCC.
+concurrent_chemo_regimen: REG-CARBO-PACLI-CONCURRENT-RT-ESOPH
+
+intent: definitive
+
+sources:
+  - SRC-RTOG-8501-HERSKOVIC-1992
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  Definitive concurrent chemoradiation for unresectable (T4b),
+  M0, medically inoperable, or surgery-declining esophageal SCC.
+  RTOG 85-01 (Herskovic NEJM 1992) established concurrent CRT
+  superior to RT alone (median OS 12.5 vs 8.9 mo; 2-yr OS 38% vs
+  10%) using cisplatin + 5-FU + 50 Gy. Modern NCCN/ESMO preferred
+  backbone substitutes weekly carboplatin + paclitaxel (lower toxicity)
+  with 50.4 Gy / 28 fx (1.8 Gy/fx); dose escalation beyond 50.4 Gy
+  has not improved outcomes (INT-0123 / RTOG 94-05 negative). Delivered
+  IMRT or VMAT preferred; 3D-CRT acceptable. Elective nodal coverage
+  per primary site (cervical / upper / mid / lower thoracic).

--- a/knowledge_base/hosted/content/regimens/reg_carbo_pacli_concurrent_rt_esoph.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_carbo_pacli_concurrent_rt_esoph.yaml
@@ -1,0 +1,68 @@
+id: REG-CARBO-PACLI-CONCURRENT-RT-ESOPH
+name: "Weekly carboplatin + paclitaxel concurrent with definitive RT (esophageal)"
+name_ua: "Щотижневий карбоплатин + паклітаксел разом із радикальною променевою терапією (стравохід)"
+alternate_names:
+  - "Weekly carbo-pacli concurrent definitive CRT esoph"
+  - "Carbo-pacli + 50.4 Gy concurrent (NCCN definitive CRT esoph SCC)"
+
+components:
+  - drug_id: DRUG-CARBOPLATIN
+    dose: "AUC 2"
+    schedule: "IV weekly during RT (5-6 weekly cycles)"
+    route: IV
+  - drug_id: DRUG-PACLITAXEL
+    dose: "50 mg/m²"
+    schedule: "IV weekly during RT (5-6 weekly cycles)"
+    route: IV
+
+cycle_length_days: 7
+total_cycles: "5-6 weekly cycles concurrent with RT 50.4 Gy in 28 fractions (definitive CRT for unresectable esophageal SCC)"
+
+toxicity_profile: moderate
+
+premedication:
+  - "Paclitaxel premed: dexamethasone 20 mg PO 12+6h pre + diphenhydramine 50 mg + ranitidine 50 mg IV 30 min pre"
+  - "5-HT3 antagonist for nausea"
+
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Grade 3 neutropenia"
+    modification: "Hold weekly dose until ANC >=1.5 x 10^9/L; resume same dose"
+    source_refs:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - condition: "Grade 2-3 peripheral neuropathy"
+    modification: "Reduce paclitaxel to 40 mg/m^2; if persistent, omit and continue carboplatin alone"
+    source_refs:
+      - SRC-NCCN-ESOPHAGEAL-2025
+  - condition: "Grade >=3 esophagitis interfering with hydration / nutrition"
+    modification: "Hold chemo and pause RT per radiation oncology; aggressive supportive care (analgesia, NG/PEG if prolonged); resume when tolerating PO"
+    source_refs:
+      - SRC-NCCN-ESOPHAGEAL-2025
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: true
+  notes: "Both components NSZU-funded; outpatient delivery feasible during RT course."
+
+sources:
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+  - SRC-RTOG-8501-HERSKOVIC-1992
+
+last_reviewed: "2026-05-08"
+
+notes: >
+  Definitive concurrent chemoradiation chemo backbone for unresectable
+  (T4b), M0, medically inoperable, or surgery-declining esophageal
+  squamous-cell carcinoma. Paired with RC-DEFINITIVE-ESOPH-SCC
+  (50.4 Gy / 28 fx) per NCCN ESOPH-F preferred definitive CRT regimen.
+  Evolved from RTOG 85-01 (cisplatin + 5-FU + 50 Gy) backbone with
+  improved tolerability profile; weekly carbo+pacli now NCCN/ESMO
+  preferred chemo backbone for definitive CRT in SCC. Distinct from
+  REG-CARBOPLATIN-PACLITAXEL-WEEKLY (CROSS neoadjuvant 5 cycles +
+  41.4 Gy / 23 fx) — same drugs/doses but different RT pairing and
+  cycle count.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/sources/src_rtog_8501_herskovic_1992.yaml
+++ b/knowledge_base/hosted/content/sources/src_rtog_8501_herskovic_1992.yaml
@@ -1,0 +1,47 @@
+id: SRC-RTOG-8501-HERSKOVIC-1992
+source_type: rct_publication
+title: Combined chemotherapy and radiotherapy compared with radiotherapy alone in patients with cancer of the esophagus
+version: '1992'
+authors:
+  - Herskovic A
+  - Martz K
+  - al-Sarraf M
+  - et al.
+journal: New England Journal of Medicine
+doi: 10.1056/NEJM199206113262403
+pmid: '1584260'
+url: https://pubmed.ncbi.nlm.nih.gov/1584260/
+access_level: subscription_required
+currency_status: current
+current_as_of: '2026-05-08'
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: NEJM (subscription)
+attribution:
+  required: true
+  text: Herskovic et al., NEJM 1992; RTOG 85-01
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: pending
+relates_to_diseases:
+  - DIS-ESOPHAGEAL
+last_verified: '2026-05-08'
+notes: >
+  RTOG 85-01 phase III randomized trial: definitive concurrent
+  chemoradiation (cisplatin 75 mg/m^2 day 1 + 5-FU 1000 mg/m^2/day x 4
+  days q4 weeks x 4 cycles, with 50 Gy radiation) vs radiation alone
+  (64 Gy) in non-metastatic esophageal carcinoma (predominantly
+  squamous-cell). Median OS 12.5 vs 8.9 months; 2-year OS 38% vs 10%.
+  Established concurrent chemoradiation as superior to radiation alone
+  and a standard of care for unresectable / medically inoperable
+  esophageal cancer; modern NCCN/ESMO definitive CRT regimens
+  (weekly carboplatin + paclitaxel with 50.4 Gy / 28 fx) evolved
+  from this RTOG 85-01 backbone with reduced toxicity.
+pages_count: 8
+references_count: 30
+corpus_role: rct_publication


### PR DESCRIPTION
## Summary
- 4 NEW files: indication + RadiationCourse (FIRST in KB) + regimen + RTOG-8501 source stub
- T4b/M0 medically inoperable esoph SCC: definitive concurrent CRT per RTOG-8501 + NCCN
- Closes #431

## §17 modeling (Option B per spec)

Phase carries `radiation_id: RC-DEFINITIVE-ESOPH-SCC` (XOR rule: exactly one FK per phase). RadiationCourse owns `concurrent_chemo_regimen` ref — mirrors `radiation_cross.yaml` golden fixture.

## Files (4 NEW)

| File | Notes |
|---|---|
| `ind_esoph_definitive_crt_scc.yaml` | Single `chemoradiation` phase with `radiation_id` |
| `rc_definitive_esoph_scc.yaml` | **First RadiationCourse entity in KB** — 50.4 Gy / 28 fx, intent: definitive |
| `reg_carbo_pacli_concurrent_rt_esoph.yaml` | New regimen (different RT pairing context vs CROSS sibling regimen) |
| `src_rtog_8501_herskovic_1992.yaml` | Source stub (PMID 1584260) — landmark NEJM 1992 trial |

## Test plan
- [x] Validator: 91 schema / 178 ref / 217 contract — identical to baseline (0 deltas)
- [x] Entities 2799 → 2803 (+4)
- [x] pytest: 21 pass / 1 pre-existing unrelated fail
- [x] Engine smoke: all 4 entities load, refs resolve
- [x] Synthetic T4b/M0 esoph SCC patient — disease resolves; algorithm wiring needs `ALGO-ESOPH-DEFINITIVE-1L` (flagged for D2 follow-up)

## Design decisions

- **RTOG-8501 source stub created** — landmark trial not previously in KB; cited from new indication
- **New regimen vs CROSS reuse** — different cycle count + concurrent context per protocol; new file
- **Algorithm wiring out of scope** — flagged for D2 algorithm-extension chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)