### PR TITLE
feat(kb): GI-2 D2 algorithm extensions for Phase C indications (5/5 engine-smoke green)

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_esoph_definitive_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_esoph_definitive_1l.yaml
@@ -1,0 +1,94 @@
+# ALGO-ESOPH-DEFINITIVE-1L — chunk gi2-d2-algo-extensions-phase-c-
+# 2026-05-08-1300. Routes esophageal squamous-cell carcinoma (SCC)
+# patients who are unresectable (cT4b invasion of adjacent structures),
+# medically inoperable (cardiopulmonary or comorbidity contraindications,
+# M0), or who decline surgery to definitive concurrent chemoradiation
+# (IND-ESOPH-DEFINITIVE-CRT-SCC: weekly carboplatin + paclitaxel +
+# 50.4 Gy / 28 fx per RTOG 85-01 / NCCN 2025). Distinct from
+# ALGO-ESOPH-RESECTABLE-1L (CROSS neoadjuvant + esophagectomy),
+# ALGO-ESOPH-METASTATIC-1L (stage IV systemic), and
+# ALGO-ESOPHAGEAL-ADJUVANT-1L (post-CROSS-non-pCR nivolumab).
+#
+# applicable_to_disease_state: "unresectable_definitive" disambiguates
+# this from the metastatic and resectable algorithms (state-agnostic) —
+# patients without disease_state continue to land on existing algorithms
+# (load-order behavior preserved per _find_algorithm fallback rules).
+id: ALGO-ESOPH-DEFINITIVE-1L
+applicable_to_disease: DIS-ESOPHAGEAL
+applicable_to_line_of_therapy: 1
+applicable_to_disease_state: unresectable_definitive
+purpose: >
+  Algorithm for unresectable / medically inoperable esophageal squamous-
+  cell carcinoma. Step 1 routes SCC histology + (cT4b OR M0 medically
+  inoperable OR patient declines surgery) to definitive concurrent CRT
+  (IND-ESOPH-DEFINITIVE-CRT-SCC). Adenocarcinoma in this disease_state
+  is not separately modeled — most EAC patients are surgical candidates
+  via CROSS or, if metastatic, route via ALGO-ESOPH-METASTATIC-1L.
+
+output_indications:
+  - IND-ESOPH-DEFINITIVE-CRT-SCC
+
+default_indication: IND-ESOPH-DEFINITIVE-CRT-SCC
+alternative_indication: null
+
+decision_tree:
+  # Step 1 — Squamous histology + (T4b OR medically inoperable OR
+  # patient declines surgery) → definitive CRT. The histology + reason-
+  # for-non-surgery clauses are wired with a finding-keyed structure
+  # where possible (histology=squamous via the same `histology` finding
+  # used by ALGO-ESOPH-METASTATIC-1L step 10/11 D1 branches; T4b /
+  # medically_inoperable / patient_declines_surgery as MDT-text
+  # conditions where no finding-keyed lookups exist yet).
+  - step: 1
+    evaluate:
+      all_of:
+        - finding: histology
+          value: squamous
+        - any_of:
+            - condition: "cT4b — unresectable due to invasion of adjacent structures"
+            - condition: "M0 medically inoperable (cardiopulmonary or comorbidity contraindications)"
+            - condition: "Patient declines surgery"
+    if_true:
+      result: IND-ESOPH-DEFINITIVE-CRT-SCC
+      notes: >
+        RTOG 85-01 (Herskovic NEJM 1992) established concurrent
+        cisplatin + 5-FU + 50 Gy superior to RT alone (2-yr OS 38%
+        vs 10%). Modern NCCN/ESMO preferred regimen: weekly
+        carboplatin AUC 2 + paclitaxel 50 mg/m² + 50.4 Gy / 28 fx
+        (1.8 Gy/fx). NCCN v3.2025 category 1. §17 phased indication —
+        single-phase chemoradiation; the RadiationCourse
+        RC-DEFINITIVE-ESOPH-SCC owns the concurrent chemo regimen
+        reference (REG-CARBO-PACLI-CONCURRENT-RT-ESOPH) per planning
+        doc §2.3 XOR rule.
+    if_false:
+      result: IND-ESOPH-DEFINITIVE-CRT-SCC
+      notes: >
+        Fallback: when finding-keyed histology=squamous does not
+        evaluate True (e.g. histology unknown / not yet captured),
+        indication still defaults to definitive CRT — the indication's
+        demographic_constraints (histology=squamous_cell_carcinoma,
+        ecog_max: 2) and red_flags_triggering_alternative
+        (RF-ESOPH-SEVERE-DYSPHAGIA-ASPIRATION) handle exclusion
+        surfacing at render time. Adenocarcinoma patients in this
+        disease_state should route via MDT review — out of v0.1
+        scope (definitive CRT for adeno is uncommon; CROSS-then-
+        surgery is preferred when feasible).
+    notes: "D2 chunk routing — squamous histology gate uses finding-keyed lookup (consistent with D1 ALGO-ESOPH-METASTATIC-1L step 10/11 branches). T4b / medically_inoperable / patient_declines_surgery remain MDT-text conditions; no concrete finding-keyed lookups exist for these in the questionnaire layer yet (D1 honest-finding pattern). Default fallback routes all definitive_state patients to CRT — adenocarcinoma exclusion handled at indication-level demographic_constraints."
+
+sources:
+  - SRC-RTOG-8501-HERSKOVIC-1992
+  - SRC-NCCN-ESOPHAGEAL-2025
+  - SRC-ESMO-ESOPHAGEAL-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300 — first
+  routing for IND-ESOPH-DEFINITIVE-CRT-SCC (Phase C C3 indication
+  using §17 RadiationCourse for the chemoradiation phase). Algorithm
+  scope is intentionally narrow: SCC + unresectable / medically
+  inoperable / declines surgery → definitive CRT. Out-of-scope:
+  definitive CRT for adenocarcinoma (rare; case-by-case MDT, route
+  via metastatic algorithm or CROSS as appropriate); salvage
+  esophagectomy for persistent / recurrent disease post-definitive-
+  CRT (separate indication path); proton-beam RT alternatives
+  (NRG-GI006 NCCN-acceptable but not separately modeled).

