### PR TITLE
feat(kb): GI-3 C1 PDAC adjuvant mFOLFIRINOX (PRODIGE-24, §17 single-phase)

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_pdac_adjuvant_mfolfirinox.yaml
+++ b/knowledge_base/hosted/content/indications/ind_pdac_adjuvant_mfolfirinox.yaml
@@ -1,0 +1,182 @@
+# IND-PDAC-ADJUVANT-MFOLFIRINOX — §17 single-phase adjuvant indication
+# (chunk gi3-c1-pdac-adj-mfolfirinox-2026-05-08-2100). Mirrors GI-2 C1
+# FLOT pattern but adjuvant-only — surgery happened pre-enrollment in
+# PRODIGE-24, so the indication phases[] models the systemic adjuvant
+# course only. The patient must already have undergone R0/R1 resection
+# to qualify; pre-resection patients route to a different indication
+# (neoadjuvant if planned, or systemic if upfront unresectable).
+id: IND-PDAC-ADJUVANT-MFOLFIRINOX
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-PDAC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Resected pancreatic ductal adenocarcinoma, stage I-III, R0 or R1 margin"
+    - "Post-resection, recovery to ECOG 0-1 within 12 weeks of surgery"
+  biomarker_requirements_required: []
+  # PRODIGE-24 did NOT stratify by biomarker — adjuvant mFOLFIRINOX is
+  # offered to all fit post-resection PDAC regardless of KRAS / BRCA / MSI
+  # status. BRCA1/2 patients may consider adjuvant trials with PARPi
+  # additions; MSI-H / dMMR patients are exceedingly rare in PDAC and
+  # remain candidates for standard mFOLFIRINOX.
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+    fit_for_chemo: true
+    # PRODIGE-24 enrolled ECOG 0-1 only; ECOG 2+ patients should be
+    # considered for less-toxic adjuvant alternatives (gem-cape,
+    # gemcitabine monotherapy) via MDT.
+
+# §17 single-phase adjuvant — surgery happened pre-enrollment in
+# PRODIGE-24 and is NOT modelled here. Patients who reach this indication
+# have already had R0/R1 resection. The adjuvant systemic course is the
+# entire scope of this indication.
+phases:
+  - phase: adjuvant
+    type: chemotherapy
+    regimen_id: REG-MFOLFIRINOX
+    cycles: 12
+
+# Legacy `recommended_regimen` left null — render layer should consume
+# `phases:` for this indication per §17 ratification (commit 9882381c).
+recommended_regimen:
+
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_survival_median: "54.4 mo (mFOLFIRINOX) vs 35.0 mo (gemcitabine); HR 0.64, p<0.001 (PRODIGE-24 / Conroy 2018)"
+  progression_free_survival: "Median DFS 21.6 mo (mFOLFIRINOX) vs 12.8 mo (gemcitabine); HR 0.58, p<0.001"
+  overall_survival_5y: "5y OS ~43% (mFOLFIRINOX) vs ~32% (gemcitabine) per PRODIGE-24 long-term update"
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-PDAC-BILIARY-OBSTRUCTION-CHOLANGITIS
+
+required_tests:
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+  - TEST-LFT
+  - TEST-CBC
+
+desired_tests:
+  - TEST-NGS-COMPREHENSIVE  # BRCA / KRAS / MSI for future-line preparedness
+
+rationale: >
+  PRODIGE-24/CCTG PA.6 (Conroy 2018, NEJM) established modified
+  FOLFIRINOX × 12 cycles as the preferred adjuvant therapy for resected
+  pancreatic ductal adenocarcinoma in fit ECOG 0-1 patients post R0/R1
+  resection. Median OS 54.4 vs 35.0 mo (HR 0.64), median DFS 21.6 vs 12.8
+  mo (HR 0.58), both p<0.001 vs gemcitabine monotherapy. NCCN v3.2025
+  category 1 + ESMO 2024 strong recommendation. mFOLFIRINOX superseded
+  gemcitabine monotherapy and gem-capecitabine (ESPAC-4) as the preferred
+  adjuvant regimen for fit patients.
+
+  Patient selection: ECOG 0-1, recovery from surgery within 12 weeks
+  (PRODIGE-24 protocol window), bilirubin <1.5 ULN (irinotecan
+  hepatotoxicity), no severe cardiac comorbidity. UGT1A1 *28/*28
+  homozygous patients should start with reduced irinotecan dose. Patients
+  unfit for mFOLFIRINOX (ECOG ≥2, severe comorbidity, persistent
+  post-operative complications) should be offered gem-capecitabine
+  (ESPAC-4) or gemcitabine monotherapy as alternative adjuvant standards
+  via MDT review.
+
+  Surgery is NOT modelled in phases[] for this indication because
+  PRODIGE-24 enrolled patients post-resection — surgical decision and
+  outcome are pre-conditions, not phases of this line of therapy.
+
+rationale_ua: >
+  PRODIGE-24/CCTG PA.6 (Conroy 2018, NEJM) встановив модифікований
+  FOLFIRINOX × 12 циклів як преферентну ад'ювантну терапію резектованої
+  протокової аденокарциноми підшлункової залози у фіт-пацієнтів ECOG 0-1
+  після R0/R1 резекції. Медіана ЗВ 54.4 vs 35.0 міс (HR 0.64), медіана
+  БХВ 21.6 vs 12.8 міс (HR 0.58), обидва p<0.001 vs гемцитабін у
+  монорежимі. NCCN v3.2025 категорія 1 + ESMO 2024 сильна рекомендація.
+  mFOLFIRINOX замінив гемцитабін у монорежимі та гем-капецитабін
+  (ESPAC-4) як преферентний ад'ювантний режим для фіт-пацієнтів.
+
+  Відбір пацієнтів: ECOG 0-1, відновлення після операції протягом 12
+  тижнів (вікно протоколу PRODIGE-24), білірубін <1.5 ULN
+  (гепатотоксичність іринотекану), відсутність тяжкої кардіальної
+  коморбідності. Пацієнти UGT1A1 *28/*28 гомозиготні — стартова
+  знижена доза іринотекану. Непридатні до mFOLFIRINOX (ECOG ≥2, тяжка
+  коморбідність, стійкі післяопераційні ускладнення) — гем-капецитабін
+  (ESPAC-4) або гемцитабін у монорежимі через MDT.
+
+  Хірургія НЕ моделюється у phases[] цього indication, оскільки
+  PRODIGE-24 включав пацієнтів після резекції — хірургічне рішення і
+  результат є передумовами, а не фазами цієї лінії терапії.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-PRODIGE-24-CONROY-2018
+    position: supports
+  - source_id: SRC-NCCN-PANCREATIC-2025
+    position: supports
+  - source_id: SRC-ESMO-PANCREATIC-2024
+    position: supports
+
+known_controversies:
+  - topic: Adjuvant mFOLFIRINOX vs gem-capecitabine for fit post-resection PDAC
+    positions:
+      - position: mFOLFIRINOX preferred for fit ECOG 0-1 patients
+        sources:
+          - SRC-PRODIGE-24-CONROY-2018
+          - SRC-NCCN-PANCREATIC-2025
+          - SRC-ESMO-PANCREATIC-2024
+        evidence_note: "PRODIGE-24 OS 54.4 vs 35.0 mo (HR 0.64) — largest absolute OS gain in adjuvant PDAC; mFOLFIRINOX is now preferred standard"
+      - position: Gem-capecitabine acceptable when mFOLFIRINOX not feasible
+        sources:
+          - SRC-NCCN-PANCREATIC-2025
+        evidence_note: "ESPAC-4 demonstrated gem-cape superiority over gem-mono (mOS 28 vs 25.5 mo, HR 0.82); reasonable adjuvant alternative when intolerance / unfit for mFOLFIRINOX"
+    our_default: "mFOLFIRINOX × 12 cycles for ECOG 0-1 patients within 12-week post-op recovery window; gem-capecitabine as MDT-determined alternative for marginal-fitness or comorbidity-limited patients"
+    rationale: "PRODIGE-24's OS gain is the largest in adjuvant PDAC trial history; mFOLFIRINOX is the preferred standard. ESPAC-4 gem-cape preserves a meaningful OS gain over gem-mono and is the appropriate fallback when mFOLFIRINOX is contraindicated."
+
+  - topic: Adjuvant initiation timing post-resection
+    positions:
+      - position: Initiate within 12 weeks of surgery
+        sources:
+          - SRC-PRODIGE-24-CONROY-2018
+        evidence_note: "PRODIGE-24 protocol enrolled patients within 3-12 weeks of resection; benefit beyond 12 weeks not established"
+      - position: NCCN allows up to 12-16 weeks for slow recoverers
+        sources:
+          - SRC-NCCN-PANCREATIC-2025
+        evidence_note: "NCCN allows clinical judgment for patients with slower post-op recovery; meaningful benefit likely retained if initiated by 16 weeks"
+    our_default: "Target 8-12 weeks post-resection; initiate by week 12 if ECOG 0-1; consider gem-based regimen if delayed beyond 12-16 weeks"
+    rationale: "PRODIGE-24's timing window is the only RCT-validated initiation interval; NCCN's broader allowance reflects pragmatic recovery variability but not direct RCT evidence."
+
+do_not_do:
+  - "Do NOT initiate mFOLFIRINOX in ECOG ≥2 patients — PRODIGE-24 excluded ECOG ≥2; route to gem-capecitabine or gemcitabine monotherapy via MDT"
+  - "Do NOT start without bilirubin <1.5 ULN — irinotecan hepatotoxicity risk; resolve biliary obstruction first"
+  - "Do NOT skip UGT1A1 testing for high-risk populations — preventable severe diarrhea + neutropenia with starting dose adjustment"
+  - "Do NOT skip G-CSF primary prophylaxis — cumulative febrile-neutropenia risk over 12 adjuvant cycles"
+  - "Do NOT use this regimen in metastatic / unresectable PDAC — adjuvant mFOLFIRINOX is for resected disease only; metastatic patients route to IND-PDAC-METASTATIC-1L-FOLFIRINOX (full FOLFIRINOX) or alternatives"
+  - "Do NOT initiate beyond 12-16 weeks post-resection without MDT review — benefit window not RCT-validated beyond protocol timing"
+
+do_not_do_en:
+  - "Do NOT initiate mFOLFIRINOX in ECOG ≥2 patients — PRODIGE-24 excluded ECOG ≥2; route to gem-capecitabine or gemcitabine monotherapy via MDT"
+  - "Do NOT start without bilirubin <1.5 ULN — irinotecan hepatotoxicity risk; resolve biliary obstruction first"
+  - "Do NOT skip UGT1A1 testing for high-risk populations — preventable severe diarrhea + neutropenia with starting dose adjustment"
+  - "Do NOT skip G-CSF primary prophylaxis — cumulative febrile-neutropenia risk over 12 adjuvant cycles"
+  - "Do NOT use this regimen in metastatic / unresectable PDAC — adjuvant mFOLFIRINOX is for resected disease only; metastatic patients route to IND-PDAC-METASTATIC-1L-FOLFIRINOX (full FOLFIRINOX) or alternatives"
+  - "Do NOT initiate beyond 12-16 weeks post-resection without MDT review — benefit window not RCT-validated beyond protocol timing"
+
+last_reviewed: "2026-05-08"
+
+actionability_review_required: true
+
+notes: >
+  GI-3 Phase C1: §17 single-phase adjuvant indication for resected PDAC,
+  mirroring GI-2 C1 FLOT periop pattern but adjuvant-only because surgery
+  happened pre-enrollment in PRODIGE-24. The phases[] block contains a
+  single chemotherapy phase (adjuvant × 12 cycles, REG-MFOLFIRINOX). The
+  surgical pre-condition is captured in stage_requirements rather than
+  phases[] — patients reaching this indication have already had R0/R1
+  resection. Engine routing from PDAC algorithm to this indication is out
+  of C1 scope — flagged for D2 algorithm-extension chunk follow-up.

--- a/knowledge_base/hosted/content/regimens/reg_mfolfirinox.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_mfolfirinox.yaml
@@ -1,0 +1,159 @@
+# REG-MFOLFIRINOX — modified FOLFIRINOX per PRODIGE-24/CCTG PA.6
+# (Conroy 2018, NEJM). Distinct entity from REG-FOLFIRINOX because the
+# adjuvant protocol diverges from ACCORD-11 metastatic FOLFIRINOX in two
+# ways:
+#   1. Irinotecan reduced from 180 → 150 mg/m²
+#   2. 5-FU bolus omitted (CIV only)
+# Modeling these as a separate regimen lets the §17 adjuvant phase point
+# at the actual study protocol rather than carrying a "use modified
+# variant" caveat on REG-FOLFIRINOX.
+id: REG-MFOLFIRINOX
+name: "mFOLFIRINOX (modified FOLFIRINOX, PRODIGE-24 protocol)"
+name_ua: "mFOLFIRINOX (модифікований FOLFIRINOX, протокол PRODIGE-24)"
+alternate_names:
+  - "Modified FOLFIRINOX"
+  - "PRODIGE-24 adjuvant regimen"
+  - "CCTG PA.6 regimen"
+
+components:
+  - drug_id: DRUG-OXALIPLATIN
+    dose: "85 mg/m²"
+    schedule: "IV day 1 every 14d"
+    route: IV
+  - drug_id: DRUG-LEUCOVORIN
+    dose: "400 mg/m²"
+    schedule: "IV day 1"
+    route: IV
+  - drug_id: DRUG-IRINOTECAN
+    dose: "150 mg/m²"
+    schedule: "IV day 1 (reduced from 180 mg/m² of full FOLFIRINOX)"
+    route: IV
+  - drug_id: DRUG-5-FLUOROURACIL
+    dose: "2400 mg/m² CIV over 46h (NO bolus — key modification vs full FOLFIRINOX)"
+    schedule: "Day 1-2 CIV"
+    route: IV
+
+cycle_length_days: 14
+total_cycles: "12 cycles (PRODIGE-24 adjuvant protocol — fixed duration, not until-progression)"
+
+toxicity_profile: severe
+
+premedication: ["5-HT3 + dexamethasone + atropine for cholinergic syndrome (irinotecan)"]
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "UGT1A1 *28/*28 homozygous"
+    modification: "Reduce irinotecan to 120 mg/m² (mFOLFIRINOX baseline already 150)"
+    rationale: "Severe neutropenia + diarrhea risk"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+  - condition: "Bilirubin 1.5-3 ULN"
+    modification: "Reduce irinotecan 25-50%"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+  - condition: "Bilirubin >3 ULN"
+    modification: "Hold irinotecan; consider gemcitabine-based adjuvant alternative"
+    source_refs: [SRC-NCCN-PANCREATIC-2025]
+  - condition: "Grade 3 diarrhea"
+    modification: "Loperamide intensive; reduce irinotecan and 5-FU 25% on next cycle"
+  - condition: "Grade 3+ neuropathy"
+    modification: "Hold or reduce oxaliplatin; complete cycles with 5-FU/LV/irinotecan if needed"
+  - condition: "Persistent grade 2+ neuropathy at cycle 6-8"
+    modification: "Discontinue oxaliplatin; continue 5-FU/LV/irinotecan to complete 12 cycles per PRODIGE-24"
+    rationale: "PRODIGE-24 allowed oxaliplatin discontinuation while preserving fluoropyrimidine + irinotecan backbone"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: true
+  notes: "All four components NSZU-funded; G-CSF primary prophylaxis recommended (febrile-neutropenia ~3% in mFOLFIRINOX vs ~10% in full FOLFIRINOX, but cumulative over 12 adjuvant cycles)."
+
+sources: [SRC-PRODIGE-24-CONROY-2018, SRC-NCCN-PANCREATIC-2025, SRC-ESMO-PANCREATIC-2024]
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# mFOLFIRINOX is the standard adjuvant PDAC regimen for fit ECOG 0-1
+# patients post-resection. Lower-toxicity variant of FOLFIRINOX (no 5-FU
+# bolus, irinotecan 150 not 180) but cumulative 12-cycle adjuvant course
+# means oxaliplatin-induced neuropathy is the dominant late toxicity.
+# STUB pending §6.1 signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Поколювання або оніміння в кистях/стопах"
+    action_ua: "Оксаліплатин — занотовуйте інтенсивність; кумулятивна нейропатія за 12 циклів — основна причина припинення оксаліплатину"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-7"
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+  - trigger_ua: "Чутливість до холоду, дискомфорт у горлі від холодного"
+    action_ua: "Очікувано перші 3-5 днів циклу — уникайте холодного"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-5"
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+  - trigger_ua: "Випадання волосся (на 2-3 тижні)"
+    action_ua: "Очікувано — волосся повертається після завершення курсу"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+  - trigger_ua: "Помірна нудота, помірна діарея"
+    action_ua: "Приймайте призначені протиблювотні і лоперамід; занотовуйте інтенсивність"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-7"
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Тяжка діарея — більше 6 разів на день, з кров'ю або сильним болем"
+    action_ua: "Подзвоніть у клініку того ж дня — іринотекан може спричиняти небезпечну діарею; потрібна корекція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C — особливо на 7-14 день циклу"
+    action_ua: "Подзвоніть у клініку того ж дня — ризик фебрильної нейтропенії накопичується протягом 12 циклів"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Поколювання стає сильним болем, заважає ходити або тримати дрібні предмети"
+    action_ua: "Подзвоніть у клініку того ж дня — нейропатія Grade 2+ потребує зниження або припинення оксаліплатину"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+  - trigger_ua: "Раптова виражена слабкість, тяжке зневоднення (запаморочення стоячи, мала кількість сечі)"
+    action_ua: "Звертайтесь у лікарню негайно — потрібна інфузійна терапія, можливо термінова"
+    urgency: er_now
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Сплутаність свідомості, висока лихоманка з ознобом"
+    action_ua: "Звертайтесь у лікарню негайно — ознаки сепсису на тлі нейтропенії"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-PANCREATIC-2025
+
+last_reviewed: "2026-05-08"
+
+notes: >
+  PRODIGE-24/CCTG PA.6 (Conroy 2018, NEJM): modified FOLFIRINOX
+  (oxaliplatin 85, leucovorin 400, irinotecan 150 — REDUCED from 180 of
+  ACCORD-11 — and 5-FU 2400 mg/m² CIV over 46h with NO bolus) × 12 cycles
+  vs gemcitabine monotherapy adjuvant after R0/R1 resected PDAC (n=493).
+  Median DFS 21.6 vs 12.8 mo (HR 0.58, p<0.001); median OS 54.4 vs 35.0 mo
+  (HR 0.64). Grade 3-4 toxicity 75.9% (mFOLFIRINOX) vs 52.9% (gem) — higher
+  but tolerable in fit ECOG 0-1 patients. Established mFOLFIRINOX as the
+  preferred adjuvant standard, superseding gemcitabine monotherapy.
+
+  Two key modifications vs full FOLFIRINOX (REG-FOLFIRINOX): irinotecan
+  150 mg/m² (not 180) and 5-FU bolus OMITTED. These reduce mucositis and
+  cumulative febrile-neutropenia risk over the 12-cycle adjuvant course.
+notes_ua: >
+  PRODIGE-24/CCTG PA.6 (Conroy 2018, NEJM): модифікований FOLFIRINOX
+  (оксаліплатин 85, лейковорин 400, іринотекан 150 — ЗНИЖЕНО зі 180 в
+  ACCORD-11 — та 5-ФУ 2400 мг/м² CIV за 46 год БЕЗ болюсу) × 12 циклів
+  vs гемцитабін у монорежимі ад'ювантно після R0/R1 резекції PDAC (n=493).
+  Медіана БХВ 21.6 vs 12.8 міс (HR 0.58, p<0.001); медіана ЗВ 54.4 vs 35.0
+  міс (HR 0.64). Toxicity Grade 3-4 75.9% (mFOLFIRINOX) vs 52.9% (gem).
+  Встановив mFOLFIRINOX як ад'ювантний стандарт у фіт-пацієнтів ECOG 0-1
+  після резекції PDAC, замінивши гемцитабін у монорежимі.
+
+  Дві ключові модифікації vs повний FOLFIRINOX (REG-FOLFIRINOX):
+  іринотекан 150 мг/м² (не 180) і 5-ФУ болюс ВИДАЛЕНО. Знижують мукозит
+  і кумулятивну фебрильну нейтропенію за 12 ад'ювантних циклів.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- §17 single-phase adjuvant indication: mFOLFIRINOX × 12 cycles post-resection PDAC
- New regimen REG-MFOLFIRINOX (distinct from existing REG-FOLFIRINOX — modified per PRODIGE-24)
- NCCN cat 1, ESMO IA
- Closes #469

## Files (2 NEW)

| File | Notes |
|---|---|
| `ind_pdac_adjuvant_mfolfirinox.yaml` | §17 single-phase: adjuvant × 12 cycles. Surgery pre-enrollment captured in stage_requirements (R0/R1 stage I-III), not phases[] |
| `reg_mfolfirinox.yaml` | mFOLFIRINOX: oxa 85 + LV 400 + iri **150** (not 180) + 5-FU 2400 CIV/46h **no bolus**, q14d × 12; 9 UA watchpoints; UGT1A1 *28/*28 dose-adjustment ladder |

## §17 phases

```yaml
phases:
  - phase: adjuvant
    type: chemotherapy
    regimen_id: REG-MFOLFIRINOX
    cycles: 12
```

## Test plan
- [x] Validator: 0/0/0 errors; 524 warnings unchanged; entities 2969 → 2971 (+2)
- [x] pytest test_phases + test_indication_schema + test_loader: 23 pass
- [x] No banned sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)