### PR TITLE
feat(kb): GI-3 A2 Cholangio HER2 zanidatamab — drug + regimen + BMA + indication

### DIFF
--- a/knowledge_base/hosted/content/biomarker_actionability/bma_her2_amp_cholangio.yaml
+++ b/knowledge_base/hosted/content/biomarker_actionability/bma_her2_amp_cholangio.yaml
@@ -1,0 +1,74 @@
+id: BMA-HER2-AMP-CHOLANGIO
+biomarker_id: BIO-HER2-SOLID
+variant_qualifier: amplification / overexpression — IHC 3+ or (IHC 2+ + ISH amplified,
+  HER2/CEP17 ≥2.0); ~5-15% of biliary tract cancer (higher in gallbladder + extrahepatic
+  CCA than intrahepatic CCA)
+disease_id: DIS-CHOLANGIOCARCINOMA
+escat_tier: IIA
+evidence_summary: 'HER2-amplified biliary tract cancer (~5-15% overall; enriched in
+  gallbladder + extrahepatic cholangiocarcinoma; ~3-5% intrahepatic CCA): zanidatamab
+  (HER2-targeted biparatopic bispecific antibody) 20 mg/kg IV q2w produced confirmed
+  ORR 41.3% (95% CI 30.4-52.8) in previously treated HER2 IHC 3+ or IHC 2+/ISH+ disease
+  in HERIZON-BTC-01 (Harding et al., Lancet Oncol 2023; n=87). FDA accelerated approval
+  November 2024 for HER2-positive (IHC 3+) BTC ≥2L. ESCAT tier IIA (FDA-approved
+  disease-specific). NCCN category 2A. HER2 testing recommended at diagnosis for
+  unresectable / metastatic BTC per SRC-NCCN-HEPATOBILIARY. Gastric-style scoring
+  (Hofmann 2008 — basolateral / lateral membranous staining ≥10%) is generally applied
+  given basolateral HER2 expression pattern in BTC.
+
+  '
+evidence_summary_ua: 'HER2-amplified рак жовчних проток (~5-15% загалом; частіше у
+  раку жовчного міхура + позапечінкова холангіокарцинома; ~3-5% внутрішньопечінкова
+  холангіокарцинома): занідатамаб (HER2-таргетне біпаратопне біспецифічне антитіло)
+  20 mg/kg в/в кожні 2 тижні дав підтверджений ORR 41.3% (95% ДІ 30.4-52.8) у
+  попередньо лікованих пацієнтів з HER2 IHC 3+ або IHC 2+/ISH+ хворобою у HERIZON-BTC-01
+  (Harding et al., Lancet Oncol 2023; n=87). FDA accelerated approval листопад 2024
+  для HER2-positive (IHC 3+) BTC ≥2L. ESCAT tier IIA (FDA-схвалений хворобо-специфічний).
+  NCCN категорія 2A. HER2-тестування рекомендовано при діагнозі для нерезектабельного
+  / метастатичного BTC per SRC-NCCN-HEPATOBILIARY. Шлунковий стиль скорингу (Hofmann
+  2008 — базолатеральне / латеральне мембранне забарвлення ≥10%) зазвичай
+  застосовується з огляду на базолатеральний патерн HER2-експресії у BTC.
+
+  '
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+regulatory_approval:
+  fda:
+  - zanidatamab — HER2-positive (IHC 3+) unresectable / locally advanced / metastatic
+    biliary tract cancer ≥2L (FDA accelerated approval November 2024)
+  ema: []
+  ukraine: []
+recommended_combinations:
+- zanidatamab monotherapy 20 mg/kg IV q2w (2L+ post gemcitabine-based 1L per SRC-NCCN-HEPATOBILIARY)
+contraindicated_monotherapy: []
+primary_sources:
+- SRC-HERIZON-BTC-01-HARDING-2023
+- SRC-NCCN-HEPATOBILIARY
+- SRC-ESMO-BTC-2023
+last_verified: '2026-05-08'
+evidence_sources:
+- source: SRC-HERIZON-BTC-01-HARDING-2023
+  level: B
+  evidence_ids: []
+  direction: Supports
+  significance: Sensitivity/Response
+  note: 'HERIZON-BTC-01 (Harding Lancet Oncol 2023): single-arm phase 2b in HER2-amplified
+    BTC 2L+ (n=87 cohort 1, IHC 3+ or IHC 2+/ISH+); confirmed ORR 41.3% (95% CI 30.4-52.8),
+    DCR 68.8%, median DoR 14.9 mo. Single-arm phase 2b — evidence tier 2 (no randomised
+    comparator).'
+actionability_review_required: true
+review_status: pending_clinical_signoff
+drafted_by: claude_extraction
+notes: 'ESCAT IIA (FDA-approved disease-specific). HER2 testing (IHC + reflex ISH for
+  IHC 2+) recommended at diagnosis for unresectable / metastatic BTC per
+  SRC-NCCN-HEPATOBILIARY. Gastric-style scoring (Hofmann 2008 — basolateral / lateral
+  membranous staining ≥10%) is generally applied. HER2 amplification frequency varies
+  by anatomic subsite: highest in gallbladder + extrahepatic cholangiocarcinoma
+  (~10-15%), lower in intrahepatic CCA (~3-5%). FDA accelerated approval Nov 2024
+  based on HERIZON-BTC-01; confirmatory study and traditional approval pending. UA
+  access: zanidatamab not registered in UA (named-patient / EAP only as of 2026-05).
+  Trastuzumab + pertuzumab combination has separate weak evidence in BTC (MyPathway
+  Meric-Bernstam 2021 ORR ~23%) but is not the FDA-approved disease-specific
+  combination — zanidatamab is the disease-specific actionable option.
+
+  '

