### PR TITLE
feat(kb): PUL-A2 NSCLC EGFR MARIPOSA ami+laz 1L

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_nsclc_egfr_1l_ami_laz.yaml
+++ b/knowledge_base/hosted/content/indications/ind_nsclc_egfr_1l_ami_laz.yaml
@@ -1,0 +1,129 @@
+id: IND-NSCLC-EGFR-1L-AMI-LAZ
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-NSCLC
+  molecular_subtype: EGFR_MUTATED_1L
+  stage_stratum: STAGE_IV_METASTATIC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Stage IV metastatic EGFR-mutated NSCLC (ex19del OR L858R activating mutation)"
+    - "No prior systemic therapy for advanced disease"
+    - "EGFR mutation confirmed by tissue or ctDNA NGS prior to initiation"
+  biomarker_requirements_required:
+    - biomarker_id: BIO-EGFR-MUTATION
+      value_constraint: "Activating EGFR mutation: exon 19 deletion (ex19del) OR L858R substitution"
+      required: true
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 1
+
+recommended_regimen: REG-AMI-LAZ-NSCLC
+concurrent_therapy: []
+followed_by:
+  - IND-NSCLC-2L-EGFR-POST-OSI-AMI-LAZ  # post-progression option (resistance-mutation guided)
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  progression_free_survival:
+    value: "Median PFS 23.7 mo (ami+laz) vs 16.6 mo (osimertinib mono); HR 0.70, p<0.001 by BICR"
+    source: SRC-MARIPOSA-CHO-2024
+  overall_response_rate:
+    value: "ORR 86% (ami+laz) vs 85% (osi mono); median DoR 25.8 vs 16.8 mo"
+    source: SRC-MARIPOSA-CHO-2024
+  overall_survival_median:
+    value: "OS interim — trend toward benefit at 2026 reporting; mature OS data evolving"
+    source: SRC-MARIPOSA-CHO-2024
+
+hard_contraindications: []
+red_flags_triggering_alternative:
+  - RF-NSCLC-FRAILTY-AGE  # frail / elderly may not tolerate IRR + VTE risk profile
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-CECT-CAP
+  - TEST-NSCLC-NGS-PANEL
+  - TEST-BRAIN-MRI-CONTRAST
+desired_tests:
+  - TEST-PDL1-IHC
+
+rationale: >
+  Amivantamab (EGFR-MET bispecific antibody) + lazertinib (3rd-gen
+  EGFR-TKI) for treatment-naive metastatic EGFR-mutated NSCLC
+  (ex19del or L858R). MARIPOSA (Cho NEJM 2024) demonstrated PFS HR
+  0.70 vs osimertinib monotherapy (median 23.7 vs 16.6 mo) with
+  BICR confirmation. FDA approved Aug 2024 as 1L alternative to
+  osimertinib mono. The dual EGFR + MET targeting addresses both
+  the activating EGFR driver and the bypass-pathway resistance
+  (MET amplification — common osimertinib resistance mechanism)
+  proactively in the 1L setting. Significant toxicity burden: VTE
+  ~37% any-grade (DOAC prophylaxis mandatory first 4 mo), rash,
+  paronychia, infusion reactions — toxicity profile is the primary
+  trade-off vs osimertinib mono. Aggressive-track for fit patients
+  with funding pathway. UA access barrier: neither component
+  registered; named-patient or cross-border treatment required.
+
+sources:
+  - source_id: SRC-MARIPOSA-CHO-2024
+    position: supports
+    relevant_quote_paraphrase: "Amivantamab + lazertinib improved PFS over osimertinib monotherapy (HR 0.70, median 23.7 vs 16.6 mo) in 1L EGFR-mutated NSCLC; basis for FDA approval Aug 2024 as 1L alternative"
+  - source_id: SRC-NCCN-NSCLC-2025
+    position: supports
+    relevant_quote_paraphrase: "Amivantamab + lazertinib is recommended as a 1L option for EGFR-mutated metastatic NSCLC (ex19del / L858R); Cat 1 (MARIPOSA)"
+  - source_id: SRC-ESMO-NSCLC-METASTATIC-2024
+    position: supports
+    relevant_quote_paraphrase: "Amivantamab + lazertinib added to ESMO 1L recommendations for EGFR-mutated metastatic NSCLC alongside osimertinib monotherapy"
+
+known_controversies:
+  - topic: "Ami+laz vs osimertinib mono vs osimertinib + chemo (FLAURA2) in 1L EGFR-mut NSCLC"
+    positions:
+      - position: "Amivantamab + lazertinib (MARIPOSA): best PFS by BICR, HR 0.70 vs osi mono; significant added toxicity (VTE, IRR, rash); IV/SC infusion burden"
+        sources: [SRC-MARIPOSA-CHO-2024]
+      - position: "Osimertinib monotherapy (FLAURA): proven workhorse standard; oral; well-tolerated; CNS-active; remains preferred in many settings for tolerability"
+        sources: [SRC-NCCN-NSCLC-2025]
+      - position: "Osimertinib + carbo + pemetrexed (FLAURA2): PFS HR 0.62 vs osi mono; intermediate toxicity; alternative for high-burden disease"
+        sources: [SRC-NCCN-NSCLC-2025, SRC-ESMO-NSCLC-METASTATIC-2024]
+    our_default: "Osimertinib mono for most patients (standard-track tolerability + UA accessibility). Ami+laz aggressive-track for fit, motivated patients with funding pathway when maximal upfront PFS prioritized over tolerability. FLAURA2 (osi+chemo) reserved for high disease burden."
+    rationale: "MARIPOSA proves superior PFS but at meaningful toxicity cost; in UA reality (ami unregistered) osi mono is default 1L; ami+laz reserved for trial / named-patient / cross-border access"
+
+do_not_do:
+  - "НЕ розпочинати без NGS-підтвердженої активуючої EGFR мутації (ex19del або L858R) — клінічної ефективності в EGFR-WT не показано."
+  - "НЕ пропускати DOAC profylactic anticoagulation перші 4 місяці — VTE rate ~37% з амі+лазертініб combination в MARIPOSA."
+  - "НЕ призначати при ECOG ≥2 — IRR + кумулятивна токсичність непереносимі; обрати осимертиніб mono."
+  - "НЕ використовувати IV формуляцію без full premedication протоколу — IRR ~65% baseline; SC формуляція strongly preferred."
+  - "НЕ ігнорувати baseline + serial ILD monitoring (CT chest) — pneumonitis ризик; permanent discontinuation Grade ≥3."
+  - "НЕ підтверджувати план без funding pathway — ані амівантамаб, ані лазертініб не зареєстровані в Україні; access requires named-patient або cross-border."
+  - "НЕ призначати при відомій historic VTE (DVT/PE) без оцінки ризику кровотечі — anticoagulation triple-therapy risk."
+  - "НЕ обирати ami+laz замість осимертинібу mono лише через 'aggressive' marketing — toxicity trade-off має бути узгоджений з пацієнтом після інформованої згоди."
+
+do_not_do_en:
+  - "Do NOT initiate without NGS-confirmed activating EGFR mutation (ex19del or L858R) — no clinical efficacy shown in EGFR-WT."
+  - "Do NOT skip DOAC prophylactic anticoagulation for the first 4 months — VTE rate ~37% with ami+lazertinib combination in MARIPOSA."
+  - "Do NOT prescribe at ECOG ≥2 — IRR + cumulative toxicity intolerable; choose osimertinib mono instead."
+  - "Do NOT use IV formulation without full premedication protocol — IRR ~65% baseline; SC formulation strongly preferred."
+  - "Do NOT ignore baseline + serial ILD monitoring (CT chest) — pneumonitis risk; permanent discontinuation Grade ≥3."
+  - "Do NOT confirm plan without funding pathway — neither amivantamab nor lazertinib registered in Ukraine; access requires named-patient or cross-border."
+  - "Do NOT prescribe in known historic VTE (DVT/PE) without bleeding-risk assessment — anticoagulation triple-therapy risk."
+  - "Do NOT select ami+laz over osimertinib mono purely on 'aggressive' marketing grounds — toxicity trade-off must be discussed with patient under informed consent."
+
+time_critical: false
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: 0
+actionability_review_required: true
+notes: >
+  STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1: ≥2
+  reviewer signoffs to publish). Aggressive-track 1L for EGFR-mut
+  metastatic NSCLC per MARIPOSA (Cho NEJM 2024). PFS HR 0.70 vs
+  osimertinib mono; FDA approved Aug 2024 as 1L alternative.
+  Distinct entity from IND-NSCLC-EGFR-MUT-MET-1L (osi mono
+  standard-track 1L), IND-NSCLC-2L-EGFR-POST-OSI-AMI-LAZ (2L
+  post-osi via MARIPOSA-2), and IND-NSCLC-2L-EGFR-EX20INS-AMIVANTAMAB
+  (2L ex20ins). Reuses DRUG-AMIVANTAMAB and DRUG-LAZERTINIB; new
+  REG-AMI-LAZ-NSCLC because MARIPOSA dosing differs from MARIPOSA-2
+  protocol (no split day 1+2; no chemo-combo arms).

