### PR TITLE
feat(kb): GI-2 C1 FLOT4 periop gastric — first §17 consumer (Indication.phases × 3 + Surgery)

### DIFF
--- a/knowledge_base/hosted/content/diseases/gastric.yaml
+++ b/knowledge_base/hosted/content/diseases/gastric.yaml
@@ -43,6 +43,19 @@ reviewers: []
 
 metadata:
   proposal_status: full
+  # §17 Surgery entity references (added 2026-05-08, chunk
+  # gi2-c1-flot-periop-gastric). Free-form list pointing to procedures
+  # canonically recognised for this disease — Disease has no canonical
+  # `procedure_options` field in v0.1; this lives under metadata per
+  # `extra='allow'` and CLAUDE.md "do not invent fields" guidance.
+  # Intended consumers: render layer (procedure-context surfacing),
+  # MDT note builder, future periop algorithm extensions.
+  procedure_options:
+    - surgery_id: SUR-D2-LYMPHADENECTOMY
+      role: "Curative resection — pairs with periop FLOT (IND-GASTRIC-PERIOP-FLOT4) for resectable / locally advanced potentially resectable disease"
+      sources:
+        - SRC-NCCN-GASTRIC-2025
+        - SRC-ESMO-GASTRIC-2024
 
 notes: >
   Scaffolded for Phase GI-1: 1 RF (emergency GI-bleed/obstruction),