--- a/knowledge_base/hosted/content/drugs/drug_zanidatamab.yaml
+++ b/knowledge_base/hosted/content/drugs/drug_zanidatamab.yaml
@@ -1,0 +1,125 @@
+id: DRUG-ZANIDATAMAB
+names:
+  preferred: "Zanidatamab"
+  ukrainian: "Занідатамаб"
+  english: "Zanidatamab"
+  brand_names:
+    - "Ziihera"
+atc_code: L01FD11
+rxnorm_id:
+drug_class: "HER2-targeted bispecific (biparatopic) IgG1 monoclonal antibody (binds HER2 ECD2 + ECD4)"
+mechanism: >
+  Humanized bispecific (biparatopic) IgG1-like monoclonal antibody binding
+  two distinct non-overlapping HER2 (ERBB2) extracellular epitopes —
+  subdomain ECD2 (the pertuzumab-like dimerization arm) and ECD4 (the
+  trastuzumab-like membrane-proximal arm) — simultaneously on the same
+  HER2 molecule and across HER2 molecules. Mechanisms: (1) enhanced HER2
+  receptor clustering, internalization, and lysosomal degradation
+  (downregulation of surface HER2 distinct from trastuzumab); (2) potent
+  antibody-dependent cellular cytotoxicity (ADCC) and antibody-dependent
+  cellular phagocytosis (ADCP) via Fc-FcγR engagement; (3) complement-
+  dependent cytotoxicity (CDC); (4) blockade of ligand-independent HER2
+  homo- and heterodimerization and downstream PI3K/AKT and MAPK signaling.
+  Dual-epitope binding produces activity in some trastuzumab-resistant
+  HER2-amplified tumors. Activity requires HER2 IHC 3+ or ISH-amplified
+  (HER2/CEP17 ≥2.0).
+
+regulatory_status:
+  fda:
+    approved: true
+    year_first_approval: 2024
+    indications_brief:
+      - "HER2-positive (IHC 3+) unresectable / locally advanced / metastatic biliary tract cancer — previously treated (≥1 prior systemic regimen); accelerated approval Nov 2024 (HERIZON-BTC-01)"
+  ema:
+    approved: false
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-08"
+    notes: "Не зареєстрований в Україні станом на 2026-05; доступ через named-patient / EAP / charitable funding pathway. НСЗУ не покриває."
+typical_dosing: >
+  20 mg/kg IV infusion every 2 weeks (q2w) until disease progression or
+  unacceptable toxicity. First infusion over 60-90 min; subsequent
+  infusions may be shortened to ~30 min if first infusion well-tolerated.
+  Premedication: antihistamine + acetaminophen + corticosteroid for
+  infusion reaction prophylaxis (especially first 2-3 infusions). Cardiac
+  monitoring: baseline LVEF (echo or MUGA) before initiation, then q3
+  months during therapy. Antidiarrheal prophylaxis advised given ~40%
+  any-grade diarrhea.
+formulations:
+  - "IV solution / concentrate for infusion (single-dose vials)"
+
+absolute_contraindications:
+  - "Severe hypersensitivity to zanidatamab"
+  - "Pre-existing severe LV systolic dysfunction (LVEF <40%) — relative; expert judgement"
+  - "Severe symptomatic heart failure (NYHA III-IV)"
+  - "Pregnancy (expected embryo-fetal toxicity per HER2-targeted class effect — oligohydramnios, fetal renal failure)"
+
+black_box_warnings:
+  - "Embryo-fetal toxicity (HER2-targeted class effect — effective contraception required during therapy and ≥4 months after last dose)"
+
+common_adverse_events:
+  - "Diarrhea (~40% any grade; ~5% Grade 3 — antidiarrheal prophylaxis recommended)"
+  - "Infusion-related reactions (~33%; mostly Grade 1-2; first infusion predominantly)"
+  - "Nausea (~25%)"
+  - "Fatigue (~25%)"
+  - "Abdominal pain (~20%)"
+  - "Decreased appetite"
+  - "Vomiting"
+  - "Anemia"
+  - "Pyrexia"
+  - "Asymptomatic LVEF decline (~10-15%)"
+
+serious_adverse_events:
+  - "Symptomatic LVEF decline / cardiomyopathy (rare; HER2-targeted class effect)"
+  - "Severe infusion reactions including anaphylaxis"
+  - "Severe diarrhea with dehydration / electrolyte derangement"
+  - "Pneumonitis / interstitial lung disease (rare)"
+  - "Embryo-fetal toxicity if exposure during pregnancy"
+
+major_interactions:
+  - "Anthracyclines — additive cardiotoxicity (sequential scheduling preferred over concurrent — limited data; HER2-targeted class effect)"
+  - "Other cardiotoxic agents — additive cardiac risk"
+  - "Live vaccines — avoid"
+
+pharmacology:
+  half_life_hours: null
+  half_life_notes: "Population PK pending publication; q2w dosing schedule consistent with antibody half-life on the order of 1-2 weeks."
+  clearance: "non-specific catabolism (proteolysis); target-mediated drug disposition"
+  protein_binding_pct: null
+  metabolism: "non-CYP; antibody catabolism"
+  volume_of_distribution_l: null
+
+sources:
+  - SRC-HERIZON-BTC-01-HARDING-2023
+  - SRC-NCCN-HEPATOBILIARY
+  - SRC-ESMO-BTC-2023
+
+last_reviewed: "2026-05-08"
+reviewers: []
+notes: >
+  HER2-targeted biparatopic bispecific antibody (Jazz Pharmaceuticals /
+  Zymeworks). FDA accelerated approval November 2024 for HER2-positive
+  (IHC 3+) previously treated unresectable / locally advanced / metastatic
+  biliary tract cancer based on HERIZON-BTC-01 (Harding et al., Lancet
+  Oncol 2023; n=87 cohort 1; ORR 41.3%, DCR 68.8%, median DoR 14.9 mo).
+  ESCAT tier IIA (FDA-approved disease-specific HER2-amplified BTC 2L+).
+  Distinct from trastuzumab in dual-epitope binding (ECD2 + ECD4) which
+  produces enhanced HER2 receptor clustering, internalization, and
+  degradation; mechanistically retains activity in some trastuzumab-
+  experienced HER2+ tumors. Diarrhea (~40%) is the dominant clinically-
+  relevant non-cardiac toxicity — antidiarrheal prophylaxis advised.
+  Cardiac surveillance per HER2-targeted class. Active development in
+  HER2+ gastric/GEJ (HERIZON-GEA-01 phase 3, with chemotherapy ±
+  tislelizumab — pending readout); HER2-amplified colorectal; breast.
+  EMA review pending. UA access: named-patient / EAP only as of 2026-05.
+
+notes_patient: >
+  Препарат-мітка нового покоління для HER2+ пухлин (зокрема рак жовчних
+  проток): зв'язується одразу з двома різними ділянками HER2-білка, що
+  посилює його руйнування на пухлинній клітині. Найчастіший побічний
+  ефект — діарея (профілактика приймається перед інфузією). Контролюємо
+  серце ехокардіограмою кожні 3 місяці. В Україні (2026-05) не
+  зареєстрований — доступний через named-patient / благодійні програми.

