### PR TITLE
feat(kb): PUL-A8 NSCLC 1L nivo+ipi+2-cycle chemo CheckMate-9LA (#504)

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_nsclc_driver_neg_met_1l_nivo_ipi_chemo.yaml
+++ b/knowledge_base/hosted/content/indications/ind_nsclc_driver_neg_met_1l_nivo_ipi_chemo.yaml
@@ -1,0 +1,106 @@
+id: IND-NSCLC-DRIVER-NEG-MET-1L-NIVO-IPI-CHEMO
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-NSCLC
+  molecular_subtype: DRIVER_NEGATIVE
+  stage_stratum: STAGE_IV_METASTATIC
+  line_of_therapy: 1
+  stage_requirements:
+    - "Stage IV metastatic NSCLC (AJCC 8th ed.)"
+    - "No actionable driver mutation (EGFR, ALK, ROS1, MET exon 14 skip, BRAF V600E, KRAS G12C, RET, NTRK)"
+    - "Any PD-L1 TPS (including TPS <1%)"
+    - "No prior systemic therapy for metastatic disease"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded:
+    - biomarker_id: BIO-EGFR-MUTATION
+      required: false
+    - biomarker_id: BIO-ALK-FUSION
+      required: false
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-NIVO-IPI-CHEMO-NSCLC-1L
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_survival_median:
+    value: "15.8 mo (nivo+ipi+chemo) vs 11.0 mo (chemo alone); HR 0.72 (96.7% CI 0.61–0.86); 3-year OS 25% vs 14%"
+    source: SRC-CHECKMATE-9LA-PAZ-ARES-2021
+  progression_free_survival:
+    value: "HR 0.67 (95% CI 0.56–0.79)"
+    source: SRC-CHECKMATE-9LA-PAZ-ARES-2021
+  overall_response_rate:
+    value: "38% vs 25%"
+    source: SRC-CHECKMATE-9LA-PAZ-ARES-2021
+
+hard_contraindications: []
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-NSCLC-NGS-PANEL
+  - TEST-PDL1-IHC
+  - TEST-CECT-CAP
+desired_tests:
+  - TEST-BRAIN-MRI-CONTRAST
+
+sources:
+  - source_id: SRC-CHECKMATE-9LA-PAZ-ARES-2021
+    weight: primary
+    position: supports
+    relevant_quote_paraphrase: >
+      Paz-Ares 2021 Lancet Oncol: CheckMate-9LA — nivo+ipi+2-cycle chemo improved OS
+      (median 15.8 vs 11.0 mo; HR 0.72) and PFS (HR 0.67) vs chemo alone in driver-negative
+      stage IV NSCLC; benefit consistent across PD-L1 TPS subgroups including TPS <1%.
+  - source_id: SRC-NCCN-NSCLC-2025
+    weight: secondary
+  - source_id: SRC-ESMO-NSCLC-METASTATIC-2024
+    weight: secondary
+
+do_not_do:
+  - "EGFR-мутований або ALK+ НМКЛЛ: таргетна терапія (осимертиніб/ALK-ТКІ) є кращою — не призначати нівосексімаб+іпілімумаб+хімію як першу лінію"
+  - "Активне автоімунне захворювання, що потребує системної імуносупресивної терапії: протипоказано призначення ніволумабу та іпілімумабу"
+  - "Важка інтерстиціальна хвороба легень або пневмоніт в анамнезі: підвищений ризик імунно-опосередкованого пневмоніту"
+  - "ECOG PS ≥3: відсутні дані безпеки та ефективності; платинова хіміотерапія протипоказана"
+
+do_not_do_en:
+  - "EGFR-mutant or ALK+ NSCLC: targeted therapy (osimertinib/ALK-TKI) is superior — do not use nivo+ipi+chemo as first-line"
+  - "Active autoimmune disease requiring systemic immunosuppression: nivolumab and ipilimumab are contraindicated"
+  - "Severe interstitial lung disease or prior pneumonitis: markedly elevated risk of immune-mediated pneumonitis"
+  - "ECOG PS ≥3: no safety/efficacy data; platinum-doublet chemotherapy contraindicated"
+
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: []
+
+notes: >
+  CheckMate-9LA (Paz-Ares 2021, Lancet Oncol; NCT03215706): Phase III RCT, 719 patients,
+  driver-negative stage IV NSCLC, any PD-L1 TPS. Nivo 360 mg q3w + Ipi 1 mg/kg q6w +
+  2 cycles platinum-doublet chemo vs 4 cycles platinum-doublet chemo alone.
+
+  Key clinical differentiation:
+    - vs CheckMate-227 (nivo+ipi alone, any PD-L1): addition of 2 chemo cycles provides
+      faster early disease control and higher early ORR; especially advantageous for
+      symptomatic disease, large burden, or when rapid response is needed.
+    - vs KEYNOTE-189/nivo+chemo: dual-IO backbone (nivo+ipi) with chemotherapy
+      provides durable long-tail OS benefit (3-year OS 25% vs 14%) not seen with PD-1 mono + chemo.
+    - PD-L1 subgroup analysis: OS benefit consistent across TPS <1% (HR 0.62),
+      TPS 1–49% (HR 0.79), TPS ≥50% (HR 0.66) — regimen is PD-L1 agnostic.
+
+  Patient selection: driver-negative stage IV NSCLC is confirmed only after negative
+  comprehensive molecular profiling (NGS panel). PD-L1 testing required to document
+  eligibility but does not stratify treatment in this indication.
+
+  Chemotherapy component: only 2 cycles administered. Histology-specific selection:
+  squamous → carboplatin AUC 6 + paclitaxel; non-squamous → carboplatin AUC 5 + pemetrexed.
+  After 2 cycles, IO doublet (nivo+ipi) continues alone.
+
+  Note: BIO-KRAS-G12C, BIO-MET-EX14, BIO-BRAF-V600E, BIO-RET-FUSION, BIO-NTRK-FUSION
+  exclusion is captured as clinical prose above; only BIO-EGFR-MUTATION and BIO-ALK-FUSION
+  are listed in biomarker_requirements_excluded as those BIO-* IDs are confirmed in KB.
+  Other driver biomarker exclusions documented in stage_requirements prose.

--- a/knowledge_base/hosted/content/regimens/reg_nivo_ipi_chemo_nsclc_1l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_nivo_ipi_chemo_nsclc_1l.yaml
@@ -1,0 +1,74 @@
+id: REG-NIVO-IPI-CHEMO-NSCLC-1L
+name: "Nivolumab + Ipilimumab + 2-Cycle Platinum-Doublet Chemotherapy (CheckMate-9LA)"
+name_ua: "Ніволумаб + Іпілімумаб + 2 цикли платиново-дублетної хіміотерапії (CheckMate-9LA)"
+alternate_names:
+  - "Nivo + Ipi + 2-cycle chemo NSCLC 1L"
+  - "CheckMate-9LA regimen"
+
+components:
+  - drug_id: DRUG-NIVOLUMAB
+    dose: "360 mg IV over 30 min"
+    schedule: "Day 1 of each 21-day cycle; indefinite until progression or unacceptable toxicity"
+    route: IV
+  - drug_id: DRUG-IPILIMUMAB
+    dose: "1 mg/kg IV over 30 min"
+    schedule: "Every 6 weeks (q6w); up to 2 years total"
+    route: IV
+  - drug_id: DRUG-CARBOPLATIN
+    dose: "AUC 6 IV (squamous) or AUC 5 IV (non-squamous)"
+    schedule: "Day 1 of cycles 1–2 only (2 cycles total)"
+    route: IV
+  - drug_id: DRUG-PACLITAXEL
+    dose: "200 mg/m² IV (squamous histology primary chemo partner)"
+    schedule: "Day 1 of cycles 1–2 only"
+    route: IV
+
+cycle_length_days: 21
+total_cycles: "Nivo q3w + Ipi q6w until progression/toxicity (up to 2 years); platinum-doublet chemo 2 cycles only"
+
+toxicity_profile: severe
+
+premedication:
+  - "Premedicate for paclitaxel: dexamethasone 20 mg IV + diphenhydramine 50 mg IV + ranitidine (or famotidine) 30 min before paclitaxel"
+  - "Hepatitis B and C screening before first dose of IO therapy"
+  - "Baseline CBC, CMP, LFTs, TSH, cortisol; ECG and LVEF if cardiac risk factors"
+
+dose_adjustments:
+  - condition: "Grade 3 immune-mediated AE (pneumonitis, hepatitis, colitis, nephritis, endocrinopathy)"
+    modification: "Hold nivolumab and/or ipilimumab; initiate methylprednisolone 1–2 mg/kg/d IV; resume IO when resolved to ≤Grade 1 and corticosteroids tapered to ≤10 mg/d prednisone equivalent"
+    rationale: "Standard immune-mediated toxicity management per ICI package insert and ASCO guidelines"
+  - condition: "Grade 4 immune-mediated AE or recurrent Grade 3 after rechallenging"
+    modification: "Permanently discontinue culprit ICI agent; may continue the other ICI agent alone if risk-benefit favorable"
+    rationale: "Permanent discontinuation reduces cumulative immune-mediated risk for severe events"
+  - condition: "Non-squamous histology (chemotherapy component)"
+    modification: "Substitute pemetrexed 500 mg/m² for paclitaxel; use carboplatin AUC 5; add folic acid 350–1000 mcg PO daily + vitamin B12 1000 mcg IM q9w starting 7 days before first pemetrexed"
+    rationale: "CheckMate-9LA protocol: carboplatin/pemetrexed for non-squamous; carboplatin/paclitaxel for squamous"
+  - condition: "Nab-paclitaxel substitution (squamous, paclitaxel intolerance)"
+    modification: "Substitute nab-paclitaxel 100 mg/m² days 1, 8, 15 for paclitaxel 200 mg/m² day 1"
+    rationale: "Per CheckMate-9LA protocol amendment — nab-paclitaxel acceptable alternative for squamous histology"
+
+sources:
+  - SRC-CHECKMATE-9LA-PAZ-ARES-2021
+
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: []
+
+notes: >
+  CheckMate-9LA (NCT03215706) regimen: nivolumab 360 mg q3w + ipilimumab 1 mg/kg q6w
+  (dual IO backbone, same as CheckMate-227 Part 1) combined with 2 cycles of
+  histology-directed platinum-doublet chemotherapy. Rationale for 2 chemo cycles:
+  rapid early disease control while IO ramps up; minimizes cumulative chemo toxicity.
+
+  Histology-specific chemo component (both used in cycles 1–2 only):
+    - Squamous: carboplatin AUC 6 + paclitaxel 200 mg/m² day 1 (or nab-paclitaxel 100 mg/m² days 1/8/15 per amendment)
+    - Non-squamous: carboplatin AUC 5 + pemetrexed 500 mg/m² (add folate/B12 supplementation)
+
+  After 2 chemo cycles, continue nivolumab 360 mg q3w + ipilimumab 1 mg/kg q6w alone
+  until progression, unacceptable toxicity, or 2 years of ipilimumab cumulative exposure.
+
+  Key distinction from CheckMate-227 (nivo+ipi alone): addition of 2-cycle chemo provides
+  faster initial tumor control, higher early ORR (38% vs ~32%), and broader benefit
+  independent of PD-L1 TPS (TPS <1% subgroup HR 0.62 for OS in CheckMate-9LA).
+
+  DRUG-IPILIMUMAB confirmed present in KB (knowledge_base/hosted/content/drugs/ipilimumab.yaml, id: DRUG-IPILIMUMAB).


### PR DESCRIPTION
## Summary

- NEW regimen `REG-NIVO-IPI-CHEMO-NSCLC-1L` (nivo 360 q3w + ipi 1 mg/kg q6w + 2-cycle platinum-doublet)
- NEW indication `IND-NSCLC-DRIVER-NEG-MET-1L-NIVO-IPI-CHEMO` (driver-neg stage IV, any PD-L1)
- Source: `SRC-CHECKMATE-9LA-PAZ-ARES-2021` (PMID 33476593, Lancet Oncol 2021)
- DRUG-IPILIMUMAB confirmed in KB; all 5 drug references verified

## Quality gates

| Gate | Baseline | Final | Delta |
|---|---|---|---|
| audit_validator schema_errors | 0 | 0 | 0 |
| audit_validator ref_errors | 0 | 0 | 0 |
| pytest failures | 1 (pre-existing) | 1 | 0 |
| loaded_entities | 3007 | 3009 | +2 |

## Notes

- Histology-specific chemo variants in `notes:` (schema has no conditional-branch component)
- `hard_contraindications: []`; clinical CIs in `do_not_do:`
- All 3 source references resolved: CM-9LA + NCCN-NSCLC-2025 + ESMO-NSCLC-METASTATIC-2024

Closes #504