### PR TITLE
Prioritize try plan controls

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -905,6 +905,15 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
 }
 .quest-readiness-critical[data-kind="ok"] { color: var(--green-700); font-weight: 600; }
 .quest-readiness-critical[data-kind="warn"] { color: var(--amber); font-weight: 600; }
+.quest-actions-top.quest-cta {
+  display: grid; grid-template-columns: minmax(220px, 1.4fr) minmax(150px, 1fr) minmax(150px, 1fr);
+  gap: 10px; margin: -4px 0 18px; padding: 12px;
+  background: white; border: 1px solid var(--green-200); border-radius: 8px;
+  box-shadow: 0 3px 12px rgba(22, 101, 52, 0.08);
+}
+.quest-actions-top.quest-cta .btn {
+  min-height: 44px; width: 100%;
+}
 .quest-grid {
   display: grid; grid-template-columns: 1fr 380px; gap: 18px;
   margin-bottom: 24px; align-items: start;
@@ -1148,6 +1157,11 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
 .quest-cta button { width: 100%; }
 .quest-cta button:disabled {
   opacity: 0.5; cursor: not-allowed;
+}
+@media (max-width: 760px) {
+  .quest-actions-top.quest-cta {
+    grid-template-columns: 1fr; padding: 10px;
+  }
 }
 
 /* Plan result modal — replaces the old in-page .quest-output section so

--- a/docs/try.html
+++ b/docs/try.html
@@ -86,6 +86,19 @@
     </div>
   </div>
 
+  <div class="try-actions quest-cta quest-actions-top" aria-label="Plan actions">
+    <button id="runBtn" class="btn btn-primary" type="button" disabled>
+      Generate full Plan
+    </button>
+    <button id="viewPlanBtn" class="btn btn-primary" type="button" disabled>
+      Show plan
+    </button>
+    <button id="pdfBtn" class="btn btn-primary" type="button" disabled
+            title="Save as PDF via your browser print dialog">
+      Download PDF
+    </button>
+  </div>
+
   <!-- Early-paint warmup: a tiny synchronous script that runs before the
        module-script below. Populates dropdowns from a localStorage cache
        (written on the previous successful boot) so repeat visitors see
@@ -182,19 +195,6 @@
           </div>
           <div class="offline-cache-text" id="offlineCacheText">Offline cache not started</div>
         </div>
-      </div>
-
-      <div class="try-actions quest-cta">
-        <button id="runBtn" class="btn btn-primary" disabled>
-          Generate full Plan
-        </button>
-        <button id="viewPlanBtn" class="btn btn-primary" type="button" disabled>
-          Show plan
-        </button>
-        <button id="pdfBtn" class="btn btn-primary" type="button" disabled
-                title="Save as PDF via your browser print dialog">
-          Download PDF
-        </button>
       </div>
 
       <div id="status" class="status is-busy">Loading questionnaires…</div>
@@ -311,6 +311,7 @@ const jsonPane = document.getElementById('jsonPane');
 const questGroups = document.getElementById('questGroups');
 const questIntro = document.getElementById('questIntro');
 const questEmpty = document.getElementById('questEmpty');
+const personalizeBtn = document.getElementById('personalizeBtn');
 const modeFormBtn = document.getElementById('modeFormBtn');
 const modeJsonBtn = document.getElementById('modeJsonBtn');
 
@@ -390,6 +391,7 @@ const UI_LOCK_TEXT = {
   planHint: 'Loading the plan view…',
   qrHint: 'Loading profile from QR…',
   renderHint: 'Rendering the plan view…',
+  actionLocked: 'Action locked while the current process finishes.',
 };
 
 // Initial render language follows the page lang (EN on /try.html, UA on
@@ -539,18 +541,33 @@ function highlightModeButtons() {
   modePatientBtn.classList.toggle('is-active', currentResultMode === 'patient');
 }
 
+function isInteractionLocked() {
+  return uiBusy || generating;
+}
+
+function setLockedTitle(el, locked) {
+  if (!el) return;
+  if (typeof el.dataset.baseTitle === 'undefined') {
+    el.dataset.baseTitle = el.getAttribute('title') || '';
+  }
+  if (locked) el.setAttribute('title', UI_LOCK_TEXT.actionLocked);
+  else if (el.dataset.baseTitle) el.setAttribute('title', el.dataset.baseTitle);
+  else el.removeAttribute('title');
+}
+
 // Patient mode is render-only on top of an already-generated treatment
 // PlanResult. It can't toggle for:
 //   * diagnostic-mode bundles (no `_render_patient_mode` for DiagnosticPlan)
 //   * example-mode (pre-built /cases/*.html — no Pyodide engine running)
 //   * pre-generation (planSource === null)
 function refreshModeButtonAvailability() {
+  const locked = isInteractionLocked();
   const canPatient = (
     pyodide
     && planSource === 'generated'
     && !planDirty
   );
-  modePatientBtn.disabled = !canPatient;
+  modePatientBtn.disabled = locked || !canPatient;
   if (!canPatient) {
     modePatientBtn.title = (
       planSource === 'example'
@@ -564,16 +581,22 @@ function refreshModeButtonAvailability() {
   } else {
     modePatientBtn.title = 'Plain-Ukrainian simplified report — for patients';
   }
-  modeClinicianBtn.disabled = (planSource === null);
+  modeClinicianBtn.disabled = locked || (planSource === null);
+  if (locked) {
+    modePatientBtn.title = UI_LOCK_TEXT.actionLocked;
+    modeClinicianBtn.title = UI_LOCK_TEXT.actionLocked;
+  }
 }
 
-function openPlanModal() {
+function openPlanModal(options = {}) {
   if (!planModal) return;
+  if (!options.force && (isInteractionLocked() || planSource === null)) return;
   planModal.hidden = false;
   highlightLangButtons();
 }
-function closePlanModal() {
+function closePlanModal(options = {}) {
   if (!planModal) return;
+  if (!options.force && isInteractionLocked()) return;
   planModal.hidden = true;
 }
 
@@ -586,7 +609,7 @@ function downloadPdf() {
   // Modal must be visible so iframe contentWindow is fully laid out and
   // print() picks up the right document.
   const wasHidden = planModal && planModal.hidden;
-  if (wasHidden) openPlanModal();
+  if (wasHidden) openPlanModal({ force: true });
   try {
     resultFrame.contentWindow.focus();
     resultFrame.contentWindow.print();
@@ -735,11 +758,8 @@ async function loadExamplePlan(caseId) {
   currentResultMode = 'clinician';
   highlightModeButtons();
   refreshModeButtonAvailability();
-  viewPlanBtn.disabled = false;
-  pdfBtn.disabled = false;
-  modalPdfBtn.disabled = false;
-  modalHtmlBtn.disabled = false;
-  openPlanModal();
+  updateWorkflowControls();
+  openPlanModal({ force: true });
   await frameReady;
 }
 
@@ -756,7 +776,7 @@ function clearPlanState() {
   currentResultMode = 'clinician';
   highlightModeButtons();
   refreshModeButtonAvailability();
-  closePlanModal();
+  closePlanModal({ force: true });
 }
 
 pdfBtn.addEventListener('click', downloadPdf);
@@ -812,6 +832,32 @@ const IMPACT_LABEL = {
   optional: 'Optional',
 };
 
+// Central action gating. The high-priority controls sit above the form, so
+// they must also reflect process locks visually instead of relying only on
+// the modal overlay/inert attribute.
+function updateWorkflowControls() {
+  const locked = isInteractionLocked();
+  let hasInput = false;
+  if (mode === 'form') hasInput = !!activeQuest;
+  else hasInput = textarea.value.trim().length > 0;
+  const planFresh = planSource !== null && !planDirty;
+  const hasPlan = planSource !== null;
+
+  runBtn.disabled = locked || !hasInput || planFresh;
+  viewPlanBtn.disabled = locked || !hasPlan;
+  pdfBtn.disabled = locked || !hasPlan;
+  modalPdfBtn.disabled = locked || !hasPlan;
+  modalHtmlBtn.disabled = locked || !hasPlan;
+
+  if (resetBtn) resetBtn.disabled = locked;
+  if (formatBtn) formatBtn.disabled = locked || mode !== 'json';
+  [diseaseSelect, exampleSelect, modeFormBtn, modeJsonBtn, personalizeBtn].forEach(el => {
+    if (el) el.disabled = locked;
+  });
+  [runBtn, viewPlanBtn, pdfBtn, resetBtn, formatBtn, diseaseSelect, exampleSelect, modeFormBtn, modeJsonBtn, personalizeBtn].forEach(el => setLockedTitle(el, locked));
+  refreshModeButtonAvailability();
+}
+
 // Decoupled from engine readiness — button is clickable as soon as
 // there is something to send. The engine itself loads lazily on click
 // (and also kicks off in the background after first interaction so the
@@ -822,11 +868,7 @@ const IMPACT_LABEL = {
 // (which auto-displays the pre-built case HTML). Re-enables the moment
 // the user edits any field (planDirty), so they can recompute.
 function updateRunBtnEnabled() {
-  let hasInput = false;
-  if (mode === 'form') hasInput = !!activeQuest;
-  else hasInput = textarea.value.trim().length > 0;
-  const planFresh = planSource !== null && !planDirty;
-  runBtn.disabled = uiBusy || generating || !hasInput || planFresh;
+  updateWorkflowControls();
 }
 
 // Mark the currently-shown plan as out-of-sync with the current input.
@@ -1661,7 +1703,7 @@ _summary
 
 // ── Generate full plan ────────────────────────────────────────────────────
 async function runEngine() {
-  if (generating) return;  // double-click / re-entry guard
+  if (uiBusy || generating || runBtn.disabled) return;  // double-click / re-entry guard
   const _ooT0 = performance.now();
   setError(null);
   const profile = buildProfile();
@@ -1674,6 +1716,7 @@ async function runEngine() {
   // plan from a moving profile. <main inert> hard-blocks pointer + keyboard
   // focus; init overlay (sibling of <main>) explains what's happening.
   generating = true;
+  updateWorkflowControls();
   if (mainTryEl) mainTryEl.inert = true;
   if (evalDebounceTimer) { clearTimeout(evalDebounceTimer); evalDebounceTimer = null; }
   if (whatIfDebounceTimer) { clearTimeout(whatIfDebounceTimer); whatIfDebounceTimer = null; }
@@ -1758,11 +1801,8 @@ html
       currentResultMode = 'clinician';
       highlightModeButtons();
       refreshModeButtonAvailability();
-      viewPlanBtn.disabled = false;
-      pdfBtn.disabled = false;
-      modalPdfBtn.disabled = false;
-      modalHtmlBtn.disabled = false;
-      openPlanModal();
+      updateWorkflowControls();
+      openPlanModal({ force: true });
       setStatus('Plan ready ✓', 'ok');
       const _ooTNow = performance.now();
       console.log(`[OO] generate ${(_ooTNow - _ooT0).toFixed(0)}ms total (engine-load ${(_ooTPython - _ooT0).toFixed(0)}ms + python ${(_ooTNow - _ooTPython).toFixed(0)}ms)`);
@@ -2142,15 +2182,16 @@ exampleSelect.addEventListener('change', async () => {
   });
 });
 
-const personalizeBtn = document.getElementById('personalizeBtn');
 personalizeBtn && personalizeBtn.addEventListener('click', () => {
+  if (isInteractionLocked()) return;
   unlockAllFields();
   setStatus('Fields unlocked — edit anything. Click «Generate» when you are ready.', 'ok');
 });
 
-modeFormBtn.addEventListener('click', () => setMode('form'));
-modeJsonBtn.addEventListener('click', () => setMode('json'));
+modeFormBtn.addEventListener('click', () => { if (!isInteractionLocked()) setMode('form'); });
+modeJsonBtn.addEventListener('click', () => { if (!isInteractionLocked()) setMode('json'); });
 formatBtn && formatBtn.addEventListener('click', () => {
+  if (isInteractionLocked()) return;
   setError(null);
   try { textarea.value = JSON.stringify(JSON.parse(textarea.value), null, 2); }
   catch (e) { setError('Invalid JSON: ' + e.message); }
@@ -2163,6 +2204,7 @@ textarea.addEventListener('input', () => {
 });
 
 resetBtn.addEventListener('click', () => {
+  if (isInteractionLocked()) return;
   if (!confirm('Clear the form and drop the draft?')) return;
   answers = {};
   textarea.value = '';

--- a/docs/ukr/try.html
+++ b/docs/ukr/try.html
@@ -86,6 +86,19 @@
     </div>
   </div>
 
+  <div class="try-actions quest-cta quest-actions-top" aria-label="Дії з планом">
+    <button id="runBtn" class="btn btn-primary" type="button" disabled>
+      Згенерувати повний Plan
+    </button>
+    <button id="viewPlanBtn" class="btn btn-primary" type="button" disabled>
+      Показати план
+    </button>
+    <button id="pdfBtn" class="btn btn-primary" type="button" disabled
+            title="Зберегти як PDF через діалог друку браузера">
+      Скачати PDF
+    </button>
+  </div>
+
   <!-- Early-paint warmup: a tiny synchronous script that runs before the
        module-script below. Populates dropdowns from a localStorage cache
        (written on the previous successful boot) so repeat visitors see
@@ -182,19 +195,6 @@
           </div>
           <div class="offline-cache-text" id="offlineCacheText">Офлайн-кеш ще не запущено</div>
         </div>
-      </div>
-
-      <div class="try-actions quest-cta">
-        <button id="runBtn" class="btn btn-primary" disabled>
-          Згенерувати повний Plan
-        </button>
-        <button id="viewPlanBtn" class="btn btn-primary" type="button" disabled>
-          Показати план
-        </button>
-        <button id="pdfBtn" class="btn btn-primary" type="button" disabled
-                title="Зберегти як PDF через діалог друку браузера">
-          Скачати PDF
-        </button>
       </div>
 
       <div id="status" class="status is-busy">Завантажую опитувальники…</div>
@@ -311,6 +311,7 @@ const jsonPane = document.getElementById('jsonPane');
 const questGroups = document.getElementById('questGroups');
 const questIntro = document.getElementById('questIntro');
 const questEmpty = document.getElementById('questEmpty');
+const personalizeBtn = document.getElementById('personalizeBtn');
 const modeFormBtn = document.getElementById('modeFormBtn');
 const modeJsonBtn = document.getElementById('modeJsonBtn');
 
@@ -390,6 +391,7 @@ const UI_LOCK_TEXT = {
   planHint: 'Завантажую перегляд плану…',
   qrHint: 'Завантажую профіль із QR…',
   renderHint: 'Перемальовую перегляд плану…',
+  actionLocked: 'Дію заблоковано, доки поточний процес не завершиться.',
 };
 
 // Initial render language follows the page lang (EN on /try.html, UA on
@@ -539,18 +541,33 @@ function highlightModeButtons() {
   modePatientBtn.classList.toggle('is-active', currentResultMode === 'patient');
 }
 
+function isInteractionLocked() {
+  return uiBusy || generating;
+}
+
+function setLockedTitle(el, locked) {
+  if (!el) return;
+  if (typeof el.dataset.baseTitle === 'undefined') {
+    el.dataset.baseTitle = el.getAttribute('title') || '';
+  }
+  if (locked) el.setAttribute('title', UI_LOCK_TEXT.actionLocked);
+  else if (el.dataset.baseTitle) el.setAttribute('title', el.dataset.baseTitle);
+  else el.removeAttribute('title');
+}
+
 // Patient mode is render-only on top of an already-generated treatment
 // PlanResult. It can't toggle for:
 //   * diagnostic-mode bundles (no `_render_patient_mode` for DiagnosticPlan)
 //   * example-mode (pre-built /cases/*.html — no Pyodide engine running)
 //   * pre-generation (planSource === null)
 function refreshModeButtonAvailability() {
+  const locked = isInteractionLocked();
   const canPatient = (
     pyodide
     && planSource === 'generated'
     && !planDirty
   );
-  modePatientBtn.disabled = !canPatient;
+  modePatientBtn.disabled = locked || !canPatient;
   if (!canPatient) {
     modePatientBtn.title = (
       planSource === 'example'
@@ -564,16 +581,22 @@ function refreshModeButtonAvailability() {
   } else {
     modePatientBtn.title = 'Спрощений звіт зрозумілою мовою — для пацієнта';
   }
-  modeClinicianBtn.disabled = (planSource === null);
+  modeClinicianBtn.disabled = locked || (planSource === null);
+  if (locked) {
+    modePatientBtn.title = UI_LOCK_TEXT.actionLocked;
+    modeClinicianBtn.title = UI_LOCK_TEXT.actionLocked;
+  }
 }
 
-function openPlanModal() {
+function openPlanModal(options = {}) {
   if (!planModal) return;
+  if (!options.force && (isInteractionLocked() || planSource === null)) return;
   planModal.hidden = false;
   highlightLangButtons();
 }
-function closePlanModal() {
+function closePlanModal(options = {}) {
   if (!planModal) return;
+  if (!options.force && isInteractionLocked()) return;
   planModal.hidden = true;
 }
 
@@ -586,7 +609,7 @@ function downloadPdf() {
   // Modal must be visible so iframe contentWindow is fully laid out and
   // print() picks up the right document.
   const wasHidden = planModal && planModal.hidden;
-  if (wasHidden) openPlanModal();
+  if (wasHidden) openPlanModal({ force: true });
   try {
     resultFrame.contentWindow.focus();
     resultFrame.contentWindow.print();
@@ -735,11 +758,8 @@ async function loadExamplePlan(caseId) {
   currentResultMode = 'clinician';
   highlightModeButtons();
   refreshModeButtonAvailability();
-  viewPlanBtn.disabled = false;
-  pdfBtn.disabled = false;
-  modalPdfBtn.disabled = false;
-  modalHtmlBtn.disabled = false;
-  openPlanModal();
+  updateWorkflowControls();
+  openPlanModal({ force: true });
   await frameReady;
 }
 
@@ -756,7 +776,7 @@ function clearPlanState() {
   currentResultMode = 'clinician';
   highlightModeButtons();
   refreshModeButtonAvailability();
-  closePlanModal();
+  closePlanModal({ force: true });
 }
 
 pdfBtn.addEventListener('click', downloadPdf);
@@ -812,6 +832,32 @@ const IMPACT_LABEL = {
   optional: 'Optional',
 };
 
+// Central action gating. The high-priority controls sit above the form, so
+// they must also reflect process locks visually instead of relying only on
+// the modal overlay/inert attribute.
+function updateWorkflowControls() {
+  const locked = isInteractionLocked();
+  let hasInput = false;
+  if (mode === 'form') hasInput = !!activeQuest;
+  else hasInput = textarea.value.trim().length > 0;
+  const planFresh = planSource !== null && !planDirty;
+  const hasPlan = planSource !== null;
+
+  runBtn.disabled = locked || !hasInput || planFresh;
+  viewPlanBtn.disabled = locked || !hasPlan;
+  pdfBtn.disabled = locked || !hasPlan;
+  modalPdfBtn.disabled = locked || !hasPlan;
+  modalHtmlBtn.disabled = locked || !hasPlan;
+
+  if (resetBtn) resetBtn.disabled = locked;
+  if (formatBtn) formatBtn.disabled = locked || mode !== 'json';
+  [diseaseSelect, exampleSelect, modeFormBtn, modeJsonBtn, personalizeBtn].forEach(el => {
+    if (el) el.disabled = locked;
+  });
+  [runBtn, viewPlanBtn, pdfBtn, resetBtn, formatBtn, diseaseSelect, exampleSelect, modeFormBtn, modeJsonBtn, personalizeBtn].forEach(el => setLockedTitle(el, locked));
+  refreshModeButtonAvailability();
+}
+
 // Decoupled from engine readiness — button is clickable as soon as
 // there is something to send. The engine itself loads lazily on click
 // (and also kicks off in the background after first interaction so the
@@ -822,11 +868,7 @@ const IMPACT_LABEL = {
 // (which auto-displays the pre-built case HTML). Re-enables the moment
 // the user edits any field (planDirty), so they can recompute.
 function updateRunBtnEnabled() {
-  let hasInput = false;
-  if (mode === 'form') hasInput = !!activeQuest;
-  else hasInput = textarea.value.trim().length > 0;
-  const planFresh = planSource !== null && !planDirty;
-  runBtn.disabled = uiBusy || generating || !hasInput || planFresh;
+  updateWorkflowControls();
 }
 
 // Mark the currently-shown plan as out-of-sync with the current input.
@@ -1661,7 +1703,7 @@ _summary
 
 // ── Generate full plan ────────────────────────────────────────────────────
 async function runEngine() {
-  if (generating) return;  // double-click / re-entry guard
+  if (uiBusy || generating || runBtn.disabled) return;  // double-click / re-entry guard
   const _ooT0 = performance.now();
   setError(null);
   const profile = buildProfile();
@@ -1674,6 +1716,7 @@ async function runEngine() {
   // plan from a moving profile. <main inert> hard-blocks pointer + keyboard
   // focus; init overlay (sibling of <main>) explains what's happening.
   generating = true;
+  updateWorkflowControls();
   if (mainTryEl) mainTryEl.inert = true;
   if (evalDebounceTimer) { clearTimeout(evalDebounceTimer); evalDebounceTimer = null; }
   if (whatIfDebounceTimer) { clearTimeout(whatIfDebounceTimer); whatIfDebounceTimer = null; }
@@ -1758,11 +1801,8 @@ html
       currentResultMode = 'clinician';
       highlightModeButtons();
       refreshModeButtonAvailability();
-      viewPlanBtn.disabled = false;
-      pdfBtn.disabled = false;
-      modalPdfBtn.disabled = false;
-      modalHtmlBtn.disabled = false;
-      openPlanModal();
+      updateWorkflowControls();
+      openPlanModal({ force: true });
       setStatus('Plan готовий ✓', 'ok');
       const _ooTNow = performance.now();
       console.log(`[OO] generate ${(_ooTNow - _ooT0).toFixed(0)}ms total (engine-load ${(_ooTPython - _ooT0).toFixed(0)}ms + python ${(_ooTNow - _ooTPython).toFixed(0)}ms)`);
@@ -2142,15 +2182,16 @@ exampleSelect.addEventListener('change', async () => {
   });
 });
 
-const personalizeBtn = document.getElementById('personalizeBtn');
 personalizeBtn && personalizeBtn.addEventListener('click', () => {
+  if (isInteractionLocked()) return;
   unlockAllFields();
   setStatus('Поля розблоковано — редагуй що завгодно. Натисни «Згенерувати» коли готовий.', 'ok');
 });
 
-modeFormBtn.addEventListener('click', () => setMode('form'));
-modeJsonBtn.addEventListener('click', () => setMode('json'));
+modeFormBtn.addEventListener('click', () => { if (!isInteractionLocked()) setMode('form'); });
+modeJsonBtn.addEventListener('click', () => { if (!isInteractionLocked()) setMode('json'); });
 formatBtn && formatBtn.addEventListener('click', () => {
+  if (isInteractionLocked()) return;
   setError(null);
   try { textarea.value = JSON.stringify(JSON.parse(textarea.value), null, 2); }
   catch (e) { setError('Невалідний JSON: ' + e.message); }
@@ -2163,6 +2204,7 @@ textarea.addEventListener('input', () => {
 });
 
 resetBtn.addEventListener('click', () => {
+  if (isInteractionLocked()) return;
   if (!confirm('Очистити форму і прибрати чернетку?')) return;
   answers = {};
   textarea.value = '';

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -2167,6 +2167,19 @@ def render_try(
     </div>
   </div>
 
+  <div class="try-actions quest-cta quest-actions-top" aria-label="{'Plan actions' if target_lang == 'en' else 'Дії з планом'}">
+    <button id="runBtn" class="btn btn-primary" type="button" disabled>
+      {'Generate full Plan' if target_lang == 'en' else 'Згенерувати повний Plan'}
+    </button>
+    <button id="viewPlanBtn" class="btn btn-primary" type="button" disabled>
+      {'Show plan' if target_lang == 'en' else 'Показати план'}
+    </button>
+    <button id="pdfBtn" class="btn btn-primary" type="button" disabled
+            title="{'Save as PDF via your browser print dialog' if target_lang == 'en' else 'Зберегти як PDF через діалог друку браузера'}">
+      {'Download PDF' if target_lang == 'en' else 'Скачати PDF'}
+    </button>
+  </div>
+
   <!-- Early-paint warmup: a tiny synchronous script that runs before the
        module-script below. Populates dropdowns from a localStorage cache
        (written on the previous successful boot) so repeat visitors see
@@ -2263,19 +2276,6 @@ def render_try(
           </div>
           <div class="offline-cache-text" id="offlineCacheText">{'Offline cache not started' if target_lang == 'en' else 'Офлайн-кеш ще не запущено'}</div>
         </div>
-      </div>
-
-      <div class="try-actions quest-cta">
-        <button id="runBtn" class="btn btn-primary" disabled>
-          {'Generate full Plan' if target_lang == 'en' else 'Згенерувати повний Plan'}
-        </button>
-        <button id="viewPlanBtn" class="btn btn-primary" type="button" disabled>
-          {'Show plan' if target_lang == 'en' else 'Показати план'}
-        </button>
-        <button id="pdfBtn" class="btn btn-primary" type="button" disabled
-                title="{'Save as PDF via your browser print dialog' if target_lang == 'en' else 'Зберегти як PDF через діалог друку браузера'}">
-          {'Download PDF' if target_lang == 'en' else 'Скачати PDF'}
-        </button>
       </div>
 
       <div id="status" class="status is-busy">{'Loading questionnaires…' if target_lang == 'en' else 'Завантажую опитувальники…'}</div>
@@ -2392,6 +2392,7 @@ const jsonPane = document.getElementById('jsonPane');
 const questGroups = document.getElementById('questGroups');
 const questIntro = document.getElementById('questIntro');
 const questEmpty = document.getElementById('questEmpty');
+const personalizeBtn = document.getElementById('personalizeBtn');
 const modeFormBtn = document.getElementById('modeFormBtn');
 const modeJsonBtn = document.getElementById('modeJsonBtn');
 
@@ -2471,6 +2472,7 @@ const UI_LOCK_TEXT = {{
   planHint: '{"Loading the plan view…" if target_lang == "en" else "Завантажую перегляд плану…"}',
   qrHint: '{"Loading profile from QR…" if target_lang == "en" else "Завантажую профіль із QR…"}',
   renderHint: '{"Rendering the plan view…" if target_lang == "en" else "Перемальовую перегляд плану…"}',
+  actionLocked: '{"Action locked while the current process finishes." if target_lang == "en" else "Дію заблоковано, доки поточний процес не завершиться."}',
 }};
 
 // Initial render language follows the page lang (EN on /try.html, UA on
@@ -2620,18 +2622,33 @@ function highlightModeButtons() {{
   modePatientBtn.classList.toggle('is-active', currentResultMode === 'patient');
 }}
 
+function isInteractionLocked() {{
+  return uiBusy || generating;
+}}
+
+function setLockedTitle(el, locked) {{
+  if (!el) return;
+  if (typeof el.dataset.baseTitle === 'undefined') {{
+    el.dataset.baseTitle = el.getAttribute('title') || '';
+  }}
+  if (locked) el.setAttribute('title', UI_LOCK_TEXT.actionLocked);
+  else if (el.dataset.baseTitle) el.setAttribute('title', el.dataset.baseTitle);
+  else el.removeAttribute('title');
+}}
+
 // Patient mode is render-only on top of an already-generated treatment
 // PlanResult. It can't toggle for:
 //   * diagnostic-mode bundles (no `_render_patient_mode` for DiagnosticPlan)
 //   * example-mode (pre-built /cases/*.html — no Pyodide engine running)
 //   * pre-generation (planSource === null)
 function refreshModeButtonAvailability() {{
+  const locked = isInteractionLocked();
   const canPatient = (
     pyodide
     && planSource === 'generated'
     && !planDirty
   );
-  modePatientBtn.disabled = !canPatient;
+  modePatientBtn.disabled = locked || !canPatient;
   if (!canPatient) {{
     modePatientBtn.title = (
       planSource === 'example'
@@ -2645,16 +2662,22 @@ function refreshModeButtonAvailability() {{
   }} else {{
     modePatientBtn.title = '{ "Plain-Ukrainian simplified report — for patients" if target_lang == "en" else "Спрощений звіт зрозумілою мовою — для пацієнта" }';
   }}
-  modeClinicianBtn.disabled = (planSource === null);
+  modeClinicianBtn.disabled = locked || (planSource === null);
+  if (locked) {{
+    modePatientBtn.title = UI_LOCK_TEXT.actionLocked;
+    modeClinicianBtn.title = UI_LOCK_TEXT.actionLocked;
+  }}
 }}
 
-function openPlanModal() {{
+function openPlanModal(options = {{}}) {{
   if (!planModal) return;
+  if (!options.force && (isInteractionLocked() || planSource === null)) return;
   planModal.hidden = false;
   highlightLangButtons();
 }}
-function closePlanModal() {{
+function closePlanModal(options = {{}}) {{
   if (!planModal) return;
+  if (!options.force && isInteractionLocked()) return;
   planModal.hidden = true;
 }}
 
@@ -2667,7 +2690,7 @@ function downloadPdf() {{
   // Modal must be visible so iframe contentWindow is fully laid out and
   // print() picks up the right document.
   const wasHidden = planModal && planModal.hidden;
-  if (wasHidden) openPlanModal();
+  if (wasHidden) openPlanModal({{ force: true }});
   try {{
     resultFrame.contentWindow.focus();
     resultFrame.contentWindow.print();
@@ -2816,11 +2839,8 @@ async function loadExamplePlan(caseId) {{
   currentResultMode = 'clinician';
   highlightModeButtons();
   refreshModeButtonAvailability();
-  viewPlanBtn.disabled = false;
-  pdfBtn.disabled = false;
-  modalPdfBtn.disabled = false;
-  modalHtmlBtn.disabled = false;
-  openPlanModal();
+  updateWorkflowControls();
+  openPlanModal({{ force: true }});
   await frameReady;
 }}
 
@@ -2837,7 +2857,7 @@ function clearPlanState() {{
   currentResultMode = 'clinician';
   highlightModeButtons();
   refreshModeButtonAvailability();
-  closePlanModal();
+  closePlanModal({{ force: true }});
 }}
 
 pdfBtn.addEventListener('click', downloadPdf);
@@ -2893,6 +2913,32 @@ const IMPACT_LABEL = {{
   optional: 'Optional',
 }};
 
+// Central action gating. The high-priority controls sit above the form, so
+// they must also reflect process locks visually instead of relying only on
+// the modal overlay/inert attribute.
+function updateWorkflowControls() {{
+  const locked = isInteractionLocked();
+  let hasInput = false;
+  if (mode === 'form') hasInput = !!activeQuest;
+  else hasInput = textarea.value.trim().length > 0;
+  const planFresh = planSource !== null && !planDirty;
+  const hasPlan = planSource !== null;
+
+  runBtn.disabled = locked || !hasInput || planFresh;
+  viewPlanBtn.disabled = locked || !hasPlan;
+  pdfBtn.disabled = locked || !hasPlan;
+  modalPdfBtn.disabled = locked || !hasPlan;
+  modalHtmlBtn.disabled = locked || !hasPlan;
+
+  if (resetBtn) resetBtn.disabled = locked;
+  if (formatBtn) formatBtn.disabled = locked || mode !== 'json';
+  [diseaseSelect, exampleSelect, modeFormBtn, modeJsonBtn, personalizeBtn].forEach(el => {{
+    if (el) el.disabled = locked;
+  }});
+  [runBtn, viewPlanBtn, pdfBtn, resetBtn, formatBtn, diseaseSelect, exampleSelect, modeFormBtn, modeJsonBtn, personalizeBtn].forEach(el => setLockedTitle(el, locked));
+  refreshModeButtonAvailability();
+}}
+
 // Decoupled from engine readiness — button is clickable as soon as
 // there is something to send. The engine itself loads lazily on click
 // (and also kicks off in the background after first interaction so the
@@ -2903,11 +2949,7 @@ const IMPACT_LABEL = {{
 // (which auto-displays the pre-built case HTML). Re-enables the moment
 // the user edits any field (planDirty), so they can recompute.
 function updateRunBtnEnabled() {{
-  let hasInput = false;
-  if (mode === 'form') hasInput = !!activeQuest;
-  else hasInput = textarea.value.trim().length > 0;
-  const planFresh = planSource !== null && !planDirty;
-  runBtn.disabled = uiBusy || generating || !hasInput || planFresh;
+  updateWorkflowControls();
 }}
 
 // Mark the currently-shown plan as out-of-sync with the current input.
@@ -3742,7 +3784,7 @@ _summary
 
 // ── Generate full plan ────────────────────────────────────────────────────
 async function runEngine() {{
-  if (generating) return;  // double-click / re-entry guard
+  if (uiBusy || generating || runBtn.disabled) return;  // double-click / re-entry guard
   const _ooT0 = performance.now();
   setError(null);
   const profile = buildProfile();
@@ -3755,6 +3797,7 @@ async function runEngine() {{
   // plan from a moving profile. <main inert> hard-blocks pointer + keyboard
   // focus; init overlay (sibling of <main>) explains what's happening.
   generating = true;
+  updateWorkflowControls();
   if (mainTryEl) mainTryEl.inert = true;
   if (evalDebounceTimer) {{ clearTimeout(evalDebounceTimer); evalDebounceTimer = null; }}
   if (whatIfDebounceTimer) {{ clearTimeout(whatIfDebounceTimer); whatIfDebounceTimer = null; }}
@@ -3839,11 +3882,8 @@ html
       currentResultMode = 'clinician';
       highlightModeButtons();
       refreshModeButtonAvailability();
-      viewPlanBtn.disabled = false;
-      pdfBtn.disabled = false;
-      modalPdfBtn.disabled = false;
-      modalHtmlBtn.disabled = false;
-      openPlanModal();
+      updateWorkflowControls();
+      openPlanModal({{ force: true }});
       setStatus('{"Plan ready ✓" if target_lang == "en" else "Plan готовий ✓"}', 'ok');
       const _ooTNow = performance.now();
       console.log(`[OO] generate ${{(_ooTNow - _ooT0).toFixed(0)}}ms total (engine-load ${{(_ooTPython - _ooT0).toFixed(0)}}ms + python ${{(_ooTNow - _ooTPython).toFixed(0)}}ms)`);
@@ -4223,15 +4263,16 @@ exampleSelect.addEventListener('change', async () => {{
   }});
 }});
 
-const personalizeBtn = document.getElementById('personalizeBtn');
 personalizeBtn && personalizeBtn.addEventListener('click', () => {{
+  if (isInteractionLocked()) return;
   unlockAllFields();
   setStatus('{"Fields unlocked — edit anything. Click «Generate» when you are ready." if target_lang == "en" else "Поля розблоковано — редагуй що завгодно. Натисни «Згенерувати» коли готовий."}', 'ok');
 }});
 
-modeFormBtn.addEventListener('click', () => setMode('form'));
-modeJsonBtn.addEventListener('click', () => setMode('json'));
+modeFormBtn.addEventListener('click', () => {{ if (!isInteractionLocked()) setMode('form'); }});
+modeJsonBtn.addEventListener('click', () => {{ if (!isInteractionLocked()) setMode('json'); }});
 formatBtn && formatBtn.addEventListener('click', () => {{
+  if (isInteractionLocked()) return;
   setError(null);
   try {{ textarea.value = JSON.stringify(JSON.parse(textarea.value), null, 2); }}
   catch (e) {{ setError('{"Invalid JSON: " if target_lang == "en" else "Невалідний JSON: "}' + e.message); }}
@@ -4244,6 +4285,7 @@ textarea.addEventListener('input', () => {{
 }});
 
 resetBtn.addEventListener('click', () => {{
+  if (isInteractionLocked()) return;
   if (!confirm('{"Clear the form and drop the draft?" if target_lang == "en" else "Очистити форму і прибрати чернетку?"}')) return;
   answers = {{}};
   textarea.value = '';

--- a/scripts/site_styles.py
+++ b/scripts/site_styles.py
@@ -913,6 +913,15 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
 }
 .quest-readiness-critical[data-kind="ok"] { color: var(--green-700); font-weight: 600; }
 .quest-readiness-critical[data-kind="warn"] { color: var(--amber); font-weight: 600; }
+.quest-actions-top.quest-cta {
+  display: grid; grid-template-columns: minmax(220px, 1.4fr) minmax(150px, 1fr) minmax(150px, 1fr);
+  gap: 10px; margin: -4px 0 18px; padding: 12px;
+  background: white; border: 1px solid var(--green-200); border-radius: 8px;
+  box-shadow: 0 3px 12px rgba(22, 101, 52, 0.08);
+}
+.quest-actions-top.quest-cta .btn {
+  min-height: 44px; width: 100%;
+}
 .quest-grid {
   display: grid; grid-template-columns: 1fr 380px; gap: 18px;
   margin-bottom: 24px; align-items: start;
@@ -1156,6 +1165,11 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
 .quest-cta button { width: 100%; }
 .quest-cta button:disabled {
   opacity: 0.5; cursor: not-allowed;
+}
+@media (max-width: 760px) {
+  .quest-actions-top.quest-cta {
+    grid-template-columns: 1fr; padding: 10px;
+  }
 }
 
 /* Plan result modal — replaces the old in-page .quest-output section so

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -228,6 +228,11 @@ def test_try_page_has_pwa_manifest_and_build_status(site_dir: Path):
     assert "fetchJsonWithTimeout" in html
     assert 'id="questReadiness"' in html
     assert 'id="readinessCriticalText"' in html
+    assert 'class="try-actions quest-cta quest-actions-top"' in html
+    assert html.index('id="questReadiness"') < html.index('id="runBtn"') < html.index('class="quest-grid"')
+    assert html.index('id="runBtn"') < html.index('id="buildCard"')
+    assert "function updateWorkflowControls()" in html
+    assert "actionLocked" in html
     assert 'class="quest-impact-card"' not in html
     assert 'rel="manifest" href="/manifest.webmanifest"' in ua_html
 


### PR DESCRIPTION
## Summary
- move Generate / Show plan / PDF controls above the questionnaire grid so they are higher-priority than build/cache metadata
- centralize try-page action gating via updateWorkflowControls()
- block action controls, mode toggles, format/clear, and selectors while generation/loading/render work is in progress

## Validation
- node --check on extracted docs/try.html module script
- pytest tests/test_build_site.py::test_try_page_has_pwa_manifest_and_build_status tests/test_build_site.py::test_try_page_wires_pyodide_and_form -q
- git diff --check
- scripts/audit_validator.py --human