--- a/knowledge_base/hosted/content/indications/ind_cholangio_2l_her2_zanidatamab.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cholangio_2l_her2_zanidatamab.yaml
@@ -1,0 +1,111 @@
+id: IND-CHOLANGIO-2L-HER2-ZANIDATAMAB
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-CHOLANGIOCARCINOMA
+  line_of_therapy: 2
+  stage_requirements:
+    - "Locally advanced unresectable or metastatic biliary tract cancer (intrahepatic / perihilar / distal cholangiocarcinoma; gallbladder cancer eligible)"
+    - "Disease progression on ≥1 prior systemic therapy (typically gem+cis ± durvalumab 1L)"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-HER2-SOLID
+      required: true
+      value_constraint: "HER2 IHC 3+ OR (IHC 2+ AND ISH amplified, HER2/CEP17 ratio ≥2.0); gastric-style scoring (Hofmann 2008 — basolateral/lateral membranous staining ≥10%)"
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-ZANIDATAMAB
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: moderate
+strength_of_recommendation: conditional
+nccn_category: "2A"
+
+expected_outcomes:
+  overall_response_rate: "41.3% (95% CI 30.4-52.8) per HERIZON-BTC-01 cohort 1 (HER2 IHC 3+ or IHC 2+/ISH+, n=87)"
+  complete_response: "~1-2%"
+  progression_free_survival: "Median PFS 5.5 mo (HERIZON-BTC-01)"
+  overall_survival_5y: "Median OS 15.5 mo (HERIZON-BTC-01); long-term f/u pending"
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-CHOLANGIOCARCINOMA-FRAILTY-AGE
+  - RF-CHOLANGIOCARCINOMA-ORGAN-DYSFUNCTION
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+desired_tests:
+  - TEST-NGS-COMPREHENSIVE
+
+rationale: >
+  Zanidatamab (HER2-targeted biparatopic bispecific antibody binding
+  HER2 ECD2 + ECD4) for HER2-amplified (IHC 3+ or IHC 2+/ISH+)
+  unresectable / locally advanced / metastatic biliary tract cancer
+  post ≥1 prior systemic line — confirmed ORR 41.3% (95% CI 30.4-52.8),
+  median DoR 14.9 mo, DCR 68.8% in HERIZON-BTC-01 (Harding Lancet Oncol
+  2023; n=87 cohort 1). FDA accelerated approval November 2024 for
+  HER2-positive (IHC 3+) BTC ≥2L. NCCN category 2A. ESCAT tier IIA
+  (FDA-approved disease-specific). HER2 amplification ~5-15% of BTC
+  overall (higher in gallbladder + extrahepatic CCA; lower in
+  intrahepatic CCA). Single-arm phase 2b — evidence tier 2 / moderate;
+  conditional recommendation reflects accelerated approval status
+  pending confirmatory data. Class HER2-targeted toxicity profile —
+  ~40% any-grade diarrhea (antidiarrheal prophylaxis advised), ~33%
+  infusion reactions (premedication + slow first infusion), cardiac
+  surveillance per HER2-targeted class. UA access barrier: zanidatamab
+  not registered (named-patient / EAP only as of 2026-05).
+
+sources:
+  - source_id: SRC-NCCN-HEPATOBILIARY
+    position: supports
+    relevant_quote_paraphrase: "Zanidatamab is a recommended option for HER2-positive (IHC 3+) advanced biliary tract cancer post ≥1 prior systemic line (HERIZON-BTC-01); FDA accelerated approval Nov 2024"
+  - source_id: SRC-ESMO-BTC-2023
+    position: supports
+    relevant_quote_paraphrase: "HER2 testing recommended in advanced biliary tract cancer; HER2-targeted therapy is an emerging 2L+ option upon HER2 amplification / overexpression confirmation"
+  - source_id: SRC-HERIZON-BTC-01-HARDING-2023
+    position: supports
+    relevant_quote_paraphrase: "HERIZON-BTC-01 cohort 1 (HER2 IHC 3+ or IHC 2+/ISH+, n=87): zanidatamab 20 mg/kg IV q2w; confirmed ORR 41.3% (95% CI 30.4-52.8), DCR 68.8%, median DoR 14.9 mo, median PFS 5.5 mo, median OS 15.5 mo"
+
+known_controversies:
+  - topic: "Zanidatamab vs trastuzumab + pertuzumab for HER2-amplified BTC 2L"
+    positions:
+      - position: "Zanidatamab: disease-specific FDA-approved (Nov 2024); HERIZON-BTC-01 ORR 41% with median DoR 14.9 mo; biparatopic dual-epitope binding produces enhanced activity vs single-epitope HER2-targeted antibodies"
+        sources: [SRC-NCCN-HEPATOBILIARY, SRC-HERIZON-BTC-01-HARDING-2023]
+      - position: "Trastuzumab + pertuzumab: MyPathway basket study (Meric-Bernstam Lancet Oncol 2021) ORR ~23% in HER2-amplified BTC; NOT FDA-approved for BTC indication; off-label / basket-trial precedent only"
+        sources: [SRC-NCCN-HEPATOBILIARY]
+        evidence_note: "No head-to-head; zanidatamab preferred based on disease-specific approval + numerically higher ORR + durable responses; trastuzumab + pertuzumab considered when zanidatamab access blocked"
+    our_default: "Zanidatamab as default 2L+ HER2-amplified BTC; trastuzumab + pertuzumab reserved when zanidatamab access blocked"
+    rationale: "FDA disease-specific accelerated approval + numerically higher / more durable response in single-arm phase 2b favor zanidatamab as the standard option upon HER2-amplification confirmation"
+
+do_not_do:
+  - "НЕ призначати без підтвердженої HER2-аmplification (IHC 3+ або IHC 2+/ISH+) — однієї лише експресії білка нижчого рівня недостатньо для цього показання."
+  - "НЕ розпочинати без baseline ехокардіограми / MUGA — клас HER2-таргетної токсичності включає LVEF-зниження."
+  - "НЕ ігнорувати премедикацію перед першими 2-3 інфузіями — інфузійні реакції ~33%."
+  - "НЕ ігнорувати профілактику діареї — ~40% any-grade; пацієнт повинен мати лоперамід вдома й чіткий план ескалації."
+  - "НЕ підтверджувати план без funding pathway — занідатамаб не зареєстрований в UA (named-patient / EAP лише)."
+
+do_not_do_en:
+  - "Do NOT prescribe without confirmed HER2-amplification (IHC 3+ or IHC 2+/ISH+) — lower-level protein expression alone is insufficient for this indication."
+  - "Do NOT start without baseline echocardiogram / MUGA — HER2-targeted class toxicity includes LVEF decline."
+  - "Do NOT skip premedication for first 2-3 infusions — infusion reactions ~33%."
+  - "Do NOT ignore diarrhea prophylaxis — ~40% any-grade; patient must have loperamide at home with clear escalation plan."
+  - "Do NOT confirm the plan without funding pathway — zanidatamab not registered in UA (named-patient / EAP only)."
+
+time_critical: false
+last_reviewed: "2026-05-08"
+reviewers: []
+reviewer_signoffs: 0
+notes: >
+  STUB — pending Clinical Co-Lead sign-off. Aggressive-track 2L+ for
+  HER2-amplified BTC. NCCN cat 2A; FDA accelerated approval Nov 2024.
+  ESCAT tier IIA (FDA-approved disease-specific). HER2 amplification
+  ~5-15% of BTC overall (higher in gallbladder + extrahepatic CCA).
+  HERIZON-BTC-01 cohort 1 (n=87, IHC 3+ or IHC 2+/ISH+): confirmed
+  ORR 41.3%, mPFS 5.5 mo, mOS 15.5 mo, DoR 14.9 mo. Confirmatory phase
+  3 pending; traditional approval pending. UA access:
+  named-patient / EAP only.

