### PR TITLE
feat(kb): HEME-1 A3 — backfill primary sources POLARIX + PERSEUS into pola-R-CHP + DVRd indications

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_dlbcl_1l_pola_r_chp.yaml
+++ b/knowledge_base/hosted/content/indications/ind_dlbcl_1l_pola_r_chp.yaml
@@ -75,6 +75,9 @@ rationale_ua: >
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
+  - source_id: SRC-POLARIX-TILLY-2022
+    position: primary
+    relevant_quote_paraphrase: "Polatuzumab vedotin+R-CHP vs R-CHOP: PFS HR 0.73 (95% CI 0.57–0.95; p=0.02); 2-year PFS 76.7% vs 70.2% (POLARIX)"
   - source_id: SRC-NCCN-BCELL-2025
     position: supports
     relevant_quote_paraphrase: Pola-R-CHP is a Category 1 preferred regimen for newly-diagnosed DLBCL with IPI ≥2 where polatuzumab is accessible

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_dvrd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_dvrd.yaml
@@ -67,6 +67,12 @@ rationale_ua: >
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
+  - source_id: SRC-PERSEUS-SONNEVELD-2024
+    position: primary
+    relevant_quote_paraphrase: "D-VRd + ASCT + D-VRd + dara-len maintenance vs VRd + ASCT + VRd + len maintenance: PFS HR 0.42 (95% CI 0.30–0.59); 48-month PFS 84.3% vs 67.7%; MRD negativity (10⁻⁵) 75.2% vs 47.5% (PERSEUS)"
+  - source_id: SRC-GRIFFIN-VOORHEES-2020
+    position: supporting
+    relevant_quote_paraphrase: "Phase 2 GRIFFIN trial established early D-VRd safety and efficacy data supporting quadruplet induction in ASCT-eligible NDMM"
   - source_id: SRC-NCCN-MM-2025
     position: supports
     relevant_quote_paraphrase: "D-VRd is a Category 1 preferred regimen for newly-diagnosed MM, particularly for high-risk cytogenetics; PERSEUS / GRIFFIN data support quadruplet over triplet"


### PR DESCRIPTION
## Summary
- `ind_dlbcl_1l_pola_r_chp.yaml`: add `SRC-POLARIX-TILLY-2022` as `position: primary`; POLARIX PFS HR 0.73 (p=0.02)
- `ind_mm_1l_dvrd.yaml`: add `SRC-PERSEUS-SONNEVELD-2024` (primary) + `SRC-GRIFFIN-VOORHEES-2020` (supporting); PERSEUS PFS HR 0.42, 48-mo PFS 84.3% vs 67.7%

## Quality gates
- `audit_validator`: schema 0 / ref 0 / contract 0 / warn 0 (no regression)
- `pytest`: pre-existing failures only (FsFF pattern on master baseline unchanged)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)