### PR TITLE
feat(kb): GI-3 C3 rectal TNT short-course (RAPIDO) — §17 3-phase + RC SCRT + TME Surgery

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_rectal_tnt_short_course_rapido.yaml
+++ b/knowledge_base/hosted/content/indications/ind_rectal_tnt_short_course_rapido.yaml
@@ -1,0 +1,226 @@
+# IND-RECTAL-TNT-SHORT-COURSE-RAPIDO — §17 Indication.phases[] consumer for
+# locally advanced rectal cancer (chunk gi3-c3-rectal-tnt-rapido-2026-05-08-2100).
+# RAPIDO total neoadjuvant therapy (TNT) — short-course RT then induction chemo
+# then TME — uses Indication.phases[] to model the 3-phase TNT sequence:
+#   1. Neoadjuvant SCRT 25 Gy / 5 fx × 1 week (RC-SCRT-25-5-RECTAL — NEW C3)
+#   2. Induction CAPOX × 6 cycles (REG-CAPOX — reused)
+#   3. TME proctectomy (SUR-TME-PROCTECTOMY — NEW C3)
+# Mirrors the §17 gold-standard pattern set by IND-GASTRIC-PERIOP-FLOT4 (C1)
+# and continued by IND-ESOPH-RESECTABLE-CROSS-NEOADJUVANT (C2).
+id: IND-RECTAL-TNT-SHORT-COURSE-RAPIDO
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-CRC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Locally advanced rectal adenocarcinoma — at least one high-risk feature: cT4a/T4b, OR cN2 (≥4 regional nodes), OR extramural vascular invasion (EMVI+), OR mesorectal fascia involvement / CRM threatened (<1 mm on MRI), OR enlarged lateral pelvic lymph nodes"
+    - "M0 (non-metastatic) per CT chest/abdomen/pelvis + pelvic MRI staging"
+    - "Tumor located in rectum (mid or low rectum within ~15 cm of anal verge); colon adenocarcinomas excluded — they receive different periop strategy"
+  biomarker_requirements_required: []
+  # RAPIDO did NOT stratify by biomarker. MSI-H rectal tumors merit MDT
+  # discussion of dostarlimab/pembrolizumab non-operative pathway (Cercek
+  # 2022 NEJM dMMR rectal pembro), but that is a separate indication.
+  # KRAS / NRAS / BRAF status do not gate periop SCRT-TNT — they drive
+  # metastatic-line selection if the patient later progresses.
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+    fit_for_chemo: true
+    # RAPIDO enrolled ECOG 0-1 only; ECOG 2+ should be considered for
+    # less-toxic alternatives (e.g., long-course CRT alone, or palliative
+    # SCRT) via MDT.
+
+# §17 ratified 2026-05-07 — 3-phase TNT indication. Each phase carries
+# exactly ONE foreign key (regimen_id / surgery_id / radiation_id) per the
+# IndicationPhase XOR validator.
+#
+# Phase-stage naming choice for chemo phase: `induction`. RAPIDO literature
+# variously calls this "induction" (when SCRT precedes it) or "consolidation"
+# (within a TNT framework). All chemo cycles here precede surgery, so the
+# phase is pre-surgical / neoadjuvant in *intent*, but `induction` is the
+# canonical TNT term and is the §17 IndicationPhaseStage value that
+# distinguishes "this chemo block initiates / induces tumor downstaging
+# before definitive local therapy" from a strictly perioperative neoadj
+# phase. Documented for the GI-3 wave to consume (GI-2 wave used
+# `neoadjuvant` / `surgery` / `adjuvant` triple — TNT extends the pattern
+# with `neoadjuvant` (RT) → `induction` (chemo) → `surgery`).
+phases:
+  - phase: neoadjuvant
+    type: radiation
+    radiation_id: RC-SCRT-25-5-RECTAL
+    duration_weeks: 1
+  - phase: induction
+    type: chemotherapy
+    regimen_id: REG-CAPOX
+    cycles: 6
+  - phase: surgery
+    type: surgery
+    surgery_id: SUR-TME-PROCTECTOMY
+    duration_weeks: 1
+
+# Legacy `recommended_regimen` left null — render layer should consume
+# `phases:` for this indication (multi-modality TNT). Engine pass-through
+# to render is part of Phase D readiness work (planning doc §2.7).
+recommended_regimen:
+
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-CRC-EMERGENCY-OBSTRUCTION-PERFORATION
+
+required_tests:
+  - TEST-MRI-PELVIS
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+
+desired_tests:
+  - TEST-CEA
+
+actionability_review_required: true
+
+rationale: >
+  RAPIDO (Bahadoer 2021, Lancet Oncology) — randomised phase 3 trial,
+  n=920, locally advanced rectal cancer with at least one high-risk
+  feature (cT4a/b, cN2, EMVI+, mesorectal fascia involvement, or
+  enlarged lateral nodes) — established total neoadjuvant therapy (TNT)
+  with short-course preoperative radiotherapy (25 Gy / 5 fx) followed
+  by induction chemotherapy (CAPOX × 6 OR FOLFOX × 9) and then TME as
+  a preferred alternative to standard long-course chemoradiation
+  (50.4 Gy / 28 fx + concurrent capecitabine) + TME + optional adjuvant
+  chemotherapy. Primary endpoint disease-related treatment failure at
+  3 years 23.7% (TNT) vs 30.4% (standard); HR 0.75 (95% CI 0.60-0.95,
+  p=0.019). pCR doubled: 28% (TNT) vs 14% (standard). NCCN v.4.2025
+  category 1 (preferred-alternative for high-risk locally advanced
+  rectal); ESMO 2024 strong recommendation.
+
+  Patient selection: ECOG 0-1, fit for oxaliplatin-containing chemo
+  (CAPOX carries ~10-15% Grade ≥3 diarrhea + ~5-10% peripheral sensory
+  neuropathy persisting beyond cycle 4 — dose-modify or switch to
+  fluoropyrimidine-only if neuropathy ≥ Grade 2). Pelvic MRI is
+  mandatory for T-stage, mesorectal fascia, and EMVI assessment;
+  CT chest/abdomen/pelvis rules out distant disease. Pre-operative
+  staging laparoscopy is NOT routine for rectal (unlike gastric).
+
+  Sequencing nuances: SCRT (1 week) → 1-2 week recovery → CAPOX × 6
+  (~18 weeks) → 6-8 week interval → TME proctectomy. Total elapsed
+  time SCRT-start to surgery ~22-26 weeks. The interval after
+  induction chemo allows tumor downstaging — a non-trivial fraction
+  achieve clinical complete response (cCR) and may enter watch-and-wait
+  protocols at expert centers (still consensus-based, not RAPIDO-trial-
+  defined; outside this indication's standard arm).
+
+  RAPIDO chemo backbone choice: trial allowed CAPOX × 6 OR FOLFOX × 9 —
+  this indication uses CAPOX as the canonical OpenOnco regimen. FOLFOX
+  variant indication may follow if curator demand surfaces.
+
+rationale_ua: >
+  RAPIDO (Bahadoer 2021, Lancet Oncology) — рандомізоване дослідження
+  3 фази, n=920, місцево-поширений рак прямої кишки з принаймні однією
+  ознакою високого ризику (cT4a/b, cN2, EMVI+, ураження мезоректальної
+  фасції або збільшені латеральні лімфовузли) — встановив тотальну
+  неоад'ювантну терапію (TNT) з коротким курсом передопераційної
+  променевої терапії (25 Гр / 5 фракцій) з подальшою індукційною
+  хіміотерапією (CAPOX × 6 АБО FOLFOX × 9) та TME як кращу альтернативу
+  стандартній довгокурсовій хіміопроменевій терапії (50.4 Гр / 28
+  фракцій + конкурентний капецитабін) + TME + опціональна ад'ювантна
+  хіміотерапія. Первинна кінцева точка — невдача лікування пов'язана
+  з захворюванням на 3-му році 23.7% (TNT) проти 30.4% (стандарт);
+  HR 0.75 (95% ДІ 0.60-0.95, p=0.019). pCR подвоївся: 28% (TNT) проти
+  14% (стандарт). NCCN v.4.2025 категорія 1 (краща альтернатива для
+  високоризикового місцево-поширеного раку прямої кишки); ESMO 2024
+  сильна рекомендація.
+
+  Відбір пацієнтів: ECOG 0-1, придатність до оксаліплатин-вмісної
+  хіміотерапії (CAPOX — ~10-15% діарея ступінь ≥3 + ~5-10%
+  периферична сенсорна нейропатія, що зберігається після 4 циклу —
+  модифікувати дозу або перейти на фторпіримідин-моно при нейропатії
+  ≥ ступінь 2). МРТ малого тазу обов'язкове для оцінки T-стадії,
+  мезоректальної фасції та EMVI; КТ грудна клітка/черевна
+  порожнина/малий таз виключає віддалене захворювання.
+
+  Послідовність: SCRT (1 тиждень) → 1-2 тижні відновлення → CAPOX × 6
+  (~18 тижнів) → інтервал 6-8 тижнів → TME проктектомія. Загальний
+  час від початку SCRT до операції ~22-26 тижнів.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-RAPIDO-BAHADOER-2021
+    position: supports
+  - source_id: SRC-NCCN-COLON-2025
+    position: supports
+  - source_id: SRC-ESMO-CRC-2024
+    position: supports
+
+known_controversies:
+  - topic: TNT (RAPIDO short-course) vs long-course CRT + selective adjuvant
+    positions:
+      - position: TNT (SCRT + induction CAPOX/FOLFOX + TME) preferred for high-risk locally advanced rectal cancer
+        sources:
+          - SRC-RAPIDO-BAHADOER-2021
+          - SRC-NCCN-COLON-2025
+        evidence_note: "Reduced 3-yr disease-related treatment failure (23.7% vs 30.4%, HR 0.75); doubled pCR (28% vs 14%); allows tumor downstaging window before surgery"
+      - position: Long-course CRT (50.4 Gy / 28 fx + concurrent capecitabine) + TME + selective adjuvant remains standard for non-high-risk locally advanced
+        sources:
+          - SRC-NCCN-COLON-2025
+          - SRC-ESMO-CRC-2024
+        evidence_note: "RAPIDO benefit was driven by high-risk subgroup; lower-risk locally advanced may not need TNT intensification — long-course CRT remains category 1 preferred"
+    our_default: "Stratify by RAPIDO eligibility (high-risk features) — TNT for cT4a/b, cN2, EMVI+, MRF+, or enlarged lateral nodes; long-course CRT for non-high-risk locally advanced. MDT-driven."
+    rationale: "RAPIDO's benefit was demonstrated in the high-risk population; extrapolating TNT to all locally advanced rectal is not yet evidence-based. Disease-related failure metric in RAPIDO was disease-specific (locoregional + distant), while long-course CRT remains adequate for tumors at lower distant-recurrence risk."
+
+  - topic: CAPOX × 6 vs FOLFOX × 9 induction chemo backbone within RAPIDO TNT
+    positions:
+      - position: CAPOX × 6 (3-mo) is preferred — oral capecitabine, fewer infusion visits, equivalent oncologic outcome in IDEA pooled analysis
+        sources:
+          - SRC-NCCN-COLON-2025
+        evidence_note: "Per-protocol RAPIDO allowed both; IDEA-collaboration showed CAPOX 3-mo non-inferior to FOLFOX 6-mo for stage III adjuvant — extrapolation to TNT induction supports CAPOX preference"
+      - position: FOLFOX × 9 (~18 weeks) acceptable when capecitabine PO not feasible (e.g., severe HFS history, swallowing disorder, DPYD heterozygote)
+        sources:
+          - SRC-NCCN-COLON-2025
+        evidence_note: "Both arms in RAPIDO; FOLFOX backbone preserved for capecitabine-intolerant patients"
+    our_default: "CAPOX × 6 as primary induction backbone; switch to FOLFOX × 9 only when capecitabine contraindicated (severe HFS, DPYD homo/heterozygote, dysphagia)"
+    rationale: "CAPOX is operationally simpler (oral, fewer visits); IDEA + RAPIDO together support equipoise. Switch to FOLFOX only when capecitabine contraindicated."
+
+do_not_do:
+  - "Do NOT use TNT short-course (RAPIDO) for low-risk locally advanced rectal — long-course CRT + TME + selective adjuvant remains the category 1 preferred alternative for non-high-risk disease"
+  - "Do NOT use this indication for colon adenocarcinoma — RAPIDO enrolled rectal only; colon receives different periop strategy (no RT)"
+  - "Do NOT skip pelvic MRI staging — mesorectal fascia / EMVI / lateral-node assessment is mandatory for RAPIDO eligibility determination"
+  - "Do NOT use TNT in metastatic (M1) rectal — periop sequence is for resectable / locally advanced non-metastatic only; metastatic receives systemic-first strategy"
+  - "Do NOT initiate CAPOX in ECOG ≥2 patients or in patients with Grade ≥2 baseline peripheral neuropathy"
+  - "Do NOT proceed to TME during ongoing GI bleed, obstruction, or perforation without emergency stabilization (decompressive ostomy may be required)"
+  - "Do NOT shorten the 6-8 week post-induction-chemo to TME interval — the downstaging window is part of RAPIDO efficacy"
+
+do_not_do_en:
+  - "Do NOT use TNT short-course (RAPIDO) for low-risk locally advanced rectal — long-course CRT + TME + selective adjuvant remains the category 1 preferred alternative for non-high-risk disease"
+  - "Do NOT use this indication for colon adenocarcinoma — RAPIDO enrolled rectal only; colon receives different periop strategy (no RT)"
+  - "Do NOT skip pelvic MRI staging — mesorectal fascia / EMVI / lateral-node assessment is mandatory for RAPIDO eligibility determination"
+  - "Do NOT use TNT in metastatic (M1) rectal — periop sequence is for resectable / locally advanced non-metastatic only; metastatic receives systemic-first strategy"
+  - "Do NOT initiate CAPOX in ECOG ≥2 patients or in patients with Grade ≥2 baseline peripheral neuropathy"
+  - "Do NOT proceed to TME during ongoing GI bleed, obstruction, or perforation without emergency stabilization (decompressive ostomy may be required)"
+  - "Do NOT shorten the 6-8 week post-induction-chemo to TME interval — the downstaging window is part of RAPIDO efficacy"
+
+last_reviewed: "2026-05-08"
+
+notes: >
+  GI-3 wave C3 chunk (gi3-c3-rectal-tnt-rapido-2026-05-08-2100). Third
+  §17 phased indication after IND-GASTRIC-PERIOP-FLOT4 (GI-2 C1) and
+  IND-ESOPH-RESECTABLE-CROSS-NEOADJUVANT (GI-2 C2). Introduces the
+  `induction` IndicationPhaseStage in clinical content (was schema-
+  available since §17 ratification 2026-05-07; first consumer here).
+  Engine routing from `algo_rectal_*` (D-prefix algorithm extension) to
+  this indication is out of C3 scope — flagged for the D-wave algorithm
+  chunks. The `recommended_regimen` field is left null intentionally
+  because TNT is multi-modality; consumers should iterate `phases:`
+  rather than dereferencing a single regimen ID.
+
+  D-prefix algorithm flag: rectal-cancer treatment routing
+  (algo_rectal_locally_advanced_*) does not yet exist; this indication
+  is reachable only through direct lookup or via crc.yaml routing once
+  the D-wave landed (separate chunk).

--- a/knowledge_base/hosted/content/procedures/proc_tme_proctectomy.yaml
+++ b/knowledge_base/hosted/content/procedures/proc_tme_proctectomy.yaml
@@ -1,0 +1,88 @@
+# Total mesorectal excision (TME) — §17.1 Surgery entity (RATIFIED
+# 2026-05-07). Lands as the surgery phase (phase 3) of
+# IND-RECTAL-TNT-SHORT-COURSE-RAPIDO (chunk
+# gi3-c3-rectal-tnt-rapido-2026-05-08-2100). The standard-of-care
+# resection for locally advanced rectal cancer per Heald (1982 / 1986)
+# pioneered the technique; now NCCN v.4.2025 category 1 + ESMO 2024.
+id: SUR-TME-PROCTECTOMY
+names:
+  preferred: "Proctectomy with total mesorectal excision (TME)"
+  ukrainian: "Проктектомія з тотальною мезоректальною ексцизією (TME)"
+  english: "Proctectomy with total mesorectal excision"
+  synonyms:
+    - "TME proctectomy"
+    - "Low anterior resection with TME (LAR-TME)"
+    - "Abdominoperineal resection with TME (APR-TME)"
+    - "Total mesorectal excision"
+    - "Heald TME"
+
+# Free-string per §17.1 sketch — surgical taxonomy not enum'd in v0.1.
+# `proctectomy_with_tme` is the canonical type; whether the specific
+# resection is low anterior (sphincter-preserving) or abdominoperineal
+# (with permanent end-colostomy) is tumor-location driven (≥1-2 cm
+# distal margin determines feasibility of LAR vs APR).
+type: proctectomy_with_tme
+intent: curative
+
+target_organ: rectum
+applicable_diseases:
+  - DIS-CRC
+
+# Operative mortality from large-volume centers; TME is technically
+# demanding and surgical-volume gradient is reproducible.
+operative_mortality_pct: "1-3% in high-volume centers; up to 5% in low-volume centers"
+
+common_complications:
+  - name: "Anastomotic leak (after sphincter-preserving LAR)"
+    frequency: "8-15%"
+  - name: "Postoperative ileus / small-bowel obstruction"
+    frequency: "5-10%"
+  - name: "Wound infection (perineal wound after APR)"
+    frequency: "10-30% APR; 3-5% LAR"
+  - name: "Urinary dysfunction (autonomic nerve injury)"
+    frequency: "10-30% transient; 5-10% persistent"
+  - name: "Sexual dysfunction (erectile / ejaculatory; dyspareunia)"
+    frequency: "20-40% transient; 10-25% persistent"
+  - name: "Low anterior resection syndrome (LARS) — bowel-frequency / urgency / incontinence"
+    frequency: "40-60% mild-moderate; 10-20% severe"
+  - name: "Permanent stoma (after APR or failed coloanal anastomosis)"
+    frequency: "Universal after APR; 5-15% after attempted LAR"
+  - name: "Pelvic abscess / sepsis"
+    frequency: "3-7%"
+
+sources:
+  - SRC-RAPIDO-BAHADOER-2021
+  - SRC-NCCN-COLON-2025
+  - SRC-ESMO-CRC-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  Total mesorectal excision (TME, Heald 1982/1986) — sharp-dissection
+  removal of the rectum with intact mesorectal envelope along the
+  anatomic perimesorectal plane — is the global standard for resectable
+  rectal adenocarcinoma per NCCN v.4.2025 and ESMO 2024. By preserving
+  the mesorectal fascia intact, TME minimizes circumferential resection
+  margin (CRM) positivity (the single strongest local-recurrence driver)
+  and removes regional nodal disease en bloc. Local recurrence rates
+  dropped from 25-40% (pre-TME conventional dissection) to 4-8% in
+  TME-trained centers. Combined with neoadjuvant therapy (CRT, SCRT, or
+  TNT regimens like RAPIDO), 5-year local control is now 90%+ in major
+  centers.
+
+  LAR vs APR decision is tumor-location driven: low rectal tumors
+  invading levators / external anal sphincter / within 1-2 cm of dentate
+  line require APR with permanent end-colostomy; mid- and high-rectal
+  tumors with adequate distal margin (≥1-2 cm fresh) are amenable to
+  sphincter-preserving LAR with coloanal or colorectal anastomosis. A
+  diverting loop ileostomy is commonly used to protect low pelvic
+  anastomoses, reversed at 8-12 weeks post-op pending integrity check
+  (water-soluble contrast enema).
+
+  Surgical timing within RAPIDO TNT: TME proctectomy follows the
+  induction-chemotherapy phase (CAPOX × 6 or FOLFOX × 9 cycles after
+  SCRT 25 Gy / 5 fx), ~22-26 weeks from SCRT start. This delayed-surgery
+  pattern allows tumor downstaging and is biologically distinct from
+  the historical Polish short-course (immediate post-RT surgery within
+  ~7 days). Watch-and-wait (non-operative management for clinical
+  complete response) is an emerging alternative in expert centers but
+  remains MDT-consensus / trial-based, not standard of care.

--- a/knowledge_base/hosted/content/radiation_courses/rc_scrt_25_5_rectal.yaml
+++ b/knowledge_base/hosted/content/radiation_courses/rc_scrt_25_5_rectal.yaml
@@ -1,0 +1,68 @@
+# Short-course preoperative radiotherapy (SCRT) — 25 Gy / 5 fx — for rectal
+# cancer. §17.1 RadiationCourse entity (RATIFIED 2026-05-07). Lands as the
+# RT phase (phase 1) of IND-RECTAL-TNT-SHORT-COURSE-RAPIDO (chunk
+# gi3-c3-rectal-tnt-rapido-2026-05-08-2100). Distinct from CROSS-style
+# concurrent CRT — RAPIDO is RT-FIRST then chemo, NOT concurrent
+# chemoradiation, so `concurrent_chemo_regimen: null`.
+id: RC-SCRT-25-5-RECTAL
+names:
+  preferred: "Short-course preoperative radiotherapy for rectal cancer (25 Gy / 5 fx)"
+  ukrainian: "Короткий курс передопераційної променевої терапії раку прямої кишки (25 Гр / 5 фракцій)"
+  english: "SCRT 25 Gy / 5 fx — preoperative short-course radiotherapy for locally advanced rectal cancer"
+  synonyms:
+    - "SCRT 5×5"
+    - "Stockholm short-course"
+    - "5×5 Gy preop rectal RT"
+    - "Short-course preoperative RT (rectal)"
+
+total_dose_gy: 25
+fractions: 5
+fraction_size_gy: 5
+target_volume: "primary rectal tumor + mesorectum + regional pelvic lymph nodes (CTV) with PTV expansion per institutional protocol; typical fields cover internal iliac, presacral, and obturator nodes"
+schedule: "1 fx/day × 5 consecutive days (Mon-Fri); total elapsed time ~1 week"
+
+# RAPIDO is an RT-FIRST sequence: SCRT alone (no concurrent chemo), then
+# chemotherapy (induction CapOx × 6 or FOLFOX × 9), then TME. This is
+# DISTINCT from concurrent long-course CRT (e.g. 50.4 Gy / 28 fx +
+# concurrent capecitabine). Therefore concurrent_chemo_regimen is
+# explicitly null per planning doc §2.4 rule 7 (Optional FK).
+concurrent_chemo_regimen:
+
+intent: neoadjuvant
+
+sources:
+  - SRC-RAPIDO-BAHADOER-2021
+  - SRC-NCCN-COLON-2025
+  - SRC-ESMO-CRC-2024
+
+last_reviewed: "2026-05-08"
+notes: >
+  Short-course preoperative radiotherapy (25 Gy / 5 fx over 1 week) is the
+  radiotherapy backbone of the RAPIDO total neoadjuvant therapy (TNT)
+  regimen for locally advanced rectal cancer (Bahadoer 2021, Lancet
+  Oncology). Within RAPIDO TNT, SCRT is followed by induction
+  chemotherapy (CAPOX × 6 or FOLFOX × 9 cycles) then TME proctectomy —
+  this is the experimental arm of the RAPIDO RCT vs the standard arm
+  (long-course CRT 50.4 Gy / 28 fx + concurrent capecitabine + TME +
+  optional adjuvant chemo).
+
+  RAPIDO results (n=920, locally advanced rectal cT4 OR cN2 OR EMVI+
+  OR mesorectal fascia involvement OR enlarged lateral lymph nodes):
+  3-year disease-related treatment failure 23.7% (TNT) vs 30.4%
+  (standard) — relative reduction of disease-related events. pCR
+  doubled (28% vs 14%). NCCN v.4.2025 category 1 / preferred-alternative;
+  ESMO 2024 strong recommendation for high-risk locally advanced rectal.
+
+  IMRT or VMAT preferred over 3D-CRT to reduce small-bowel and bladder
+  dose. SCRT is RT-FIRST then chemo (NOT concurrent chemoradiation) —
+  this is the key sequencing distinction from CROSS-style neoadj CRT.
+  Surgery (TME) follows after the induction-chemo phase, ~22-26 weeks
+  from SCRT start, allowing tumor downstaging.
+
+  Distinguishing 5×5 SCRT from long-course 25-fx CRT: short-course is
+  hypofractionated (5 Gy/fx, large daily dose) — biologically more potent
+  per fx but acceptable late-toxicity profile when followed by surgery
+  within 4-8 weeks (Stockholm III) or after induction chemo (RAPIDO TNT
+  pattern). NOT to be confused with the older "Polish short-course"
+  (immediate surgery within 7 days post-RT) — RAPIDO inserts the chemo
+  phase between RT and surgery.


### PR DESCRIPTION
## Summary
- §17 3-phase TNT indication for locally advanced rectal cancer per RAPIDO RCT
- New SCRT 25 Gy / 5 fx RadiationCourse + TME-proctectomy Surgery
- First clinical consumer of `induction` IndicationPhaseStage (extends C1's neoadj→surgery→adj pattern)
- Closes #470

## Files (3 NEW)

| File | Notes |
|---|---|
| `ind_rectal_tnt_short_course_rapido.yaml` | §17 3-phase: neoadj RT → induction CapOx → TME surgery |
| `rc_scrt_25_5_rectal.yaml` | 25 Gy / 5 fx, intent=neoadjuvant, **concurrent_chemo_regimen: null** (RT-first, NOT concurrent CRT) |
| `proc_tme_proctectomy.yaml` | type=proctectomy_with_tme; 8 complications including LARS, urinary/sexual dysfunction; mortality 1-3% high-volume |

## §17 phases

```yaml
phases:
  - phase: neoadjuvant     # RT
    type: radiation
    radiation_id: RC-SCRT-25-5-RECTAL
    duration_weeks: 1
  - phase: induction       # chemo
    type: chemotherapy
    regimen_id: REG-CAPOX
    cycles: 6
  - phase: surgery
    type: surgery
    surgery_id: SUR-TME-PROCTECTOMY
```

XOR-FK invariant clean per phase. RAPIDO is RT-first sequence (NOT concurrent CRT — distinct from CROSS pattern in GI-2 C2).

## Test plan
- [x] Validator: 0/0/0 errors; 524 warnings unchanged; entities 2969 → 2972 (+3)
- [x] pytest 39/39 pass (test_phases, test_radiation_course, test_surgery, test_indication_schema, test_loader)
- [x] No banned sources
- [x] capox.yaml reused (no edit); crc.yaml untouched

## D-prefix follow-up flag

`algo_rectal_locally_advanced_*` doesn't exist yet — indication reachable only via direct lookup or D-wave algorithm-extension chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)