--- a/knowledge_base/hosted/content/algorithms/algo_esoph_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_esoph_metastatic_1l.yaml
@@ -3,11 +3,19 @@ applicable_to_disease: DIS-ESOPHAGEAL
 applicable_to_line_of_therapy: 1
 purpose: >
   Select 1L systemic therapy for metastatic or unresectable locally advanced
-  esophageal carcinoma. Routes by histology (ESCC vs adenocarcinoma/EAC) and
-  PD-L1 CPS to ICI+chemotherapy combinations. Distinct from ALGO-ESOPH-
-  RESECTABLE-1L (neoadjuvant CROSS) and ALGO-ESOPHAGEAL-ADJUVANT-1L.
+  esophageal carcinoma. Step 0 (D2 chunk gi2-d2-algo-extensions-phase-c-
+  2026-05-08-1300) checks RF-OLIGOMET-DEFINITION first — when ≤3 metastases
+  + controllable primary + ECOG 0-1 + amenable to local therapy + no
+  peritoneal/leptomeningeal/>3-brain-mets exclusions, route to systemic-
+  plus-local oligomet track (RENAISSANCE-pattern, adenocarcinoma-grade
+  evidence; ESCC case-by-case). Otherwise routes by histology (ESCC vs
+  adenocarcinoma/EAC) and PD-L1 CPS to ICI+chemotherapy combinations.
+  Distinct from ALGO-ESOPH-RESECTABLE-1L (neoadjuvant CROSS),
+  ALGO-ESOPH-DEFINITIVE-1L (definitive CRT for unresectable SCC), and
+  ALGO-ESOPHAGEAL-ADJUVANT-1L.
 
 output_indications:
+  - IND-ESOPH-OLIGOMET-SYSTEMIC-PLUS-LOCAL
   - IND-ESOPH-METASTATIC-1L-SCC-IPI-NIVO
   - IND-ESOPH-METASTATIC-1L-HER2-TRASTUZUMAB-CHEMO
   - IND-ESOPH-METASTATIC-1L-NIVO-CHEMO-SCC
@@ -17,6 +25,37 @@ default_indication: IND-ESOPH-METASTATIC-1L-NIVO-CHEMO-SCC
 alternative_indication: IND-ESOPH-METASTATIC-1L-PEMBRO-CHEMO
 
 decision_tree:
