### PR TITLE
feat(kb): PUL-A5 NSCLC perioperative pembro (KEYNOTE-671) — first pulmonary §17 consumer

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_nsclc_perioperative_pembro.yaml
+++ b/knowledge_base/hosted/content/indications/ind_nsclc_perioperative_pembro.yaml
@@ -1,0 +1,241 @@
+# IND-NSCLC-PERIOPERATIVE-PEMBRO — §17 3-phase perioperative indication
+# for resectable stage II/IIIA/IIIB NSCLC (chunk
+# pul-a5-kn671-perioperative-2026-05-09-1100). Mirrors GI-2 C1 FLOT periop
+# pattern: neoadjuvant pembro+chemo × 4 → anatomic lobectomy → adjuvant
+# pembro × 13. First clinical-content consumer of §17 schema in NSCLC,
+# and first IO-containing periop indication.
+id: IND-NSCLC-PERIOPERATIVE-PEMBRO
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-NSCLC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Resectable stage II NSCLC (T1-2N1 or T3N0, M0)"
+    - "Resectable stage IIIA NSCLC (T1-2N2 or T3N1 or T4N0-1, M0)"
+    - "Resectable stage IIIB NSCLC (T3-T4N2 or T4N0-1 with chest wall / mediastinal involvement, M0) — selected MDT-confirmed cases"
+    - "MDT-confirmed surgical resectability (anatomic lobectomy or sleeve / pneumonectomy as required for R0)"
+  biomarker_requirements_required: []
+  # KEYNOTE-671 enrolled regardless of PD-L1 TPS — benefit was observed
+  # across PD-L1 strata (TPS <1%, 1-49%, ≥50%). PD-L1 testing recommended
+  # for prognostic / counseling purposes but does NOT gate the periop
+  # pathway.
+  biomarker_requirements_excluded:
+    - biomarker_id: BIO-EGFR-MUTATION
+      value_constraint: "activating mutation present (exon 19 deletion, L858R, exon 20 insertion, etc.)"
+      required: false
+    - biomarker_id: BIO-ALK-FUSION
+      value_constraint: "ALK rearrangement / fusion present"
+      required: false
+  demographic_constraints:
+    ecog_max: 1
+    fit_for_chemo: true
+    fit_for_surgery: true
+    # KEYNOTE-671 enrolled ECOG 0-1 only and required surgical fitness.
+    # ECOG 2+ patients should be considered for definitive chemoradiation
+    # (PACIFIC pathway) or upfront surgery without IO via MDT.
+
+# §17 ratified 2026-05-07 — 3-phase periop indication. The phased
+# representation supersedes the single `recommended_regimen` field for
+# multi-modality lines of therapy. Each phase carries exactly ONE foreign
+# key (regimen_id / surgery_id / radiation_id) per the IndicationPhase
+# XOR validator. Cycle counts: 4 neoadjuvant + 13 adjuvant = 17 total
+# pembro cycles (~1 yr exposure) per KEYNOTE-671 protocol.
+phases:
+  - phase: neoadjuvant
+    type: chemotherapy
+    regimen_id: REG-PEMBRO-CHEMO-NEOADJ-NSCLC
+    cycles: 4
+  - phase: surgery
+    type: surgery
+    surgery_id: SUR-LUNG-LOBECTOMY
+    duration_weeks: 1
+  - phase: adjuvant
+    type: immunotherapy
+    regimen_id: REG-PEMBRO-ADJUVANT-NSCLC
+    cycles: 13
+
+# Legacy `recommended_regimen` left null — render layer should consume
+# `phases:` for this indication per §17 ratification (commit 9882381c).
+recommended_regimen:
+
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_survival_median: "OS update (Spicer NEJM 2024): mOS not reached (perioperative pembro) vs 52.4 mo (placebo); HR 0.72, p=0.005"
+  progression_free_survival: "24-mo EFS 62.4% (perioperative pembro) vs 40.6% (placebo); HR 0.58, 95% CI 0.46-0.72, p<0.001 (KEYNOTE-671 / Wakelee NEJM 2023)"
+  complete_response: "pCR 18.1% (perioperative pembro) vs 4.0% (placebo); mPR 30.2% vs 11.0% — at surgical specimen"
+
+hard_contraindications: []
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
+
+desired_tests: []
+
+rationale: >
+  KEYNOTE-671 (Wakelee NEJM 2023; Spicer NEJM 2024 OS update) established
+  perioperative pembrolizumab — 4 cycles neoadjuvant pembrolizumab +
+  cisplatin-based doublet (cisplatin/pemetrexed for non-squamous,
+  cisplatin/gemcitabine for squamous) → anatomic lobectomy → 13 cycles
+  adjuvant pembrolizumab — as the standard perioperative regimen for
+  resectable stage II/IIIA/IIIB NSCLC without targetable EGFR/ALK
+  alterations. n=797 randomized; 24-mo EFS 62.4% vs 40.6% (HR 0.58,
+  p<0.001); pCR 18.1% vs 4.0%; mPR 30.2% vs 11.0%; OS update mOS not
+  reached vs 52.4 mo (HR 0.72, p=0.005). FDA approval Oct 2023; NCCN
+  v3.2025 category 1 + ESMO 2024 strong recommendation.
+
+  Patient selection: ECOG 0-1, fit for cisplatin-based chemotherapy
+  (CrCl ≥60, no significant ototoxicity / neuropathy at baseline), and
+  fit for anatomic lobectomy (FEV1 + DLCO meeting thoracic-surgical
+  thresholds; no decompensated cardiopulmonary comorbidity). KEYNOTE-671
+  excluded ECOG ≥2 and patients unfit for cisplatin or surgery.
+
+  EGFR / ALK testing is mandatory before initiating perioperative pembro
+  (FDA label requirement) — driver-positive resectable NSCLC has
+  superior adjuvant TKI options (osimertinib per ADAURA for EGFR Δ19/L858R,
+  alectinib per ALINA for ALK), and IO efficacy is reduced in
+  driver-positive disease. PD-L1 testing recommended for prognostic /
+  counseling purposes but does NOT gate the periop pathway — KEYNOTE-671
+  benefit was observed across PD-L1 TPS strata.
+
+  Restaging after 4 neoadjuvant cycles drives the surgical decision: CT
+  chest/abdomen/pelvis ± PET to confirm operability and rule out new
+  metastases. Patients with new oligo-progression on neoadjuvant should
+  be re-evaluated at MDT — some may still proceed to resection if
+  oligo-progressive disease is locally controllable; others convert to
+  systemic-only management. Patients with frank progression do NOT
+  proceed to lobectomy.
+
+  Carboplatin (AUC 5) substitution for cisplatin is NCCN-allowed as a
+  real-world tolerability variant in patients with renal impairment,
+  ototoxicity, or neuropathy, but is NOT the trial protocol — note the
+  protocol-deviation in the plan rationale when carbo is substituted.
+
+rationale_ua: >
+  KEYNOTE-671 (Wakelee NEJM 2023; Spicer NEJM 2024 OS-оновлення) встановив
+  периоопераційний пембролізумаб — 4 цикли неоад'ювантного пембро +
+  цисплатин-вмісного дублета (цисплатин/пеметрексед для non-squamous,
+  цисплатин/гемцитабін для squamous) → анатомічна лобектомія → 13 циклів
+  ад'ювантного пембро — стандартним периоопераційним режимом для
+  резектабельної стадії II/IIIA/IIIB НДРЛ без таргетабельних EGFR/ALK
+  альтерацій. n=797; 24-міс EFS 62.4% проти 40.6% (HR 0.58); pCR 18.1%
+  проти 4.0%; OS mOS не досягнута проти 52.4 міс (HR 0.72). FDA-схвалення
+  жовт 2023; NCCN v3.2025 категорія 1 + ESMO 2024 сильна рекомендація.
+
+  Відбір пацієнтів: ECOG 0-1, придатність до цисплатин-вмісної хіміотерапії
+  (CrCl ≥60), і придатність до анатомічної лобектомії (FEV1 + DLCO
+  відповідають торакально-хірургічним порогам). KEYNOTE-671 виключив
+  ECOG ≥2 і пацієнтів непридатних до цисплатину або хірургії.
+
+  EGFR / ALK-тестування — обов'язкове перед стартом периоопераційного
+  пембро (FDA-етикетка) — драйвер-позитивний резектабельний НДРЛ має
+  кращі ад'ювантні TKI (osimertinib ADAURA, alectinib ALINA).
+  PD-L1-тестування — для прогностичних цілей, не гейтить периоопераційний
+  шлях.
+
+  Заміна цисплатину карбоплатином (AUC 5) — допустимий NCCN-варіант для
+  пацієнтів з нирковою недостатністю, ототоксичністю, нейропатією; це
+  НЕ трайл-протокол.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-KEYNOTE-671-WAKELEE-2023
+    position: supports
+  - source_id: SRC-NCCN-NSCLC-2025
+    position: supports
+  - source_id: SRC-ESMO-NSCLC-EARLY-2024
+    position: supports
+
+known_controversies:
+  - topic: Cisplatin (trial protocol) vs carboplatin (real-world tolerability) for the chemo backbone
+    positions:
+      - position: Cisplatin-based doublet per KEYNOTE-671 protocol
+        sources:
+          - SRC-KEYNOTE-671-WAKELEE-2023
+        evidence_note: "KEYNOTE-671 used cisplatin 75 mg/m² + pemetrexed 500 mg/m² (non-sq) or cisplatin 75 mg/m² + gemcitabine 1000 mg/m² days 1+8 (sq) — this is the protocol that generated the EFS/OS benefit"
+      - position: Carboplatin (AUC 5) substitution acceptable for cisplatin-unfit patients
+        sources:
+          - SRC-NCCN-NSCLC-2025
+        evidence_note: "NCCN allows carbo substitution for renal impairment, ototoxicity, neuropathy; carbo+pem and carbo+pacli are validated chemo backbones in NSCLC overall but were NOT the KEYNOTE-671 protocol — efficacy extrapolation based on shared chemo activity, not direct trial evidence"
+    our_default: "Cisplatin-based doublet per KEYNOTE-671 protocol when patient fit; carbo substitution allowed for cisplatin-unfit (note protocol-deviation in plan rationale)"
+    rationale: "Trial protocol cisplatin generated the published EFS/OS benefit; carbo substitution is an extrapolation supported by NCCN consensus but not direct RCT in the periop-pembro context."
+
+  - topic: Surgical timing — 4-12 week window from neoadjuvant cycle 4 to lobectomy
+    positions:
+      - position: 4-6 weeks post-cycle-4 to allow IO washout and chemo recovery
+        sources:
+          - SRC-KEYNOTE-671-WAKELEE-2023
+        evidence_note: "KEYNOTE-671 protocol allowed surgery 4-6 weeks post-cycle-4 to balance pembro half-life (clearance ~26 days) with avoidance of disease progression"
+      - position: Up to 8-12 weeks acceptable if surgical scheduling / fitness optimization needed
+        sources:
+          - SRC-NCCN-NSCLC-2025
+        evidence_note: "NCCN allows wider window for fitness optimization, prehabilitation, scheduling — provided no progression on restaging"
+    our_default: "Target 4-6 weeks post-neoadjuvant-cycle-4 to lobectomy per trial protocol; wider window (up to 8-12 wks) acceptable for fitness optimization with restaging confirmation of stable / responding disease"
+    rationale: "Trial protocol window optimal; real-world flexibility allowed within NCCN bounds. Progression on restaging excludes patient from surgical phase."
+
+  - topic: Adjuvant phase completion when post-op fitness declines or new toxicity emerges
+    positions:
+      - position: Continue all 13 adjuvant cycles per KEYNOTE-671 protocol if no recurrence / dose-limiting irAE
+        sources:
+          - SRC-KEYNOTE-671-WAKELEE-2023
+        evidence_note: "Per-protocol adjuvant phase contributes to the published OS benefit; abbreviating reduces cumulative IO exposure and may attenuate benefit"
+      - position: De-escalate or discontinue adjuvant if grade ≥3 irAE recurrence
+        sources:
+          - SRC-NCCN-NSCLC-2025
+        evidence_note: "NCCN allows clinical judgment when post-op irAE recurrence threatens curative-intent patient quality of life; permanent discontinuation acceptable for refractory grade ≥3 irAE"
+    our_default: "Complete 13 adjuvant cycles unless grade ≥3 irAE recurrence or recurrence; partial completion (e.g., 6-9 cycles) acceptable if irAE-driven discontinuation per MDT"
+    rationale: "Per-protocol completion drives the OS benefit; irAE-driven de-escalation is defensible in curative-intent context where quality of life and irAE-mortality risk weigh heavily."
+
+do_not_do:
+  - "Do NOT initiate perioperative pembro without EGFR / ALK testing — FDA label requires driver-status before pembro start; driver-positive disease has superior adjuvant TKI options"
+  - "Do NOT initiate perioperative pembro in ECOG ≥2 — KEYNOTE-671 excluded ECOG ≥2; route to definitive chemoradiation (PACIFIC) or upfront surgery without IO via MDT"
+  - "Do NOT initiate perioperative pembro in active autoimmune disease requiring systemic immunosuppression — irAE risk significantly elevated; route to chemo-only neoadj or upfront surgery"
+  - "Do NOT proceed to lobectomy if frank progression on neoadjuvant restaging — convert to systemic-only management"
+  - "Do NOT use this indication for stage I NSCLC — KEYNOTE-671 enrolled stage II-IIIB; stage I (T1-2aN0) is upfront surgery + observation or upfront surgery + adjuvant chemo (CALGB-9633 / JBR-10) without IO"
+  - "Do NOT use this indication for unresectable stage III NSCLC — route to definitive chemoradiation + consolidation durvalumab (PACIFIC) instead"
+  - "Do NOT skip pneumonitis baseline assessment (PFTs, baseline chest CT) — pre-existing ILD or compromised lung function elevates pneumonitis risk in lung-cancer cohort"
+  - "Do NOT refer to a low-volume thoracic-surgical center — operative mortality 4-6% at lower-volume centers vs 1-3% at high-volume (>40 lobectomies/yr) centers"
+
+do_not_do_en:
+  - "Do NOT initiate perioperative pembro without EGFR / ALK testing — FDA label requires driver-status before pembro start; driver-positive disease has superior adjuvant TKI options"
+  - "Do NOT initiate perioperative pembro in ECOG ≥2 — KEYNOTE-671 excluded ECOG ≥2; route to definitive chemoradiation (PACIFIC) or upfront surgery without IO via MDT"
+  - "Do NOT initiate perioperative pembro in active autoimmune disease requiring systemic immunosuppression — irAE risk significantly elevated; route to chemo-only neoadj or upfront surgery"
+  - "Do NOT proceed to lobectomy if frank progression on neoadjuvant restaging — convert to systemic-only management"
+  - "Do NOT use this indication for stage I NSCLC — KEYNOTE-671 enrolled stage II-IIIB; stage I (T1-2aN0) is upfront surgery + observation or upfront surgery + adjuvant chemo (CALGB-9633 / JBR-10) without IO"
+  - "Do NOT use this indication for unresectable stage III NSCLC — route to definitive chemoradiation + consolidation durvalumab (PACIFIC) instead"
+  - "Do NOT skip pneumonitis baseline assessment (PFTs, baseline chest CT) — pre-existing ILD or compromised lung function elevates pneumonitis risk in lung-cancer cohort"
+  - "Do NOT refer to a low-volume thoracic-surgical center — operative mortality 4-6% at lower-volume centers vs 1-3% at high-volume (>40 lobectomies/yr) centers"
+
+last_reviewed: "2026-05-09"
+
+actionability_review_required: true
+
+notes: >
+  PUL-A5: §17 3-phase periop indication for resectable stage II/IIIA/IIIB
+  NSCLC, mirroring GI-2 C1 FLOT periop pattern. The phases[] block models
+  neoadjuvant pembrolizumab + cisplatin-doublet × 4 →
+  anatomic lobectomy (SUR-LUNG-LOBECTOMY, NEW in this chunk) → adjuvant
+  pembrolizumab × 13 (REG-PEMBRO-ADJUVANT-NSCLC, NEW in this chunk).
+  evidence_level: high + nccn_category 1 reflect the level-1 evidence
+  (Wakelee NEJM 2023 + Spicer NEJM 2024 OS update). First IO-containing
+  periop indication in OpenOnco; first lung-resection Surgery entity.
+
+  Active autoimmune disease handled in `do_not_do` rather than
+  `biomarker_requirements_excluded` — autoimmune disease is a clinical-
+  status flag, not a Biomarker entity, so it does not fit the BMA-style
+  exclusion shape. Surface in plan rationale via the do_not_do list.
+
+  Engine routing: `algo_nsclc_resectable_periop` does not yet exist —
+  flagged for D2 algorithm-extension chunk follow-up. The
+  `recommended_regimen` field is left null intentionally because the
+  periop sequence is multi-modality; consumers should iterate `phases:`
+  rather than dereferencing a single regimen ID.

