### PR TITLE
feat(kb): PUL-D wave algorithm extensions — 3 new + 3 edits (#509)

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_mesothelioma_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mesothelioma_2l.yaml
@@ -1,0 +1,40 @@
+id: ALGO-MESOTHELIOMA-2L
+applicable_to_disease: DIS-MESOTHELIOMA
+applicable_to_line_of_therapy: 2
+purpose: >
+  Select 2L systemic therapy for relapsed malignant pleural mesothelioma (MPM)
+  after at least one prior platinum-based chemotherapy line.
+  Routes ECOG-fit patients to nivolumab monotherapy per CONFIRM trial.
+
+output_indications:
+  - IND-MESOTHELIOMA-2L-NIVO
+
+default_indication: IND-MESOTHELIOMA-2L-NIVO
+
+decision_tree:
+  - step: 1
+    evaluate:
+      any_of:
+        - red_flag: RF-FITNESS-ECOG-FIT
+        - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+    if_true:
+      result: IND-MESOTHELIOMA-2L-NIVO
+      notes: >
+        ECOG 0-2 + relapsed MPM after prior platinum: nivolumab 240 mg IV q2w (CONFIRM:
+        OS HR 0.72, 95% CI 0.55-0.94; p=0.02; mOS 9.2 vs 6.6 mo placebo).
+        First phase-3 IO trial with OS benefit in 2L MPM. Any histology, any PD-L1.
+        Up to 24 cycles (approx 12 months) per protocol.
+    if_false:
+      result: null
+      notes: >
+        ECOG ≥3 or frailty: systemic therapy benefit minimal. Best supportive care
+        and symptom management. Palliative referral.
+
+sources:
+  - SRC-CONFIRM-FENNELL-2021
+  - SRC-NCCN-NSCLC-2025
+last_reviewed: "2026-05-09"
+notes: >
+  Single active 2L indication: IND-MESOTHELIOMA-2L-NIVO (CONFIRM phase 3).
+  Additional options (vinorelbine, gemcitabine) are non-IO alternatives; not modelled.
+  Clinical trial enrollment preferred for ECOG 0-2 at relapse per NCCN.

--- a/knowledge_base/hosted/content/algorithms/algo_nsclc_adjuvant.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_nsclc_adjuvant.yaml
@@ -1,0 +1,57 @@
+id: ALGO-NSCLC-ADJUVANT
+applicable_to_disease: DIS-NSCLC
+applicable_to_line_of_therapy: 1
+purpose: >
+  Select adjuvant systemic therapy for completely resected stage IB-IIIA NSCLC
+  after adjuvant platinum-based chemotherapy. Routes EGFR-positive patients to
+  targeted adjuvant discussion (osimertinib; not yet modelled), PD-L1 SP142 ≥1%
+  stage II-IIIA patients to atezolizumab adjuvant (IMpower010). Default observation.
+
+output_indications:
+  - IND-NSCLC-ADJUVANT-ATEZO-PDL1POS
+
+default_indication: IND-NSCLC-ADJUVANT-ATEZO-PDL1POS
+
+decision_tree:
+  - step: 1
+    evaluate:
+      any_of:
+        - red_flag: RF-NSCLC-EGFR-EX19DEL-ACTIONABLE
+    if_true:
+      result: null
+      notes: >
+        EGFR ex19del or L858R: osimertinib 80 mg QD x3 years adjuvant preferred
+        (ADAURA: DFS HR 0.20 for stage II-IIIA; NCCN Cat 1). Not yet modelled in KB.
+        Route to MDT for osimertinib adjuvant discussion.
+    if_false:
+      next_step: 2
+
+  - step: 2
+    evaluate:
+      any_of:
+        - condition: "PD-L1 SP142 IHC ≥1% on resected tumour specimen (IMpower010 SP142 assay; not interchangeable with 22C3 TPS)"
+        - red_flag: RF-NSCLC-PDL1-50-PLUS
+    if_true:
+      result: IND-NSCLC-ADJUVANT-ATEZO-PDL1POS
+      notes: >
+        PD-L1 SP142 ≥1%, completely resected stage IB (≥4 cm) / II / IIIA, post adj chemo:
+        atezolizumab 1200 mg IV q3w x16 cycles (1 year). IMpower010: DFS HR 0.66
+        (95% CI 0.50-0.88) in PD-L1 SP142 ≥1% stage II-IIIA subgroup. SP142 assay
+        is NOT interchangeable with 22C3 TPS — confirm correct assay was used.
+    if_false:
+      result: null
+      notes: >
+        PD-L1 SP142 <1% or assay not performed: no approved adjuvant IO indication.
+        Observation after completion of adjuvant platinum-based chemotherapy.
+
+sources:
+  - SRC-IMPOWER-010-FELIP-2021
+  - SRC-NCCN-NSCLC-2025
+last_reviewed: "2026-05-09"
+notes: >
+  Adjuvant NSCLC routing: EGFR ex19del/L858R → osimertinib adj (not modelled, ADAURA);
+  PD-L1 SP142 ≥1% → IND-NSCLC-ADJUVANT-ATEZO-PDL1POS (IMpower010);
+  all others → observation.
+  ALK fusion adj: alectinib (ALINA) not yet modelled.
+  Note: RF-NSCLC-PDL1-50-PLUS used as proxy — may over-trigger for SP142 ≥1% gate.
+  Verify RF scope if engine produces unexpected results.

--- a/knowledge_base/hosted/content/algorithms/algo_nsclc_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_nsclc_metastatic_1l.yaml
@@ -18,6 +18,7 @@ output_indications:
   - IND-NSCLC-NTRK-FUSION-1L-LAROTRECTINIB
   - IND-NSCLC-PDL1-HIGH-MET-1L
   - IND-NSCLC-PDL1-LOW-NONSQ-MET-1L
+  - IND-NSCLC-DRIVER-NEG-MET-1L-NIVO-IPI-CHEMO
 
 default_indication: IND-NSCLC-PDL1-LOW-NONSQ-MET-1L
 alternative_indication: IND-NSCLC-PDL1-HIGH-MET-1L
@@ -142,7 +143,7 @@ decision_tree:
 
   # Step 9 — Driver-negative: PD-L1 TPS gate.
   # TPS ≥50%: pembrolizumab monotherapy (KEYNOTE-024: OS HR 0.63).
-  # TPS <50%: chemo+ICI (KEYNOTE-189 non-squamous or KEYNOTE-407 squamous).
+  # TPS <50%: chemo+ICI — step 10 gates nivo+ipi+chemo vs pembro+chemo preference.
   - step: 9
     evaluate:
       any_of:
@@ -154,14 +155,31 @@ decision_tree:
         (KEYNOTE-024; OS HR 0.63). Pembro+chemo also acceptable if rapid progression
         or visceral crisis requiring faster tumor reduction.
     if_false:
+      next_step: 10
+
+  # Step 10 — Driver-negative, PD-L1 <50%: nivo+ipi+chemo vs pembro+chemo gate.
+  # CheckMate-9LA (nivo+ipi+2-cycle chemo) and KEYNOTE-189/407 (pembro+chemo)
+  # are both NCCN Cat 1 for all-comers PD-L1 <50%. MDT preference routes between them.
+  - step: 10
+    evaluate:
+      any_of:
+        - condition: "Nivo+ipi+2-cycle chemo (CheckMate-9LA) accessible and preferred per MDT"
+    if_true:
+      result: IND-NSCLC-DRIVER-NEG-MET-1L-NIVO-IPI-CHEMO
+      notes: >
+        Nivo+ipi+chemo accessible: nivolumab 360 mg q3w + ipilimumab 1 mg/kg q6w +
+        2 cycles histology-appropriate platinum-doublet (CheckMate-9LA: OS HR 0.72;
+        mOS 15.8 mo; 3-yr OS 25% vs 14%). Benefit consistent across all PD-L1 subgroups
+        including TPS <1%. Alternative to pembro+chemo when this regimen is preferred.
+    if_false:
       result: IND-NSCLC-PDL1-LOW-NONSQ-MET-1L
       notes: >
-        PD-L1 TPS <50% or unknown: pembrolizumab + platinum + pemetrexed (non-squamous;
-        KEYNOTE-189) or pembrolizumab + carboplatin + paclitaxel/nab-paclitaxel (squamous;
-        KEYNOTE-407). TMB-high (≥10 mut/Mb) may support pembro mono even at low TPS.
+        PD-L1 TPS <50% or unknown + pembro+chemo preferred: pembrolizumab +
+        platinum-doublet (KEYNOTE-189 non-squamous or KEYNOTE-407 squamous).
+        TMB-high (≥10 mut/Mb) may support pembro mono even at low TPS.
 
 sources: [SRC-NCCN-NSCLC-2025, SRC-ESMO-NSCLC-METASTATIC-2024]
-last_reviewed: "2026-05-04"
+last_reviewed: "2026-05-09"
 notes: >
   NSCLC DRIVER CASCADE (1L):
   EGFR (ex19del/L858R/ex20ins) → ALK fusion → ROS1 fusion → MET ex14 →
@@ -183,6 +201,10 @@ notes: >
 
   KRAS G12C: no approved 1L inhibitor — routes to ICI+chemo backbone 1L;
   sotorasib/adagrasib are 2L options.
+
+  Step 10 added 2026-05-09: driver-negative PD-L1 <50% fork between
+  nivo+ipi+chemo (CheckMate-9LA; CM-9LA) and pembro+chemo (KEYNOTE-189/407).
+  Both are NCCN Cat 1; MDT preference gates between them.
 
   Updated 2026-05-04: expanded step 4 cascade to cover all 5 remaining
   driver subtypes with per-driver 1L indications now authored.

--- a/knowledge_base/hosted/content/algorithms/algo_nsclc_resectable_periop.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_nsclc_resectable_periop.yaml
@@ -1,0 +1,55 @@
+id: ALGO-NSCLC-RESECTABLE-PERIOP
+applicable_to_disease: DIS-NSCLC
+applicable_to_line_of_therapy: 1
+purpose: >
+  Select perioperative systemic regimen for resectable stage II–IIIB NSCLC.
+  Routes driver-negative patients (no EGFR/ALK) to perioperative pembrolizumab
+  (KEYNOTE-671: neoadj pembro+chemo x4 → lobectomy → adj pembro x13).
+  EGFR/ALK-positive patients require TKI-based adjuvant (not yet modelled in KB).
+
+output_indications:
+  - IND-NSCLC-PERIOPERATIVE-PEMBRO
+
+default_indication: IND-NSCLC-PERIOPERATIVE-PEMBRO
+
+decision_tree:
+  - step: 1
+    evaluate:
+      any_of:
+        - red_flag: RF-NSCLC-EGFR-EX19DEL-ACTIONABLE
+        - red_flag: RF-NSCLC-ALK-FUSION-ACTIONABLE
+    if_true:
+      result: null
+      notes: >
+        EGFR sensitizing mutation or ALK fusion detected: pembrolizumab-based
+        perioperative therapy is not standard. For EGFR ex19del/L858R: osimertinib
+        80 mg QD x3 years adjuvant (ADAURA: DFS HR 0.20 stage II-IIIA; NCCN Cat 1).
+        Not yet modelled in KB. Refer to MDT for targeted adjuvant discussion.
+    if_false:
+      next_step: 2
+
+  - step: 2
+    evaluate:
+      any_of:
+        - condition: "Resectable stage II, IIIA, or IIIB (T3-4N2M0) NSCLC eligible for anatomic resection"
+    if_true:
+      result: IND-NSCLC-PERIOPERATIVE-PEMBRO
+      notes: >
+        Perioperative pembrolizumab: neoadjuvant pembro 200 mg IV q3w + histology-appropriate
+        platinum-doublet x4 cycles → curative-intent anatomic resection (lobectomy preferred) →
+        adjuvant pembro 200 mg IV q3w x13 cycles. KEYNOTE-671: pEFS HR 0.58 (p<0.001);
+        major pathological response 30.2% vs 11.0%. Chemo: carbo+paclitaxel (squamous);
+        carbo+pemetrexed (non-squamous).
+    if_false:
+      result: null
+      notes: >
+        Stage IA or unresectable NSCLC: not within KN-671 scope. Route to
+        ALGO-NSCLC-METASTATIC-1L for stage IV, or stage III definitive CRT pathway.
+
+sources:
+  - SRC-NCCN-NSCLC-2025
+last_reviewed: "2026-05-09"
+notes: >
+  Perioperative NSCLC routing: driver-negative stage II-IIIB only.
+  Single modelled indication: IND-NSCLC-PERIOPERATIVE-PEMBRO (KN-671).
+  EGFR adj (ADAURA) and atezo adj (IMpower010) handled by ALGO-NSCLC-ADJUVANT.

--- a/knowledge_base/hosted/content/algorithms/algo_sclc_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_sclc_1l.yaml
@@ -2,15 +2,17 @@ id: ALGO-SCLC-1L
 applicable_to_disease: DIS-SCLC
 applicable_to_line_of_therapy: 1
 purpose: >
-  Select 1L SCLC regimen by stage: limited → EP + concurrent RT;
-  extensive → EP + ICI (durvalumab or atezolizumab).
+  Select 1L SCLC regimen by stage: limited → EP + concurrent RT (with durvalumab
+  consolidation post-cCRT if eligible; ADRIATIC); extensive → EP + ICI
+  (durvalumab or atezolizumab).
 
 output_indications:
   - IND-SCLC-EXTENSIVE-1L
   - IND-SCLC-LIMITED-1L
+  - IND-SCLC-LS-CONSOLIDATION-DURVA
 
 default_indication: IND-SCLC-EXTENSIVE-1L
-alternative_indication: IND-SCLC-LIMITED-1L
+alternative_indication: IND-SCLC-LS-CONSOLIDATION-DURVA
 
 decision_tree:
   - step: 1
@@ -18,14 +20,35 @@ decision_tree:
       any_of:
         - condition: "Limited-stage (one hemithorax + tolerable RT field)"
     if_true:
-      result: IND-SCLC-LIMITED-1L
+      next_step: 2
     if_false:
       result: IND-SCLC-EXTENSIVE-1L
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+      notes: "Extensive-stage SCLC: EP + ICI (durvalumab or atezolizumab). Engine routes to default."
 
-sources: [SRC-NCCN-SCLC-2025, SRC-ESMO-SCLC-2021]
-last_reviewed: null
+  - step: 2
+    evaluate:
+      all_of:
+        - condition: "Concurrent platinum-based chemoradiotherapy (cCRT) completed"
+        - condition: "No disease progression on or after cCRT"
+        - condition: "Start within 1-42 days of completing last RT fraction (ADRIATIC window)"
+    if_true:
+      result: IND-SCLC-LS-CONSOLIDATION-DURVA
+      notes: >
+        LS-SCLC post-cCRT without PD: durvalumab 1500 mg IV q4w x24 months
+        (ADRIATIC: OS HR 0.73; mOS 55.9 vs 33.4 mo; NCCN Cat 1 2025).
+        Start within 1-42 days of last RT fraction. ECOG 0-1 at consolidation start.
+    if_false:
+      result: IND-SCLC-LIMITED-1L
+      notes: >
+        Consolidation durvalumab not indicated (PD on cCRT, ECOG ≥2, or durvalumab
+        inaccessible): observation post-cCRT. IND-SCLC-LIMITED-1L represents the
+        cCRT phase (EP + concurrent RT).
+
+sources: [SRC-NCCN-SCLC-2025, SRC-ESMO-SCLC-2021, SRC-ADRIATIC-CHENG-2024]
+last_reviewed: "2026-05-09"
 notes: >
-  Stage-driven binary fork. Frailty (RF-SCLC-FRAILTY-AGE) triggers
-  sequential rather than concurrent CRT for limited; reduced-intensity
-  EP+ICI for extensive.
+  Stage-driven fork with LS post-cCRT consolidation branch (ADRIATIC).
+  Step 1: stage gate → LS routes to step 2 for consolidation eligibility.
+  Step 2: durvalumab consolidation gate (cCRT complete, no PD, ADRIATIC window).
+  Frailty (RF-SCLC-FRAILTY-AGE) triggers sequential rather than concurrent CRT
+  for limited; reduced-intensity EP+ICI for extensive.

--- a/knowledge_base/hosted/content/algorithms/algo_sclc_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_sclc_2l.yaml
@@ -11,6 +11,7 @@ output_indications:
   - IND-SCLC-RR-TOPOTECAN
   - IND-SCLC-RR-LURBINECTEDIN
   - IND-SCLC-PLATINUM-RECHALLENGE
+  - IND-SCLC-RR-TARLATAMAB
 
 default_indication: IND-SCLC-RR-TOPOTECAN
 alternative_indication: IND-SCLC-RR-LURBINECTEDIN
@@ -42,12 +43,32 @@ decision_tree:
       result: null
       notes: "ECOG ≥3: systemic therapy benefit minimal. Best supportive care + corticosteroids for paraneoplastic symptoms. Palliative/hospice referral."
 
-  # Step 3 — Platinum rechallenge gate for CTFI ≥180 days.
+  # Step 3 — DLL3+ tarlatamab gate (NEW — NCCN Cat 1 2025).
+  # DLL3 is expressed in ~80-90% of SCLC. Tarlatamab (DeLLphi-301) is NCCN
+  # Category 1 preferred 2L+ option for DLL3+ patients as of 2025 guidelines.
+  # Route DLL3-negative or assay-unavailable patients to CTFI-based chemo routing.
+  - step: 3
+    evaluate:
+      any_of:
+        - condition: "DLL3 IHC positive (≥1% tumour cells; any DLL3 expression per DeLLphi-301 eligibility)"
+    if_true:
+      result: IND-SCLC-RR-TARLATAMAB
+      notes: >
+        DLL3+ SCLC relapsed/refractory: tarlatamab 10 mg IV q2w preferred
+        (DeLLphi-301: ORR 40.0%; mDoR 9.7 mo; mOS 14.3 mo; NCCN Cat 1 2025).
+        DeLLphi-301 enrolled patients with ≥2 prior lines; NCCN and ESMO list
+        as 2L+ preferred option for DLL3+. Monitor for CRS (grade 1-2 common).
+        If tarlatamab inaccessible or DLL3 assay unavailable: route to step 4.
+    if_false:
+      next_step: 4
+      notes: "DLL3 negative or assay not performed: CTFI-based chemotherapy routing."
+
+  # Step 4 — Platinum rechallenge gate for CTFI ≥180 days.
   # CTFI = time from end of 1L platinum chemotherapy to disease progression/recurrence.
   # CTFI ≥180 days (highly platinum-sensitive): platinum rechallenge preferred (ORR ~50-60%,
   # superior to topotecan ~24% or lurbinectedin ~35% in this sensitivity category).
-  # CTFI <180 days: proceed to step 4 (lurbinectedin vs topotecan routing).
-  - step: 3
+  # CTFI <180 days: proceed to step 5 (lurbinectedin vs topotecan routing).
+  - step: 4
     evaluate:
       any_of:
         - condition: "CTFI ≥ 180 days from end of 1L platinum chemotherapy"
@@ -62,19 +83,19 @@ decision_tree:
         If patient declines rechallenge or has contraindication to platinum:
         proceed to lurbinectedin (if accessible) or topotecan.
     if_false:
-      next_step: 4
-      notes: "CTFI <180 days: route to step 4 for CTFI ≥30d gate and lurbinectedin access."
+      next_step: 5
+      notes: "CTFI <180 days: route to step 5 for CTFI ≥30d gate and lurbinectedin access."
 
-  # Step 4 — CTFI ≥30d gate for lurbinectedin eligibility.
+  # Step 5 — CTFI ≥30d gate for lurbinectedin eligibility.
   # Lurbinectedin FDA label requires CTFI ≥30 days from last platinum dose.
   # CTFI <30 days (platinum-refractory): topotecan only.
-  - step: 4
+  - step: 5
     evaluate:
       any_of:
         - condition: "CTFI ≥ 30 days from last platinum dose"
     if_true:
-      next_step: 5
-      notes: "CTFI 30-179 days: lurbinectedin within FDA-label eligibility. Route to step 5 for access gate."
+      next_step: 6
+      notes: "CTFI 30-179 days: lurbinectedin within FDA-label eligibility. Route to step 6 for access gate."
     if_false:
       result: IND-SCLC-RR-TOPOTECAN
       notes: >
@@ -84,11 +105,11 @@ decision_tree:
         CAV (cyclophosphamide+doxorubicin+vincristine) is NCCN Category 2A alternative
         but rarely used given topotecan similar efficacy and better tolerability.
 
-  # Step 5 — Lurbinectedin access gate (CTFI 30-179 days).
+  # Step 6 — Lurbinectedin access gate (CTFI 30-179 days).
   # Lurbinectedin is preferred per NCCN Cat 2A when accessible (ORR 35% overall;
   # 45% for CTFI ≥90d). Not registered or reimbursed in Ukraine — topotecan is
   # the accessible standard.
-  - step: 5
+  - step: 6
     evaluate:
       all_of:
         - condition: "Lurbinectedin accessible (registered/reimbursed or international pharmacy available)"
@@ -113,15 +134,20 @@ sources:
   - SRC-ESMO-SCLC-2021
   - SRC-TRIGO-2020
 
-last_reviewed: "2026-05-04"
+last_reviewed: "2026-05-09"
 notes: >
-  SCLC 2L routing: 5-step algorithm — clinical trial gate → PS gate →
-  CTFI ≥180d rechallenge gate → CTFI ≥30d gate → lurbinectedin access gate.
+  SCLC 2L routing: 6-step algorithm — clinical trial gate → PS gate →
+  DLL3+ tarlatamab gate (NEW) → CTFI ≥180d rechallenge gate →
+  CTFI ≥30d gate → lurbinectedin access gate.
 
-  Three active indications:
+  Four active indications:
+  - IND-SCLC-RR-TARLATAMAB (NCCN Cat 1 2025; DLL3+; DeLLphi-301; ORR 40%; mOS 14.3mo)
   - IND-SCLC-PLATINUM-RECHALLENGE (NCCN Cat 2A; CTFI ≥180d; ORR ~50-60%)
   - IND-SCLC-RR-LURBINECTEDIN (NCCN Cat 2A; CTFI 30-179d; not registered UA)
   - IND-SCLC-RR-TOPOTECAN (NCCN Cat 1; all CTFI; registered UA; default)
+
+  Step renumbering (2026-05-09): new tarlatamab step inserted as step 3;
+  old steps 3→4, 4→5, 5→6 with all next_step cross-references updated.
 
   CAV (cyclophosphamide+doxorubicin+vincristine) is NCCN Category 2A alternative for
   CTFI ≥90 days but rarely used given topotecan non-inferiority and better tolerability


### PR DESCRIPTION
## Summary

**3 NEW algorithms:**
- `ALGO-NSCLC-RESECTABLE-PERIOP` → IND-NSCLC-PERIOPERATIVE-PEMBRO (KN-671)
- `ALGO-MESOTHELIOMA-2L` → IND-MESOTHELIOMA-2L-NIVO (CONFIRM; OS HR 0.72)
- `ALGO-NSCLC-ADJUVANT` → IND-NSCLC-ADJUVANT-ATEZO-PDL1POS (IMpower010)

**3 EDITS:**
- `algo_sclc_1l`: step 1 LS→step 2 gate; new step 2 ADRIATIC consolidation durva; IND-SCLC-LS-CONSOLIDATION-DURVA added
- `algo_sclc_2l`: new step 3 DLL3+ tarlatamab gate; old steps renumbered 3→4, 4→5, 5→6; IND-SCLC-RR-TARLATAMAB added
- `algo_nsclc_metastatic_1l`: step 9 if_false → next_step 10; new step 10 CheckMate-9LA vs pembro+chemo gate; IND-NSCLC-DRIVER-NEG-MET-1L-NIVO-IPI-CHEMO added

## Quality gates

| Gate | Baseline | Final | Delta |
|---|---|---|---|
| schema_errors | 0 | 0 | 0 |
| ref_errors | 0 | 0 | 0 |
| pytest failures | 1 (pre-existing) | 1 | 0 |
| loaded_entities | 3013 | 3016 | +3 |

Engine smoke: 32 algo tests pass including `test_algorithms_reference_existing_indications` (validates all output_indications IDs).

Closes #509