+  # Step 0 (D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300) —
+  # RF-OLIGOMET-DEFINITION gate. When patient meets OMEC-1 oligomet
+  # consensus criteria (≤3 distant mets, ECOG 0-1, controllable primary,
+  # all sites amenable to local therapy; not peritoneal carcinomatosis /
+  # leptomeningeal / >3 brain mets), route to systemic-plus-local
+  # oligomet track. Indication primarily intended for EAC + GEJ Siewert I
+  # adenocarcinoma (RENAISSANCE-pattern); ESCC oligomet on case-by-case
+  # MDT basis with explicit weaker-evidence acknowledgement. Falls through
+  # to existing standard 1L metastatic histology hierarchy when the RF
+  # does not fire (>3 mets, peritoneal, leptomeningeal, etc.).
+  - step: 0
+    evaluate:
+      any_of:
+        - red_flag: RF-OLIGOMET-DEFINITION
+    if_true:
+      result: IND-ESOPH-OLIGOMET-SYSTEMIC-PLUS-LOCAL
+      notes: >
+        OMEC-1 oligomet consensus (Kroese 2023, PMID 36947929) +
+        RENAISSANCE / AIO-FLOT5 design extrapolated to esophageal
+        histology (Al-Batran BMC Cancer 2017; NCT02578368). ≤3 distant
+        metastatic lesions + controllable primary + ECOG 0-1 + all sites
+        amenable to local therapy. Aggressive plan track — induction
+        FLOT (adeno) or nivo+chemo (ESCC) → restaging at ~12 wk →
+        metastasis-directed local therapy (esophagectomy + metastasectomy
+        or SBRT) in responders → adjuvant systemic continuation. NCCN
+        v3.2025 2B, ESMO 2024 conditional. Confidence: moderate
+        (RENAISSANCE primary OS pending; ESCC histology extrapolated).
+    if_false:
+      next_step: 10
+    notes: "D2 chunk new branch — prepended oligomet step gates the standard histology hierarchy. Fires only when RF-OLIGOMET-DEFINITION composite trigger evaluates True (≤3 mets + ECOG≤1 + primary controllable + all sites amenable + none of peritoneal/leptomeningeal/>3-brain). HER2-positive oligomet excluded at indication-level (biomarker_requirements_excluded) so HER2+ patients still route to step 11 trastuzumab branch."
+
   # Step 10 (D1 chunk gi2-d1-algo-extensions-2026-05-07-2030) — SCC + PD-L1 CPS≥1
   # + chemo-spare preference → nivolumab + ipilimumab (CheckMate-648 nivo+ipi arm).
   # CM-648 enrolled ESCC only; chemo-sparing arm benefits from avoiding cytotoxic
@@ -144,14 +183,19 @@ sources:
   - SRC-NCCN-ESOPHAGEAL-2025
   - SRC-ESMO-ESOPHAGEAL-2024
 
-last_reviewed: "2026-05-04"
+last_reviewed: "2026-05-08"
 notes: >
-  This algorithm covers metastatic/unresectable advanced disease only.
-  Resectable: ALGO-ESOPH-RESECTABLE-1L (CROSS neoadjuvant → esophagectomy).
-  Adjuvant post-CROSS-non-pCR: ALGO-ESOPHAGEAL-ADJUVANT-1L (nivolumab 1yr).
-  2L post-ICI+chemo: limited options — cytotoxic taxane or irinotecan.
-  2L post-chemo-only: nivo (ATTRACTION-3, ESCC) or pembro CPS≥10 (KEYNOTE-181)
-  per ALGO-ESOPH-2L.
+  Step 0 (D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300):
+  RF-OLIGOMET-DEFINITION gate routes oligometastatic patients to
+  IND-ESOPH-OLIGOMET-SYSTEMIC-PLUS-LOCAL before standard histology
+  hierarchy. This algorithm covers metastatic/unresectable advanced
+  disease only. Resectable: ALGO-ESOPH-RESECTABLE-1L (CROSS
+  neoadjuvant → esophagectomy). Definitive CRT for unresectable T4b /
+  medically inoperable SCC: ALGO-ESOPH-DEFINITIVE-1L. Adjuvant post-
+  CROSS-non-pCR: ALGO-ESOPHAGEAL-ADJUVANT-1L (nivolumab 1yr). 2L
+  post-ICI+chemo: limited options — cytotoxic taxane or irinotecan.
+  2L post-chemo-only: nivo (ATTRACTION-3, ESCC) or pembro CPS≥10
+  (KEYNOTE-181) per ALGO-ESOPH-2L.
 
   ESCC vs EAC 1L choice:
   - ESCC CPS≥1: nivo+chemo preferred (CheckMate-648, largest benefit HR 0.54)