--- a/knowledge_base/hosted/content/regimens/reg_zanidatamab.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_zanidatamab.yaml
@@ -1,0 +1,91 @@
+id: REG-ZANIDATAMAB
+name: "Zanidatamab — 2L+ HER2-amplified biliary tract cancer (HERIZON-BTC-01)"
+name_ua: "Занідатамаб — 2L+ HER2-аmplified рак жовчних проток (HERIZON-BTC-01)"
+alternate_names: ["HERIZON-BTC-01 regimen", "Ziihera BTC"]
+
+components:
+  - drug_id: DRUG-ZANIDATAMAB
+    dose: "20 mg/kg"
+    schedule: "IV q2 weeks until progression / unacceptable toxicity"
+    route: IV
+
+cycle_length_days: 14
+total_cycles: "Until progression or unacceptable toxicity"
+toxicity_profile: moderate
+
+premedication:
+  - "Infusion-reaction prophylaxis: antihistamine (e.g. diphenhydramine 25-50 mg IV) + acetaminophen 650-1000 mg PO + corticosteroid (e.g. dexamethasone 4-8 mg IV) prior to first 2-3 infusions; may taper if first cycles well-tolerated"
+  - "Antidiarrheal prophylaxis advised — patient education on early loperamide use given ~40% any-grade diarrhea"
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Grade 1-2 infusion reaction"
+    modification: "Slow or interrupt infusion; resume at 50% rate after symptoms resolve; ensure premedication for next cycle"
+    rationale: "Most infusion reactions are Grade 1-2 and confined to first 2-3 infusions"
+    source_refs: [SRC-HERIZON-BTC-01-HARDING-2023]
+  - condition: "Grade 3 infusion reaction"
+    modification: "Stop infusion; permanent discontinuation if recurrent; supportive management (IV steroids, antihistamine, fluids)"
+  - condition: "Grade 4 infusion reaction / anaphylaxis"
+    modification: "Permanently discontinue zanidatamab"
+  - condition: "Grade 3 diarrhea despite optimal antidiarrheal management"
+    modification: "Hold until ≤Grade 1; resume at next-lower dose level on recovery; rule out infectious cause"
+    rationale: "Diarrhea is the dominant non-cardiac toxicity (~40% any grade, ~5% G3)"
+  - condition: "LVEF decline >10 percentage points to <50%, or symptomatic CHF"
+    modification: "Hold; cardiology consult + repeat echo q3-4 wk; resume only if LVEF normalizes asymptomatic; permanently discontinue if symptomatic CHF or persistent decline"
+    rationale: "HER2-targeted class effect — cardiac surveillance required"
+  - condition: "Suspected pneumonitis / ILD (any grade)"
+    modification: "Hold; HRCT chest + pulmonology consult; Grade ≥2 — permanent discontinuation + corticosteroids"
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: >
+    Zanidatamab not registered in Ukraine as of 2026-05; not on NSZU
+    onco package. Access pathway: named-patient / EAP / charitable
+    funding. For UA-restricted patients with HER2-amplified BTC 2L+,
+    fallback options are limited — FOLFOX (REG-FOLFOX) per ABC-06 is
+    the realistic NSZU-covered chemotherapy backbone, accepting that
+    HER2 status is not exploitable without zanidatamab access.
+
+sources:
+  - SRC-HERIZON-BTC-01-HARDING-2023
+  - SRC-NCCN-HEPATOBILIARY
+  - SRC-ESMO-BTC-2023
+
+last_reviewed: "2026-05-08"
+notes: >
+  HERIZON-BTC-01 (Harding et al., Lancet Oncol 2023; NCT04466891):
+  single-arm phase 2b trial of zanidatamab 20 mg/kg IV q2w in HER2-
+  amplified (IHC 3+ or IHC 2+/ISH+) unresectable / locally advanced /
+  metastatic biliary tract cancer progressed on prior gemcitabine-
+  based therapy; primary efficacy cohort 1 (HER2 IHC 3+ or IHC 2+/ISH+)
+  n=87 — confirmed ORR per independent central review 41.3%
+  (95% CI 30.4-52.8); DCR 68.8%; median DoR 14.9 mo. Treatment-related
+  Grade ≥3 AEs in 18%; no treatment-related deaths. Most common AEs:
+  diarrhea (~40%), infusion-related reactions (~33%), nausea, fatigue.
+  Single-arm phase 2b — evidence tier 2 / moderate (no randomised
+  comparator). FDA accelerated approval November 2024 for previously
+  treated HER2-positive (IHC 3+) BTC. NCCN category 2A; ESCAT tier IIA
+  (FDA-approved disease-specific). Confirmatory phase 3 (HERIZON-GEA-01
+  in HER2+ gastric/GEJ) and ongoing BTC studies pending. UA access:
+  named-patient / EAP only as of 2026-05.
+notes_ua: >
+  HERIZON-BTC-01 (Harding et al., Lancet Oncol 2023; NCT04466891):
+  однораменне дослідження фази 2b занідатамабу 20 mg/kg в/в кожні 2
+  тижні у пацієнтів з HER2-аmplified (IHC 3+ або IHC 2+/ISH+)
+  нерезектабельним / місцево-поширеним / метастатичним раком жовчних
+  проток після прогресування на гемцитабін-базованій терапії; первинна
+  ефективнісна когорта 1 (HER2 IHC 3+ або IHC 2+/ISH+) n=87 —
+  підтверджена ORR за незалежним центральним оглядом 41.3%
+  (95% ДІ 30.4-52.8); DCR 68.8%; медіана DoR 14.9 міс. Лікування-
+  пов'язані небажані явища ≥3 ст у 18%; смертей, пов'язаних з
+  лікуванням, не було. Найчастіші побічні ефекти: діарея (~40%),
+  інфузійні реакції (~33%), нудота, втома. Однораменне фаза 2b —
+  рівень доказовості 2 / помірний (без рандомізованого порівняння).
+  FDA accelerated approval листопад 2024 для попередньо лікованого
+  HER2-positive (IHC 3+) раку жовчних проток. NCCN категорія 2A;
+  ESCAT tier IIA. Доступ в Україні: named-patient / EAP лише
+  станом на 2026-05.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- HERIZON-BTC-01 (Harding Lancet Oncol 2023) — zanidatamab in HER2-amplified biliary 2L+
- 4 NEW entities: drug, regimen, BMA (Phase 1.5 schema), indication
- FDA accelerated approval 2024-11
- Closes #464

