### PR TITLE
feat(kb): GI-3 A-CHOLANGIO 1L IO — TOPAZ-1 + KEYNOTE-966 (NCCN/ESMO 2024+ preferred)

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_cholangio_advanced_gem_cis.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cholangio_advanced_gem_cis.yaml
@@ -28,13 +28,44 @@ required_tests: []
 desired_tests: []
 
 rationale: >
-  Advanced / unresectable / metastatic biliary tract carcinoma. Gem+cis is the global 1L standard since 2010.
+  Advanced / unresectable / metastatic biliary tract carcinoma. Gem+cis was the
+  global 1L standard since 2010 (ABC-02). Since 2022 (TOPAZ-1) and 2023
+  (KEYNOTE-966), durva+gem-cis and pembro+gem-cis have become NCCN category 1
+  preferred 1L regimens — gem+cis monotherapy is now retained primarily for
+  patients with IO contraindications (active autoimmune disease, prior solid
+  organ transplant) or for those unable to receive IO due to access
+  limitations.
 
 sources:
   - source_id: SRC-NCCN-CNS-2025
+
+known_controversies:
+  - topic: "1L systemic therapy choice in advanced BTC: gem+cis monotherapy vs IO+gem+cis (TOPAZ-1 / KEYNOTE-966)"
+    positions:
+      - position: "IO+gem+cis is preferred 1L for IO-eligible patients (NCCN/ESMO 2024+)"
+        sources: [SRC-TOPAZ-1-OH-2022, SRC-KEYNOTE-966-KELLEY-2023, SRC-NCCN-HEPATOBILIARY, SRC-ESMO-BTC-2023]
+        evidence_note: >
+          TOPAZ-1: mOS 12.8 vs 11.5 mo (HR 0.80, p=0.021), 24-mo OS 24.9% vs 10.4%.
+          KEYNOTE-966: mOS 12.7 vs 10.9 mo (HR 0.83, p=0.0034). Both NCCN cat 1.
+      - position: "Gem+cis monotherapy retained as fallback for IO-contraindicated or IO-inaccessible patients"
+        sources: [SRC-NCCN-HEPATOBILIARY, SRC-ESMO-BTC-2023]
+        evidence_note: >
+          Active autoimmune disease, prior solid organ transplant, severe
+          immunosuppression, or access barriers (UA: durva/pembro NOT NSZU-
+          reimbursed for BTC) keep gem+cis monotherapy clinically and
+          pragmatically relevant.
+    our_default: "Default to IO+gem+cis (TOPAZ-1 or KEYNOTE-966) for IO-eligible patients with ECOG 0-1; route to gem+cis monotherapy only if IO contraindicated or inaccessible."
+    rationale: >
+      Two NCCN cat 1 RCTs since 2022 establish IO+chemo as new SOC. Gem+cis
+      monotherapy stays in KB as the IO-contraindicated / access-limited path.
 
 reviewer_signoffs: 0
 notes: >
   STUB scaffold. Auto-generated minimal indication so engine can route
   end-to-end. Pending Clinical Co-Lead review per CHARTER §6.1 dev-mode
   signoff exemption.
+
+  Status as of 2026-05-08: legacy / IO-contraindicated fallback. Preferred
+  1L indications for IO-eligible patients are
+  IND-CHOLANGIO-METASTATIC-1L-DURVA-CHEMO (TOPAZ-1) and
+  IND-CHOLANGIO-METASTATIC-1L-PEMBRO-CHEMO (KEYNOTE-966).