--- a/knowledge_base/hosted/content/algorithms/algo_gastric_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gastric_metastatic_1l.yaml
@@ -2,13 +2,19 @@ id: ALGO-GASTRIC-METASTATIC-1L
 applicable_to_disease: DIS-GASTRIC
 applicable_to_line_of_therapy: 1
 purpose: >
-  Algorithm for gastric/GEJ adenocarcinoma metastatic 1L. HER2+ →
-  TOGA trastuzumab+chemo (treatment-defining); HER2- + PD-L1 CPS ≥5 →
-  FOLFOX+nivo. CLDN18.2+ zolbetuximab and MSI-H pembro mono pathways
-  await full authoring (separate Indications when zolbetuximab regimen
-  is added).
+  Algorithm for gastric/GEJ adenocarcinoma metastatic 1L. Step 0
+  (D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300) checks
+  RF-OLIGOMET-DEFINITION first — when ≤3 metastases + controllable
+  primary + ECOG 0-1 + amenable to local therapy + no peritoneal/
+  leptomeningeal/>3-brain-mets exclusions, route to the systemic-
+  plus-local oligomet track. Otherwise falls through to standard 1L
+  metastatic biomarker hierarchy: HER2+ → TOGA trastuzumab+chemo
+  (treatment-defining); CLDN18.2+ HER2- → zolbetuximab (SPOTLIGHT/
+  GLOW); FGFR2b+ HER2- → bemarituzumab (FORTITUDE-101); HER2- +
+  PD-L1 CPS ≥1 → FOLFOX+nivo (CheckMate-649).
 
 output_indications:
+  - IND-GASTRIC-OLIGOMET-SYSTEMIC-PLUS-LOCAL
   - IND-GASTRIC-METASTATIC-1L-HER2-TOGA
   - IND-GASTRIC-METASTATIC-1L-CLDN18-2-ZOLBETUXIMAB
   - IND-GASTRIC-METASTATIC-1L-FGFR2B-BEMARITUZUMAB
@@ -18,6 +24,35 @@ default_indication: IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI
 alternative_indication: IND-GASTRIC-METASTATIC-1L-HER2-TOGA
 
 decision_tree:
+  # Step 0 (D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300) —
+  # RF-OLIGOMET-DEFINITION gate. When patient meets OMEC-1 oligomet
+  # consensus criteria (≤3 distant mets, ECOG 0-1, controllable primary,
+  # all sites amenable to local therapy; not peritoneal carcinomatosis /
+  # leptomeningeal / >3 brain mets), route to systemic-plus-local
+  # oligomet track (induction FLOT → restaging → metastasis-directed
+  # local therapy → adjuvant FLOT per RENAISSANCE / AIO-FLOT5 design).
+  # Falls through to existing standard 1L metastatic biomarker hierarchy
+  # when the RF does not fire (>3 mets, peritoneal, leptomeningeal, etc.).
+  - step: 0
+    evaluate:
+      any_of:
+        - red_flag: RF-OLIGOMET-DEFINITION
+    if_true:
+      result: IND-GASTRIC-OLIGOMET-SYSTEMIC-PLUS-LOCAL
+      notes: >
+        OMEC-1 oligomet consensus (Kroese 2023, PMID 36947929) +
+        RENAISSANCE / AIO-FLOT5 design (Al-Batran BMC Cancer 2017;
+        NCT02578368). ≤3 distant metastatic lesions + controllable
+        primary + ECOG 0-1 + all sites amenable to local therapy.
+        Aggressive plan track — induction FLOT → restaging at ~12 wk
+        → metastasis-directed local therapy (metastasectomy or SBRT)
+        in responders → adjuvant FLOT continuation. NCCN v3.2025 2B,
+        ESMO 2024 conditional. Confidence: moderate (RENAISSANCE
+        primary OS pending).
+    if_false:
+      next_step: 1
+    notes: "D2 chunk new branch — prepended oligomet step gates the standard biomarker hierarchy. Fires only when RF-OLIGOMET-DEFINITION composite trigger evaluates True (≤3 mets + ECOG≤1 + primary controllable + all sites amenable + none of peritoneal/leptomeningeal/>3-brain). HER2-positive oligomet excluded at indication-level (biomarker_requirements_excluded) so HER2+ patients still route to TOGA at step 1."
+
   # Step 1 — HER2+ routes to trastuzumab+chemo (TOGA / KEYNOTE-811).
   - step: 1
     evaluate:
