### PR TITLE
fix(kb): GI-2 C5-backfill — wire REG-FLOT to oligomet indications

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_esoph_oligomet_systemic_plus_local.yaml
+++ b/knowledge_base/hosted/content/indications/ind_esoph_oligomet_systemic_plus_local.yaml
@@ -23,7 +23,7 @@ applicable_to:
 # Phase C extensions. Sequence described in description / notes / rationale
 # text. C2 + C4 chunks will populate Surgery + RadiationCourse for esoph;
 # oligomet phases backfilled when those entities exist.
-recommended_regimen:
+recommended_regimen: REG-FLOT
 concurrent_therapy: []
 followed_by: []
 
@@ -173,8 +173,8 @@ notes: >
   entities exist. Sequence (induction FLOT → restaging → local therapy
   → adjuvant FLOT for adenocarcinoma; nivo-chemo for ESCC) described
   in description / rationale / do_not_do text only. recommended_regimen:
-  null because REG-FLOT entity does not yet exist in KB (tracked as
-  separate gap).
+  REG-FLOT (backfilled 2026-05-08 after C1 PR #435 created REG-FLOT;
+  closes #438). Esoph use is extrapolation from gastric (RENAISSANCE).
 
   ESCC histology asymmetry flagged in known_controversies — RENAISSANCE
   evidence does not directly support ESCC; case-by-case MDT decision

--- a/knowledge_base/hosted/content/indications/ind_gastric_oligomet_systemic_plus_local.yaml
+++ b/knowledge_base/hosted/content/indications/ind_gastric_oligomet_systemic_plus_local.yaml
@@ -21,7 +21,7 @@ applicable_to:
 # Surgery, SBRT RadiationCourse) for gastric oligomet are future Phase C
 # extensions. Sequence described in description / notes / rationale text.
 # Future chunk will populate phases when local-therapy entities exist.
-recommended_regimen:
+recommended_regimen: REG-FLOT
 concurrent_therapy: []
 followed_by: []
 
@@ -160,8 +160,8 @@ notes: >
   SBRT RadiationCourse) for gastric oligomet are future Phase C
   extensions. Sequence (induction FLOT → restaging → local therapy →
   adjuvant FLOT) described in description / rationale / do_not_do
-  text only. recommended_regimen: null because REG-FLOT entity does
-  not yet exist in KB (tracked as separate gap).
+  text only. recommended_regimen: REG-FLOT (backfilled 2026-05-08
+  after C1 PR #435 created REG-FLOT; closes #438).
 
   Algorithm wiring deferred — ALGO-GASTRIC-METASTATIC-1L does not yet
   have an oligomet branch. D2 follow-up: extend algorithm with oligomet


### PR DESCRIPTION
## Summary
- Wire `recommended_regimen: null` → `REG-FLOT` on 2 oligomet indications now that REG-FLOT exists post-C1 merge
- Closes #438

## Files (2 EDIT, 6 / 6 lines)

| File | Change |
|---|---|
| `ind_gastric_oligomet_systemic_plus_local.yaml` | recommended_regimen null → REG-FLOT + notes comment update |
| `ind_esoph_oligomet_systemic_plus_local.yaml` | same pattern |

## Honest finding: ref_errors did NOT drop

Brief predicted `-2 ref errors`. Empirically **0 drop**. Reason: `Indication.recommended_regimen` is `Optional[str]` (per `knowledge_base/schemas/indication.py:221`), so `null` was already valid and produced no referential-integrity error. The FK swap is still correct (upgrades from valid-null to valid-resolved), but the validator metric is unchanged.

| Metric | Pre | Post |
|---|---|---|
| Schema errors | 91 | 91 |
| Ref-integrity errors | 178 | 178 |
| Contract warnings | 217 | 217 |
| Total entities | 2810 | 2810 |

## Test plan
- [x] Validator: zero deltas (expected per Optional[str] semantics)
- [x] pytest test_loader.py: 1 pre-existing baseline fail verified via stash round-trip (legacy regimen YAMLs, unrelated)
- [x] No banned sources; no `-A`; no `--no-verify`
- [x] No main-tree edits; worktree-isolated throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)