### PR TITLE
feat(kb): GI-3 A2 Cholangio IDH1 ivosidenib — drug + regimen + indication

### DIFF
--- a/knowledge_base/hosted/content/drugs/drug_ivosidenib.yaml
+++ b/knowledge_base/hosted/content/drugs/drug_ivosidenib.yaml
@@ -1,0 +1,202 @@
+id: DRUG-IVOSIDENIB
+names:
+  preferred: "Ivosidenib"
+  ukrainian: "Івосиденіб"
+  english: "Ivosidenib"
+  brand_names: ["Tibsovo"]
+atc_code: L01XX67
+rxnorm_id: "2054428"
+drug_class: "Mutant-selective IDH1 inhibitor (small-molecule, oral)"
+
+mechanism: >
+  Orally bioavailable small-molecule inhibitor of mutant isocitrate
+  dehydrogenase 1 (mIDH1) — selective for the neomorphic R132 hotspot
+  variants (R132H, R132C, R132G, R132L, R132S). Wild-type IDH1
+  catalyzes oxidative decarboxylation of isocitrate to α-ketoglutarate
+  (αKG); R132 mutations confer a neomorphic gain-of-function activity
+  reducing αKG to the oncometabolite 2-hydroxyglutarate (2-HG).
+  Pathologic 2-HG accumulation competitively inhibits αKG-dependent
+  dioxygenases (TET2, KDM histone demethylases, prolyl hydroxylases),
+  leading to hypermethylation of DNA and histones and a block in
+  cellular differentiation. Ivosidenib binds the mutant-IDH1 active
+  site, suppresses 2-HG production by ~95–98%, restores αKG-dependent
+  enzyme activity, and re-enables terminal differentiation of
+  malignant clones — producing a differentiation response in IDH1-
+  mutant AML and an antiproliferative / disease-control effect in
+  IDH1-mutant cholangiocarcinoma. Selective for mutant over
+  wild-type IDH1; minimal activity against IDH2-mutant disease (use
+  enasidenib or vorasidenib for IDH2 / dual-isoform contexts).
+
+regulatory_status:
+  fda:
+    approved: true
+    year_first_approval: 2018
+    indications_brief:
+      - "Relapsed/refractory IDH1-mutated AML — FDA approved July 2018 (AG120-C-001 phase 1; ORR 41.6%, CR+CRh 30.4%)"
+      - "Newly diagnosed IDH1-mutated AML in adults ≥75 yr or with comorbidities precluding intensive chemo — FDA approved May 2019 (AG120-C-001 expansion)"
+      - "Newly diagnosed IDH1-mutated AML in combination with azacitidine — FDA approved May 2022 (AGILE phase 3; mOS 24.0 vs 7.9 mo, HR 0.44)"
+      - "Previously-treated locally advanced or metastatic IDH1-mutated cholangiocarcinoma — FDA approved August 2021 (ClarIDHy phase 3; mPFS 2.7 vs 1.4 mo, HR 0.37)"
+      - "Relapsed/refractory IDH1-mutated myelodysplastic syndromes — FDA approved October 2023"
+  ema:
+    approved: true
+    year_first_approval: 2023
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-07"
+    notes: |
+      Івосиденіб НЕ зареєстрований в Україні станом на 2026-05-07
+      (drlz.com.ua). НЕ входить до НСЗУ. Шляхи доступу:
+      - Named-patient import — за рахунок пацієнта (Servier);
+      - Servier EAP — обмежено для IDH1-mutated cholangiocarcinoma
+        пост-1L gem+cis ± durvalumab та для IDH1-mutated AML;
+      - Cross-border EU center referral (наказ МОЗ 988);
+      - Clinical trials — вторинні дослідження mIDH1i + checkpoint
+        inhibitors / chemo combos.
+      Альтернатива при недоступному ivosidenib:
+      - Cholangiocarcinoma 2L: FOLFOX (ABC-06) або клінічне дослідження;
+      - AML R/R: venetoclax-based combos, salvage chemo, або
+        клінічне дослідження.
+
+typical_dosing: >
+  Standard adult dose: 500 mg PO once daily, continuous, with or
+  without food (avoid high-fat meals — increase exposure ~25%).
+  Treatment continued until disease progression or unacceptable
+  toxicity. Indication-specific notes:
+  - Cholangiocarcinoma: 500 mg PO once daily continuous (28-day
+    cycle for accounting; no scheduled break).
+  - AML monotherapy (R/R or 1L unfit): 500 mg PO once daily
+    continuous; minimum 6 months of therapy recommended to allow
+    differentiation response (median time-to-CR ~2 months).
+  - AML + azacitidine (AGILE): ivosidenib 500 mg PO daily +
+    azacitidine 75 mg/m² SC/IV days 1–7 of each 28-day cycle.
+
+  Dose modifications:
+  - QTc >480 ms: hold ivosidenib until QTc ≤480 ms; resume at
+    250 mg daily; permanent reduction or discontinuation if recurrent.
+  - QTc >500 ms or torsades de pointes / polymorphic VT: discontinue
+    permanently.
+  - Differentiation syndrome (any grade): start dexamethasone 10 mg
+    IV q12h + hemodynamic / hydration / diuresis support; hold
+    ivosidenib only if severe (grade ≥3) and resume at the same
+    dose after symptom resolution.
+  - Leukocytosis (WBC >25 × 10⁹/L or symptomatic): hydroxyurea ±
+    leukapheresis; do not discontinue ivosidenib unless severe.
+  - Strong CYP3A4 inhibitor concomitant: reduce to 250 mg daily;
+    avoid where possible.
+  - Strong CYP3A4 inducer: avoid combination — ivosidenib exposure
+    substantially reduced.
+  - Hepatic impairment: no dose adjustment for mild–moderate
+    (Child-Pugh A/B); not studied in severe (Child-Pugh C).
+  - Renal impairment: no adjustment for mild–moderate; not studied
+    in severe (CrCl <30 mL/min) or dialysis.
+
+formulations:
+  - "Oral tablet 250 mg (Tibsovo)"
+
+absolute_contraindications:
+  - "Severe hypersensitivity to ivosidenib"
+  - "Pregnancy (Category D — embryo-fetal toxicity in animal studies)"
+  - "Concomitant strong CYP3A4 inhibitors with QT-prolonging activity (relative — manage with dose reduction)"
+
+black_box_warnings:
+  - "Differentiation syndrome (in IDH1-mutant AML) — potentially fatal; manifests within 1 day to 3 months of therapy start; symptoms include fever, dyspnea, hypoxia, pulmonary infiltrates, pleural / pericardial effusion, rapid weight gain, peripheral edema, hepatic / renal / multi-organ dysfunction. Initiate corticosteroids (dexamethasone 10 mg IV q12h) and hemodynamic monitoring at first suspicion; do not wait for confirmation. Boxed warning applies to AML indication; clinically relevant in cholangiocarcinoma at much lower frequency"
+
+common_adverse_events:
+  - "Fatigue (~40-45%)"
+  - "Nausea (~35-40%)"
+  - "Diarrhea (~30-35%)"
+  - "Decreased appetite (~25-30%)"
+  - "Abdominal pain (~25%)"
+  - "Vomiting (~20-25%)"
+  - "Cough (~20%)"
+  - "Edema peripheral (~20%)"
+  - "Arthralgia (~20%)"
+  - "Dyspnea (~20%; AML > cholangio)"
+  - "Anemia (~20%)"
+  - "Rash (~15-20%)"
+  - "Constipation (~15%)"
+  - "Headache (~15%)"
+  - "Pyrexia (~15%)"
+  - "Pleural effusion (~10-15%; AML > cholangio)"
+  - "QT prolongation (~10-15% any grade; G≥3 ~5-10%)"
+
+serious_adverse_events:
+  - "Differentiation syndrome (~10-25% in IDH1-mutant AML; rare in cholangio) — boxed warning; potentially fatal"
+  - "QT prolongation / torsades de pointes (G≥3 ~5-10%) — baseline + serial ECG mandatory; correct hypokalemia / hypomagnesemia"
+  - "Leukocytosis (in AML, ~30-40%) — manage with hydroxyurea ± leukapheresis"
+  - "Guillain-Barré syndrome (rare, post-marketing)"
+  - "Hepatic enzyme elevations (G≥3 ~5%)"
+  - "Tumor lysis syndrome (rare; AML setting)"
+  - "Severe hypersensitivity reactions (rare)"
+
+major_interactions:
+  - "Strong CYP3A4 inhibitors (ketoconazole, itraconazole, ritonavir, clarithromycin, grapefruit juice) — increase ivosidenib AUC; reduce ivosidenib to 250 mg daily or avoid"
+  - "Strong CYP3A4 inducers (rifampin, carbamazepine, phenytoin, St. John's wort) — decrease ivosidenib AUC; avoid combination"
+  - "Sensitive CYP3A4 substrates (simvastatin, midazolam) — ivosidenib induces CYP3A4; substrate exposure decreased"
+  - "Sensitive CYP2C9 substrates (warfarin) — ivosidenib weakly inhibits CYP2C9; close INR monitoring"
+  - "QT-prolonging drugs (ondansetron, methadone, fluoroquinolones, azole antifungals, antiarrhythmics class IA/III) — additive QT prolongation; ECG + electrolyte monitoring"
+  - "Hormonal contraceptives — ivosidenib induces CYP3A4; oral contraceptive efficacy may be reduced; advise non-hormonal backup"
+
+pharmacology:
+  half_life_hours: 93
+  half_life_notes: "Mean terminal t½ ~93 hours after multiple-dose steady state (range ~40–120 h); steady state reached by day 14 of continuous daily dosing. Long half-life rationalizes once-daily dosing."
+  clearance: "Hepatic (primarily CYP3A4-mediated oxidation); fecal elimination predominant (~77%), renal minor (~17%, ~10% as parent)"
+  protein_binding_pct: 92
+  metabolism: "CYP3A4 (major); ivosidenib also induces CYP3A4, CYP2B6, CYP2C8, CYP2C9, UGT1A1; weak inhibitor of CYP2C9, OAT3, OATP1B1"
+  volume_of_distribution_l: 234
+
+sources:
+  - SRC-CLARIDHY-ABOU-ALFA-2020
+  - SRC-NCCN-HEPATOBILIARY
+  - SRC-ESMO-BTC-2023
+
+last_reviewed: "2026-05-07"
+reviewers: []
+notes: >
+  Mutant-selective IDH1 inhibitor (Servier; formerly Agios Pharmaceuticals,
+  development code AG-120; transferred to Servier in 2021 with the Agios
+  oncology divestiture). FDA-approved July 2018 for relapsed/refractory
+  IDH1-mutant AML on the basis of AG120-C-001 phase 1 (DiNardo et al.
+  NEJM 2018 — ORR 41.6%, CR+CRh 30.4%). FDA-approved August 2021 for
+  previously-treated IDH1-mutant locally advanced / metastatic
+  cholangiocarcinoma on the basis of ClarIDHy phase 3 (Abou-Alfa et al.
+  Lancet Oncol 2020 — ivosidenib vs placebo: mPFS 2.7 vs 1.4 mo, HR 0.37,
+  p<0.0001; OS HR 0.79 with 70.5% placebo-arm crossover, RPSFT-adjusted
+  OS HR 0.49). FDA-approved May 2022 for newly-diagnosed IDH1-mutant
+  AML in combination with azacitidine on the basis of AGILE phase 3
+  (Montesinos et al. NEJM 2022 — ivosidenib+aza vs placebo+aza: mOS 24.0
+  vs 7.9 mo, HR 0.44). FDA-approved October 2023 for r/r IDH1-mutant
+  MDS. EMA approved 2023 for cholangiocarcinoma + AML.
+
+  IDH1 R132 mutations are mutually exclusive with FGFR2 fusions in
+  intrahepatic cholangiocarcinoma (~13–20% prevalence) and with FLT3 /
+  NPM1 mutations in AML at lower mutual-exclusivity rates. IDH1 R132C
+  is the dominant variant in cholangio (~70% of IDH1 mutations);
+  R132H predominates in AML and in glioma. Resistance mechanisms in
+  AML: IDH2 isoform-switching, second-site IDH1 mutations (e.g.,
+  S280F gatekeeper), receptor tyrosine kinase upregulation. In
+  cholangio, resistance patterns less characterized; emerging
+  data suggest 2-HG re-elevation through IDH2 / RTK upregulation.
+
+  Vorasidenib (dual mIDH1/2 inhibitor; Servier) FDA-approved 2024
+  for IDH-mutant grade 2 glioma (INDIGO trial); not active in
+  cholangiocarcinoma per current data. STUB pending Clinical
+  Co-Lead sign-off (CHARTER §6.1: ≥2 reviewers for clinical content).
+
+notes_patient: >
+  Івосиденіб — щоденна таблетка для холангіокарциноми з мутацією IDH1
+  після прогресування на 1L хіміотерапії (gemcitabine+cisplatin ±
+  durvalumab). Приймати раз на день, з їжею або без (уникати жирної
+  їжі). Контролюємо ЕКГ (QT-інтервал) на старті та регулярно
+  (тиждень 1, 2, 4, далі щомісяця або за клінічними показаннями), а
+  також рівні калію та магнію — їх дефіцит підвищує ризик аритмії.
+  При AML додатково моніторимо синдром диференціації (задишка,
+  набряк, лихоманка, інфільтрати в легенях) — потребує негайного
+  введення дексаметазону. Період напіввиведення ~93 години — пропуск
+  однієї дози не критичний, наступну приймати у звичайний час (не
+  подвоювати). Уникати грейпфрутового соку та сильних інгібіторів /
+  індукторів CYP3A4. Гормональна контрацепція може мати знижену
+  ефективність — потрібен бар'єрний метод як додаток.

