### PR TITLE
Fix try generate status hiding

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -692,6 +692,7 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
   box-shadow: 0 1px 4px rgba(2,132,199,0.10);
   transition: background 200ms ease, color 200ms ease, border-color 200ms ease;
 }
+.status-top[hidden] { display: none; }
 .status-top.is-ok {
   background: var(--green-50); color: var(--green-800); border-color: var(--green-500);
 }

--- a/docs/try.html
+++ b/docs/try.html
@@ -183,7 +183,7 @@
           <span id="pwaInstallState" class="build-state">Browser</span>
         </div>
         <dl class="build-meta">
-          <div><dt>Core</dt><dd id="coreVersion">v1cc86e13bfcd</dd></div>
+          <div><dt>Core</dt><dd id="coreVersion">v44e0759c8f81</dd></div>
           <div><dt>Disease</dt><dd id="diseaseVersion">—</dd></div>
           <div><dt>Cache</dt><dd id="cacheState">Checking…</dd></div>
           <div><dt>Offline</dt><dd id="offlineState">Network required for first launch</dd></div>
@@ -440,6 +440,8 @@ function setStatus(msg, kind = 'info', topMode = 'auto') {
   if (mode === 'hide' || !msg) {
     status.classList.remove('is-busy');
     statusTop.hidden = true;
+    statusTop.classList.remove('is-busy', 'is-ok', 'is-warn', 'has-progress');
+    statusTopText.textContent = '';
     clearLoadingProgress();
     return;
   }
@@ -518,7 +520,7 @@ async function refreshBuildPanel(diseaseId = null) {
     : 'Browser');
 
   if (bundleIndex) {
-    setText(coreVersionEl, 'v' + (bundleIndex.core_version || '1cc86e13bfcd'));
+    setText(coreVersionEl, 'v' + (bundleIndex.core_version || '44e0759c8f81'));
     if (offlineCacheTotal <= 0) {
       const total = offlineBundleUrls().length;
       setOfflineCacheProgress(0, total, 0);

--- a/docs/ukr/try.html
+++ b/docs/ukr/try.html
@@ -183,7 +183,7 @@
           <span id="pwaInstallState" class="build-state">Браузер</span>
         </div>
         <dl class="build-meta">
-          <div><dt>Core</dt><dd id="coreVersion">v1cc86e13bfcd</dd></div>
+          <div><dt>Core</dt><dd id="coreVersion">v44e0759c8f81</dd></div>
           <div><dt>Хвороба</dt><dd id="diseaseVersion">—</dd></div>
           <div><dt>Кеш</dt><dd id="cacheState">Перевіряю…</dd></div>
           <div><dt>Offline</dt><dd id="offlineState">Мережа потрібна для першого запуску</dd></div>
@@ -440,6 +440,8 @@ function setStatus(msg, kind = 'info', topMode = 'auto') {
   if (mode === 'hide' || !msg) {
     status.classList.remove('is-busy');
     statusTop.hidden = true;
+    statusTop.classList.remove('is-busy', 'is-ok', 'is-warn', 'has-progress');
+    statusTopText.textContent = '';
     clearLoadingProgress();
     return;
   }
@@ -518,7 +520,7 @@ async function refreshBuildPanel(diseaseId = null) {
     : 'Браузер');
 
   if (bundleIndex) {
-    setText(coreVersionEl, 'v' + (bundleIndex.core_version || '1cc86e13bfcd'));
+    setText(coreVersionEl, 'v' + (bundleIndex.core_version || '44e0759c8f81'));
     if (offlineCacheTotal <= 0) {
       const total = offlineBundleUrls().length;
       setOfflineCacheProgress(0, total, 0);

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -2521,6 +2521,8 @@ function setStatus(msg, kind = 'info', topMode = 'auto') {{
   if (mode === 'hide' || !msg) {{
     status.classList.remove('is-busy');
     statusTop.hidden = true;
+    statusTop.classList.remove('is-busy', 'is-ok', 'is-warn', 'has-progress');
+    statusTopText.textContent = '';
     clearLoadingProgress();
     return;
   }}

--- a/scripts/site_styles.py
+++ b/scripts/site_styles.py
@@ -700,6 +700,7 @@ main { max-width: 1100px; margin: 0 auto; padding: 0 24px 48px; }
   box-shadow: 0 1px 4px rgba(2,132,199,0.10);
   transition: background 200ms ease, color 200ms ease, border-color 200ms ease;
 }
+.status-top[hidden] { display: none; }
 .status-top.is-ok {
   background: var(--green-50); color: var(--green-800); border-color: var(--green-500);
 }

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -233,6 +233,8 @@ def test_try_page_has_pwa_manifest_and_build_status(site_dir: Path):
     assert html.index('id="runBtn"') < html.index('id="buildCard"')
     assert "function updateWorkflowControls()" in html
     assert "actionLocked" in html
+    assert ".status-top[hidden] { display: none; }" in (site_dir / "style.css").read_text(encoding="utf-8")
+    assert "statusTopText.textContent = ''" in html
     assert 'class="quest-impact-card"' not in html
     assert 'rel="manifest" href="/manifest.webmanifest"' in ua_html
 


### PR DESCRIPTION
## Summary
- make the try page top status banner obey the hidden state even though .status-top sets display:flex
- clear stale top-status classes/text when status is hidden, so Будую персональний план… cannot remain visible after success
- add focused build assertions for the status hiding guard

## Validation
- node --check on extracted docs/try.html module script
- pytest tests/test_build_site.py::test_try_page_has_pwa_manifest_and_build_status tests/test_build_site.py::test_try_page_wires_pyodide_and_form -q
- git diff --check
- scripts/audit_validator.py --human