--- a/knowledge_base/hosted/content/indications/ind_cholangio_metastatic_1l_durva_chemo.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cholangio_metastatic_1l_durva_chemo.yaml
@@ -1,0 +1,112 @@
+id: IND-CHOLANGIO-METASTATIC-1L-DURVA-CHEMO
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-CHOLANGIOCARCINOMA
+  line_of_therapy: 1
+  stage_requirements:
+    - "Advanced / unresectable / metastatic biliary tract carcinoma"
+    - "Includes intrahepatic cholangiocarcinoma, extrahepatic cholangiocarcinoma, and gallbladder cancer (per TOPAZ-1 inclusion)"
+    - "Treatment-naive (no prior systemic therapy for advanced disease)"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+
+recommended_regimen: REG-DURVA-GEM-CIS-CHOLANGIO
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "26.7% vs 18.7% (durva+gem-cis vs gem-cis; TOPAZ-1)"
+  progression_free_survival: "mPFS 7.2 vs 5.7 mo (HR 0.75)"
+  overall_survival_median: "mOS 12.8 vs 11.5 mo (HR 0.80, 95% CI 0.66-0.97, p=0.021)"
+  notes: "TOPAZ-1, N=685. Benefit consistent across PD-L1 CPS subgroups and BTC anatomic subsites (intra-/extrahepatic cholangiocarcinoma, gallbladder cancer). 24-month OS 24.9% vs 10.4% (durable tail benefit characteristic of IO addition)."
+
+hard_contraindications: []
+# Free-text contraindications (autoimmune disease, prior solid-organ transplant,
+# ECOG PS ≥ 2, severe renal impairment CrCl <50 mL/min) described in `notes:` /
+# `do_not_do:` — schema requires Contraindication entity IDs which are not yet
+# authored for IO-related contraindications. Stub gap; flag for D-prefix follow-up.
+
+red_flags_triggering_alternative: []
+
+required_tests: []
+# Required tests (biopsy confirmation, baseline LFT/CBC/CMP/CrCl, TSH baseline
+# pre-IO, CT C/A/P or MRI) described in `notes:` — schema requires Test entity
+# IDs not yet authored for these. Flagged for D-prefix follow-up.
+
+desired_tests: []
+# Desired tests (MSI/MMR, CGP for FGFR2/IDH1/BRAF/HER2/NTRK, PD-L1 CPS) described
+# in `notes:` — schema requires Test entity IDs not yet authored.
+
+rationale: >
+  TOPAZ-1 (Oh DY et al., NEJM Evid 2022;1(8):EVIDoa2200015; NCT03875235):
+  durvalumab 1500 mg q3w + gemcitabine 1000 mg/m² + cisplatin 25 mg/m²
+  (D1, D8 q3w x up to 8 cycles), then durvalumab maintenance, vs placebo +
+  gem-cis in 1L advanced BTC (n=685). mOS 12.8 vs 11.5 mo (HR 0.80, 95%
+  CI 0.66-0.97, p=0.021); benefit grew at later time points (24-month OS
+  24.9% vs 10.4%) consistent with IO durable-response tail. FDA-approved
+  Sep 2022; NCCN category 1 preferred 1L regimen. Choice between TOPAZ-1
+  (durva) and KEYNOTE-966 (pembro) is institutional / access-driven — no
+  head-to-head comparison; both are NCCN category 1. TOPAZ-1 has tighter
+  HR and clearer survival curve separation but smaller trial (n=685 vs
+  n=1069 KEYNOTE-966).
+
+rationale_ua: >
+  TOPAZ-1: дурвалумаб + гемцитабін + цисплатин для 1L прогресуючого раку
+  жовчних шляхів. mOS 12.8 vs 11.5 міс (HR 0.80). 24-міс OS 24.9% vs
+  10.4% — характерний "хвостовий" приріст від додавання імунотерапії.
+  Стандарт першої лінії з 2022 року для прогресуючого/метастатичного
+  BTC; NCCN категорія 1.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-TOPAZ-1-OH-2022
+    position: supports
+  - source_id: SRC-NCCN-HEPATOBILIARY
+    position: supports
+  - source_id: SRC-ESMO-BTC-2023
+    position: supports
+
+do_not_do:
+  - "Не використовуйте за наявності активного аутоімунного захворювання (відносне протипоказання для дурвалумабу — оцінити ризик/користь індивідуально)"
+  - "Не продовжуйте дурвалумаб після прогресування — переходьте на 2L (FGFR2/IDH1/BRAF-таргетна терапія за наявності маркерів, або FOLFOX)"
+  - "Не використовуйте при ECOG PS ≥ 2 — TOPAZ-1 не включала цих пацієнтів, перевагу має гем+цис монотерапія"
+  - "Не пропускайте CGP (FGFR2, IDH1, BRAF, HER2, NTRK) на старті — потрібно для планування 2L"
+
+last_reviewed: "2026-05-08"
+notes: >
+  STUB scaffold — TOPAZ-1 1L IO+chemo for advanced BTC, NCCN category 1
+  preferred. Auto-generated minimal indication so engine can route
+  end-to-end with new 2024+ standard-of-care; pending Clinical Co-Lead
+  review per CHARTER §6.1 dev-mode signoff exemption.
+
+  Clinical contraindications (free-text, pending Contraindication-entity
+  authoring): active autoimmune disease requiring systemic
+  immunosuppression (durvalumab); prior solid-organ transplant (rejection
+  risk); ECOG PS ≥ 2 (not enrolled in TOPAZ-1 — gem+cis monotherapy
+  preferred via existing IND-CHOLANGIO-ADVANCED-GEM-CIS); severe renal
+  impairment CrCl <50 mL/min (cisplatin contraindication — carboplatin
+  substitution case-by-case).
+
+  Required tests (free-text, pending Test-entity authoring): histologic
+  confirmation of BTC; baseline LFTs/CBC/CMP/CrCl; TSH baseline (IO
+  thyroiditis monitoring); CT C/A/P or MRI staging.
+
+  Desired tests: MSI/MMR (rare MSI-H in BTC, may inform later-line pembro
+  monotherapy); CGP for FGFR2 fusions, IDH1, BRAF, HER2, NTRK (2L+ planning
+  per existing FGFR2-fusion 2L indications); PD-L1 CPS (informational —
+  TOPAZ-1 benefit subgroup-independent).
+
+  Phasing (induction x 8 → durva maintenance) described in regimen
+  `notes:`; §17 phased-indication structure not used for v0.1 (opt-in per
+  planning doc §2.5). D-prefix algo flag: `algo_cholangio_1l` may need
+  extension to surface 1L IO-combo option (out of A scope; flagged in PR).
+  Existing `ind_cholangio_advanced_gem_cis` retained as legacy /
+  IO-contraindicated fallback path.

