### PR TITLE
feat(kb): GI-3 A-PDAC NAPOLI-3 NALIRIFOX 1L mPDAC

### DIFF
--- a/knowledge_base/hosted/content/drugs/drug_liposomal_irinotecan.yaml
+++ b/knowledge_base/hosted/content/drugs/drug_liposomal_irinotecan.yaml
@@ -1,0 +1,135 @@
+id: DRUG-LIPOSOMAL-IRINOTECAN
+names:
+  preferred: "Liposomal irinotecan"
+  ukrainian: "Ліпосомальний іринотекан"
+  english: "Liposomal irinotecan"
+  synonyms: ["nal-IRI", "nanoliposomal irinotecan", "PEP02", "MM-398"]
+  brand_names: ["Onivyde"]
+atc_code: L01CE02
+rxnorm_id: "1922513"
+drug_class: "Topoisomerase I inhibitor (PEGylated liposomal nanoparticle formulation of irinotecan)"
+mechanism: >
+  Nanoliposomal (PEGylated) formulation of irinotecan that prolongs
+  circulation time and enhances tumor accumulation via the enhanced
+  permeability and retention (EPR) effect, increasing intra-tumoral
+  conversion to active metabolite SN-38 (~100-1000× more potent than
+  parent). SN-38 stabilizes the topoisomerase-I/DNA cleavable complex,
+  producing single-strand DNA breaks that become lethal double-strand
+  breaks during S-phase replication. SN-38 glucuronidation by UGT1A1
+  to inactive SN-38G is the main inactivation pathway; UGT1A1*28
+  homozygotes (Gilbert-syndrome variant) and *6 carriers have impaired
+  clearance and increased risk of severe neutropenia and diarrhea —
+  starting-dose reduction recommended. Compared with conventional
+  irinotecan, the liposomal carrier delivers higher and more sustained
+  intra-tumoral SN-38 exposure at lower peak plasma drug concentrations.
+
+regulatory_status:
+  fda:
+    approved: true
+    year_first_approval: 2015
+    indications_brief:
+      - "Metastatic adenocarcinoma of the pancreas — 1L with oxaliplatin + 5-FU + leucovorin (NALIRIFOX, NAPOLI-3, approved 2024)"
+      - "Metastatic adenocarcinoma of the pancreas — 2L after gemcitabine-based therapy, with 5-FU + leucovorin (NAPOLI-1, approved 2015)"
+  ema:
+    approved: true
+    year_first_approval: 2016
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-08"
+    notes: "ONIVYDE not registered in Ukraine as of 2026-05-08 — significant access barrier for both 1L NALIRIFOX and 2L nal-IRI+5-FU/LV regimens."
+
+typical_dosing: >
+  NALIRIFOX (1L mPDAC, NAPOLI-3): 50 mg/m² (free base, equivalent to
+  ~60 mg/m² salt) IV over 90 min day 1 every 14 d, with oxaliplatin
+  60 mg/m² + leucovorin 400 mg/m² + 5-FU 2400 mg/m² CIV over 46 h.
+  2L mPDAC (NAPOLI-1, with 5-FU/LV): 70 mg/m² (free base, equivalent
+  to ~80 mg/m² salt) IV over 90 min day 1 every 14 d.
+  UGT1A1 *28/*28 or *6/*6: reduce starting dose ~25-30% (e.g. NAPOLI-1
+  schedule → 50 mg/m² free base; NALIRIFOX schedule → 40 mg/m² free base
+  starting dose, escalate to 50 mg/m² if tolerated).
+  Bilirubin >2× ULN: do not initiate — relieve biliary obstruction first.
+
+formulations:
+  - "IV concentrate for solution for infusion 4.3 mg/mL (free base) — 10-mL single-use vial (43 mg free base / 50 mg salt equivalent)"
+
+absolute_contraindications:
+  - "Severe hypersensitivity to liposomal irinotecan or any component"
+  - "Severe pre-existing diarrhea or active inflammatory bowel disease"
+  - "Severe baseline myelosuppression (ANC <1.5 / Plt <100)"
+  - "Total bilirubin >2× ULN (relative — biliary obstruction must be relieved first)"
+  - "Pregnancy"
+
+black_box_warnings:
+  - "Severe diarrhea — early cholinergic (within 24 h) and late delayed (>24 h, can be life-threatening)"
+  - "Severe and life-threatening neutropenia (febrile neutropenia, sepsis)"
+
+common_adverse_events:
+  - "Late delayed diarrhea (Grade 3-4 ~13% NAPOLI-1; loperamide PRN, aggressive hydration)"
+  - "Acute cholinergic syndrome (early, within 24 h — atropine 0.25-1 mg SC/IV prophylaxis or treatment)"
+  - "Neutropenia (Grade 3-4 ~27% NAPOLI-1)"
+  - "Anemia (~30-40%)"
+  - "Thrombocytopenia"
+  - "Nausea / vomiting (moderately emetogenic)"
+  - "Fatigue / asthenia (~14%)"
+  - "Decreased appetite, weight loss"
+  - "Mucositis"
+  - "Alopecia (less than free irinotecan)"
+
+serious_adverse_events:
+  - "Severe diarrhea with dehydration / sepsis"
+  - "Febrile neutropenia"
+  - "Interstitial pneumonitis / pulmonary toxicity (rare)"
+  - "Severe infusion reactions (rare; differentiate from acute cholinergic syndrome)"
+  - "Bowel perforation (rare)"
+  - "Renal failure (secondary to dehydration)"
+  - "Hepatotoxicity (in setting of biliary obstruction)"
+
+major_interactions:
+  - "Strong CYP3A4 inducers (rifampin, phenytoin, carbamazepine, St. John's wort) — reduce SN-38 exposure; avoid if possible"
+  - "Strong CYP3A4 inhibitors (ketoconazole, ritonavir, clarithromycin) — increase SN-38 exposure and toxicity; avoid"
+  - "UGT1A1 inhibitors (atazanavir, indinavir) — increase SN-38 exposure; avoid"
+  - "Live vaccines — avoid during therapy"
+  - "Other myelosuppressive agents — additive cytopenias"
+
+pharmacology:
+  half_life_hours: 26
+  half_life_notes: "Liposomal irinotecan terminal t½ ~26 h (free irinotecan t½ ~6-12 h, SN-38 ~10-20 h); liposomal carrier prolongs circulation and increases intra-tumoral exposure to SN-38 vs free irinotecan."
+  clearance: "hepatic (carboxylesterase activation of irinotecan to SN-38, CYP3A4 to inactive APC/NPC, UGT1A1 glucuronidation of SN-38) + biliary excretion"
+  protein_binding_pct: null
+  metabolism: "carboxylesterase, CYP3A4, UGT1A1 (SN-38 glucuronidation)"
+
+sources:
+  - SRC-NAPOLI-3-WAINBERG-2024
+  - SRC-NCCN-PANCREATIC-2025
+  - SRC-ESMO-PANCREATIC-2024
+
+last_reviewed: "2026-05-08"
+reviewers: []
+notes: >
+  ONIVYDE (liposomal irinotecan) is FDA-approved for two PDAC indications:
+  (1) 1L mPDAC in combination with oxaliplatin + 5-FU + leucovorin
+  (NALIRIFOX regimen) based on NAPOLI-3 (Wainberg, Lancet 2023; FDA
+  approval 2024); (2) 2L mPDAC after gemcitabine-based 1L therapy in
+  combination with 5-FU + leucovorin based on NAPOLI-1 (Wang-Gillam,
+  Lancet 2016; FDA approval 2015). Dose is expressed in free-base
+  equivalents per FDA label — the salt-equivalent conversion (free base
+  × ~1.15) is found in older literature and may cause confusion;
+  NAPOLI-3 used 50 mg/m² free base (NALIRIFOX), NAPOLI-1 used 70 mg/m²
+  free base (2L). Liposomal formulation is NOT interchangeable with
+  conventional irinotecan — different pharmacokinetics, different
+  approved indications, distinct dosing. UGT1A1 testing strongly
+  recommended before initiation; *28/*28 homozygotes need starting-dose
+  reduction. Atropine 0.25-1 mg SC/IV for acute cholinergic syndrome
+  (within 30 min of infusion). Loperamide schedule for late diarrhea:
+  4 mg at first loose stool then 2 mg q2h until 12 h diarrhea-free.
+  ONIVYDE not registered in Ukraine — significant access barrier.
+
+notes_patient: >
+  Хіміотерапія, що блокує фермент topoisomerase у пухлинних клітинах. Ліпосомальна форма
+  іринотекану — ліки "загорнуті" в крихітні жирові кульки, що дозволяє їм довше
+  залишатися в крові та краще накопичуватися в пухлині. Часто застосовують у комбінації
+  з іншими хіміопрепаратами (NALIRIFOX або з 5-FU/лейковорином). Контролюємо діарею —
+  вона буває рання (перші години — лікуємо атропіном) та пізня (через 1-2 дні — лоперамід).

--- a/knowledge_base/hosted/content/indications/ind_pdac_metastatic_1l_nalirifox.yaml
+++ b/knowledge_base/hosted/content/indications/ind_pdac_metastatic_1l_nalirifox.yaml
@@ -1,0 +1,150 @@
+id: IND-PDAC-METASTATIC-1L-NALIRIFOX
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-PDAC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Stage IV (metastatic) pancreatic ductal adenocarcinoma"
+    - "Locally advanced unresectable PDAC (selected; off-label per NAPOLI-3 enrollment criteria but NCCN-supported extrapolation)"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+
+recommended_regimen: REG-NALIRIFOX
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~41.8% ORR (NALIRIFOX arm, NAPOLI-3) vs 36.2% gem-nab-pac"
+  progression_free_survival: "Median PFS 7.4 mo (vs 5.6 mo gem-nab-pac; HR 0.69, 95% CI 0.58-0.83, p<0.0001; NAPOLI-3)"
+  overall_survival_median: "Median OS 11.1 mo (vs 9.2 mo gem-nab-pac; HR 0.83, 95% CI 0.70-0.99, p=0.04; NAPOLI-3)"
+
+hard_contraindications: []
+
+red_flags_triggering_alternative:
+  - RF-PDAC-BILIARY-OBSTRUCTION-CHOLANGITIS
+  - RF-PDAC-FRAILTY-AGE
+  - RF-PDAC-INFECTION-SCREENING
+
+required_tests:
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+
+desired_tests:
+  - TEST-NGS-COMPREHENSIVE  # for BRCA / KRAS G12C / MSI biomarker landscape
+  - TEST-CT-PET
+
+rationale: >
+  NAPOLI-3 (Wainberg, Lancet 2023, n=770, phase 3 open-label RCT;
+  NCT04083235) demonstrated superiority of NALIRIFOX (liposomal
+  irinotecan + oxaliplatin + 5-FU + leucovorin) over gem-nab-pac as 1L
+  therapy in metastatic PDAC, ECOG 0-1: mOS 11.1 vs 9.2 mo (HR 0.83,
+  95% CI 0.70-0.99, p=0.04); mPFS 7.4 vs 5.6 mo (HR 0.69, p<0.0001);
+  ORR 41.8% vs 36.2%. NCCN 2025 lists NALIRIFOX as a Category 1 1L
+  preferred option for fit (ECOG 0-1) mPDAC alongside FOLFIRINOX and
+  gem-nab-pac. NALIRIFOX vs FOLFIRINOX: no head-to-head trial; cross-
+  trial OS appears comparable (NAPOLI-3 mOS 11.1 mo vs ACCORD-11
+  FOLFIRINOX mOS 11.1 mo); NALIRIFOX may have somewhat better tolerability
+  (lower neutropenia 14% vs ~46%, less alopecia) but more Grade ≥3
+  diarrhea (20% vs ~13%) and nausea. Mechanism: liposomal carrier
+  prolongs SN-38 intra-tumoral exposure vs free irinotecan. Eligibility
+  same as FOLFIRINOX: PS 0-1, bilirubin <1.5-2× ULN, no severe cardiac
+  comorbidity. UGT1A1*28/*28 homozygotes need starting-dose reduction
+  (40 mg/m² free base cycle 1, escalate to 50 if tolerated).
+
+rationale_ua: >
+  NAPOLI-3 (Wainberg, Lancet 2023, n=770, фаза 3 відкрите РКД;
+  NCT04083235) продемонстрував перевагу NALIRIFOX (ліпосомальний
+  іринотекан + оксаліплатин + 5-FU + лейковорин) над gem-nab-pac як
+  1L терапії при метастатичному ПДАК, ECOG 0-1: мЗВ 11.1 проти 9.2
+  міс. (HR 0.83, 95% ДІ 0.70-0.99, p=0.04); мВБП 7.4 проти 5.6 міс.
+  (HR 0.69, p<0.0001); ЗВВ 41.8% проти 36.2%. NCCN 2025 відносить
+  NALIRIFOX до Категорії 1 1L преферованих опцій для fit (ECOG 0-1)
+  мПДАК поряд з FOLFIRINOX та gem-nab-pac. NALIRIFOX vs FOLFIRINOX:
+  немає прямого порівняльного дослідження; крос-трайл ЗВ виглядає
+  співставною; NALIRIFOX може мати дещо кращу переносимість (менша
+  нейтропенія 14% vs ~46%, менша алопеція) але більше діареї Grade ≥3
+  (20% vs ~13%) та нудоти. Механізм: ліпосомальний носій подовжує
+  внутрішньопухлинну експозицію SN-38 проти вільного іринотекану.
+  Прийнятність як для FOLFIRINOX: PS 0-1, білірубін <1.5-2× ULN, без
+  тяжкої серцевої коморбідності. UGT1A1*28/*28 гомозиготи потребують
+  зниження стартової дози (40 мг/м² free base цикл 1, ескалація до 50
+  при переносимості).
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-NAPOLI-3-WAINBERG-2024
+    position: supports
+    relevant_quote_paraphrase: "NALIRIFOX improved OS vs gem-nab-pac as 1L mPDAC: mOS 11.1 vs 9.2 mo, HR 0.83, p=0.04; mPFS 7.4 vs 5.6 mo, HR 0.69, p<0.0001 (NAPOLI-3 phase 3, n=770)"
+  - source_id: SRC-NCCN-PANCREATIC-2025
+    position: supports
+    relevant_quote_paraphrase: "NCCN lists NALIRIFOX as Category 1 preferred 1L option for fit (ECOG 0-1) mPDAC alongside FOLFIRINOX and gem-nab-pac"
+  - source_id: SRC-ESMO-PANCREATIC-2024
+    position: supports
+    relevant_quote_paraphrase: "ESMO recognizes NALIRIFOX as a 1L option for fit patients with mPDAC based on NAPOLI-3 OS benefit"
+
+do_not_do:
+  - "Не призначати при тотальному білірубіні >2× ULN — спочатку дренувати жовчну обструкцію; ліпосомальний іринотекан є гепатично метаболізованим"
+  - "Не призначати пацієнтам з ECOG ≥2 — NAPOLI-3 включав лише ECOG 0-1; для ECOG 1-2 / літніх / borderline-fit використовувати gem-nab-pac"
+  - "Не пропускати UGT1A1 генотипування для груп ризику — *28/*28 гомозиготи потребують зниження стартової дози (40 мг/м² free base) для запобігання тяжкій діареї та нейтропенії"
+  - "Не пропускати профілактику пізньої діареї лоперамідом — Grade 3-4 у ~20% (вище ніж в gem-nab-pac); пацієнт повинен мати лоперамід вдома та знати схему"
+  - "Не починати при відсутності судинного доступу (PICC або порт) для 46-годинної CI 5-FU"
+  - "Не плутати ліпосомальний іринотекан з конвенційним іринотеканом — різна фармакокінетика, різні схеми, різні показання; ONIVYDE не взаємозамінний з Camptosar"
+
+do_not_do_en:
+  - "Do NOT initiate without resolved jaundice (bilirubin <1.5-2× ULN) — liposomal irinotecan hepatically metabolized"
+  - "Do NOT use in PS ≥2 — NAPOLI-3 enrolled only ECOG 0-1; for ECOG 1-2 / older / borderline-fit use gem-nab-pac"
+  - "Do NOT skip UGT1A1 testing for high-risk populations — *28/*28 homozygotes need starting-dose reduction (40 mg/m² free base) to prevent severe diarrhea + neutropenia"
+  - "Do NOT skip late-diarrhea loperamide prophylaxis education — Grade 3-4 ~20% (higher than gem-nab-pac); patient must have loperamide at home and know the schedule"
+  - "Do NOT start without vascular access (PICC or port) for 46-h continuous-infusion 5-FU"
+  - "Do NOT confuse liposomal irinotecan with conventional irinotecan — different pharmacokinetics, dosing, and approved indications; ONIVYDE and Camptosar are not interchangeable"
+
+known_controversies:
+  - topic: "NALIRIFOX vs FOLFIRINOX as preferred 1L mPDAC for fit ECOG 0-1 patients"
+    positions:
+      - position: "NALIRIFOX is Category 1 with phase 3 OS benefit vs gem-nab-pac (HR 0.83); cross-trial mOS comparable to FOLFIRINOX (~11 mo); somewhat better tolerability (lower neutropenia, less alopecia)"
+        sources:
+          - SRC-NAPOLI-3-WAINBERG-2024
+          - SRC-NCCN-PANCREATIC-2025
+      - position: "FOLFIRINOX (ACCORD-11) is the long-established standard with decades of community experience and full Ukraine NSZU access; NALIRIFOX has more Grade ≥3 diarrhea (20% vs ~13%); ONIVYDE not registered in Ukraine"
+        sources:
+          - SRC-NCCN-PANCREATIC-2025
+          - SRC-ESMO-PANCREATIC-2024
+    our_default: "FOLFIRINOX preferred in Ukraine where ONIVYDE is not registered (full NSZU access); NALIRIFOX preferred where ONIVYDE is accessible AND patient cannot tolerate FOLFIRINOX neutropenia profile"
+    rationale: "Cross-trial efficacy looks comparable; access (ONIVYDE registration in Ukraine) and tolerability profile drive choice"
+
+time_critical: false
+last_reviewed: "2026-05-08"
+reviewers: []
+reviewer_signoffs: []
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: >
+  NAPOLI-3 (PMID 37708904) is the landmark RCT establishing NALIRIFOX as
+  Category 1 1L option for fit ECOG 0-1 mPDAC. FDA approval for
+  liposomal irinotecan in 1L mPDAC: 2024 (label expansion from prior
+  2015 2L approval). ONIVYDE not registered in Ukraine — significant
+  access barrier. Sister 1L indications: IND-PDAC-METASTATIC-1L-FOLFIRINOX
+  (preferred Ukraine default with full NSZU access) and
+  IND-PDAC-METASTATIC-1L-GEM-NAB-PAC (frailty-friendly alternative).
+  Algorithm partner: ALGO-PDAC-METASTATIC-1L (pending update to add
+  NALIRIFOX as Category 1 alongside FOLFIRINOX/gem-nab-pac).
+  Clinical exclusions captured at the regimen-level dose_adjustments
+  (REG-NALIRIFOX) rather than as hard_contraindications IDs since the
+  Contraindication-entity scaffold for these conditions (bilirubin >2×
+  ULN, ECOG ≥2, severe myelosuppression, pre-existing Grade ≥2
+  peripheral neuropathy, active IBD/severe diarrhea) is not yet
+  authored. Pending Contraindication entities can be added in a
+  follow-up chunk when the contraindication taxonomy is filled in.
+  UGT1A1 genotyping desired pre-treatment but TEST-UGT1A1-GENOTYPE
+  entity is not yet authored; see drug-level pharmacology notes.

--- a/knowledge_base/hosted/content/regimens/reg_nalirifox.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_nalirifox.yaml
@@ -1,0 +1,96 @@
+id: REG-NALIRIFOX
+name: "NALIRIFOX"
+name_ua: "NALIRIFOX"
+alternate_names: ["NAPOLI-3 regimen", "lipo-IRI + oxaliplatin + 5-FU/LV"]
+
+components:
+  - drug_id: DRUG-LIPOSOMAL-IRINOTECAN
+    dose: "50 mg/m² free base (≈60 mg/m² salt equivalent)"
+    schedule: "IV over 90 min, day 1 every 14d"
+    route: IV
+  - drug_id: DRUG-OXALIPLATIN
+    dose: "60 mg/m²"
+    schedule: "IV day 1 every 14d"
+    route: IV
+  - drug_id: DRUG-LEUCOVORIN
+    dose: "400 mg/m²"
+    schedule: "IV day 1 (after liposomal irinotecan + oxaliplatin)"
+    route: IV
+  - drug_id: DRUG-5-FLUOROURACIL
+    dose: "2400 mg/m² CIV over 46 h"
+    schedule: "Day 1 starting after leucovorin, every 14d"
+    route: IV
+
+cycle_length_days: 14
+total_cycles: "Until disease progression or unacceptable toxicity"
+
+toxicity_profile: severe
+
+premedication:
+  - "Atropine 0.25-1 mg IV/SQ for acute cholinergic syndrome (early-onset diarrhea, diaphoresis) during or within 30 min of liposomal irinotecan"
+  - "Antiemetics: moderate-to-high emetogenic protocol (5-HT3 antagonist + dexamethasone day 1; consider NK1 antagonist)"
+  - "Loperamide patient education for late-onset diarrhea (≥24h post-infusion): 4 mg at onset, then 2 mg q2h until diarrhea-free 12h"
+  - "G-CSF secondary prophylaxis after febrile neutropenia episode (consider primary prophylaxis in high-risk patients)"
+
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "UGT1A1 *28/*28 homozygous"
+    modification: "Reduce liposomal irinotecan starting dose to 40 mg/m² free base (cycle 1); escalate to 50 mg/m² if tolerated"
+    rationale: "Severe neutropenia + diarrhea risk due to impaired SN-38 glucuronidation"
+    source_refs: [SRC-NAPOLI-3-WAINBERG-2024, SRC-NCCN-PANCREATIC-2025]
+  - condition: "Bilirubin 1.5-2× ULN"
+    modification: "Hold or reduce liposomal irinotecan; resolve biliary obstruction first"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+  - condition: "Bilirubin >2× ULN"
+    modification: "Do not initiate; hold all components — relieve biliary obstruction (stenting/PBD) first"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+  - condition: "Grade 3-4 diarrhea"
+    modification: "Aggressive loperamide; IV hydration if severe; reduce liposomal irinotecan to 40 mg/m² free base; consider 5-FU 25% reduction"
+    source_refs: [SRC-NAPOLI-3-WAINBERG-2024]
+  - condition: "Grade 3-4 neutropenia or febrile neutropenia"
+    modification: "Hold until ANC ≥1500; reduce liposomal irinotecan and 5-FU; G-CSF secondary prophylaxis"
+    source_refs: [SRC-NAPOLI-3-WAINBERG-2024]
+  - condition: "Grade ≥3 peripheral neuropathy"
+    modification: "Hold or reduce oxaliplatin; consider oxaliplatin discontinuation if persistent at next cycle"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+  - condition: "Grade 3 mucositis or hand-foot syndrome"
+    modification: "Reduce 5-FU by 25%; consider uridine triacetate if severe 5-FU toxicity"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: >
+    Liposomal irinotecan (ONIVYDE) NOT registered in Ukraine as of 2026-05-08
+    — significant access barrier. Oxaliplatin, 5-FU, and leucovorin are all
+    NSZU-funded. Without ONIVYDE access, accessible alternatives are
+    FOLFIRINOX (REG-FOLFIRINOX) for ECOG 0-1 fit patients or gem-nab-pac
+    (REG-GEM-NAB-PAC) for ECOG 1-2 / borderline-fit patients.
+
+between_visit_watchpoints: []
+
+sources: [SRC-NAPOLI-3-WAINBERG-2024, SRC-NCCN-PANCREATIC-2025, SRC-ESMO-PANCREATIC-2024]
+
+last_reviewed: "2026-05-08"
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+
+notes: >
+  NAPOLI-3 (Wainberg, Lancet 2023; n=770, phase 3 RCT; NCT04083235):
+  NALIRIFOX vs gem-nab-pac as 1L therapy in metastatic PDAC, ECOG 0-1.
+  mOS 11.1 vs 9.2 mo (HR 0.83, 95% CI 0.70-0.99, p=0.04); mPFS 7.4 vs
+  5.6 mo (HR 0.69, 95% CI 0.58-0.83, p<0.0001); ORR 41.8% vs 36.2%.
+  Grade ≥3 TEAEs comparable: diarrhea (20% vs 4.5%), nausea (12% vs 3%),
+  hypokalemia (15% vs 4%), neutropenia (14% vs 25%), febrile neutropenia
+  (3% vs 1%), peripheral neuropathy (3% vs 2%), thrombocytopenia (2% vs
+  9%). NCCN Category 1 (preferred) 1L option for mPDAC alongside
+  FOLFIRINOX and gem-nab-pac. Eligibility: PS 0-1, bilirubin <1.5-2× ULN,
+  no severe cardiac comorbidity. NALIRIFOX vs FOLFIRINOX: no head-to-head
+  trial; cross-trial OS appears comparable; NALIRIFOX may have somewhat
+  better tolerability profile (lower neutropenia, less alopecia) but
+  more diarrhea and nausea. Choice between FOLFIRINOX and NALIRIFOX in
+  Ukraine is dominated by ONIVYDE access (not registered) — FOLFIRINOX
+  remains the accessible Category 1 option. between_visit_watchpoints
+  authoring deferred to PATIENT_MODE Phase 3 backlog.


### PR DESCRIPTION
## Summary
- 3 NEW files: drug (liposomal irinotecan), regimen (NALIRIFOX), indication (1L mPDAC)
- NCCN 2024 alternative-preferred 1L per NAPOLI-3 RCT
- Closes #458

## Files (3 NEW)

| File | Notes |
|---|---|
| `drug_liposomal_irinotecan.yaml` | NEW DRUG-LIPOSOMAL-IRINOTECAN (distinct from conventional DRUG-IRINOTECAN) |
| `reg_nalirifox.yaml` | Lipo-irinotecan 50 + oxa 60 + 5-FU 2400 CIV/46h + LV 400, q14d |
| `ind_pdac_metastatic_1l_nalirifox.yaml` | NCCN cat 1; sister to FOLFIRINOX + gem+nab-pac 1L options |

## Drug reuse decision
`DRUG-LIPOSOMAL-IRINOTECAN` did NOT exist (only conventional `DRUG-IRINOTECAN`). Created new drug entity per pharmacological + regulatory distinction.

## Test plan
- [x] Validator: 91 / 215 — identical pre/post
- [x] Entities 2823 → 2826 (+3)
- [x] pytest 10 pass / 1 pre-existing baseline fail unchanged

## Honest findings flagged

1. **Pre-existing `reg_nal_iri_5fu_lv_pdac.yaml`** (NAPOLI-1 2L) has dangling `DRG-NAL-IRI` ref + uses `agents:` instead of `components:`. **Out of scope** for this chunk; left untouched per allowlist.
2. **Test entity refs** — `TEST-UGT1A1-GENOTYPE`, `TEST-BILIRUBIN-TOTAL`, `TEST-CA19-9` don't exist; clinical narrative kept as text, not ID refs.
3. **Ukraine availability** — ONIVYDE not registered in UA; flagged on regimen `ukraine_availability` + indication `known_controversies`. FOLFIRINOX remains UA-accessible Category 1 default.

## Pending
- Two-Clinical-Co-Lead signoff per CHARTER §6.1
- Algorithm extension to surface NALIRIFOX as 3rd 1L option — D-prefix follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)