--- a/knowledge_base/hosted/content/procedures/proc_lung_lobectomy.yaml
+++ b/knowledge_base/hosted/content/procedures/proc_lung_lobectomy.yaml
@@ -1,0 +1,93 @@
+# SUR-LUNG-LOBECTOMY — Anatomic lung lobectomy with mediastinal nodal
+# dissection. §17.1 Surgery entity (RATIFIED 2026-05-07). First lung-
+# resection procedure landing in the PUL wave (chunk
+# pul-a5-kn671-perioperative-2026-05-09-1100). Referenced from
+# `IND-NSCLC-PERIOPERATIVE-PEMBRO.phases[1].surgery_id`.
+id: SUR-LUNG-LOBECTOMY
+names:
+  preferred: "Anatomic lung lobectomy with mediastinal lymph node dissection"
+  ukrainian: "Анатомічна лобектомія легені з медіастинальною лімфодисекцією"
+  english: "Anatomic lung lobectomy with mediastinal lymph node dissection"
+  synonyms:
+    - "Lobectomy"
+    - "Pulmonary lobectomy"
+    - "Anatomic lung resection (lobectomy)"
+    - "VATS lobectomy"
+    - "RATS lobectomy"
+    - "Open lobectomy"
+
+# Free-string per §17.1 sketch — surgical taxonomy not enum'd in v0.1.
+type: lobectomy
+intent: curative
+
+target_organ: lung
+applicable_diseases:
+  - DIS-NSCLC
+
+# Operative mortality from large-volume thoracic centers; ACOSOG-Z0030 +
+# STS database modern series report 30-day mortality 1-3% at high-volume
+# (>40 lobectomies/yr) centers, 4-6% at lower-volume centers. CALGB-140503
+# (sublobar vs lobar) confirmed comparable safety profile for VATS / RATS
+# vs open in matched cohorts.
+operative_mortality_pct: "1-3% in high-volume centers (>40 lobectomies/yr); 4-6% in lower-volume centers"
+
+common_complications:
+  - name: "Prolonged air leak (>5 days)"
+    frequency: "8-15%"
+  - name: "Pneumonia"
+    frequency: "5-10%"
+  - name: "Atrial arrhythmia (AF / atrial flutter)"
+    frequency: "10-20%"
+  - name: "Chylothorax"
+    frequency: "1-3%"
+  - name: "Persistent post-thoracotomy pain syndrome"
+    frequency: "15-25% (lower with VATS / RATS than open)"
+  - name: "Bronchopleural fistula (BPF)"
+    frequency: "<1% after lobectomy; 4-10% after pneumonectomy"
+  - name: "Wound infection / empyema"
+    frequency: "2-5%"
+  - name: "Recurrent laryngeal nerve injury (left-sided / mediastinal dissection)"
+    frequency: "1-3%"
+  - name: "Postoperative bleeding requiring intervention"
+    frequency: "1-3%"
+
+sources:
+  - SRC-NCCN-NSCLC-2025
+  - SRC-ESMO-NSCLC-EARLY-2024
+  - SRC-KEYNOTE-671-WAKELEE-2023
+
+last_reviewed: "2026-05-09"
+notes: >
+  Anatomic lobectomy with mediastinal lymph node dissection (or
+  systematic sampling of stations 2R/4R/7/8/9 right; 5/6/7/8/9 left) is
+  the curative-intent operation for resectable stage I-IIIB NSCLC per
+  NCCN v3.2025 and ESMO 2024. Pneumonectomy is reserved for tumors
+  involving the mainstem bronchus or proximal pulmonary artery where
+  lobectomy / sleeve resection is not feasible — pneumonectomy carries
+  meaningfully higher mortality (5-10%) and BPF risk (4-10%) than
+  lobectomy.
+
+  Sublobar resection (segmentectomy / wedge): JCOG-0802 and CALGB-140503
+  established that anatomic segmentectomy is non-inferior to lobectomy
+  for peripheral cT1aN0 NSCLC ≤2 cm; for larger tumors, locally-advanced
+  disease, or central locations lobectomy remains the standard.
+
+  Minimally invasive approach: VATS or RATS lobectomy is preferred over
+  open thoracotomy when oncologically feasible — lower morbidity (pain,
+  pulmonary complications), shorter hospital stay, equivalent oncologic
+  outcomes per multiple meta-analyses + the VIOLET RCT (Lim 2022).
+
+  Mediastinal nodal dissection is mandatory for accurate pathologic
+  staging — at least 3 N2 stations + N1 nodes per NCCN. Extent of
+  dissection (systematic sampling vs complete dissection) is
+  surgeon-discretion; ACOSOG-Z0030 showed equivalent survival with
+  systematic sampling in cN0/cN1 disease.
+
+  Center-volume gradient: high-volume thoracic centers (>40
+  lobectomies/yr) show 30-day mortality ~1-3% vs ~4-6% at low-volume
+  centers; NCCN recommends referral to high-volume centers for
+  resectable NSCLC.
+
+  Pairs with neoadjuvant pembro+chemo and adjuvant pembro in the
+  KEYNOTE-671 perioperative sequence (Wakelee NEJM 2023) — see
+  IND-NSCLC-PERIOPERATIVE-PEMBRO.