--- a/knowledge_base/hosted/content/indications/ind_cholangio_metastatic_1l_pembro_chemo.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cholangio_metastatic_1l_pembro_chemo.yaml
@@ -1,0 +1,115 @@
+id: IND-CHOLANGIO-METASTATIC-1L-PEMBRO-CHEMO
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-CHOLANGIOCARCINOMA
+  line_of_therapy: 1
+  stage_requirements:
+    - "Advanced / unresectable / metastatic biliary tract carcinoma"
+    - "Includes intrahepatic cholangiocarcinoma, extrahepatic cholangiocarcinoma, and gallbladder cancer (per KEYNOTE-966 inclusion)"
+    - "Treatment-naive (no prior systemic therapy for advanced disease)"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+
+recommended_regimen: REG-PEMBRO-GEM-CIS-CHOLANGIO
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "29% vs 29% (no improvement in objective response rate; KEYNOTE-966)"
+  progression_free_survival: "mPFS 6.5 vs 5.6 mo (HR 0.86; not statistically significant)"
+  overall_survival_median: "mOS 12.7 vs 10.9 mo (HR 0.83, 95% CI 0.72-0.95, p=0.0034)"
+  notes: "KEYNOTE-966, N=1069. OS benefit driven primarily by tail of curve (durable IO responders); ORR and PFS gains modest/non-significant. Benefit consistent across PD-L1 CPS subgroups and BTC anatomic subsites."
+
+hard_contraindications: []
+# Free-text contraindications (autoimmune, prior solid-organ transplant,
+# ECOG PS ≥ 2, severe renal impairment CrCl <50 mL/min) described in `notes:` /
+# `do_not_do:` — schema requires Contraindication entity IDs which are not yet
+# authored for IO-related contraindications. Stub gap; flag for D-prefix follow-up.
+
+red_flags_triggering_alternative: []
+
+required_tests: []
+# Required tests (biopsy confirmation, baseline LFT/CBC/CMP/CrCl, TSH baseline
+# pre-IO, CT C/A/P or MRI) described in `notes:` — schema requires Test entity
+# IDs not yet authored for these. Flagged for D-prefix follow-up.
+
+desired_tests: []
+# Desired tests (MSI/MMR, CGP for FGFR2/IDH1/BRAF/HER2/NTRK, PD-L1 CPS) described
+# in `notes:` — schema requires Test entity IDs not yet authored.
+
+rationale: >
+  KEYNOTE-966 (Kelley RK et al., Lancet 2023;401(10391):1853-1865;
+  NCT04003636): pembrolizumab 200 mg q3w + gemcitabine 1000 mg/m² +
+  cisplatin 25 mg/m² (D1, D8 q3w; cisplatin capped at 8 cycles, gem
+  continued indefinitely with pembro), vs placebo + gem-cis in 1L
+  advanced BTC (n=1069). mOS 12.7 vs 10.9 mo (HR 0.83, 95% CI 0.72-0.95,
+  p=0.0034). Modest absolute survival gain (~1.8 mo) with HR 0.83;
+  ORR and PFS not improved. Larger trial than TOPAZ-1 (1069 vs 685) but
+  weaker effect size. FDA-approved Oct 2023; NCCN category 1 alternative
+  preferred 1L regimen alongside TOPAZ-1. Choice between TOPAZ-1 (durva)
+  and KEYNOTE-966 (pembro) is institutional / access-driven — no
+  head-to-head; both NCCN cat 1.
+
+rationale_ua: >
+  KEYNOTE-966: пембролізумаб + гемцитабін + цисплатин для 1L прогресуючого
+  раку жовчних шляхів. mOS 12.7 vs 10.9 міс (HR 0.83). Більша когорта
+  (n=1069) ніж TOPAZ-1, але менший ефект. NCCN категорія 1, схвалено
+  FDA жовтень 2023. Вибір між durva і pembro — інституційний / за
+  доступністю; обидва прийнятні.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-KEYNOTE-966-KELLEY-2023
+    position: supports
+  - source_id: SRC-NCCN-HEPATOBILIARY
+    position: supports
+  - source_id: SRC-ESMO-BTC-2023
+    position: supports
+
+do_not_do:
+  - "Не використовуйте за наявності активного аутоімунного захворювання (відносне протипоказання для пембролізумабу — оцінити ризик/користь індивідуально)"
+  - "Не продовжуйте пембролізумаб після прогресування — переходьте на 2L"
+  - "Не використовуйте при ECOG PS ≥ 2 — KEYNOTE-966 не включала цих пацієнтів"
+  - "Не пропускайте CGP (FGFR2, IDH1, BRAF, HER2, NTRK) на старті — потрібно для планування 2L"
+  - "Не перевищуйте 35 циклів пембролізумабу (~2 роки) за дизайном KEYNOTE"
+
+last_reviewed: "2026-05-08"
+notes: >
+  STUB scaffold — KEYNOTE-966 1L IO+chemo for advanced BTC, NCCN
+  category 1 alternative. Auto-generated minimal indication so engine
+  can route end-to-end with new 2024+ standard-of-care; pending
+  Clinical Co-Lead review per CHARTER §6.1 dev-mode signoff exemption.
+
+  Clinical contraindications (free-text, pending Contraindication-entity
+  authoring): active autoimmune disease requiring systemic
+  immunosuppression (pembrolizumab); prior solid-organ transplant
+  (rejection risk); ECOG PS ≥ 2 (not enrolled in KEYNOTE-966 — gem+cis
+  monotherapy preferred via existing IND-CHOLANGIO-ADVANCED-GEM-CIS);
+  severe renal impairment CrCl <50 mL/min (cisplatin contraindication
+  — carboplatin substitution case-by-case).
+
+  Required tests (free-text, pending Test-entity authoring): histologic
+  confirmation of BTC; baseline LFTs/CBC/CMP/CrCl; TSH baseline (IO
+  thyroiditis monitoring); CT C/A/P or MRI staging.
+
+  Desired tests: MSI/MMR (rare MSI-H in BTC); CGP for FGFR2 fusions,
+  IDH1, BRAF, HER2, NTRK (2L+ planning per existing FGFR2-fusion 2L
+  indications); PD-L1 CPS (informational — KEYNOTE-966 benefit
+  subgroup-independent).
+
+  Protocol differs from TOPAZ-1: gemcitabine continues past 8 cycles as
+  maintenance with pembrolizumab (cisplatin alone capped at 8 cycles);
+  pembrolizumab maximum 35 cycles (~2 years) per KEYNOTE design. §17
+  phased-indication structure not used for v0.1 (opt-in per planning
+  doc §2.5). D-prefix algo flag: `algo_cholangio_1l` may need extension
+  to surface 1L IO-combo option (out of A scope; flagged in PR). Existing
+  `ind_cholangio_advanced_gem_cis` retained as legacy / IO-contraindicated
+  fallback path.