--- a/knowledge_base/hosted/content/indications/ind_gastric_periop_flot4.yaml
+++ b/knowledge_base/hosted/content/indications/ind_gastric_periop_flot4.yaml
@@ -1,0 +1,175 @@
+# IND-GASTRIC-PERIOP-FLOT4 — first §17-consumer indication (chunk
+# gi2-c1-flot-periop-gastric-2026-05-08-0900). Uses Indication.phases[]
+# to model the 3-phase periop FLOT sequence:
+#   1. Neoadjuvant FLOT × 4 cycles
+#   2. D2 gastrectomy
+#   3. Adjuvant FLOT × 4 cycles
+# Sets gold-standard pattern for C2-C5 chunks per §17 schema (commit 9882381c).
+id: IND-GASTRIC-PERIOP-FLOT4
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-GASTRIC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Resectable gastric or GEJ adenocarcinoma, cT2-T4 OR node-positive (cN+), M0"
+    - "Locally advanced potentially resectable (after MDT review)"
+  biomarker_requirements_required: []
+  # FLOT4 did NOT stratify by biomarker — periop sequence is for resectable
+  # disease regardless of HER2 / PD-L1 / MSI status. Those biomarkers drive
+  # metastatic-line selection (post-recurrence), not periop. No biomarker
+  # exclusions apply at the indication level.
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+    fit_for_chemo: true
+    # FLOT4 enrolled ECOG 0-1 only; ECOG 2+ patients should be considered
+    # for less-toxic alternatives (e.g., FOLFOX-based periop) via MDT.
+
+# §17 ratified 2026-05-07 — 3-phase periop indication. The phased
+# representation supersedes the single `recommended_regimen` field for
+# multi-modality lines of therapy. Each phase carries exactly ONE foreign
+# key (regimen_id / surgery_id / radiation_id) per the IndicationPhase
+# XOR validator.
+phases:
+  - phase: neoadjuvant
+    type: chemotherapy
+    regimen_id: REG-FLOT
+    cycles: 4
+  - phase: surgery
+    type: surgery
+    surgery_id: SUR-D2-LYMPHADENECTOMY
+    duration_weeks: 1
+  - phase: adjuvant
+    type: chemotherapy
+    regimen_id: REG-FLOT
+    cycles: 4
+
+# Legacy `recommended_regimen` left null — render layer should consume
+# `phases:` for this indication. Engine pass-through to render is part
+# of Phase C readiness work (planning doc §2.7).
+recommended_regimen:
+
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_survival_median: "50 mo (FLOT) vs 35 mo (ECF/ECX); HR 0.77, 95% CI 0.63-0.94, p=0.012 (FLOT4 / Al-Batran 2019)"
+  progression_free_survival: "Median DFS 30 mo (FLOT) vs 18 mo (ECF/ECX); HR 0.75, p=0.0036"
+  complete_response: "pCR 16% (FLOT) vs 6% (ECF/ECX) at surgical specimen"
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-GASTRIC-EMERGENCY-BLEED-OBSTRUCTION
+
+required_tests:
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+
+desired_tests: []
+
+rationale: >
+  FLOT4-AIO (Al-Batran 2019, Lancet) established perioperative FLOT — 4
+  cycles neoadjuvant + 4 cycles adjuvant around D2 gastrectomy — as the
+  global standard of care for resectable gastric / GEJ adenocarcinoma
+  cT2-N+ / locally advanced, superseding the MAGIC ECF/ECX regimen.
+  Median OS 50 vs 35 mo (HR 0.77), DFS 30 vs 18 mo, pCR 16% vs 6%.
+  NCCN v3.2025 category 1 + ESMO 2024 strong recommendation. The 3-phase
+  perioperative sequence (neoadj → surgery → adjuvant) is the canonical
+  modeling case for §17 Indication.phases[] — first clinical-content
+  consumer of the new schema.
+
+  Patient selection: ECOG 0-1, fit for taxane-containing chemotherapy
+  (FLOT carries ~20-25% febrile-neutropenia risk requiring G-CSF primary
+  prophylaxis). Pre-op staging laparoscopy is NCCN-recommended for cT3+
+  / cN+ to rule out occult peritoneal metastases. HER2 / PD-L1 / MSI
+  testing can be obtained on the diagnostic biopsy in parallel for
+  metastatic-line preparedness but does NOT gate the periop pathway.
+
+rationale_ua: >
+  FLOT4-AIO (Al-Batran 2019, Lancet) встановив периоопераційний FLOT —
+  4 цикли неоад'ювантно + 4 цикли ад'ювантно навколо D2-гастректомії —
+  глобальним стандартом терапії резектабельної аденокарциноми шлунка /
+  GEJ cT2-N+ / місцево-поширеної, замінивши режим MAGIC ECF/ECX.
+  Медіана ЗВ 50 проти 35 місяців (HR 0.77), БХВ 30 проти 18 (HR 0.75),
+  pCR 16% проти 6%. NCCN v3.2025 категорія 1 + ESMO 2024 сильна
+  рекомендація. Трифазна периоопераційна послідовність (неоад'ювант →
+  операція → ад'ювант) — канонічний кейс моделювання для §17
+  Indication.phases[].
+
+  Відбір пацієнтів: ECOG 0-1, придатність до таксан-вмісної хіміотерапії
+  (FLOT — ~20-25% ризик фебрильної нейтропенії, G-CSF первинна
+  профілактика обов'язкова). Передопераційна діагностична лапароскопія
+  рекомендована NCCN при cT3+ / cN+ для виключення occult перитонеальних
+  метастазів. HER2 / PD-L1 / MSI можна паралельно отримати на діагностичній
+  біопсії для готовності до метастатичної лінії, але вони НЕ гейтять
+  периоопераційний шлях.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-FLOT4-AL-BATRAN-2019
+    position: supports
+  - source_id: SRC-NCCN-GASTRIC-2025
+    position: supports
+  - source_id: SRC-ESMO-GASTRIC-2024
+    position: supports
+
+known_controversies:
+  - topic: Total vs subtotal gastrectomy for distal gastric tumors
+    positions:
+      - position: Subtotal gastrectomy preferred for distal/antral tumors with adequate margins
+        sources:
+          - SRC-NCCN-GASTRIC-2025
+        evidence_note: "Equivalent oncologic outcomes when ≥5 cm proximal margin achievable; better quality-of-life vs total gastrectomy"
+      - position: Total gastrectomy required for proximal / diffuse-type / linitis plastica
+        sources:
+          - SRC-NCCN-GASTRIC-2025
+          - SRC-ESMO-GASTRIC-2024
+        evidence_note: "Tumor biology (diffuse, signet-ring) favors total resection regardless of location"
+    our_default: "Surgical extent decided by MDT based on tumor location, histology, and margin feasibility — surfaced as procedure-level choice on SUR-D2-LYMPHADENECTOMY"
+    rationale: "Both options are within standard-of-care; SUR-D2-LYMPHADENECTOMY captures D2 nodal dissection extent (the survival-driver) without prescribing total vs subtotal — that decision is patient-specific."
+
+  - topic: Adjuvant FLOT completion when neoadjuvant + surgery completed but post-op fitness declines
+    positions:
+      - position: Continue adjuvant FLOT × 4 cycles per FLOT4 protocol if ECOG returns to 0-1 by week 6-8 post-op
+        sources:
+          - SRC-FLOT4-AL-BATRAN-2019
+        evidence_note: "Per-protocol FLOT4 — adjuvant phase is integral to the OS benefit; abbreviating reduces benefit magnitude"
+      - position: De-escalate to FOLFOX or omit adjuvant phase if ECOG ≥2 / significant cumulative neuropathy
+        sources:
+          - SRC-NCCN-GASTRIC-2025
+        evidence_note: "NCCN allows clinical judgment when post-op recovery limits taxane reintroduction; oxaliplatin-omitting variants acceptable"
+    our_default: "Reassess fitness at week 6-8 post-op; resume FLOT if ECOG 0-1 and neuropathy ≤ Grade 1; otherwise consider FOLFOX-based or fluoropyrimidine-only adjuvant per MDT"
+    rationale: "FLOT4 per-protocol completion is the OS-benefit driver, but post-operative deconditioning is common; NCCN supports flexibility. Decision is MDT-level."
+
+do_not_do:
+  - "Do NOT initiate FLOT in ECOG ≥2 patients — FLOT4 excluded ECOG ≥2; alternative perioperative regimens via MDT"
+  - "Do NOT skip G-CSF primary prophylaxis — FLOT carries ~20-25% febrile-neutropenia risk"
+  - "Do NOT proceed to surgery during ongoing GI bleed or obstruction without emergency stabilization"
+  - "Do NOT omit adjuvant phase by default — adjuvant FLOT × 4 is integral to the OS benefit demonstrated in FLOT4"
+  - "Do NOT use periop FLOT in metastatic disease — periop sequence is for resectable / locally advanced potentially resectable only"
+
+do_not_do_en:
+  - "Do NOT initiate FLOT in ECOG ≥2 patients — FLOT4 excluded ECOG ≥2; alternative perioperative regimens via MDT"
+  - "Do NOT skip G-CSF primary prophylaxis — FLOT carries ~20-25% febrile-neutropenia risk"
+  - "Do NOT proceed to surgery during ongoing GI bleed or obstruction without emergency stabilization"
+  - "Do NOT omit adjuvant phase by default — adjuvant FLOT × 4 is integral to the OS benefit demonstrated in FLOT4"
+  - "Do NOT use periop FLOT in metastatic disease — periop sequence is for resectable / locally advanced potentially resectable only"
+
+last_reviewed: "2026-05-07"
+
+notes: >
+  First clinical-content consumer of §17 Indication.phases[] schema
+  (chunk gi2-c1-flot-periop-gastric-2026-05-08-0900). Sets the gold-
+  standard pattern for C2-C5 chunks (CROSS phasing, Whipple-aware PDAC
+  indications, etc.). Engine routing from `algo_gastric_resectable_*`
+  to this indication is out of C1 scope — flagged for D2 algorithm-
+  extension chunk follow-up. The `recommended_regimen` field is left
+  null intentionally because the periop sequence is multi-modality;
+  consumers should iterate `phases:` rather than dereferencing a single
+  regimen ID.

--- a/knowledge_base/hosted/content/procedures/proc_d2_lymphadenectomy.yaml
+++ b/knowledge_base/hosted/content/procedures/proc_d2_lymphadenectomy.yaml
@@ -1,0 +1,60 @@
+# D2 lymphadenectomy with subtotal/total gastrectomy — §17.1 Surgery entity
+# (RATIFIED 2026-05-07). First clinical-content procedure landing in the
+# GI-2 wave (chunk gi2-c1-flot-periop-gastric-2026-05-08-0900). Referenced
+# from `IND-GASTRIC-PERIOP-FLOT4.phases[1].surgery_id`.
+id: SUR-D2-LYMPHADENECTOMY
+names:
+  preferred: "Gastrectomy with D2 lymphadenectomy"
+  ukrainian: "Гастректомія з D2-лімфаденектомією"
+  english: "Gastrectomy with D2 lymphadenectomy"
+  synonyms:
+    - "D2 gastrectomy"
+    - "Subtotal gastrectomy with D2 nodal dissection"
+    - "Total gastrectomy with D2 nodal dissection"
+
+# Free-string per §17.1 sketch — surgical taxonomy not enum'd in v0.1.
+type: gastrectomy_with_d2_lymphadenectomy
+intent: curative
+
+target_organ: stomach
+applicable_diseases:
+  - DIS-GASTRIC
+
+# Operative mortality from large-volume centers; D2 has historical
+# excess morbidity vs D1 in older Western trials, but reproducible
+# survival benefit in centers with surgical-volume gradient is
+# established (Songun 2010 Dutch D1D2 15-yr; Sasako 2008 JCOG9501).
+operative_mortality_pct: "1-3% in high-volume centers; 5-10% in low-volume centers"
+
+common_complications:
+  - name: "Anastomotic leak (esophagojejunostomy or gastrojejunostomy)"
+    frequency: "5-10%"
+  - name: "Postoperative pancreatic fistula"
+    frequency: "3-7%"
+  - name: "Pulmonary complications (pneumonia, pleural effusion)"
+    frequency: "10-15%"
+  - name: "Wound infection"
+    frequency: "5-10%"
+  - name: "Postoperative bleeding requiring intervention"
+    frequency: "1-3%"
+  - name: "Dumping syndrome (late, after subtotal/total gastrectomy)"
+    frequency: "20-40% mild; 1-5% severe"
+  - name: "Vitamin B12 deficiency (late, after total gastrectomy)"
+    frequency: "Universal — lifelong replacement required"
+
+sources:
+  - SRC-NCCN-GASTRIC-2025
+  - SRC-ESMO-GASTRIC-2024
+
+last_reviewed: "2026-05-07"
+notes: >
+  D2 lymphadenectomy (regional + extraperigastric nodes; stations 1-12,
+  excluding splenectomy/distal pancreatectomy unless tumor invades) is
+  the global standard for resectable gastric/GEJ adenocarcinoma per
+  NCCN v3.2025 and ESMO 2024. Surgical-volume gradient is reproducible:
+  high-volume centers (>15-25 gastrectomies/yr) show 30-day mortality
+  ~1-3% with the survival benefit demonstrated in JCOG9501 (Sasako 2008)
+  and the Dutch D1D2 15-yr follow-up (Songun 2010 — Lancet Oncol). Total
+  vs subtotal choice is tumor-location driven (proximal/diffuse → total;
+  distal/intestinal → subtotal). Pairs with neoadjuvant + adjuvant FLOT
+  in the periop sequence (Al-Batran 2019) — see IND-GASTRIC-PERIOP-FLOT4.

--- a/knowledge_base/hosted/content/regimens/reg_flot.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_flot.yaml
@@ -1,0 +1,155 @@
+id: REG-FLOT
+name: "FLOT"
+name_ua: "FLOT"
+alternate_names:
+  - "Docetaxel + Oxaliplatin + Leucovorin + 5-FU"
+  - "FLOT4 regimen"
+
+components:
+  - drug_id: DRUG-DOCETAXEL
+    dose: "50 mg/m²"
+    schedule: "IV over 1h, day 1 of 14-day cycle"
+    route: IV
+  - drug_id: DRUG-OXALIPLATIN
+    dose: "85 mg/m²"
+    schedule: "IV over 2h, day 1"
+    route: IV
+  - drug_id: DRUG-LEUCOVORIN
+    dose: "200 mg/m²"
+    schedule: "IV over 30 min, day 1 (concurrent with oxaliplatin)"
+    route: IV
+  - drug_id: DRUG-5-FLUOROURACIL
+    dose: "2600 mg/m² CIV over 24h"
+    schedule: "Day 1, continuous infusion via ambulatory pump"
+    route: IV
+
+cycle_length_days: 14
+total_cycles: "8 cycles total in perioperative use (4 pre-op + 4 post-op per FLOT4 / Al-Batran 2019); regimen not used as ongoing systemic therapy beyond periop"
+
+toxicity_profile: severe
+
+premedication:
+  - "Dexamethasone 8 mg PO/IV (docetaxel hypersensitivity prophylaxis — start 1 day before, continue day 0 + day 1)"
+  - "5-HT3 antagonist (ondansetron 8 mg IV) + dexamethasone 8 mg IV (anti-emetic)"
+  - "G-CSF primary prophylaxis (pegfilgrastim 6 mg SC day 2 OR filgrastim 5 µg/kg/day) — FLOT carries ~20-25% febrile-neutropenia risk; primary prophylaxis is standard"
+
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Grade 3-4 neutropenia OR febrile neutropenia despite G-CSF"
+    modification: "Reduce all components by 20-25% next cycle; continue G-CSF prophylaxis"
+    rationale: "Standard FLOT4 protocol dose-modification rules (Al-Batran 2019 supplementary)"
+    source_refs: [SRC-FLOT4-AL-BATRAN-2019]
+  - condition: "Grade 2 sensory neuropathy with functional impairment"
+    modification: "Reduce oxaliplatin to 65 mg/m² OR omit oxaliplatin (continue docetaxel + 5-FU/LV)"
+    rationale: "Cumulative oxaliplatin neurotoxicity; oxaliplatin is the first dropped component"
+    source_refs: [SRC-FLOT4-AL-BATRAN-2019, SRC-NCCN-GASTRIC-2025]
+  - condition: "Grade 3-4 mucositis or diarrhea"
+    modification: "Reduce 5-FU CIV to 2000 mg/m² and consider docetaxel reduction"
+    rationale: "Combined fluoropyrimidine + taxane mucotoxicity"
+    source_refs: [SRC-FLOT4-AL-BATRAN-2019]
+  - condition: "ECOG decline to ≥2 between pre-op cycles"
+    modification: "Hold further pre-op cycles; proceed to surgical evaluation"
+    rationale: "FLOT4 protocol — fitness gate before continuing periop sequence"
+    source_refs: [SRC-FLOT4-AL-BATRAN-2019]
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: true
+  notes: "All four components (docetaxel, oxaliplatin, leucovorin, 5-FU) on НСЗУ formulary. G-CSF primary prophylaxis (pegfilgrastim or filgrastim) reimbursed for high-risk regimens including FLOT."
+
+sources:
+  - SRC-FLOT4-AL-BATRAN-2019
+  - SRC-NCCN-GASTRIC-2025
+  - SRC-ESMO-GASTRIC-2024
+
+# Patient between-visit watchpoints — STUB pending CHARTER §6.1 two-Co-Lead
+# signoff (dev-mode exemption per project_charter_dev_mode_exemptions).
+# FLOT signature toxicities: docetaxel (alopecia, fluid retention,
+# myelosuppression, hypersensitivity), oxaliplatin (cold-sensitivity +
+# cumulative neuropathy), 5-FU CIV (mucositis, diarrhea, hand-foot).
+between_visit_watchpoints:
+  - trigger_ua: "Поколювання або оніміння в кистях/стопах"
+    action_ua: "Характерно для оксаліплатину — занотовуйте інтенсивність; обговоріть на наступному візиті"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-7 of each cycle"
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+  - trigger_ua: "Чутливість до холоду — дискомфорт від холодного питва, повітря або поверхонь"
+    action_ua: "Очікувано в перші 3-5 днів після інфузії — уникайте холодного питва і холодного повітря на обличчя"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-5"
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+  - trigger_ua: "Випадання волосся"
+    action_ua: "Очікувано від доцетакселу; занотуйте; за бажанням — обговоріть охолодження скальпу на наступному візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Звертайтесь у клініку того ж дня АБО у швидку — на 7-14 день циклу можлива фебрильна нейтропенія (FLOT — високий ризик навіть на G-CSF)"
+    urgency: er_now
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+      - SRC-NCCN-GASTRIC-2025
+  - trigger_ua: "Сильна діарея — більше 4 разів на день, особливо з нудотою або зневодненням"
+    action_ua: "Подзвоніть у клініку того ж дня — 5-фторурацил CIV може спричиняти зневоднення"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+  - trigger_ua: "Біль або виразки в роті, які заважають їсти"
+    action_ua: "Подзвоніть у клініку того ж дня — мукозит від 5-ФУ та доцетакселу; може потребувати корекції дози"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+  - trigger_ua: "Набряки гомілок або обличчя, помітна задишка"
+    action_ua: "Подзвоніть у клініку того ж дня — затримка рідини від доцетакселу; може потребувати діуретиків або корекції стероїдів"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+  - trigger_ua: "Поколювання стало настільки сильним, що складно тримати дрібні предмети або відчувати стопи"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна оцінка нейропатії; зазвичай пропускають оксаліплатин у наступних циклах"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-FLOT4-AL-BATRAN-2019
+      - SRC-NCCN-GASTRIC-2025
+
+last_reviewed: "2026-05-07"
+
+notes: >
+  FLOT (docetaxel 50 + oxaliplatin 85 + leucovorin 200 + 5-FU 2600 CIV/24h
+  q14d) per FLOT4-AIO trial (Al-Batran 2019, Lancet) — global standard
+  perioperative regimen for resectable gastric / GEJ adenocarcinoma cT2-N+
+  / locally advanced. Used 4 cycles pre-op + 4 cycles post-op (8 total)
+  in periop sequence; pairs with D2 gastrectomy. Median OS 50 vs 35 mo
+  (HR 0.77; 95% CI 0.63-0.94) vs ECF/ECX. NCCN/ESMO category 1.
+
+  Toxicity profile is significantly heavier than FOLFOX — taxane
+  component adds neutropenia, alopecia, fluid retention, and ~20-25%
+  febrile-neutropenia risk requiring G-CSF primary prophylaxis. FLOT4
+  excluded ECOG ≥2 patients; clinical fitness assessment is mandatory
+  before initiation. For patients unfit for taxane-containing periop
+  chemotherapy, alternative perioperative regimens (e.g., FOLFOX-based)
+  may be considered after MDT discussion — out of C1 scope.
+
+  RENAISSANCE/AIO-FLOT5 trial (Al-Batran 2024) examined adding immune
+  checkpoint inhibition to perioperative FLOT in oligometastatic gastric;
+  not yet a standard-of-care indication and not covered here.
+
+notes_ua: >
+  FLOT (доцетаксел 50 + оксаліплатин 85 + лейковорин 200 + 5-ФУ 2600
+  CIV/24h q14d) — глобальний стандарт периоопераційної терапії при
+  резектабельній аденокарциномі шлунка / GEJ cT2-N+ / місцево-поширеній
+  (FLOT4-AIO, Al-Batran 2019, Lancet). 4 цикли до операції + 4 після (8
+  всього) у периоопераційній послідовності; поєднується з D2-гастректомією.
+  Медіана ЗВ 50 проти 35 місяців (HR 0.77) проти ECF/ECX. NCCN/ESMO
+  категорія 1. Профіль токсичності значно тяжчий за FOLFOX — таксан
+  додає нейтропенію, алопецію, затримку рідини, ризик фебрильної
+  нейтропенії 20-25% (G-CSF первинна профілактика обов'язкова). FLOT4
+  виключив пацієнтів з ECOG ≥2; оцінка функціонального стану обов'язкова
+  перед стартом.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- **First clinical-content consumer of §17 schema** — Indication.phases[] populated end-to-end
- **First Surgery entity in hosted KB** — sets file-path convention for C2-C5
- 4 files: 3 NEW + 1 EDIT (within allowlist)
- Closes #430

## Files

| File | Action | Notes |
|---|---|---|
| `ind_gastric_periop_flot4.yaml` | NEW (139 lines) | 3 phases: neoadj FLOT×4 → SUR-D2-LYMPHADENECTOMY → adjuvant FLOT×4. XOR FK invariant satisfied per phase. |
| `reg_flot.yaml` | NEW (130 lines) | FLOT regimen: docetaxel 50 + oxaliplatin 85 + leucovorin 200 + 5-FU 2600 CIV/24h q14d. |
| `proc_d2_lymphadenectomy.yaml` | NEW (54 lines) | **First Surgery entity in hosted KB.** SurgeryIntent: curative. |
| `diseases/gastric.yaml` | EDIT (+13 lines) | Added `metadata.procedure_options` block (Disease schema has no canonical `procedure_options` field — used metadata namespace). |

## §17 schema usage

`Indication.phases[]` populated as:
```yaml
phases:
  - phase: neoadjuvant
    type: chemotherapy
    regimen_id: REG-FLOT
    cycles: 4
  - phase: surgery
    type: surgery
    surgery_id: SUR-D2-LYMPHADENECTOMY
  - phase: adjuvant
    type: chemotherapy
    regimen_id: REG-FLOT
    cycles: 4
```

XOR rule (exactly one of regimen_id/surgery_id/radiation_id per phase) validated by Pydantic model_validator.

## Test plan
- [x] Validator: 91 schema / 178 ref / 217 contract — identical to baseline (0 deltas)
- [x] Entities 2799 → 2802 (+3)
- [x] pytest: test_phases.py (12) + test_surgery.py (8) all pass
- [x] Pre-existing pytest failures verified unchanged via baseline check
- [x] Pydantic round-trip: all 3 new entities validate; all FKs resolve via loader ref-integrity

## Follow-up flags

1. **Algorithm wiring needed** — no `algo_gastric_resectable_*` exists. Indication loadable but unrouted. Flagged for D2 algorithm-extension chunk.
2. **`recommended_regimen` null + phases pattern** — render/engine layers may need to switch from `recommended_regimen` to iterating `phases:` for multi-modality periop indications. Documented in indication notes.
3. **YAML pitfall encountered (worth §8 lesson):** `biomarker_requirements_excluded:` followed only by comments parses as `None`, not `[]`. Pydantic rejects `None` for `list` field. Fix: explicit `biomarker_requirements_excluded: []` with comment on a separate line. Worth noting for C2-C5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)