@@ -91,17 +126,22 @@ sources:
   - SRC-NCCN-GASTRIC-2025
   - SRC-ESMO-GASTRIC-2024
 
-last_reviewed: "2026-04-30"
+last_reviewed: "2026-05-08"
 notes: >
-  HER2+ branch (step 1) routes to TOGA via RF-GASTRIC-HIGH-RISK-BIOLOGY.
-  CLDN18.2-positive HER2-negative branch (step 2) added W1.B2 chunk
-  2026-04-30 — routes to zolbetuximab+chemo (SPOTLIGHT/GLOW; FDA Oct
-  2024). PD-L1 CPS≥1 + HER2-negative branch (step 3, formerly step 2)
-  routes to nivolumab+chemo (CheckMate-649). The CLDN18.2 step
-  precedes PD-L1 because zolbetuximab + chemo is treatment-defining
-  when CLDN18.2≥75% AND PD-L1<5; for dual-positive CLDN18.2≥75% AND
-  PD-L1≥5 the indication's known_controversies surfaces the MDT
-  trade-off.
-  Out-of-scope: T-DXd 2L+ HER2+, FLOT periop for resectable, MSI-H
-  KEYNOTE-859 pembrolizumab as separate algorithm branch (pending
-  dedicated indication).
+  Step 0 (D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300):
+  RF-OLIGOMET-DEFINITION gate routes oligometastatic patients to
+  IND-GASTRIC-OLIGOMET-SYSTEMIC-PLUS-LOCAL before standard biomarker
+  hierarchy. HER2+ branch (step 1) routes to TOGA via
+  RF-GASTRIC-HIGH-RISK-BIOLOGY. CLDN18.2-positive HER2-negative
+  branch (step 2) added W1.B2 chunk 2026-04-30 — routes to
+  zolbetuximab+chemo (SPOTLIGHT/GLOW; FDA Oct 2024). FGFR2b+ HER2-
+  branch (step 10) added D1 chunk 2026-05-07 — routes to bemarituzumab
+  + mFOLFOX6 (FORTITUDE-101). PD-L1 CPS≥1 + HER2-negative branch
+  (step 3) routes to nivolumab+chemo (CheckMate-649). The CLDN18.2
+  step precedes PD-L1 because zolbetuximab + chemo is treatment-
+  defining when CLDN18.2≥75% AND PD-L1<5; for dual-positive
+  CLDN18.2≥75% AND PD-L1≥5 the indication's known_controversies
+  surfaces the MDT trade-off.
+  Out-of-scope: T-DXd 2L+ HER2+, FLOT periop for resectable
+  (ALGO-GASTRIC-RESECTABLE-PERIOP), MSI-H KEYNOTE-859 pembrolizumab
+  as separate algorithm branch (pending dedicated indication).

