### PR TITLE
feat(kb): GI-2 C4 esophagectomy technique selection — 3 Surgery entities (TIME/ROBOT)

### DIFF
--- a/knowledge_base/hosted/content/diseases/esophageal.yaml
+++ b/knowledge_base/hosted/content/diseases/esophageal.yaml
@@ -40,6 +40,36 @@ reviewers: []
 
 metadata:
   proposal_status: full
+  # §17 Surgery entity references (added 2026-05-08, chunk
+  # gi2-c4-mie-ramie-selection). Three valid esophagectomy techniques
+  # with equivalent oncologic outcomes per TIME (open vs MIE) and ROBOT
+  # (open vs RAMIE) RCTs; technique selection by surgeon expertise +
+  # patient factors. Disease has no canonical `procedure_options` field
+  # in v0.1; this lives under metadata per `extra='allow'` and CLAUDE.md
+  # "do not invent fields" guidance, mirroring the gastric.yaml
+  # precedent set by chunk gi2-c1-flot-periop-gastric.
+  # Intended consumers: render layer (procedure-context surfacing),
+  # MDT note builder, future technique-selection algorithm extensions.
+  procedure_options:
+    - surgery_id: SUR-ESOPHAGECTOMY-OPEN
+      role: "Curative resection — historical reference operation (Ivor-Lewis or McKeown); valid where surgeon expertise favours it or extensive local invasion requires open exposure"
+      sources:
+        - SRC-TIME-BIERE-2012
+        - SRC-ROBOT-VAN-DER-SLUIS-2019
+        - SRC-NCCN-ESOPHAGEAL-2025
+        - SRC-ESMO-ESOPHAGEAL-2024
+    - surgery_id: SUR-ESOPHAGECTOMY-MIE
+      role: "Curative resection — minimally invasive (thoracoscopic + laparoscopic); reduced pulmonary morbidity vs open per TIME RCT (Biere 2012); equivalent oncologic outcomes; preferred where MIE expertise is established"
+      sources:
+        - SRC-TIME-BIERE-2012
+        - SRC-NCCN-ESOPHAGEAL-2025
+        - SRC-ESMO-ESOPHAGEAL-2024
+    - surgery_id: SUR-ESOPHAGECTOMY-RAMIE
+      role: "Curative resection — robot-assisted minimally invasive; reduced surgery-related + cardiopulmonary complications and improved QoL vs open per ROBOT RCT (van der Sluis 2019); equivalent oncologic outcomes; preferred where robotic-surgery programs are established"
+      sources:
+        - SRC-ROBOT-VAN-DER-SLUIS-2019
+        - SRC-NCCN-ESOPHAGEAL-2025
+        - SRC-ESMO-ESOPHAGEAL-2024
 
 notes: >
   Scaffolded for Phase GI-1: 1 RF (high-grade dysphagia / aspiration —

--- a/knowledge_base/hosted/content/procedures/proc_esophagectomy_mie.yaml
+++ b/knowledge_base/hosted/content/procedures/proc_esophagectomy_mie.yaml
@@ -1,0 +1,66 @@
+# Minimally invasive esophagectomy (MIE) — §17.1 Surgery entity (RATIFIED
+# 2026-05-07). Third procedure landing in the GI-2 wave (chunk
+# gi2-c4-mie-ramie-selection-2026-05-08-1100). Equivalent oncologic
+# outcomes to open per TIME RCT (Biere 2012) with reduced pulmonary
+# morbidity. Referenced from `DIS-ESOPHAGEAL.metadata.procedure_options`.
+id: SUR-ESOPHAGECTOMY-MIE
+names:
+  preferred: "Minimally invasive esophagectomy (MIE)"
+  ukrainian: "Мінімально інвазивна езофагектомія (МІЕ)"
+  english: "Minimally invasive esophagectomy"
+  synonyms:
+    - "MIE"
+    - "Thoracoscopic-laparoscopic esophagectomy"
+    - "Total MIE"
+    - "Minimally invasive Ivor-Lewis"
+    - "Minimally invasive McKeown"
+
+# Free-string per §17.1 sketch — surgical taxonomy not enum'd in v0.1.
+type: minimally_invasive_esophagectomy
+intent: curative
+
+target_organ: esophagus
+applicable_diseases:
+  - DIS-ESOPHAGEAL
+
+# TIME (Biere 2012) MIE arm: in-hospital mortality 3% (2/59); 30-day
+# mortality similar to open. High-volume MIE centers report ~1-3%.
+operative_mortality_pct: "1-3% in high-volume centers (TIME MIE arm: 3% in-hospital)"
+
+common_complications:
+  - name: "Pulmonary infection within 2 weeks (primary TIME endpoint — significantly reduced vs open)"
+    frequency: "9% MIE vs 29% open (TIME, p=0.005)"
+  - name: "Anastomotic leak (intrathoracic or cervical depending on configuration)"
+    frequency: "10-20%"
+  - name: "Recurrent laryngeal nerve / vocal cord injury"
+    frequency: "2% MIE vs 14% open (TIME)"
+  - name: "Chyle leak / chylothorax"
+    frequency: "1-5%"
+  - name: "Cardiac complications (arrhythmia, MI)"
+    frequency: "10-15%"
+  - name: "Anastomotic stricture (late)"
+    frequency: "10-25%"
+  - name: "Conversion to open"
+    frequency: "5-10%"
+
+sources:
+  - SRC-TIME-BIERE-2012
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  Minimally invasive esophagectomy (MIE — thoracoscopic + laparoscopic,
+  with either intrathoracic Ivor-Lewis or cervical McKeown anastomosis)
+  was established as a valid alternative to open by the TIME RCT (Biere
+  et al., Lancet 2012; n=115; pulmonary infection within 2 weeks 9% MIE
+  vs 29% open, p=0.005). Long-term follow-up (Straatman 2017, Ann Surg)
+  confirmed equivalent oncologic outcomes (3-yr OS 50.5% MIE vs 40.4%
+  open; n.s.) and lymph node yield. MIE is preferred over open in
+  centers with established minimally-invasive expertise and amenable
+  patient anatomy / tumor extent. Hybrid MIE (laparoscopic abdomen +
+  open thoracotomy) is a documented variant — the MIRO trial (Mariette
+  2019) compared hybrid vs full open and showed major complication
+  reduction at 30 days. Pure totally-MIE remains the reference for the
+  TIME comparison. Pairs with neoadjuvant CROSS chemoradiotherapy in
+  the resectable pathway.

--- a/knowledge_base/hosted/content/procedures/proc_esophagectomy_open.yaml
+++ b/knowledge_base/hosted/content/procedures/proc_esophagectomy_open.yaml
@@ -1,0 +1,68 @@
+# Open esophagectomy (Ivor-Lewis or McKeown) — §17.1 Surgery entity
+# (RATIFIED 2026-05-07). Second clinical-content procedure landing in the
+# GI-2 wave (chunk gi2-c4-mie-ramie-selection-2026-05-08-1100). One of three
+# valid technique options (open / MIE / RAMIE) per TIME and ROBOT RCTs;
+# referenced from `DIS-ESOPHAGEAL.metadata.procedure_options`.
+id: SUR-ESOPHAGECTOMY-OPEN
+names:
+  preferred: "Open esophagectomy (Ivor-Lewis or McKeown)"
+  ukrainian: "Відкрита езофагектомія (Айвор-Льюїс або МакКеоун)"
+  english: "Open esophagectomy (Ivor-Lewis or McKeown)"
+  synonyms:
+    - "Ivor-Lewis esophagectomy"
+    - "McKeown esophagectomy"
+    - "Three-incision esophagectomy"
+    - "Transthoracic esophagectomy"
+    - "Open transthoracic esophagectomy"
+
+# Free-string per §17.1 sketch — surgical taxonomy not enum'd in v0.1.
+type: open_esophagectomy
+intent: curative
+
+target_organ: esophagus
+applicable_diseases:
+  - DIS-ESOPHAGEAL
+
+# Open esophagectomy historical morbidity / mortality — moderate-volume
+# centers; high-volume centers report 1-3% but global registry data
+# (e.g. ECCG) places the moderate-center band at 4-10%. TIME (Biere
+# 2012) open arm: in-hospital mortality 3% (1/56). ROBOT (van der Sluis
+# 2019) open arm: in-hospital mortality 4%.
+operative_mortality_pct: "4-10% (moderate-volume centers); 1-3% in high-volume centers"
+
+common_complications:
+  - name: "Anastomotic leak (intrathoracic — Ivor-Lewis; cervical — McKeown)"
+    frequency: "10-25% (cervical leaks more common, intrathoracic leaks more morbid)"
+  - name: "Pulmonary complications (pneumonia, ARDS, prolonged ventilation)"
+    frequency: "29% open arm in TIME (vs 9% MIE)"
+  - name: "Recurrent laryngeal nerve / vocal cord injury"
+    frequency: "5-15% (higher with cervical anastomosis / McKeown 3-field)"
+  - name: "Chyle leak / chylothorax"
+    frequency: "1-5%"
+  - name: "Cardiac complications (arrhythmia, MI)"
+    frequency: "10-20%"
+  - name: "Wound infection"
+    frequency: "5-15%"
+  - name: "Anastomotic stricture (late)"
+    frequency: "10-30%"
+
+sources:
+  - SRC-TIME-BIERE-2012
+  - SRC-ROBOT-VAN-DER-SLUIS-2019
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  Open esophagectomy (Ivor-Lewis = right thoracotomy + laparotomy with
+  intrathoracic anastomosis; McKeown = right thoracotomy + laparotomy +
+  cervical anastomosis) is the historical reference operation. Both TIME
+  (Biere 2012, Lancet) and ROBOT (van der Sluis 2019, Ann Surg) RCTs
+  randomised against open and demonstrated equivalent oncologic outcomes
+  (R0 rate, lymph node yield, 3-yr survival) with reduced respiratory
+  morbidity for MIE / RAMIE arms. Open remains a valid technique where
+  surgeon expertise favours it, in tumors with extensive local invasion
+  requiring open exposure, or where minimally-invasive infrastructure /
+  expertise is unavailable. Technique selection is by surgeon expertise +
+  patient factors; oncologic outcomes are equivalent across the three
+  techniques.

--- a/knowledge_base/hosted/content/procedures/proc_esophagectomy_ramie.yaml
+++ b/knowledge_base/hosted/content/procedures/proc_esophagectomy_ramie.yaml
@@ -1,0 +1,67 @@
+# Robot-assisted minimally invasive esophagectomy (RAMIE) — §17.1 Surgery
+# entity (RATIFIED 2026-05-07). Fourth procedure landing in the GI-2 wave
+# (chunk gi2-c4-mie-ramie-selection-2026-05-08-1100). Equivalent oncologic
+# outcomes to open per ROBOT RCT (van der Sluis 2019) with improved QoL
+# and reduced cardiopulmonary complications. Referenced from
+# `DIS-ESOPHAGEAL.metadata.procedure_options`.
+id: SUR-ESOPHAGECTOMY-RAMIE
+names:
+  preferred: "Robot-assisted minimally invasive esophagectomy (RAMIE)"
+  ukrainian: "Роботизована мінімально інвазивна езофагектомія (RAMIE)"
+  english: "Robot-assisted minimally invasive esophagectomy"
+  synonyms:
+    - "RAMIE"
+    - "Robot-assisted esophagectomy"
+    - "Robotic esophagectomy"
+    - "Robot-assisted thoracoscopic-laparoscopic esophagectomy"
+
+# Free-string per §17.1 sketch — surgical taxonomy not enum'd in v0.1.
+type: robot_assisted_minimally_invasive_esophagectomy
+intent: curative
+
+target_organ: esophagus
+applicable_diseases:
+  - DIS-ESOPHAGEAL
+
+# ROBOT (van der Sluis 2019) RAMIE arm: in-hospital mortality 4% (2/54).
+# High-volume robotic centers report 1-4%. Mortality is comparable across
+# the three esophagectomy techniques; the differentiator is morbidity
+# (cardiopulmonary) and patient-reported QoL.
+operative_mortality_pct: "1-4% in high-volume robotic centers (ROBOT RAMIE arm: 4% in-hospital)"
+
+common_complications:
+  - name: "Overall surgery-related complications (primary ROBOT endpoint — significantly reduced vs open)"
+    frequency: "59% RAMIE vs 80% open (ROBOT, p=0.02)"
+  - name: "Cardiopulmonary complications (Clavien-Dindo grade ≥2)"
+    frequency: "32% RAMIE vs 58% open (ROBOT, p=0.005 pulmonary; p=0.02 cardiac)"
+  - name: "Anastomotic leak (intrathoracic — Ivor-Lewis configuration most common)"
+    frequency: "10-20%"
+  - name: "Recurrent laryngeal nerve / vocal cord injury"
+    frequency: "2-10%"
+  - name: "Chyle leak / chylothorax"
+    frequency: "1-5%"
+  - name: "Anastomotic stricture (late)"
+    frequency: "10-25%"
+  - name: "Conversion to open"
+    frequency: "5-10%"
+
+sources:
+  - SRC-ROBOT-VAN-DER-SLUIS-2019
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  Robot-assisted minimally invasive esophagectomy (RAMIE) was validated
+  against open transthoracic esophagectomy by the ROBOT RCT (van der
+  Sluis et al., Ann Surg 2019; n=112; 50% reduction in surgery-related
+  complications, 59% RAMIE vs 80% open, p=0.02; better functional
+  recovery + QoL at 6 weeks and 3 months postoperatively). Oncologic
+  outcomes (R0, lymph node yield, 5-yr OS) were equivalent. RAMIE is
+  preferred over open in centers with established robotic-surgery
+  programs and adequate case volume; head-to-head RCT data vs MIE
+  (RAMIE-2 / RAMIE-China) are emerging but as of NCCN v3.2025 / ESMO
+  2024, RAMIE and MIE are positioned as equivalent minimally-invasive
+  options with selection driven by surgeon expertise + center
+  infrastructure. Pairs with neoadjuvant CROSS chemoradiotherapy in the
+  resectable pathway.


### PR DESCRIPTION
## Summary
- 3 NEW Surgery entities for esophagectomy technique selection per TIME (open vs MIE) and ROBOT (open vs RAMIE) RCTs
- esophageal.yaml extended with metadata.procedure_options block (mirrors C1 gastric.yaml precedent)
- Closes #437

## Files (4: 3 NEW + 1 EDIT, 231 insertions)

| File | Notes |
|---|---|
| `proc_esophagectomy_open.yaml` | SUR-ESOPHAGECTOMY-OPEN (Ivor-Lewis / McKeown; mortality 4–10%; 7 complications) |
| `proc_esophagectomy_mie.yaml` | SUR-ESOPHAGECTOMY-MIE (TIME RCT — pulmonary infection 9% vs 29% open; 7 complications) |
| `proc_esophagectomy_ramie.yaml` | SUR-ESOPHAGECTOMY-RAMIE (ROBOT RCT — surg-complications 59% vs 80% open; 7 complications) |
| `diseases/esophageal.yaml` | EDIT: metadata.procedure_options referencing all 3 SUR IDs |

## Test plan
- [x] Validator: 2809 → 2812 entities (+3); procedures 1 → 4; zero new schema errors
- [x] pytest test_surgery.py + test_loader.py: 9 pass, 1 pre-existing unrelated fail (verified)
- [x] Pydantic round-trip: all 3 Surgery YAMLs validate via `Surgery.model_validate`
- [x] Disease's procedure_options resolves all 3 SUR IDs

## Design decisions

- **Disease filename `esophageal.yaml`** (no `dis_` prefix) — matches C1's gastric.yaml convention
- **`metadata.procedure_options` namespace** — Disease has no canonical `procedure_options` field in v0.1; used Pydantic `extra='allow'` per C1 precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)