--- a/knowledge_base/hosted/content/regimens/reg_pembro_adjuvant.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_adjuvant.yaml
@@ -1,0 +1,137 @@
+id: REG-PEMBRO-ADJUVANT-NSCLC
+name: "Pembrolizumab adjuvant (resected NSCLC; KEYNOTE-671)"
+name_ua: "Пембролізумаб ад'ювантно (резекований НДРЛ; KEYNOTE-671)"
+alternate_names:
+  - "KEYNOTE-671 adjuvant phase"
+  - "Perioperative pembrolizumab — adjuvant phase"
+
+# Reuse rationale: REG-PEMBRO-ADJUVANT-MELANOMA exists at 18 cycles
+# (~12 mo, KEYNOTE-054 protocol). KEYNOTE-671 adjuvant is 13 cycles
+# (~9 mo, ~1 year inclusive of 4 neoadjuvant cycles for total 17 cycles
+# / ~1 yr pembro exposure). Cycle count differs → separate regimen.
+components:
+  - drug_id: DRUG-PEMBROLIZUMAB
+    dose: "200 mg IV q3 weeks (or 400 mg IV q6 weeks)"
+    schedule: "Day 1 every 3 weeks (or q6w), starting within 4-12 weeks of surgical resection"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "13 cycles (~9 months) per KEYNOTE-671 adjuvant phase"
+toxicity_profile: low-moderate
+
+premedication: []
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Severe immune-related adverse event (gr ≥3 colitis, pneumonitis, hepatitis, nephritis, dermatitis)"
+    modification: "Hold pembrolizumab; high-dose corticosteroids (1-2 mg/kg prednisone equiv); consider permanent discontinuation in adjuvant setting given non-curative-uplift toxicity threshold"
+    rationale: "irAE risk-benefit threshold lower in adjuvant than metastatic — curative-intent patient should not be exposed to gr ≥3 toxicity recurrence"
+    source_refs:
+      - SRC-NCCN-NSCLC-2025
+  - condition: "Endocrinopathy (hypothyroidism, hypopituitarism, T1DM, primary adrenal insufficiency)"
+    modification: "Hormone replacement; pembrolizumab can usually be continued"
+    rationale: "Endocrine irAEs typically permanent but manageable with replacement"
+  - condition: "Pneumonitis grade ≥2"
+    modification: "Hold; chest CT; high-dose steroids; permanent discontinuation if grade ≥3"
+    rationale: "Pneumonitis is leading cause of pembrolizumab-related mortality; lower threshold to discontinue in adjuvant; baseline lung-cancer / post-resection patients are higher-risk than melanoma cohort"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Pembrolizumab registered in Ukraine; reimbursement for NSCLC perioperative
+    adjuvant phase variable / often out-of-pocket. Self-pay course
+    (~13 cycles × ~USD 4-7K) is substantial; private insurance / cross-
+    border are realistic routes. Major access barrier given the
+    curative-intent nature.
+
+sources:
+  - SRC-KEYNOTE-671-WAKELEE-2023
+  - SRC-NCCN-NSCLC-2025
+  - SRC-ESMO-NSCLC-EARLY-2024
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# Pembrolizumab adjuvant for resected NSCLC (KEYNOTE-671 adj phase).
+# Same irAE pattern as pembro-mono other indications. STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома після інфузій"
+    action_ua: "Очікувано — відпочивайте більше у дні 1-3"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Шкірний свербіж або сухість шкіри"
+    action_ua: "Часто і зазвичай легко — використовуйте зволожувач"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Помірна діарея (3-4 рази на день)"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Жовтяниця, біль у правому верхньому квадранті живота"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Виражена слабкість, постійна спрага, втрата ваги"
+    action_ua: "Подзвоніть у клініку того ж дня — можлива імунна реакція щитоподібної залози або новий діабет"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Нова задишка, сухий кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний пневмоніт; на тлі легеневої резекції потребує термінової оцінки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Тяжка діарея або виражена слабкість + низький тиск"
+    action_ua: "Звертайтесь у лікарню негайно — можливий тяжкий коліт або криз надниркових залоз"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Сильна задишка у спокої, синюшність губ"
+    action_ua: "Звертайтесь у лікарню негайно — тяжкий імунний пневмоніт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NSCLC-2025
+
+last_reviewed: "2026-05-09"
+reviewer_signoffs: []
+notes: >
+  KEYNOTE-671 adjuvant phase (Wakelee NEJM 2023): pembrolizumab 200 mg
+  q3w × 13 cycles (~9 months) starting within 4-12 weeks of complete
+  surgical resection, following 4 cycles of neoadjuvant pembrolizumab +
+  cisplatin-based doublet (REG-PEMBRO-CHEMO-NEOADJ-NSCLC). Total
+  perioperative pembrolizumab exposure: 17 cycles / ~1 year. EFS HR 0.58
+  and OS HR 0.72 reflect the contribution of the full perioperative
+  package; adjuvant phase contribution is not independently dissectable
+  from the trial design.
+
+  Distinct from REG-PEMBRO-ADJUVANT-MELANOMA (18 cycles, KEYNOTE-054
+  protocol) — separate Regimen entity to capture the KEYNOTE-671-specific
+  cycle count and NSCLC-specific monitoring (post-resection pneumonitis
+  baseline elevated; lower irAE-discontinuation threshold).
+
+  Excludes patients with EGFR-activating mutations or ALK fusion (FDA
+  label) — driver-positive resectable NSCLC has superior adjuvant TKI
+  options (osimertinib per ADAURA, alectinib per ALINA).
+
+notes_ua: >
+  KEYNOTE-671 ад'ювантна фаза (Wakelee NEJM 2023): пембролізумаб 200 мг
+  q3w × 13 циклів (~9 місяців) починаючи в межах 4-12 тижнів від повної
+  хірургічної резекції, після 4 циклів неоад'ювантного пембролізумабу +
+  цисплатин-вмісного дублета (REG-PEMBRO-CHEMO-NEOADJ-NSCLC). Загальна
+  периопераційна експозиція пембролізумабу: 17 циклів / ~1 рік. EFS HR
+  0.58 і OS HR 0.72 відображають внесок повного периопераційного пакета.
+
+  Відрізняється від REG-PEMBRO-ADJUVANT-MELANOMA (18 циклів, KEYNOTE-054
+  протокол) — окрема Regimen-сутність для специфічного KEYNOTE-671 числа
+  циклів і NSCLC-специфічного моніторингу.
+
+  Виключаються пацієнти з активуючими мутаціями EGFR або ALK-fusion
+  (FDA-етикетка) — драйвер-позитивний резектабельний НДРЛ має кращі
+  ад'ювантні TKI (osimertinib ADAURA, alectinib ALINA).
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/regimens/reg_pembro_chemo_neoadj_nsclc.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_pembro_chemo_neoadj_nsclc.yaml
@@ -1,0 +1,188 @@
+id: REG-PEMBRO-CHEMO-NEOADJ-NSCLC
+name: "Pembrolizumab + cisplatin-based chemo (NSCLC neoadjuvant; KEYNOTE-671)"
+name_ua: "Пембролізумаб + цисплатин-вмісна хіміотерапія (НДРЛ неоад'юв; KEYNOTE-671)"
+alternate_names:
+  - "KEYNOTE-671 neoadjuvant regimen"
+  - "Perioperative pembrolizumab — neoadjuvant phase"
+
+# Trial protocol per Wakelee NEJM 2023: pembrolizumab + cisplatin-based
+# doublet (cisplatin + pemetrexed for non-squamous; cisplatin +
+# gemcitabine for squamous) × 4 cycles q3w. Default components reflect
+# the dominant non-squamous cisplatin + pemetrexed pairing; squamous-
+# histology and carboplatin-substitution variants documented in `notes:`.
+components:
+  - drug_id: DRUG-PEMBROLIZUMAB
+    dose: "200 mg IV q3 weeks"
+    schedule: "Day 1 of cycles 1-4"
+    route: IV
+  - drug_id: DRUG-CISPLATIN
+    dose: "75 mg/m² IV"
+    schedule: "Day 1 of cycles 1-4"
+    route: IV
+  - drug_id: DRUG-PEMETREXED
+    dose: "500 mg/m² IV (non-squamous histology)"
+    schedule: "Day 1 of cycles 1-4"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "4 cycles neoadjuvant per KEYNOTE-671 protocol"
+toxicity_profile: moderate-severe
+
+premedication:
+  - "Folic acid 400-1000 mcg PO daily + Vit B12 1000 mcg IM q9 weeks (pemetrexed)"
+  - "Dexamethasone 4 mg PO BID days 0, 1, 2 (pemetrexed rash prophylaxis)"
+  - "High-emetogenic antiemetic protocol (cisplatin) — 5-HT3 + NK1 + dexamethasone"
+  - "IV hydration (cisplatin nephroprotection) — pre + post infusion"
+mandatory_supportive_care: []
+monitoring_schedule_id:
+
+dose_adjustments:
+  - condition: "Renal impairment (CrCl <60)"
+    modification: "Substitute carboplatin AUC 5 for cisplatin; avoid pemetrexed if CrCl <45"
+    rationale: "Cisplatin nephrotoxicity threshold; pemetrexed cleared renally"
+  - condition: "Squamous histology"
+    modification: "Substitute gemcitabine 1000 mg/m² IV days 1+8 for pemetrexed (KEYNOTE-671 squamous arm)"
+    rationale: "Pemetrexed approved in non-squamous only; KEYNOTE-671 protocol used cisplatin+gemcitabine for squamous"
+  - condition: "Immune-mediated AE grade ≥2"
+    modification: "Hold pembrolizumab; corticosteroids; permanent discontinuation if grade ≥3 recurrent"
+  - condition: "Cisplatin-induced ototoxicity / neuropathy grade ≥2"
+    modification: "Substitute carboplatin AUC 5"
+  - condition: "Febrile neutropenia"
+    modification: "G-CSF secondary prophylaxis; consider dose reduction"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Pembrolizumab registered in Ukraine; reimbursement for NSCLC perioperative
+    indication variable / often out-of-pocket. Cisplatin + pemetrexed +
+    gemcitabine reimbursed as standard chemo backbone. Total 4-cycle
+    neoadjuvant cost dominated by pembro out-of-pocket component.
+
+sources:
+  - SRC-KEYNOTE-671-WAKELEE-2023
+  - SRC-NCCN-NSCLC-2025
+  - SRC-ESMO-NSCLC-EARLY-2024
+
+# Patient between-visit watchpoints (PATIENT_MODE_SPEC §3.4).
+# KEYNOTE-671 neoadjuvant: pembro + cisplatin-doublet × 4. Combines
+# IO irAEs with cisplatin emesis/nephro/neuro/oto-toxicity + pemetrexed
+# mucositis (or gemcitabine cytopenia in squamous arm). STUB pending §6.1.
+between_visit_watchpoints:
+  - trigger_ua: "Помірна нудота, втома 3-7 днів після інфузії"
+    action_ua: "Очікувано від цисплатину — занотовуйте; протиблювотні за призначенням"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-7"
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Поколювання, оніміння у пальцях рук і ніг"
+    action_ua: "Очікувано від цисплатину — занотовуйте, обговоримо на візиті"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Дзвін у вухах, зниження слуху"
+    action_ua: "Подзвоніть у клініку того ж дня — ототоксичність цисплатину, можлива заміна на карбоплатин"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Шкірний свербіж, висип"
+    action_ua: "Зустрічається на тлі пембролізумабу — використовуйте зволожувач; занотовуйте"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Зниження апетиту, легкий мукозит"
+    action_ua: "Поширене на пеметрексед — м'яка щітка; полоскання з содою; B12+фолат за призначенням"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Лихоманка вище 38°C — особливо на 7-14 день циклу"
+    action_ua: "Подзвоніть у клініку того ж дня — нейтропенія можлива"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Day 7-14"
+    sources:
+      - SRC-NCCN-NSCLC-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Помірна діарея (3-4 рази на день)"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний коліт"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Нова задишка, сухий кашель"
+    action_ua: "Подзвоніть у клініку того ж дня — імунний пневмоніт або прогресування пухлини потребують оцінки"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Жовтяниця, біль у правому верхньому квадранті живота"
+    action_ua: "Подзвоніть у клініку того ж дня — можливий імунний гепатит"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Зменшення сечовипускання, набряки"
+    action_ua: "Подзвоніть у клініку того ж дня — нефротоксичність цисплатину"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Тяжка діарея (≥7 разів на день, з кров'ю)"
+    action_ua: "Звертайтесь у лікарню негайно — тяжкий імунний коліт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NSCLC-2025
+  - trigger_ua: "Сильна задишка у спокої, синюшність губ"
+    action_ua: "Звертайтесь у лікарню негайно — тяжкий імунний пневмоніт"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-NSCLC-2025
+
+last_reviewed: "2026-05-09"
+notes: >
+  KEYNOTE-671 (Wakelee NEJM 2023, Spicer NEJM 2024 OS update): neoadjuvant
+  pembrolizumab 200 mg q3w + cisplatin-based doublet × 4 cycles followed by
+  surgery and adjuvant pembrolizumab × 13 cycles, in resectable stage
+  II/IIIA/IIIB (T3-T4N2) NSCLC. 24-mo EFS 62.4% vs 40.6% (HR 0.58,
+  p<0.001); pCR 18.1% vs 4.0%; mPR 30.2% vs 11.0%; OS update mOS not
+  reached vs 52.4 mo (HR 0.72, p=0.005). FDA approval Oct 2023; NCCN
+  v3.2025 category 1.
+
+  Trial protocol used cisplatin-based doublet specifically:
+    * Non-squamous: cisplatin 75 mg/m² + pemetrexed 500 mg/m² q3w
+    * Squamous: cisplatin 75 mg/m² + gemcitabine 1000 mg/m² days 1+8 q3w
+  Carboplatin (AUC 5) substitution for cisplatin is NCCN-allowed as a
+  real-world tolerability variant in patients with renal impairment,
+  ototoxicity, neuropathy, or other cisplatin-contraindications, but is
+  NOT the trial protocol — note this in the plan rationale when carbo is
+  substituted.
+
+  Pembrolizumab is administered concurrently with chemo cycles 1-4
+  (neoadjuvant), then continues post-resection as adjuvant monotherapy
+  × 13 cycles (REG-PEMBRO-ADJUVANT-NSCLC) for total ~17 cycles
+  pembrolizumab over the perioperative course.
+
+  Excludes patients with EGFR-activating mutations or ALK fusion —
+  driver-positive resectable NSCLC has superior adjuvant TKI options
+  (osimertinib per ADAURA, alectinib per ALINA) and IO efficacy is
+  reduced in driver-positive disease (FDA label requires EGFR/ALK
+  testing before perioperative pembro initiation).
+
+notes_ua: >
+  KEYNOTE-671 (Wakelee NEJM 2023, Spicer NEJM 2024 OS-оновлення):
+  неоад'ювантний пембролізумаб 200 мг q3w + цисплатин-вмісний дублет ×
+  4 цикли із подальшою операцією і ад'ювантним пембролізумабом × 13
+  циклів, при резектабельній стадії II/IIIA/IIIB (T3-T4N2) НДРЛ.
+  24-міс EFS 62.4% проти 40.6% (HR 0.58); pCR 18.1% проти 4.0%; OS
+  mOS не досягнута проти 52.4 міс (HR 0.72). FDA-схвалення жовт 2023;
+  NCCN v3.2025 категорія 1.
+
+  Протокол випробування використовував цисплатин-вмісний дублет:
+    * Non-squamous: цисплатин 75 мг/м² + пеметрексед 500 мг/м² q3w
+    * Squamous: цисплатин 75 мг/м² + гемцитабін 1000 мг/м² дні 1+8 q3w
+  Заміна карбоплатином (AUC 5) — допустимий NCCN варіант для пацієнтів
+  з нирковою недостатністю, ототоксичністю, нейропатією; це НЕ
+  трайл-протокол.
+
+  Виключаються пацієнти з активуючими мутаціями EGFR або ALK-fusion —
+  драйвер-позитивний резектабельний НДРЛ має кращі ад'ювантні TKI
+  (osimertinib ADAURA, alectinib ALINA); FDA-етикетка вимагає
+  EGFR/ALK-тестування перед стартом периоопераційного пембро.
+
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- First pulmonary §17 consumer: 3-phase perioperative pembro NSCLC per KEYNOTE-671 RCT
- 4 NEW: indication + 2 regimens + 1 Surgery (first lung-resection entity in OpenOnco)
- Closes #498

## Files (4 NEW)

| File | Notes |
|---|---|
| `ind_nsclc_perioperative_pembro.yaml` | §17 3-phase: neoadj IO+chemo × 4 → SUR-LUNG-LOBECTOMY → adj IO × 13 |
| `reg_pembro_chemo_neoadj_nsclc.yaml` | Cis+pem (nonsq) or cis+gem (sq) + pembro 200 q3w × 4 |
| `reg_pembro_adjuvant.yaml` | Pembro 200 mg q3w × 13 cycles (~1 year) |
| `proc_lung_lobectomy.yaml` | First lung-resection Surgery in KB; intent: curative |

## §17 phases

```yaml
phases:
  - phase: neoadjuvant
    type: chemotherapy
    regimen_id: REG-PEMBRO-CHEMO-NEOADJ-NSCLC
    cycles: 4
  - phase: surgery
    type: surgery
    surgery_id: SUR-LUNG-LOBECTOMY
  - phase: adjuvant
    type: immunotherapy
    regimen_id: REG-PEMBRO-ADJUVANT-NSCLC
    cycles: 13
```

## Honest findings (per spec defects)

1. **Protocol fidelity correction**: brief said "carbo+pem/pacli" but actual KN-671 protocol is **cisplatin-based** (cis+pem nonsq, cis+gem sq). Agent used cisplatin per source; carbo substitution documented as NCCN-allowed tolerability variant in `notes:` + `dose_adjustments:` + `known_controversies:`.
2. **Schema-correct autoimmune placement**: brief proposed `biomarker_requirements_excluded` for autoimmune disease, but that field expects `BiomarkerRequirement` entities (not narrative strings). Agent moved to `do_not_do`. EGFR-MUTATION + ALK-FUSION kept in excluded with valid BIO IDs.

## Reuse decisions
- **No regimen reuse**: melanoma KN-054 adjuvant pembro is 18 cycles; KN-671 is 13 — distinct regimens
- **No surgery reuse**: no existing lung procedure (this is first one)

## Test plan
- [x] Validator: 0/0/0 errors; 524 warnings unchanged; entities 2998 → 3002 (+4)
- [x] pytest 31/31 (test_phases, test_surgery, test_indication_schema, test_loader)
- [x] No banned sources

## D2 follow-up flag

`algo_nsclc_resectable_periop` doesn't exist yet — engine routing for KN-671 perioperative requires new algorithm in D2 wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)