--- a/knowledge_base/hosted/content/algorithms/algo_gastric_resectable_periop.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gastric_resectable_periop.yaml
@@ -1,0 +1,90 @@
+# ALGO-GASTRIC-RESECTABLE-PERIOP — chunk gi2-d2-algo-extensions-phase-c-
+# 2026-05-08-1300. Routes resectable gastric / GEJ adenocarcinoma stage
+# II-III (cT2-T4 / cN+ / locally advanced potentially resectable, M0,
+# ECOG 0-1, fit for taxane chemo) to perioperative FLOT4 (4 cycles
+# neoadjuvant FLOT → D2 gastrectomy → 4 cycles adjuvant FLOT) per
+# FLOT4-AIO (Al-Batran 2019 Lancet). Distinct from ALGO-GASTRIC-
+# METASTATIC-1L (stage IV) and ALGO-GASTRIC-2L (post-progression).
+#
+# applicable_to_disease_state: "resectable" disambiguates this from
+# ALGO-GASTRIC-METASTATIC-1L (state-agnostic) when the patient profile
+# carries disease_state="resectable" — patients without disease_state
+# continue to land on the metastatic algorithm (load-order behavior
+# preserved per _find_algorithm fallback rules).
+id: ALGO-GASTRIC-RESECTABLE-PERIOP
+applicable_to_disease: DIS-GASTRIC
+applicable_to_line_of_therapy: 1
+applicable_to_disease_state: resectable
+purpose: >
+  Algorithm for resectable / locally advanced potentially resectable
+  gastric or GEJ Siewert II/III adenocarcinoma. Step 1 routes adeno +
+  stage II-III (cT2-T4 / cN+) + ECOG 0-1 + fit-for-chemo to perioperative
+  FLOT4 (IND-GASTRIC-PERIOP-FLOT4). Default fallback also points to
+  FLOT4 — the indication itself carries hard contraindications
+  (RF-GASTRIC-EMERGENCY-BLEED-OBSTRUCTION) that the engine surfaces
+  via red_flags_triggering_alternative on the indication.
+
+output_indications:
+  - IND-GASTRIC-PERIOP-FLOT4
+
+default_indication: IND-GASTRIC-PERIOP-FLOT4
+alternative_indication: null
+
+decision_tree:
+  # Step 1 — Resectable adeno + stage II-III locally advanced + ECOG 0-1
+  # + fit for chemo → perioperative FLOT4. The fitness gate is wired via
+  # CSD-7A pan-disease RFs (RF-FITNESS-ECOG-FIT, RF-FITNESS-ECOG-INTERMEDIATE)
+  # following the pattern in ALGO-ESOPH-RESECTABLE-1L. Histology + stage +
+  # resectability conditions remain as MDT-evaluated text — no concrete
+  # finding-keyed lookups exist for these in the questionnaire layer yet
+  # (per D1 honest finding: existing English-string `condition:` clauses
+  # functionally fall through to default_indication; documented here for
+  # clinical readability).
+  - step: 1
+    evaluate:
+      all_of:
+        - condition: "Adenocarcinoma histology (gastric or GEJ Siewert II/III)"
+        - condition: "Resectable cT2-T4 or N+ M0 disease (or locally advanced potentially resectable per MDT)"
+        - any_of:
+            - red_flag: RF-FITNESS-ECOG-FIT
+            - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+    if_true:
+      result: IND-GASTRIC-PERIOP-FLOT4
+      notes: >
+        FLOT4-AIO (Al-Batran 2019, Lancet) — perioperative FLOT × 4
+        cycles neoadjuvant + D2 gastrectomy + FLOT × 4 cycles adjuvant.
+        Median OS 50 vs 35 mo (HR 0.77), DFS 30 vs 18 mo (HR 0.75),
+        pCR 16% vs 6%. NCCN v3.2025 category 1 + ESMO 2024 strong
+        recommendation. Phased indication uses §17 Indication.phases[]
+        (REG-FLOT × 4 → SUR-D2-LYMPHADENECTOMY → REG-FLOT × 4).
+    if_false:
+      result: IND-GASTRIC-PERIOP-FLOT4
+      notes: >
+        Fallback: even when fitness-RF clause does not fire, indication
+        defaults to FLOT4 — the indication's demographic_constraints
+        (ecog_max: 1, fit_for_chemo: true) and red_flags_triggering_
+        alternative (RF-GASTRIC-EMERGENCY-BLEED-OBSTRUCTION) handle
+        contraindication surfacing at render time. Patients with
+        ECOG ≥2 or unfit-for-taxane status should be routed to MDT
+        for FOLFOX-based or fluoropyrimidine-only periop alternatives
+        (out of scope for v0.1 — ratification awaiting separate IND).
+    notes: "D2 chunk routing — adeno + stage II-III resectable + ECOG 0-1 + fit-for-chemo gates entry to periop FLOT4. Fitness RFs (RF-FITNESS-ECOG-FIT / -INTERMEDIATE) provide structured fitness signal; histology + stage + resectability remain MDT-text conditions consistent with ALGO-ESOPH-RESECTABLE-1L wiring pattern (no concrete finding-keyed lookups available for these gates in the questionnaire layer yet)."
+
+sources:
+  - SRC-FLOT4-AL-BATRAN-2019
+  - SRC-NCCN-GASTRIC-2025
+  - SRC-ESMO-GASTRIC-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  D2 chunk gi2-d2-algo-extensions-phase-c-2026-05-08-1300 — first
+  routing for IND-GASTRIC-PERIOP-FLOT4 (Phase C C1 indication, the
+  §17 Indication.phases[] gold-standard exemplar). Algorithm scope
+  is intentionally narrow: routes resectable adeno to FLOT4 periop
+  with no biomarker stratification (FLOT4 did not stratify; HER2 /
+  PD-L1 / MSI testing on diagnostic biopsy informs metastatic-line
+  preparedness but does not gate periop pathway). Out-of-scope:
+  FOLFOX-based or fluoropyrimidine-only periop alternatives for
+  ECOG ≥2 / unfit-for-taxane patients (separate indication pending);
+  CROSS neoadjuvant for GEJ Siewert I (handled by ALGO-ESOPH-
+  RESECTABLE-1L); MAGIC ECF/ECX (legacy, superseded by FLOT4).


