### PR TITLE
feat(kb): GI-3 W0-PDAC primary-trial source backfill (4 sources)

### DIFF
--- a/knowledge_base/hosted/content/sources/src_espac_5f_ghaneh_2023.yaml
+++ b/knowledge_base/hosted/content/sources/src_espac_5f_ghaneh_2023.yaml
@@ -1,0 +1,50 @@
+id: SRC-ESPAC-5F-GHANEH-2023
+source_type: rct_publication
+title: "Immediate surgery compared with short-course neoadjuvant gemcitabine plus capecitabine, FOLFIRINOX, or chemoradiotherapy in patients with borderline resectable pancreatic cancer (ESPAC5): a four-arm, multicentre, randomised, phase 2 trial"
+version: "2023"
+authors:
+  - Ghaneh P
+  - Palmer D
+  - Cicconi S
+  - et al.
+journal: Lancet Gastroenterology & Hepatology
+doi: 10.1016/S2468-1253(22)00348-X
+pmid: "36521500"
+url: https://pubmed.ncbi.nlm.nih.gov/36521500
+access_level: subscription_required
+currency_status: current
+current_as_of: "2023-02-01"
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Lancet Gastroenterology & Hepatology (subscription)
+attribution:
+  required: true
+  text: "Ghaneh P et al., Lancet Gastroenterol Hepatol 2023; ESPAC5 (formerly ESPAC-5f) trial"
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-05-08"
+relates_to_diseases:
+  - DIS-PDAC
+last_verified: "2026-05-08"
+notes: >
+  ESPAC5 (formerly ESPAC-5f) four-arm phase-2 RCT (NCT02172976):
+  immediate surgery vs short-course neoadjuvant therapy in borderline
+  resectable pancreatic ductal adenocarcinoma (n=90; randomised across
+  four arms — immediate surgery, gemcitabine + capecitabine,
+  FOLFIRINOX, or capecitabine-based chemoradiotherapy). Primary
+  endpoint resection rate did not differ (62% vs 55% pooled
+  neoadjuvant). However, 1-year OS favoured neoadjuvant therapy (77%
+  vs 42%; HR for death 0.27 pooled). Established proof-of-concept that
+  short-course neoadjuvant chemotherapy improves survival in
+  borderline-resectable PDAC; supports neoadjuvant FOLFIRINOX or
+  gemcitabine + capecitabine as preferred approach over upfront
+  surgery for borderline-resectable disease. Underpowered for
+  between-arm comparison; results informed subsequent phase-3 designs
+  including PREOPANC-2.
+corpus_role: primary_trial

--- a/knowledge_base/hosted/content/sources/src_napoli_3_wainberg_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_napoli_3_wainberg_2024.yaml
@@ -1,0 +1,48 @@
+id: SRC-NAPOLI-3-WAINBERG-2024
+source_type: rct_publication
+title: "NALIRIFOX versus nab-paclitaxel and gemcitabine in treatment-naive patients with metastatic pancreatic ductal adenocarcinoma (NAPOLI 3): a randomised, open-label, phase 3 trial"
+version: "2023"
+authors:
+  - Wainberg ZA
+  - Melisi D
+  - Macarulla T
+  - et al.
+journal: Lancet
+doi: 10.1016/S0140-6736(23)01366-1
+pmid: "37708904"
+url: https://pubmed.ncbi.nlm.nih.gov/37708904
+access_level: subscription_required
+currency_status: current
+current_as_of: "2023-10-07"
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Lancet (subscription)
+attribution:
+  required: true
+  text: "Wainberg ZA et al., Lancet 2023; NAPOLI 3 trial"
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-05-08"
+relates_to_diseases:
+  - DIS-PDAC
+last_verified: "2026-05-08"
+notes: >
+  NAPOLI 3 phase-3 RCT (NCT04083235): liposomal-irinotecan + 5-FU +
+  leucovorin + oxaliplatin (NALIRIFOX; n=383) vs nab-paclitaxel +
+  gemcitabine (n=387) as 1L therapy in metastatic pancreatic ductal
+  adenocarcinoma. Median OS 11.1 vs 9.2 mo (HR 0.83; p=0.04); median
+  PFS 7.4 vs 5.6 mo (HR 0.69). Grade ≥3 TEAEs comparable. Established
+  NALIRIFOX as a preferred 1L option for metastatic PDAC (ECOG 0-1)
+  alongside FOLFIRINOX and gem/nab-paclitaxel; first phase-3 trial
+  demonstrating OS benefit over nab-paclitaxel/gemcitabine in this
+  population. NCCN category 1 listing for 1L mPDAC (good performance
+  status). Note: although NCT registration year is 2019, primary
+  publication appeared 2023; spec retains 2024 in id for consistency
+  with manifest.
+corpus_role: primary_trial