--- a/knowledge_base/hosted/content/regimens/reg_durva_gem_cis_cholangio.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_durva_gem_cis_cholangio.yaml
@@ -1,0 +1,93 @@
+id: REG-DURVA-GEM-CIS-CHOLANGIO
+name: "Durvalumab + gemcitabine + cisplatin (TOPAZ-1) — 1L advanced biliary tract cancer"
+name_ua: "Дурвалумаб + гемцитабін + цисплатин (TOPAZ-1) — 1L прогресуючий рак жовчних шляхів"
+alternate_names:
+  - "TOPAZ-1 regimen"
+  - "Durva-GemCis"
+  - "Imfinzi + gem-cis"
+
+components:
+  - drug_id: DRUG-DURVALUMAB
+    dose: "1500 mg IV q3 weeks"
+    schedule: "Day 1 q3w with chemo (cycles 1-8); then maintenance 1500 mg q4w until progression or unacceptable toxicity"
+    route: IV
+  - drug_id: DRUG-GEMCITABINE
+    dose: "1000 mg/m² IV"
+    schedule: "Days 1 and 8 of every 21-day cycle, cycles 1-8"
+    route: IV
+  - drug_id: DRUG-CISPLATIN
+    dose: "25 mg/m² IV"
+    schedule: "Days 1 and 8 of every 21-day cycle, cycles 1-8"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "Up to 8 cycles of induction durva + gem + cis (q3w); then durvalumab monotherapy maintenance q4w until progression, unacceptable toxicity, or 24 months total"
+toxicity_profile: severe
+
+premedication:
+  - "Standard cisplatin hydration: pre/post IV fluids 1-2 L NS, mannitol or furosemide as needed; avoid in CrCl <50 mL/min (consider carboplatin substitution case-by-case)"
+  - "Triple antiemetic prophylaxis MANDATORY (high-emetogenic cisplatin): 5-HT3 (palonosetron or ondansetron) + NK1-RA (aprepitant/fosaprepitant) + dexamethasone; consider olanzapine add-on"
+  - "Magnesium and potassium repletion as needed (cisplatin nephrotoxicity / electrolyte wasting)"
+  - "No specific durvalumab premedication required (low infusion-reaction rate)"
+
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Cisplatin grade 2+ nephrotoxicity (CrCl decline) or unable to tolerate hydration"
+    modification: "Reduce cisplatin to 20 mg/m² OR substitute carboplatin AUC 4-5 (TOPAZ-1 protocol; carbo-substitution accepted in NCCN/ESMO guidance for cisplatin-ineligible)"
+    source_refs: [SRC-NCCN-HEPATOBILIARY, SRC-ESMO-BTC-2023]
+  - condition: "Grade 3-4 neutropenia / thrombocytopenia"
+    modification: "Hold gem+cis until recovery; reduce gemcitabine to 800 mg/m²; consider G-CSF support"
+    source_refs: [SRC-TOPAZ-1-OH-2022]
+  - condition: "Grade 2+ peripheral neuropathy"
+    modification: "Hold cisplatin; reduce by 25% on resume; consider permanent discontinuation if grade 3+"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Immune-mediated AE (durvalumab) — grade 2"
+    modification: "Hold durvalumab; corticosteroids 0.5-1 mg/kg/day prednisone equivalent; resume when grade ≤1 and steroid taper to ≤10 mg/day"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Immune-mediated AE — grade 3-4"
+    modification: "Permanent discontinuation of durvalumab; high-dose corticosteroids 1-2 mg/kg/day; specialist consultation"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: |
+    Дурвалумаб зареєстровано в UA (Imfinzi, AstraZeneca); НСЗУ-реімбурсація
+    обмежена окремими онкологічними програмами (uvNSCLC, SCLC); BTC-показ
+    не покрито станом на 2026-05-08. Гемцитабін + цисплатин — повністю
+    зареєстровані та реімбурсуються в межах НСЗУ-онкопакету. Альтернативні
+    шляхи доступу до дурвалумабу для BTC: out-of-pocket, AstraZeneca patient
+    support, cross-border (EU онкоцентр за наказом МОЗ 988), клінічні
+    випробування.
+
+sources:
+  - SRC-TOPAZ-1-OH-2022
+  - SRC-NCCN-HEPATOBILIARY
+  - SRC-ESMO-BTC-2023
+
+last_reviewed: "2026-05-08"
+notes: >
+  TOPAZ-1 (Oh DY et al., NEJM Evid 2022;1(8):EVIDoa2200015; NCT03875235):
+  durvalumab 1500 mg q3w + gemcitabine 1000 mg/m² + cisplatin 25 mg/m²
+  (D1, D8 q3w x up to 8 cycles), then durvalumab 1500 mg q4w maintenance,
+  vs placebo + gem-cis in 1L advanced BTC (n=685). Primary endpoint OS:
+  mOS 12.8 vs 11.5 mo (HR 0.80, 95% CI 0.66-0.97, p=0.021); mPFS 7.2 vs
+  5.7 mo (HR 0.75); ORR 26.7% vs 18.7%. Benefit consistent across PD-L1
+  CPS subgroups and BTC anatomic subsites (intra-/extrahepatic
+  cholangiocarcinoma, gallbladder cancer). FDA-approved Sep 2022 for 1L
+  advanced BTC. NCCN category 1 preferred regimen. Cisplatin (D1/D8
+  schedule, not standard D1-only) is per protocol — total cycles capped
+  at 8 for chemo backbone; durvalumab maintenance continues until
+  progression / toxicity. STUB pending Clinical Co-Lead sign-off per
+  CHARTER §6.1 dev-mode exemption.
+notes_ua: >
+  TOPAZ-1: дурвалумаб + гемцитабін + цисплатин для 1L прогресуючого
+  раку жовчних шляхів (внутрішньопечінкова / позапечінкова
+  холангіокарцинома, рак жовчного міхура). mOS 12.8 vs 11.5 міс
+  (HR 0.80). NCCN категорія 1, схвалено FDA вересень 2022. Стандарт
+  лікування першої лінії з 2022 року для прогресуючого/метастатичного
+  BTC. STUB — очікує клінічного підпису.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_pembro_gem_cis_cholangio.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_gem_cis_cholangio.yaml
@@ -1,0 +1,95 @@
+id: REG-PEMBRO-GEM-CIS-CHOLANGIO
+name: "Pembrolizumab + gemcitabine + cisplatin (KEYNOTE-966) — 1L advanced biliary tract cancer"
+name_ua: "Пембролізумаб + гемцитабін + цисплатин (KEYNOTE-966) — 1L прогресуючий рак жовчних шляхів"
+alternate_names:
+  - "KEYNOTE-966 regimen"
+  - "Pembro-GemCis"
+  - "Keytruda + gem-cis"
+
+components:
+  - drug_id: DRUG-PEMBROLIZUMAB
+    dose: "200 mg IV q3 weeks"
+    schedule: "Day 1 q3w throughout (concurrent with chemo cycles 1-8 then maintenance with gemcitabine until progression / toxicity / 35 cycles total)"
+    route: IV
+  - drug_id: DRUG-GEMCITABINE
+    dose: "1000 mg/m² IV"
+    schedule: "Days 1 and 8 of every 21-day cycle, continued until progression / toxicity (no fixed cap; cisplatin stops at cycle 8)"
+    route: IV
+  - drug_id: DRUG-CISPLATIN
+    dose: "25 mg/m² IV"
+    schedule: "Days 1 and 8 of every 21-day cycle, cycles 1-8 only (capped at 8 cycles per protocol)"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "Cisplatin: up to 8 cycles. Gemcitabine + pembrolizumab: continue until progression, unacceptable toxicity, or 35 cycles (~2 years) of pembrolizumab"
+toxicity_profile: severe
+
+premedication:
+  - "Standard cisplatin hydration: pre/post IV fluids 1-2 L NS, mannitol or furosemide as needed; avoid in CrCl <50 mL/min (consider carboplatin substitution case-by-case)"
+  - "Triple antiemetic prophylaxis MANDATORY (high-emetogenic cisplatin): 5-HT3 (palonosetron or ondansetron) + NK1-RA (aprepitant/fosaprepitant) + dexamethasone; consider olanzapine add-on"
+  - "Magnesium and potassium repletion as needed (cisplatin nephrotoxicity / electrolyte wasting)"
+  - "No specific pembrolizumab premedication required (low infusion-reaction rate)"
+
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Cisplatin grade 2+ nephrotoxicity (CrCl decline) or unable to tolerate hydration"
+    modification: "Reduce cisplatin to 20 mg/m² OR substitute carboplatin AUC 4-5 (KEYNOTE-966 protocol; carbo-substitution accepted in NCCN/ESMO guidance for cisplatin-ineligible)"
+    source_refs: [SRC-NCCN-HEPATOBILIARY, SRC-ESMO-BTC-2023]
+  - condition: "Grade 3-4 neutropenia / thrombocytopenia"
+    modification: "Hold gem+cis until recovery; reduce gemcitabine to 800 mg/m²; consider G-CSF support"
+    source_refs: [SRC-KEYNOTE-966-KELLEY-2023]
+  - condition: "Grade 2+ peripheral neuropathy"
+    modification: "Hold cisplatin; reduce by 25% on resume; consider permanent discontinuation if grade 3+"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Immune-mediated AE (pembrolizumab) — grade 2"
+    modification: "Hold pembrolizumab; corticosteroids 0.5-1 mg/kg/day prednisone equivalent; resume when grade ≤1 and steroid taper to ≤10 mg/day"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Immune-mediated AE — grade 3-4"
+    modification: "Permanent discontinuation of pembrolizumab; high-dose corticosteroids 1-2 mg/kg/day; specialist consultation"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: |
+    Пембролізумаб зареєстровано в UA (Keytruda, MSD); НСЗУ-реімбурсація
+    обмежена окремими онкологічними програмами (NSCLC, melanoma, MSI-H);
+    BTC-показ не покрито станом на 2026-05-08. Гемцитабін + цисплатин —
+    повністю зареєстровані та реімбурсуються в межах НСЗУ-онкопакету.
+    Альтернативні шляхи доступу до пембролізумабу для BTC: out-of-pocket,
+    MSD patient assistance, cross-border (EU онкоцентр за наказом МОЗ
+    988), клінічні випробування.
+
+sources:
+  - SRC-KEYNOTE-966-KELLEY-2023
+  - SRC-NCCN-HEPATOBILIARY
+  - SRC-ESMO-BTC-2023
+
+last_reviewed: "2026-05-08"
+notes: >
+  KEYNOTE-966 (Kelley RK et al., Lancet 2023;401(10391):1853-1865;
+  NCT04003636): pembrolizumab 200 mg q3w + gemcitabine 1000 mg/m² +
+  cisplatin 25 mg/m² (D1, D8 q3w; cisplatin capped at 8 cycles, gem
+  continued indefinitely with pembro), vs placebo + gem-cis in 1L
+  advanced BTC (n=1069). Primary endpoint OS: mOS 12.7 vs 10.9 mo
+  (HR 0.83, 95% CI 0.72-0.95, p=0.0034); mPFS 6.5 vs 5.6 mo (HR 0.86,
+  ns); ORR 29% vs 29% (no improvement). Benefit consistent across
+  PD-L1 CPS subgroups; magnitude smaller than TOPAZ-1 but corroborates
+  anti-PD-(L)1 + chemo as new 1L standard. FDA-approved Oct 2023.
+  NCCN category 1 alternative preferred regimen alongside TOPAZ-1.
+  Note: KEYNOTE-966 differs from TOPAZ-1 in that gemcitabine continues
+  past 8 cycles as maintenance with pembrolizumab (cisplatin capped at
+  cycle 8); TOPAZ-1 stops both gem and cis at cycle 8 with durvalumab
+  monotherapy maintenance. STUB pending Clinical Co-Lead sign-off per
+  CHARTER §6.1 dev-mode exemption.
+notes_ua: >
+  KEYNOTE-966: пембролізумаб + гемцитабін + цисплатин для 1L прогресуючого
+  раку жовчних шляхів (внутрішньопечінкова / позапечінкова
+  холангіокарцинома, рак жовчного міхура). mOS 12.7 vs 10.9 міс
+  (HR 0.83). NCCN категорія 1, схвалено FDA жовтень 2023. Стандарт
+  1L разом із TOPAZ-1; вибір між durva і pembro — інституційний / за
+  доступністю. STUB — очікує клінічного підпису.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- 2 NEW IO+chemo cholangio 1L indications + 2 NEW regimens
- Existing gem+cis indication repositioned as IO-contraindicated / access-limited fallback
- Closes #457