--- a/knowledge_base/hosted/content/indications/ind_cholangio_2l_idh1_ivosidenib.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cholangio_2l_idh1_ivosidenib.yaml
@@ -1,0 +1,115 @@
+id: IND-CHOLANGIO-2L-IDH1-IVOSIDENIB
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-CHOLANGIOCARCINOMA
+  line_of_therapy: 2
+  stage_requirements:
+    - "Locally advanced unresectable or metastatic intrahepatic cholangiocarcinoma"
+    - "Disease progression on ≥1 prior systemic therapy (typically gem+cis ± durvalumab 1L)"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-IDH-MUTATION
+      required: true
+      value_constraint: "IDH1 R132 hotspot mutation positive (R132C / R132L / R132G / R132H / R132S; tumor NGS preferred; ctDNA acceptable when tumor tissue insufficient). IDH2 mutations NOT eligible."
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-IVOSIDENIB-CHOLANGIO
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~2% (PR only; ClarIDHy ITT — disease-control measure more relevant)"
+  complete_response: "0%"
+  progression_free_survival: "Median PFS 2.7 mo vs 1.4 mo placebo, HR 0.37, p<0.0001 (ClarIDHy); 6-mo PFS rate 32% vs not reached on placebo"
+  overall_survival_5y: "Median OS 10.3 mo ITT (HR 0.79 with 70.5% placebo crossover); RPSFT-adjusted mOS HR 0.49 favoring ivosidenib (ClarIDHy)"
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-CHOLANGIOCARCINOMA-FRAILTY-AGE
+  - RF-CHOLANGIOCARCINOMA-ORGAN-DYSFUNCTION
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-ECG
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+desired_tests:
+  - TEST-NGS-COMPREHENSIVE
+
+rationale: >
+  Ivosidenib for IDH1-R132-mutated advanced cholangiocarcinoma post
+  ≥1 prior systemic line — mPFS 2.7 vs 1.4 mo (HR 0.37, p<0.0001),
+  RPSFT-adjusted mOS HR 0.49 (ClarIDHy phase 3, Abou-Alfa Lancet
+  Oncol 2020). FDA approved August 2021; EMA 2023. IDH1 R132 hotspot
+  mutations occur in ~13–20% of intrahepatic cholangiocarcinoma and
+  are mutually exclusive with FGFR2 fusions; comprehensive molecular
+  profiling at diagnosis should test both. NCCN-Hepatobiliary
+  category 1 (FDA-approved with phase 3 evidence). Toxicity profile
+  favorable — well-tolerated oral therapy in a generally elderly /
+  debilitated post-1L cholangiocarcinoma population. Class boxed
+  warning for differentiation syndrome derives from AML setting; in
+  ClarIDHy cholangio cohort it was not observed but clinicians should
+  remain aware. UA access barrier: ivosidenib not registered
+  (named-patient / Servier EAP only). Alternative when ivosidenib
+  unavailable: FOLFOX 2L (ABC-06) or clinical trial; vorasidenib
+  (dual mIDH1/2) NOT active in cholangiocarcinoma per current data
+  and is not an alternative.
+
+sources:
+  - source_id: SRC-NCCN-HEPATOBILIARY
+    position: supports
+    relevant_quote_paraphrase: "Ivosidenib is a recommended option (category 1) for IDH1-R132 mutated locally advanced or metastatic cholangiocarcinoma after progression on prior systemic therapy; FDA approved August 2021 on ClarIDHy phase 3 data."
+  - source_id: SRC-ESMO-BTC-2023
+    position: supports
+    relevant_quote_paraphrase: "IDH1 mutation testing is recommended in advanced biliary tract cancer; ivosidenib is the standard 2L option for IDH1-mutated intrahepatic cholangiocarcinoma post chemotherapy failure."
+  - source_id: SRC-CLARIDHY-ABOU-ALFA-2020
+    position: supports
+    relevant_quote_paraphrase: "ClarIDHy phase 3 (n=185, ivosidenib vs placebo, 2:1, advanced IDH1-mutated cholangiocarcinoma post ≥1L chemotherapy): mPFS 2.7 vs 1.4 mo, HR 0.37 (95% CI 0.25–0.54, p<0.0001); RPSFT-adjusted mOS HR 0.49 with 70.5% placebo-arm crossover."
+
+known_controversies:
+  - topic: "Modest absolute mPFS gain (2.7 vs 1.4 mo) — is the magnitude clinically meaningful?"
+    positions:
+      - position: "Yes — HR 0.37 is robust; 6-month PFS rate 32% vs not reached on placebo demonstrates a tail of long-term disease control absent in placebo arm; well-tolerated oral monotherapy in an otherwise rapidly-progressing post-1L population without alternative biomarker-driven options"
+        sources: [SRC-NCCN-HEPATOBILIARY, SRC-CLARIDHY-ABOU-ALFA-2020]
+      - position: "Modest — absolute mPFS gap is small; ITT mOS not significantly different (crossover-confounded); cost-effectiveness contested in some payer environments"
+        sources: [SRC-CLARIDHY-ABOU-ALFA-2020]
+    our_default: "Recommend ivosidenib as 2L standard for IDH1-R132 cholangio when biomarker confirmed and access available; align with NCCN cat 1 + ESMO; alternative is FOLFOX 2L (ABC-06) — comparable mPFS but inferior tolerability in elderly population"
+    rationale: "Phase 3 randomized evidence + regulatory approval + guideline endorsement; tolerability profile favors ivosidenib over FOLFOX in post-1L cholangio population; tail of long-term responders justifies use despite modest median gain"
+
+do_not_do:
+  - "НЕ призначати без тестування на мутацію IDH1 R132 (NGS пухлини або ctDNA) — ампліфікація / IDH2-мутація / IDH1-мутації поза R132 НЕ є показанням."
+  - "НЕ розпочинати без вихідної ЕКГ та корекції електролітів (K, Mg, Ca) — QT-подовження є класовим побічним ефектом."
+  - "НЕ комбінувати з потужними CYP3A4 індукторами (rifampin, carbamazepine, phenytoin, St. John's wort) — експозиція ivosidenib різко знижується."
+  - "НЕ ігнорувати моніторинг QTc (ЕКГ на тиждень 1, 2, 4, далі щомісяця або за клінічними показаннями)."
+  - "НЕ покладатися на гормональну контрацепцію як єдиний метод — ivosidenib індукує CYP3A4; потрібен бар'єрний метод."
+  - "НЕ підтверджувати план без funding pathway — ivosidenib не зареєстрований в UA."
+
+do_not_do_en:
+  - "Do NOT prescribe without confirmed IDH1 R132 mutation testing (tumor NGS or ctDNA) — amplification, IDH2 mutation, or non-R132 IDH1 mutations are NOT eligible."
+  - "Do NOT start without baseline ECG and correction of electrolytes (K, Mg, Ca) — QT prolongation is a class adverse effect."
+  - "Do NOT combine with strong CYP3A4 inducers (rifampin, carbamazepine, phenytoin, St. John's wort) — ivosidenib exposure is sharply reduced."
+  - "Do NOT skip QTc monitoring (ECG at week 1, 2, 4, then monthly or as clinically indicated)."
+  - "Do NOT rely on hormonal contraception as the sole method — ivosidenib induces CYP3A4; barrier contraception is required."
+  - "Do NOT confirm the plan without funding pathway — ivosidenib not registered in UA."
+
+time_critical: false
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: 0
+actionability_review_required: true
+notes: >
+  STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1: ≥2
+  reviewers for clinical content). Aggressive-track 2L+ for
+  IDH1-R132 mutated intrahepatic cholangiocarcinoma. NCCN cat 1
+  (2025 hepatobiliary); FDA Aug 2021; EMA 2023. References existing
+  BMA-IDH1-R132-CHOLANGIO (BIO-IDH-MUTATION) for biomarker
+  evidence linkage. Primary citation SRC-CLARIDHY-ABOU-ALFA-2020
+  ingested in W0-CHOLANGIO PR #456. UA access: named-patient /
+  Servier EAP pathway only.