### PR DESCRIPTION
## Summary
- 2 NEW algorithms + 2 EDIT routing 4 Phase C indications (FLOT periop, definitive CRT, gastric/esoph oligomet)
- Engine smoke 5/5 pass including HER2-neg CPS=25 regression check
- Closes #443

## Files (4 algorithms: 2 NEW + 2 EDIT)

| File | Action | Routing |
|---|---|---|
| `algo_gastric_resectable_periop.yaml` | NEW | stage II-III adeno → IND-GASTRIC-PERIOP-FLOT4 |
| `algo_esoph_definitive_1l.yaml` | NEW | SCC T4b/M0/inoperable → IND-ESOPH-DEFINITIVE-CRT-SCC |
| `algo_gastric_metastatic_1l.yaml` | EDIT | step 0 prepended: RF-OLIGOMET fires → IND-GASTRIC-OLIGOMET; falls through to existing biomarker hierarchy |
| `algo_esoph_metastatic_1l.yaml` | EDIT | step 0 prepended: same oligomet pattern |

## Engine smoke 5/5 PASS

| # | Patient profile | Algorithm | → Indication |
|---|---|---|---|
| 1 | Resectable gastric stage III | ALGO-GASTRIC-RESECTABLE-PERIOP | IND-GASTRIC-PERIOP-FLOT4 |
| 2 | Esoph SCC T4b | ALGO-ESOPH-DEFINITIVE-1L | IND-ESOPH-DEFINITIVE-CRT-SCC |
| 3 | Gastric oligomet | ALGO-GASTRIC-METASTATIC-1L (step 0 fires) | IND-GASTRIC-OLIGOMET-SYSTEMIC-PLUS-LOCAL |
| 4 | Esoph adeno oligomet | ALGO-ESOPH-METASTATIC-1L (step 0 fires) | IND-ESOPH-OLIGOMET-SYSTEMIC-PLUS-LOCAL |
| 5 | **Regression**: HER2-neg CPS=25 (5 mets, NOT oligomet) | ALGO-GASTRIC-METASTATIC-1L (step 0 falls through, step 3 fires) | IND-GASTRIC-METASTATIC-1L-PDL1-CHEMO-ICI ✓ |

## Authoring decisions

1. **`applicable_to_disease_state`** (`resectable` / `unresectable_definitive`) on new algorithms disambiguates from state-agnostic `metastatic_1l`. Existing profiles without `disease_state` continue landing on metastatic_1l (load-order behavior preserved).
2. **Oligomet as FIRST list element** per `walk_algorithm` `next(iter(steps))` semantics (list order, not step number); `if_false: {next_step: 1}` (gastric) / `{next_step: 10}` (esoph) routes back into biomarker hierarchy.
3. **HER2+ oligomet excluded at indication-level** (`biomarker_requirements_excluded`), so HER2+ patients still pre-route at step 1 TOGA / step 11 trastuzumab.

## Test plan
- [x] Validator: 91 schema / 217 contract — identical to baseline
- [x] Entities 2813 → 2815 (+2 NEW algorithms; EDITs unchanged count)
- [x] Test suite: 11 fail / 89 pass identical pre/post (pre-existing regimen baseline)
- [x] Engine smoke: 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)