## Files (5: 4 NEW + 1 EDIT)

| File | Notes |
|---|---|
| `ind_cholangio_metastatic_1l_durva_chemo.yaml` | NEW — TOPAZ-1 (durva monotherapy maintenance after 8 cycles) |
| `ind_cholangio_metastatic_1l_pembro_chemo.yaml` | NEW — KEYNOTE-966 (pembro + gem continued, cis capped 8 cycles, pembro 35-cycle max) |
| `reg_durva_gem_cis_cholangio.yaml` | NEW |
| `reg_pembro_gem_cis_cholangio.yaml` | NEW |
| `ind_cholangio_advanced_gem_cis.yaml` | EDIT — added `known_controversies` block; repositioned as IO-contraindicated fallback |

## Regimen design

Both share gem+cis backbone but distinct IO + maintenance:
- **TOPAZ-1**: durvalumab 1500 mg q3w × 8 cycles → durva monotherapy maintenance until progression
- **KEYNOTE-966**: pembrolizumab 200 mg q3w during chemo (cis capped 8 cycles, gem continued); pembro 35-cycle max

## Schema-field choices

- `hard_contraindications`, `required_tests`, `desired_tests` left `[]` (schema requires entity IDs; detail in `notes:` + `do_not_do`)
- **Avoided esoph-template pitfall** — esoph 1L files have free-text strings in those fields which fail validation
- `biomarker_requirements_excluded: []` (no BIO-AUTOIMMUNE-DISEASE entity)
- §17 phases not used (opt-in per planning §2.5)
- evidence_level: high, strength_of_recommendation: strong, nccn_category: 1

## Test plan
- [x] Validator: 91 / 215 — identical pre/post
- [x] Entities 2823 → 2827 (+4)
- [x] pytest 10 pass / 1 pre-existing baseline fail verified unrelated
- [x] No banned sources (TOPAZ-1, KEYNOTE-966, NCCN-HEPATOBILIARY, ESMO-BTC-2023 only)

## D-prefix follow-up flag

`algo_cholangio_1l` likely needs extension to surface 1L IO-combo path. Out of A scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)