### PR TITLE
fix(kb): citation backfill — wire W0-6 sources to BMA-EBV + DRUG-PAZOPANIB

### DIFF
--- a/knowledge_base/hosted/content/biomarker_actionability/bma_ebv_positive_gastric.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_ebv_positive_gastric.yaml
@@ -54,6 +54,7 @@ contraindicated_monotherapy: []
 primary_sources:
   - SRC-TCGA-GASTRIC-BASS-2014
   - SRC-KIM-PEMBRO-EBV-NATMED-2018
+  - SRC-KEYNOTE-061-SHITARA-2018
   - SRC-NCCN-GASTRIC-2025
   - SRC-ESMO-GASTRIC-2024
 last_verified: "2026-05-07"
@@ -79,6 +80,18 @@ evidence_sources:
       and single-center design — hypothesis-generating, not
       practice-changing on its own, but the canonical primary citation
       for the exceptional ICI response signal in EBV+ gastric.
+  - source: SRC-KEYNOTE-061-SHITARA-2018
+    level: "Tier 1 (parent randomised phase 3)"
+    direction: Context
+    significance: "Parent trial citation; EBV+ subset analysis pending"
+    note: >
+      Shitara et al. Lancet 2018 (KEYNOTE-061; PMID 29880231) —
+      pembrolizumab vs paclitaxel as 2L gastric/GEJ adenocarcinoma
+      after platinum/fluoropyrimidine failure. Cited here as the
+      parent randomised trial; the EBV+ subset analysis (Janjigian
+      et al.) is still pending source-ingestion and is not used to
+      support an EBV-specific claim in this BMA. No EBV-specific
+      subset claim is made on the basis of this citation alone.
   - source: SRC-NCCN-GASTRIC-2025
     level: "Category 2B"
     direction: Supports
@@ -104,9 +117,11 @@ notes: >
   TCGA gastric classification paper (Bass et al., Nature 2014) and
   Kim et al. Nature Medicine 2018 (pembrolizumab response in EBV+
   metastatic gastric). NCCN gastric v2025 and ESMO gastric 2024 retained
-  as guideline corroboration. Outstanding source-stub follow-up:
-  KEYNOTE-061 EBV+ subset analysis (Janjigian) for confirmatory ICI
-  signal in a randomised setting. Co-positivity with MSI-H, PD-L1
+  as guideline corroboration. KEYNOTE-061 EBV+ subset analysis
+  (Janjigian) is still pending source-ingestion; the parent trial
+  KN-061 is now cited as Shitara 2018 Lancet (PMID 29880231) for
+  context, but no EBV-specific subset claim is asserted on the basis
+  of that citation. Co-positivity with MSI-H, PD-L1
   CPS+, HER2+ is mostly mutually exclusive (EBV+ rarely overlaps with
   MSI-H — both confer immunogenicity through different mechanisms);
   HER2+ and EBV+ cooccur in <2% of cases. NOT a 1L-routing biomarker

--- a/knowledge_base/hosted/content/drugs/drug_pazopanib.yaml
+++ b/knowledge_base/hosted/content/drugs/drug_pazopanib.yaml
@@ -127,6 +127,9 @@ pharmacology:
   volume_of_distribution_l: null
 
 sources:
+  - SRC-VEG105192-STERNBERG-2010
+  - SRC-PALETTE-VAN-DER-GRAAF-2012
+  - SRC-COMPARZ-MOTZER-2013
   - SRC-NCCN-KIDNEY-2025
   - SRC-ESMO-RCC-2024
 
@@ -156,10 +159,12 @@ notes: >
   later-line monotherapy. STUB pending Clinical Co-Lead sign-off
   (CHARTER §6.1: ≥2 reviewers for clinical content). Drug-stub
   created to resolve pre-existing ref-error from REG-PAZOPANIB-RCC.
-  Primary RCT citations (VEG105192, PALETTE, COMPARZ) not yet
-  ingested as Source entities — flagged for source ingestion in a
-  future chunk; current sources are NCCN + ESMO guidelines as
-  fallback, both of which cite the primary trials.
+  Primary RCT citations now wired (W0-6 source backfill, PR #445):
+  SRC-VEG105192-STERNBERG-2010 (RCC FDA approval basis),
+  SRC-PALETTE-VAN-DER-GRAAF-2012 (STS FDA approval basis), and
+  SRC-COMPARZ-MOTZER-2013 (RCC non-inferiority vs sunitinib).
+  NCCN-Kidney 2025 and ESMO-RCC 2024 retained as guideline
+  corroboration.
 
 notes_patient: >
   Пазопаніб — щоденна таблетка для нирково-клітинного раку та саркоми м'яких тканин. Приймати натще (за 1 годину до або 2 години після їжі). Контролюємо печінкові ферменти регулярно (перші місяці часто), артеріальний тиск, та функцію щитоподібної залози. Можливе знебарвлення волосся — це очікувано, не потребує дій.


### PR DESCRIPTION
## Summary
- 2 entities cite-upgraded with W0-6 sources (PR #445)
- bma_ebv_positive_gastric: + SRC-KEYNOTE-061-SHITARA-2018 (parent trial; subset analysis still future-ingest)
- drug_pazopanib: + 3 primary RCTs (VEG105192, PALETTE, COMPARZ); fallback flag removed
- drug_bemarituzumab: idempotency — already properly cited; no edit
- Closes #447

## Test plan
- [x] Validator: 2812 / 91 schema / 215 ref — identical pre/post (no regression)
- [x] pytest: 6 pass / 1 pre-existing fail — identical
- [x] Diff: 2 files M, 0 new, allowlist-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)