--- a/knowledge_base/hosted/content/regimens/reg_ami_laz_nsclc.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_ami_laz_nsclc.yaml
@@ -1,0 +1,122 @@
+id: REG-AMI-LAZ-NSCLC
+name: "Amivantamab + Lazertinib (MARIPOSA) — 1L EGFR-mut NSCLC"
+name_ua: "Амівантамаб + Лазертініб (MARIPOSA) — 1L EGFR-mut НДРЛ"
+alternate_names:
+  - "Ami + Laz"
+  - "Rybrevant + Lazcluze"
+  - "MARIPOSA ami+laz arm"
+
+components:
+  - drug_id: DRUG-AMIVANTAMAB
+    dose: "1050 mg IV (<80 kg) OR 1400 mg IV (≥80 kg); SC formulation 1600 mg / 2240 mg available (PALOMA-3)"
+    schedule: "Weekly (split day 1+2 of Cycle 1, then weekly weeks 2-4), then every 2 weeks from week 5 onward"
+    route: IV
+  - drug_id: DRUG-LAZERTINIB
+    dose: "240 mg PO once daily"
+    schedule: "Continuous"
+    route: PO
+
+cycle_length_days: 28
+total_cycles: "Continuous until progression or unacceptable toxicity"
+toxicity_profile: severe
+
+premedication:
+  - "IV amivantamab cycle 1 day 1: methylprednisolone 40 mg IV + diphenhydramine 25-50 mg IV + acetaminophen 650-1000 mg PO 30-60 min pre-infusion (mitigates IRR ~65% baseline → ~5% with full premed)"
+  - "Cycle 1 day 2 + subsequent: continue dexamethasone 8 mg PO + antihistamine + antipyretic; SC formulation reduces premed burden"
+mandatory_supportive_care: []
+# DOAC (apixaban / rivaroxaban) prophylaxis required first 4 mo per
+# MARIPOSA protocol — VTE rate elevated in ami+laz arm vs osi mono
+# (~37% any-grade vs ~9%). Surfaced in dose_adjustments + notes; no
+# SUP entity yet (TODO: SUP-VTE-PROPHYLAXIS-AMI-LAZ shared with 2L
+# regimen).
+monitoring_schedule_id: null
+
+dose_adjustments:
+  - condition: "Infusion-related reaction Grade ≥2"
+    modification: "Hold infusion; resume at 50% rate after symptom resolution; continue premedication next cycles"
+    source_refs: [SRC-MARIPOSA-CHO-2024]
+  - condition: "Rash Grade ≥3"
+    modification: "Hold both drugs; topical / oral steroids + doxycycline; resume at lower dose"
+    source_refs: [SRC-MARIPOSA-CHO-2024]
+  - condition: "VTE event despite prophylaxis"
+    modification: "Therapeutic anticoagulation; continue ami+laz unless contraindicated"
+    rationale: "VTE rate ~37% any-grade in MARIPOSA ami+laz arm; prophylaxis mandatory first 4 mo"
+    source_refs: [SRC-MARIPOSA-CHO-2024]
+  - condition: "ILD / pneumonitis any grade"
+    modification: "Hold both drugs; corticosteroids; permanent discontinuation if Grade ≥3"
+  - condition: "Hepatic transaminase elevation Grade ≥3"
+    modification: "Hold lazertinib; resume at lower dose after recovery"
+  - condition: "Paronychia Grade ≥3"
+    modification: "Hold amivantamab until ≤Grade 1; topical steroids, antibiotics; resume at lower dose"
+
+ukraine_availability:
+  all_components_registered: false
+  all_components_reimbursed: false
+  notes: >
+    Both components NOT registered in UA (per drlz.com.ua snapshot
+    2026-04-27). Access only via Janssen named-patient pathway,
+    cross-border (EU) treatment per наказ МОЗ 988, or clinical trial.
+    Funding = primary barrier in UA setting. Osimertinib (1L sister
+    REG-OSIMERTINIB-NSCLC) remains workhorse standard 1L when
+    ami+laz inaccessible.
+
+sources:
+  - SRC-MARIPOSA-CHO-2024
+  - SRC-NCCN-NSCLC-2025
+  - SRC-ESMO-NSCLC-METASTATIC-2024
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Amivantamab + lazertinib for 1L EGFR-mut NSCLC (MARIPOSA).
+# EGFR + MET bispecific + 3rd-gen EGFR TKI. Signature: acneiform
+# rash, paronychia, infusion reactions, VTE. STUB pending §6.1
+# signoff.
+between_visit_watchpoints:
+  - trigger_ua: "Акнеформний висип на обличчі, шиї"
+    action_ua: "Очікувано на тлі амівантамабу/лазертинібу — використовуйте призначені креми"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Запалення та біль навколо нігтів (паронихії)"
+    action_ua: "Поширене — носіть м'яке взуття, уникайте травм нігтів"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Помірна нудота, помірна діарея"
+    action_ua: "Зустрічається — занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Біль або припухлість в одній нозі"
+    action_ua: "Подзвоніть у клініку того ж дня — амівантамаб підвищує ризик тромбозу; антикоагулянти зазвичай призначаються профілактично"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+      - SRC-MARIPOSA-CHO-2024
+  - trigger_ua: "Виражена реакція на інфузію амівантамабу: задишка, висип, набряк"
+    action_ua: "Інфузія в клініці — медперсонал реагує негайно. Премедикація стероїдами + антигістамінними знижує ризик"
+    urgency: er_now
+    cycle_day_window: "First infusion"
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Раптова задишка, біль у грудях"
+    action_ua: "Звертайтесь у лікарню негайно — можлива легенева тромбоемболія або пневмоніт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NSCLC-2025
+
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  MARIPOSA (Cho NEJM 2024, NCT04487080): amivantamab + lazertinib vs
+  osimertinib monotherapy in 1L EGFR-mutated (ex19del or L858R)
+  advanced NSCLC (n=1074 across three arms). Median PFS 23.7 vs 16.6
+  mo (HR 0.70; p<0.001) by BICR. ORR 86% vs 85%; median DoR 25.8 vs
+  16.8 mo. Significant added toxicity vs osimertinib alone: VTE
+  ~37% any-grade (DOAC prophylaxis mandatory first 4 mo), rash,
+  paronychia, infusion reactions. Basis for FDA approval Aug 2024 as
+  1L alternative to osimertinib monotherapy. SC amivantamab
+  (PALOMA-3) preferred where available — IRR rate <10% vs ~65% IV.
+  Distinct from MARIPOSA-2 (2L post-osi) regimen
+  (REG-AMIVANTAMAB-LAZERTINIB-NSCLC-2L) which uses split-day cycle 1
+  with chemotherapy-combo arms. STUB pending §6.1 sign-off.


### PR DESCRIPTION
## Summary
- Amivantamab + lazertinib 1L EGFR-mut NSCLC per MARIPOSA (Cho NEJM 2024)
- 2 NEW: indication + regimen
- Closes #489

## Honest reuse decision: NO

Existing `REG-AMIVANTAMAB-LAZERTINIB-NSCLC-2L` is MARIPOSA-2 (post-osi 2L) with distinct protocol (split day 1+2 cycle 1; chemo-combo arms). MARIPOSA 1L uses weekly × 4 → q2w (doublet only) — different PFS, dosing, tox, FDA scope. Reuse would conflate two trials.

## Test plan
- [x] Validator: 0/0/0 errors; 524 warnings unchanged; entities 2989 → 2991
- [x] pytest 11 pass
- [x] DRUG-AMIVANTAMAB + DRUG-LAZERTINIB reused (drugs are universal, regimens trial-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)