--- a/knowledge_base/hosted/content/regimens/reg_ivosidenib_cholangio.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_ivosidenib_cholangio.yaml
@@ -1,0 +1,144 @@
+id: REG-IVOSIDENIB-CHOLANGIO
+name: "Ivosidenib monotherapy (ClarIDHy) — 2L+ IDH1-mutated cholangiocarcinoma"
+name_ua: "Івосиденіб монотерапія (ClarIDHy) — 2L+ IDH1-mutated CCA"
+alternate_names:
+  - "Ivosidenib"
+  - "Tibsovo"
+
+components:
+  - drug_id: DRUG-IVOSIDENIB
+    dose: "500 mg PO once daily, continuous"
+    schedule: "PO daily, 28-day cycle (continuous; no scheduled break)"
+    route: PO
+
+cycle_length_days: 28
+total_cycles: "Until progression / unacceptable toxicity"
+
+toxicity_profile: low
+
+premedication: []
+
+mandatory_supportive_care: []
+monitoring_schedule_id: null
+# Ivosidenib supportive-care protocol (encoded in notes / dose_adjustments
+# below; no dedicated SUP entity yet — flagged for future supportive_care
+# expansion):
+#  - Baseline + serial ECG (week 1, 2, 4, then monthly or at clinical
+#    discretion) for QTc monitoring; aim QTcF <480 ms
+#  - Baseline + pre-cycle electrolytes (K, Mg, Ca) — correct hypokalemia
+#    / hypomagnesemia before initiation; recheck with concomitant
+#    QT-prolonging drugs or new GI losses
+#  - Baseline + monthly LFTs and CBC
+#  - Pre-treatment confirmation of IDH1 R132 mutation by tumor NGS
+#    (DNA preferred; ctDNA acceptable when tumor tissue insufficient)
+#  - Differentiation-syndrome vigilance is primarily an AML concern;
+#    in cholangiocarcinoma it is rare but plausible — clinicians
+#    should remain aware
+
+dose_adjustments:
+  - condition: "QTcF prolongation 481–500 ms (grade 2)"
+    modification: "Hold ivosidenib until QTcF ≤480 ms; resume at the same dose with weekly ECG monitoring; correct K / Mg / Ca; review concomitant QT-prolonging drugs"
+    source_refs: [SRC-NCCN-HEPATOBILIARY, SRC-CLARIDHY-ABOU-ALFA-2020]
+  - condition: "QTcF >500 ms (grade 3)"
+    modification: "Hold ivosidenib until QTcF ≤480 ms; resume at 250 mg daily; permanent reduction or discontinuation if recurrent at 250 mg"
+    source_refs: [SRC-NCCN-HEPATOBILIARY, SRC-CLARIDHY-ABOU-ALFA-2020]
+  - condition: "QTcF prolongation with arrhythmia (torsades de pointes, polymorphic VT, signs/symptoms of serious arrhythmia)"
+    modification: "Discontinue ivosidenib permanently"
+    source_refs: [SRC-NCCN-HEPATOBILIARY, SRC-CLARIDHY-ABOU-ALFA-2020]
+  - condition: "Suspected differentiation syndrome (rare in cholangio; any grade)"
+    modification: "Initiate dexamethasone 10 mg IV q12h + hemodynamic / hydration / diuresis support immediately; hold ivosidenib only if grade ≥3; resume at same dose after symptom resolution"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Grade 3 non-hematologic toxicity (excluding QT, differentiation syndrome) attributed to ivosidenib"
+    modification: "Hold ivosidenib until ≤grade 1 or baseline; resume at 250 mg daily; discontinue if recurrent at 250 mg"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Strong CYP3A4 inhibitor concomitant (unavoidable)"
+    modification: "Reduce ivosidenib to 250 mg daily; monitor QTc weekly; revert to 500 mg ≥5 half-lives after inhibitor discontinuation"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+  - condition: "Strong CYP3A4 inducer concomitant"
+    modification: "Avoid combination — ivosidenib exposure substantially reduced; consider alternate non-inducing agent"
+    source_refs: [SRC-NCCN-HEPATOBILIARY]
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: |
+    Івосиденіб НЕ зареєстровано в UA (drlz.com.ua станом на
+    2026-05-07; FDA серпень 2021 для cholangio, EMA 2023). НЕ
+    входить до НСЗУ. Шляхи доступу:
+    - Named-patient import — за рахунок пацієнта;
+    - Servier EAP — обмежено для IDH1-mutated CCA пост-1L
+      gem+cis ± durvalumab;
+    - Cross-border (EU): EU гепатобіліарні центри (наказ МОЗ 988);
+    - Clinical trials (NCT search: IDH1 + cholangiocarcinoma).
+    Альтернатива при недоступному ivosidenib: FOLFOX 2L (ABC-06)
+    або клінічне дослідження. Vorasidenib (dual mIDH1/2) NOT active
+    у cholangio і не є альтернативою.
+
+sources:
+  - SRC-NCCN-HEPATOBILIARY
+  - SRC-ESMO-BTC-2023
+  - SRC-CLARIDHY-ABOU-ALFA-2020
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Ivosidenib for IDH1-mutated cholangiocarcinoma 2L+ (ClarIDHy).
+# Toxicity signature: QT prolongation, fatigue, GI (nausea, diarrhea),
+# rare differentiation syndrome (boxed warning is AML-specific).
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, втрата апетиту"
+    action_ua: "Часто проходить — занотовуйте; підтримуючий протиблювотний при потребі"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Помірна діарея (3–4 рази на день, без зневоднення)"
+    action_ua: "Лоперамід за схемою; пийте більше рідини; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Втома, що не заважає щоденній активності"
+    action_ua: "Очікувано — занотовуйте; режим сну, легка фізична активність"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Серцебиття, перебої в роботі серця, запаморочення"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна ЕКГ для контролю QT-інтервалу"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-HEPATOBILIARY
+      - SRC-CLARIDHY-ABOU-ALFA-2020
+  - trigger_ua: "Виражена діарея (≥6 разів на день) або зневоднення"
+    action_ua: "Подзвоніть у клініку того ж дня — потрібна корекція дози та підтримка"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова задишка, набряк ніг, швидке збільшення ваги"
+    action_ua: "Звертайтесь у лікарню негайно — рідко може бути ознакою синдрому диференціації; потребує негайного введення дексаметазону"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-HEPATOBILIARY
+  - trigger_ua: "Втрата свідомості, виражене запаморочення з серцебиттям"
+    action_ua: "Звертайтесь у лікарню негайно — можлива серйозна аритмія через QT-подовження"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-HEPATOBILIARY
+      - SRC-CLARIDHY-ABOU-ALFA-2020
+
+last_reviewed: "2026-05-07"
+
+notes: >
+  ClarIDHy phase 3 (Abou-Alfa et al. Lancet Oncol 2020): ivosidenib
+  500 mg PO daily continuous vs placebo in advanced/metastatic
+  IDH1-mutant cholangiocarcinoma post ≥1L systemic therapy (typically
+  gemcitabine/cisplatin ± durvalumab in modern practice). N=185
+  randomized 2:1 (ivo n=124, pbo n=61). mPFS 2.7 vs 1.4 mo, HR 0.37
+  (95% CI 0.25–0.54), p<0.0001. Disease control rate 53% vs 28%.
+  ORR 2% (no CR; 2 PR by independent review). mOS HR 0.79 ITT (NS,
+  with 70.5% placebo-arm crossover); RPSFT-adjusted mOS HR 0.49 — OS
+  benefit recognized in label. FDA-approved August 2021; EMA approved
+  2023. Toxicity well tolerated overall (G≥3 AE 30% ivo vs 22% pbo);
+  notable AEs: ascites (G≥3 7% ivo vs 5% pbo, attributable to disease
+  progression in part), fatigue, nausea, QTc prolongation (any grade
+  ~9%, G≥3 ~1%). Differentiation syndrome — boxed warning class
+  effect — not observed in ClarIDHy cholangio cohort but possible
+  per labelling and AML experience; clinicians should remain aware.
+  STUB pending Clinical Co-Lead sign-off; SRC-CLARIDHY-ABOU-ALFA-2020
+  ingested as primary citation (W0-CHOLANGIO PR #456).


### PR DESCRIPTION
## Summary
- ClarIDHy (Abou-Alfa Lancet Oncol 2020) — ivosidenib in IDH1-R132 mutated cholangio 2L
- 3 NEW entities: drug, regimen, indication (BMA-IDH1-R132-CHOLANGIO already exists; referenced)
- FDA approved 2021 / EMA 2023; NCCN cat 1
- Closes #463

## Files (3 NEW)

| File | Notes |
|---|---|
| `drug_ivosidenib.yaml` | IDH1 inhibitor (mutant-selective R132H/C/G/L); diff syndrome boxed warning, QT prolongation, leukocytosis |
| `reg_ivosidenib_cholangio.yaml` | 500 mg PO QD continuous |
| `ind_cholangio_2l_idh1_ivosidenib.yaml` | NCCN cat 1; references existing BMA-IDH1-R132-CHOLANGIO |

## Clinical content

ClarIDHy phase 3:
- mPFS 2.7 vs 1.4 mo (HR 0.37, p<0.0001)
- RPSFT-adjusted mOS HR 0.49
- biomarker_id: `BIO-IDH-MUTATION` (referenced via existing BMA)

Variation from FGFR2 sister indication: `TEST-ECG` added to `required_tests` for QT-prolongation class effect.

## Schema choices

- `hard_contraindications: []`, `biomarker_requirements_excluded: []` per §9.1
- `evidence_level: high`, `strength_of_recommendation: strong`, `nccn_category: "1"`
- `actionability_review_required: true` per Phase 1.5
- UA non-registration documented in known_controversies

## Test plan
- [x] Validator: 2962 → 2965 (+3); schema/ref/contract 0/0/0; warnings 524 unchanged
- [x] pytest 16 passed (test_indication_schema, test_loader, test_loader_cache)
- [x] No banned sources (OncoKB/SNOMED/MedDRA)
- [x] All sources pre-existing — no source stubs added

🤖 Generated with [Claude Code](https://claude.com/claude-code)