### PR TITLE
feat(kb): GI-2 C2 CROSS RT phasing — convert free-text to §17 phases (RadiationCourse #2)

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_esoph_resectable_cross_neoadjuvant.yaml
+++ b/knowledge_base/hosted/content/indications/ind_esoph_resectable_cross_neoadjuvant.yaml
@@ -10,6 +10,23 @@ applicable_to:
   demographic_constraints:
     ecog_max: 2
 
+# §17 phased indication (RATIFIED 2026-05-07). Single neoadjuvant
+# chemoradiation phase: the RadiationCourse RC-CROSS-NEOADJ owns the
+# concurrent chemo regimen reference (REG-CARBOPLATIN-PACLITAXEL-WEEKLY)
+# per planning doc §2.3 — XOR rule permits exactly ONE of regimen_id /
+# surgery_id / radiation_id per phase. The post-CROSS surgery phase
+# (esophagectomy) lands in the C4 chunk (#437) once the Surgery entity
+# for esophagectomy is defined.
+phases:
+  - phase: neoadjuvant
+    type: chemoradiation
+    radiation_id: RC-CROSS-NEOADJ
+    duration_weeks: 5
+
+# `recommended_regimen` preserved for backward-compat — render layer may
+# still dereference this for non-§17-aware code paths. Going forward the
+# phased timeline (RadiationCourse RC-CROSS-NEOADJ → esophagectomy →
+# adjuvant nivolumab) is the canonical representation.
 recommended_regimen: REG-CARBOPLATIN-PACLITAXEL-WEEKLY
 concurrent_therapy: []
 followed_by: []
@@ -60,11 +77,18 @@ do_not_do_en:
   - "Do NOT proceed to surgery without restaging post-CRT (occult progression detection)"
   - "Do NOT initiate RT without addressing severe dysphagia / aspiration risk first"
   - "Do NOT skip CheckMate-577 nivolumab adjuvant for residual ypT+ or ypN+ post-CROSS"
-last_reviewed: "2026-04-26"
+last_reviewed: "2026-05-08"
 notes: >
-  PARTIAL — RT 41.4 Gy / 23 fractions concurrent with chemo is NOT
-  modellable in current OpenOnco schema. This Indication captures
-  the chemo backbone; the RT + esophagectomy + adjuvant nivolumab
-  sequence is documented here but cannot be enforced by the engine
-  until PROPOSAL §17 (Surgery + RadiationCourse + Indication.phases)
-  is ratified.
+  §17 phased indication (RATIFIED 2026-05-07). Free-text RT description
+  in this `notes:` block has been replaced by structured `phases:` field
+  with radiation_id=RC-CROSS-NEOADJ; the RadiationCourse owns the
+  concurrent chemo regimen reference
+  (concurrent_chemo_regimen=REG-CARBOPLATIN-PACLITAXEL-WEEKLY) per
+  planning doc §2.3 (XOR rule on phase fields). The post-CROSS surgery
+  phase (esophagectomy) is deferred to C4 chunk (#437) — this entity
+  models the neoadjuvant CRT phase only. Backward-compat: legacy
+  `recommended_regimen=REG-CARBOPLATIN-PACLITAXEL-WEEKLY` preserved so
+  non-§17-aware render paths continue to surface the chemo backbone.
+  Adjuvant nivolumab post-resection (CheckMate-577, ypT+ or ypN+) is a
+  separate downstream indication and remains out of scope for this
+  chunk.

--- a/knowledge_base/hosted/content/radiation_courses/rc_cross_neoadj.yaml
+++ b/knowledge_base/hosted/content/radiation_courses/rc_cross_neoadj.yaml
@@ -1,0 +1,44 @@
+id: RC-CROSS-NEOADJ
+names:
+  preferred: "CROSS neoadjuvant chemoradiation for resectable esophageal cancer"
+  ukrainian: "CROSS неоад'ювантна хіміопроменева терапія резектабельного раку стравоходу"
+  english: "CROSS regimen — neoadjuvant CRT for esophageal cancer (41.4 Gy / 23 fx + weekly carbo+pacli × 5)"
+  synonyms:
+    - "CROSS CRT"
+    - "Neoadj CRT 41.4 Gy / 23 fx"
+    - "van Hagen 2012 neoadj CRT"
+
+total_dose_gy: 41.4
+fractions: 23
+fraction_size_gy: 1.8
+target_volume: "primary tumor + involved nodes (CTV) with PTV expansion per institutional protocol"
+schedule: "5 fx/week × 4.6 weeks (Mon-Fri); concurrent with weekly carbo+pacli × 5 cycles"
+
+# Concurrent weekly carboplatin AUC 2 + paclitaxel 50 mg/m^2 × 5 cycles
+# (REG-CARBOPLATIN-PACLITAXEL-WEEKLY) — the canonical CROSS chemo backbone
+# per van Hagen 2012. Distinct from definitive-CRT regimen
+# (REG-CARBO-PACLI-CONCURRENT-RT-ESOPH, 5-6 cycles paired with 28-fx /
+# 50.4 Gy course). Loader resolves via planning doc §2.4 rule 7.
+concurrent_chemo_regimen: REG-CARBOPLATIN-PACLITAXEL-WEEKLY
+
+intent: neoadjuvant
+
+sources:
+  - SRC-CROSS-VAN-HAGEN-2012
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  van Hagen 2012 (NEJM) established CROSS as standard neoadjuvant
+  chemoradiation for resectable esophageal / GEJ cancer (squamous and
+  adenocarcinoma, cT1b N+ M0 or cT2-4a any N M0). 41.4 Gy in 23 fractions
+  (1.8 Gy/fx) over ~4.6 weeks concurrent with weekly carboplatin AUC 2 +
+  paclitaxel 50 mg/m^2 × 5 cycles, followed by esophagectomy 6-8 weeks
+  post-CRT. Median OS ~49 mo (CRT+S) vs ~24 mo (S alone), HR 0.66 (95% CI
+  0.50-0.87, p=0.003); pCR ~29% squamous, ~23% adeno; 5-yr OS ~47%
+  (combined). NCCN category 1 + ESMO 2024 strong recommendation. IMRT
+  or VMAT preferred (3D-CRT acceptable). Distinct from definitive CRT
+  (50.4 Gy / 28 fx) by total dose, fraction count, and intent (CRT here
+  is a bridge to surgery, not definitive). Surgery (esophagectomy) phase
+  modeled separately — see C4 chunk for Surgery entities.


### PR DESCRIPTION
## Summary
- EDIT existing CROSS neoadjuvant indication: free-text RT → §17 structured phases
- NEW second RadiationCourse entity in KB (after C3's RC-DEFINITIVE-ESOPH-SCC)
- Backward-compat preserved (recommended_regimen unchanged)
- Closes #436

## Files (2: 1 EDIT + 1 NEW)

| File | Action | Notes |
|---|---|---|
| `ind_esoph_resectable_cross_neoadjuvant.yaml` | EDIT | Added `phases:` (single neoadj chemoradiation with `radiation_id: RC-CROSS-NEOADJ`, `duration_weeks: 5`); preserved `recommended_regimen: REG-CARBOPLATIN-PACLITAXEL-WEEKLY` for back-compat; bumped `last_reviewed`; rewrote notes for §17 structural phasing |
| `rc_cross_neoadj.yaml` | NEW | 41.4 Gy / 23 fx / 1.8 Gy/fx, intent: neoadjuvant, concurrent_chemo_regimen: REG-CARBOPLATIN-PACLITAXEL-WEEKLY |

## Test plan
- [x] Validator: 91 schema / 178 ref / 217 contract — identical to baseline
- [x] Entities 2809 → 2810 (+1 RC); radiation_courses 1 → 2
- [x] pytest test_phases.py + test_radiation_course.py: 20/20 pass
- [x] Pre-existing `test_seed_loads_without_errors` baseline fail verified (legacy regimen YAMLs, unrelated)

## Design decisions

- **Filename adaptation**: Chunk spec said `ind_esoph_neoadj_cross.yaml` (descriptive); actual existing file is `ind_esoph_resectable_cross_neoadjuvant.yaml`. Agent adapted to existing filename.
- **XOR rule pattern**: Phase populates `radiation_id` only; RadiationCourse owns the chemo regimen ref (mirrors C3 definitive-CRT pattern from `rc_definitive_esoph_scc.yaml`)
- **Surgery phase deferred to C4** (esophagectomy Surgery entities)
- **Adjuvant nivo** remains separate downstream indication

🤖 Generated with [Claude Code](https://claude.com/claude-code)