## Files (4 NEW)

| File | Notes |
|---|---|
| `drug_zanidatamab.yaml` | Bispecific anti-HER2 mAb (ECD2 + ECD4); FDA accelerated 2024-11 |
| `reg_zanidatamab.yaml` | 20 mg/kg IV q2w, continuous |
| `bma_her2_amp_cholangio.yaml` | Phase 1.5 evidence_sources block; ESCAT IIA; mirrors `bma_her2_amp_gastric` template |
| `ind_cholangio_2l_her2_zanidatamab.yaml` | NCCN 2A; conditional strength; mirrors FGFR2 cholangio sister indication structure |

## Schema choices

- Phase 1.5 `evidence_sources` block (no legacy `oncokb_*`)
- `actionability_review_required: true`
- `escat_tier: IIA` (FDA-approved disease-specific)
- `evidence_level: moderate` (single-arm phase 2b)
- `strength_of_recommendation: conditional` (accelerated approval)
- `nccn_category: "2A"`
- All empty lists explicit `: []` per §9.1
- UA narration with `pending_clinical_signoff` flag

## Test plan
- [x] Validator: 2962 → 2966 (+4); schema/ref/contract 0/0/0; warnings 524 unchanged
- [x] pytest 38 + 58 pass (loader, indication_schema, biomarker_schema, BMA suite)
- [x] 3 pre-existing BMA failures (`bma_bap1_mut_rcc_prognostic.yaml`) confirmed on master via stash round-trip — unrelated
- [x] No banned sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)