--- a/knowledge_base/hosted/content/sources/src_norpact_1_labori_2024.yaml
+++ b/knowledge_base/hosted/content/sources/src_norpact_1_labori_2024.yaml
@@ -1,0 +1,48 @@
+id: SRC-NORPACT-1-LABORI-2024
+source_type: rct_publication
+title: "Neoadjuvant FOLFIRINOX versus upfront surgery for resectable pancreatic head cancer (NORPACT-1): a multicentre, randomised, phase 2 trial"
+version: "2024"
+authors:
+  - Labori KJ
+  - Bratlie SO
+  - Andersson B
+  - et al.
+journal: Lancet Gastroenterology & Hepatology
+doi: 10.1016/S2468-1253(23)00405-3
+pmid: "38237621"
+url: https://pubmed.ncbi.nlm.nih.gov/38237621
+access_level: subscription_required
+currency_status: current
+current_as_of: "2024-03-01"
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Lancet Gastroenterology & Hepatology (subscription)
+attribution:
+  required: true
+  text: "Labori KJ et al., Lancet Gastroenterol Hepatol 2024; NORPACT-1 trial"
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-05-08"
+relates_to_diseases:
+  - DIS-PDAC
+last_verified: "2026-05-08"
+notes: >
+  NORPACT-1 phase-2 RCT (NCT02919202): neoadjuvant FOLFIRINOX (4 cycles)
+  followed by surgery and 8 cycles adjuvant chemotherapy vs upfront
+  surgery + 12 cycles adjuvant chemotherapy in resectable pancreatic
+  head ductal adenocarcinoma (n=140 across Nordic centres). Primary
+  endpoint OS at 18 months from randomisation: no statistically
+  significant difference (60% vs 73%; HR for OS 1.52, but per-protocol
+  analyses similar). Resection rate 82% (neoadjuvant) vs 89% (upfront).
+  Did not demonstrate superiority of neoadjuvant FOLFIRINOX in
+  resectable (NOT borderline-resectable) PDAC; supports current
+  guidance that upfront surgery + adjuvant mFOLFIRINOX remains an
+  acceptable standard for clearly resectable disease. Important
+  counterweight to enthusiasm for universal neoadjuvant approach.
+corpus_role: primary_trial

--- a/knowledge_base/hosted/content/sources/src_prodige_24_conroy_2018.yaml
+++ b/knowledge_base/hosted/content/sources/src_prodige_24_conroy_2018.yaml
@@ -1,0 +1,46 @@
+id: SRC-PRODIGE-24-CONROY-2018
+source_type: rct_publication
+title: "FOLFIRINOX or Gemcitabine as Adjuvant Therapy for Pancreatic Cancer"
+version: "2018"
+authors:
+  - Conroy T
+  - Hammel P
+  - Hebbar M
+  - et al.
+journal: New England Journal of Medicine
+doi: 10.1056/NEJMoa1809775
+pmid: "30575490"
+url: https://pubmed.ncbi.nlm.nih.gov/30575490
+access_level: subscription_required
+currency_status: current
+current_as_of: "2018-12-20"
+evidence_tier: 1
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: NEJM (subscription)
+attribution:
+  required: true
+  text: "Conroy T et al., NEJM 2018; PRODIGE-24/CCTG PA.6 trial"
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-05-08"
+relates_to_diseases:
+  - DIS-PDAC
+last_verified: "2026-05-08"
+notes: >
+  PRODIGE-24/CCTG PA.6 phase-3 RCT (NCT01526135): modified FOLFIRINOX
+  (mFOLFIRINOX; oxaliplatin 85 mg/m^2, irinotecan 150-180 mg/m^2,
+  leucovorin, 5-FU continuous infusion) vs gemcitabine adjuvant therapy
+  after R0/R1 resection of pancreatic ductal adenocarcinoma (n=493,
+  Unicancer-GI PRODIGE Group + Canadian Cancer Trials Group). Median
+  DFS 21.6 vs 12.8 mo (HR 0.58; p<0.001); median OS 54.4 vs 35.0 mo
+  (HR 0.64). Higher grade 3-4 toxicity in mFOLFIRINOX arm (75.9% vs
+  52.9%) but tolerable. Established mFOLFIRINOX as new standard
+  adjuvant therapy for fit patients (ECOG 0-1) after PDAC resection;
+  superseded gemcitabine monotherapy as preferred regimen.
+corpus_role: primary_trial


### PR DESCRIPTION
## Summary
- 4 NEW PDAC primary-trial sources
- Closes #451
- **3/4 spec PMIDs were defective (75% rate) — agent corrected all via PubMed WebFetch verification**

## Sources (all PMIDs verified)

| ID | Verified PMID | Journal | Year |
|---|---|---|---|
| SRC-PRODIGE-24-CONROY-2018 | 30575490 | NEJM | 2018 |
| SRC-NAPOLI-3-WAINBERG-2024 | 37708904 | Lancet | 2023 |
| SRC-NORPACT-1-LABORI-2024 | 38237621 | Lancet Gastroenterol Hepatol | 2024 |
| SRC-ESPAC-5F-GHANEH-2023 | 36521500 | Lancet Gastroenterol Hepatol | 2023 |

## PMID corrections (per refactor lesson §10.1)

- **PRODIGE-24**: spec 29445964 → real 30575490 (spec PMID was a diabetes paper)
- **NAPOLI-3**: spec 38199018 → real 37708904 (spec PMID was an unrelated case report)
- **ESPAC-5F**: spec 36495459 → real 36521500 (spec PMID was bioinformatics)
- **NORPACT-1**: not in spec; located via PubMed search → 38237621

**75% defect rate strongly validates `§10.1 verify each PMID via NCBI esearch + title match` pattern.** Future source-stub chunks should bake PMID verification as Step 1 of authoring.

## Test plan
- [x] All 4 PMIDs verified via PubMed WebFetch (titles match expected trials)
- [x] No pre-existing skeletal entities — all 4 created NEW
- [x] Validator: 91 schema / 215 ref — identical pre/post
- [x] Entities += 4
- [x] test_loader pre-existing failure verified unrelated via stash round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)