### PR TITLE
feat(kb): HEME-1 A1 — CLL 1L acalabrutinib+venetoclax+obinutuzumab AMPLIFY (IND-CLL-1L-AVO)

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_cll_1l_avo.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cll_1l_avo.yaml
@@ -1,0 +1,124 @@
+id: IND-CLL-1L-AVO
+plan_track: aggressive
+applicable_to:
+  disease_id: DIS-CLL
+  line_of_therapy: 1
+  stage_requirements:
+    - "Previously untreated CLL/SLL requiring therapy per IWCLL 2018 criteria"
+    - "Fixed-duration regimen (14 cycles); suitable for patients preferring time-limited therapy over continuous BTKi"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+recommended_regimen: REG-AVO-CLL-1L
+concurrent_therapy: []
+followed_by: []
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: '1'
+expected_outcomes:
+  progression_free_survival:
+    value: "36-mo PFS 83.1% (AVO arm, AMPLIFY); AVO vs chemo HR 0.42"
+    source: SRC-AMPLIFY-BROWN-2025
+    median_followup_months: 36
+  overall_response_rate:
+    value: "Substantially higher uMRD rates vs chemoimmunotherapy; fixed-duration all arms ≤14 cycles"
+    source: SRC-AMPLIFY-BROWN-2025
+hard_contraindications:
+  - CI-HBV-NO-PROPHYLAXIS
+red_flags_triggering_alternative: []
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-URIC-ACID
+  - TEST-B2-MICROGLOBULIN
+  - TEST-FISH-PANEL
+  - TEST-NGS-LYMPHOID-PANEL
+  - TEST-IMMUNOGLOBULINS
+  - TEST-HBV-SEROLOGY
+  - TEST-HCV-ANTIBODY
+  - TEST-HIV-SEROLOGY
+  - TEST-CECT-CAP
+  - TEST-ECHO
+desired_tests: []
+rationale: >
+  Aggressive-track 1L for CLL — fixed-duration acalabrutinib + venetoclax +
+  obinutuzumab (14 cycles) per AMPLIFY trial (Brown JR et al., NEJM 2025).
+  AMPLIFY established AVO as superior to chemoimmunotherapy (FCR/BR) in
+  previously untreated CLL: 36-mo PFS 83.1% vs 66.5% (HR 0.42). The AVO arm
+  adds obinutuzumab (cycles 2-7) on top of AV backbone, yielding deeper MRD
+  responses. Key advantages: finite duration (14 cycles), depth of MRD
+  negativity, no continuous drug exposure after treatment end. Key risks: TLS
+  during venetoclax ramp-up (cycle 3), obinutuzumab infusion reactions, HBV
+  reactivation risk with anti-CD20, BTKi-associated bleeding and arrhythmia
+  risk. Preferred for patients who value time-limited therapy and can tolerate
+  combined toxicity profile (ECOG 0-2).
+rationale_ua: >
+  Агресивний-track 1L для ХЛЛ — фіксована тривалість акалабрутиніб +
+  венетоклакс + обінутузумаб (14 циклів) за даними AMPLIFY (Brown JR et al.,
+  NEJM 2025). Переваги: обмежена тривалість, глибока МЗХ-негативність. Ризики:
+  TLS під час нарощування венетоклаксу (цикл 3), інфузійні реакції на
+  обінутузумаб, реактивація HBV, кровотеча та аритмія на тлі BTKi.
+sources:
+  - source_id: SRC-AMPLIFY-BROWN-2025
+    position: supports
+    relevant_quote_paraphrase: >
+      AMPLIFY trial: AVO 36-mo PFS 83.1% vs chemo 66.5% (HR 0.42); fixed-duration
+      14 cycles established as superior to chemoimmunotherapy in previously untreated CLL
+  - source_id: SRC-NCCN-BCELL-2025
+    position: supports
+    relevant_quote_paraphrase: >
+      NCCN B-Cell Lymphomas 2025: acalabrutinib + venetoclax + obinutuzumab is
+      a Category 1 recommended regimen for 1L CLL
+  - source_id: SRC-ESMO-CLL-2024
+    position: supports
+    relevant_quote_paraphrase: >
+      ESMO CLL 2024 guidelines support fixed-duration venetoclax-based combinations
+      as 1L standard; AVO adds BTKi backbone per emerging trial data
+known_controversies:
+  - topic: AVO vs AV (acalabrutinib + venetoclax without obinutuzumab) for 1L CLL
+    positions:
+      - position: AVO adds obinutuzumab (deeper MRD, higher obi-related toxicity burden)
+        sources:
+          - SRC-AMPLIFY-BROWN-2025
+      - position: AV (without obi) also superior to chemo in AMPLIFY (36-mo PFS 76.5%, HR 0.65 vs chemo) with simpler logistics
+        sources:
+          - SRC-AMPLIFY-BROWN-2025
+    our_default: AVO preferred when patients can tolerate anti-CD20 addition and deeper MRD is prioritized
+    rationale: >
+      AMPLIFY 36-mo PFS: AVO 83.1% vs AV 76.5% vs chemo 66.5%. AVO not
+      directly tested against VenO (CLL14 regimen); cross-trial comparison
+      only. Choice between AVO and AV depends on patient fitness, TLS risk,
+      and preference for obi-related infusion-visit burden.
+do_not_do:
+  - "НЕ пропускати venetoclax 5-тижневе нарощування — зафіксований летальний TLS."
+  - "НЕ призначати strong CYP3A inhibitor (азоли, ритонавір) одночасно з венетоклаксом без корекції дози — летальне підвищення концентрації."
+  - "НЕ починати без HBV скринінгу + entecavir prophylaxis при HBsAg+ або anti-HBc+ (ризик реактивації на тлі обінутузумабу)."
+  - "НЕ пропускати TLS профілактику (алопуринол + гідратація) перед циклом 3 — особливо при ALC >25K або bulky disease."
+  - "НЕ поєднувати BTKi (акалабрутиніб) із варфарином без суворого моніторингу — ризик кровотечі."
+  - "НЕ продовжувати терапію після 14 циклів (фіксована тривалість; AMPLIFY — не режим до прогресії)."
+do_not_do_en:
+  - "Do NOT skip the venetoclax 5-week ramp-up — fatal TLS documented."
+  - "Do NOT co-administer strong CYP3A inhibitors (azoles, ritonavir) with venetoclax without dose adjustment — fatal concentration increase."
+  - "Do NOT start without HBV screening + entecavir prophylaxis if HBsAg+ or anti-HBc+ (anti-CD20 reactivation risk with obinutuzumab)."
+  - "Do NOT skip TLS prophylaxis (allopurinol + hydration) before cycle 3 — especially with ALC >25K or bulky disease."
+  - "Do NOT combine acalabrutinib with warfarin without strict monitoring — bleeding risk."
+  - "Do NOT continue beyond 14 cycles — AVO is fixed-duration per AMPLIFY; this is not a continuous-until-progression regimen."
+time_critical: false
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: []
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+notes: >
+  STUB — pending Co-Lead sign-off. Aggressive-track for CLL 1L fixed-duration
+  triple therapy. AMPLIFY (NCT03836261, Brown JR et al., NEJM 2025): 3-arm
+  (AV vs AVO vs chemoimmuno, n=867). Primary endpoint: PFS. AVO vs chemo
+  HR 0.42 (36-mo PFS 83.1% vs 66.5%); AV vs chemo HR 0.65 (36-mo PFS 76.5%).
+  AVO NOT directly compared to VenO (CLL14) — cross-trial only. Obi starts
+  cycle 2 (not cycle 1) with acalabrutinib lead-in; venetoclax ramp cycle 3.
+  AMPLIFY enrolled patients without del(17p)/TP53 mutation. Applicability to
+  del(17p)/TP53-mutated CLL: limited data; BTKi-based regimens generally
+  preferred for high-risk cytogenetics per NCCN — discuss per patient.

--- a/knowledge_base/hosted/content/regimens/reg_avo_cll_1l.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_avo_cll_1l.yaml
@@ -1,0 +1,137 @@
+id: REG-AVO-CLL-1L
+name: "Acalabrutinib + Venetoclax + Obinutuzumab (AVO), fixed-duration 14 cycles (AMPLIFY)"
+name_ua: "Акалабрутиніб + Венетоклакс + Обінутузумаб (AVO), фіксована тривалість 14 циклів (AMPLIFY)"
+alternate_names: ["AVO", "A+VO", "acala-ven-obi", "AMPLIFY-AVO"]
+
+components:
+  - drug_id: DRUG-ACALABRUTINIB
+    dose: "100 mg PO BID"
+    schedule: "Continuous twice daily, cycles 1-14 (entire duration)"
+    route: PO
+  - drug_id: DRUG-VENETOCLAX
+    dose: >
+      5-week ramp-up starting cycle 3 day 1:
+      week 1 20 mg → week 2 50 mg → week 3 100 mg → week 4 200 mg → week 5 400 mg;
+      then 400 mg QD maintenance through cycle 14
+    schedule: "PO daily, cycles 3-14 (ramp begins cycle 3 day 1)"
+    route: PO
+  - drug_id: DRUG-OBINUTUZUMAB
+    dose: >
+      Cycle 2 day 1: 100 mg IV; cycle 2 day 2: 900 mg IV; cycle 2 days 8+15: 1000 mg IV;
+      cycles 3-7 day 1: 1000 mg IV
+    schedule: "IV monthly (28-day cycles), cycles 2-7 (6 cycles total)"
+    route: IV
+
+cycle_length_days: 28
+total_cycles: "14 (fixed-duration)"
+toxicity_profile: moderate-high
+
+premedication:
+  - "Pre-obinutuzumab (cycle 2 day 1): methylprednisolone 80 mg IV + acetaminophen 650 mg PO + diphenhydramine 25-50 mg PO"
+  - "Pre-obinutuzumab (subsequent infusions, if no prior Grade ≥3 IRR): acetaminophen + antihistamine; methylprednisolone optional"
+  - "Pre-venetoclax ramp-up: allopurinol start 72h prior to cycle 3 day 1; hydration + serial labs during ramp steps"
+
+mandatory_supportive_care:
+  - SUP-TLS-PROPHYLAXIS
+  - SUP-PJP-PROPHYLAXIS
+
+monitoring_schedule_id: MON-CLL-BTKI
+
+dose_adjustments:
+  - condition: "Concomitant strong CYP3A inhibitor (azoles, ritonavir, cobicistat)"
+    modification: "Hold venetoclax during inhibitor course OR reduce venetoclax to 70 mg if inhibitor cannot be avoided; acalabrutinib: reduce to 100 mg QD or hold"
+    rationale: "Both venetoclax and acalabrutinib are CYP3A substrates; co-administration with strong inhibitors causes dangerous concentration increase"
+    source_refs: [SRC-NCCN-BCELL-2025]
+  - condition: "High tumor burden (ALC >25K OR any LN ≥10 cm OR LN ≥5 cm + ALC ≥25K)"
+    modification: "Hospitalize for first 3 venetoclax ramp-up steps with q6h TLS labs (K, phosphate, uric acid, creatinine, LDH)"
+    rationale: "Fatal TLS documented when ramp-up done outpatient in high-burden patients"
+  - condition: "ANC <1000 OR febrile neutropenia"
+    modification: "Hold venetoclax; consider G-CSF; resume at same or lower ramp step after recovery"
+  - condition: "Grade ≥3 atrial fibrillation on acalabrutinib"
+    modification: "Hold acalabrutinib; resume at lower dose or discontinue depending on severity"
+  - condition: "Severe hepatic impairment (Child-Pugh C)"
+    modification: "Avoid venetoclax; use with caution if Child-Pugh B"
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Acalabrutinib: registered, NOT reimbursed via НСЗУ — funding gap.
+    Venetoclax: registered, NOT reimbursed via НСЗУ for most indications.
+    Obinutuzumab: registered + reimbursed for some CLL indications.
+    All three components required; full funding pathway must be confirmed
+    before initiating.
+
+sources: [SRC-AMPLIFY-BROWN-2025, SRC-NCCN-BCELL-2025]
+
+between_visit_watchpoints:
+  - trigger_ua: "Помірна втома після інфузії обінутузумабу"
+    action_ua: "Очікувано у перші 1-3 дні після інфузії — більше відпочивайте; занотовуйте інтенсивність"
+    urgency: log_at_next_visit
+    cycle_day_window: "Day 1-3 of obi cycles"
+    sources:
+      - SRC-AMPLIFY-BROWN-2025
+  - trigger_ua: "Помірна нудота або діарея під час прийому акалабрутинібу або венетоклаксу"
+    action_ua: "Приймайте з їжею та великою кількістю рідини; занотовуйте частоту"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Головний біль (перші тижні акалабрутинібу)"
+    action_ua: "Часто минає за 1-2 місяці — приймайте парацетамол; уникайте НПЗП через ризик кровотечі"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Незвичні синці, кровотеча з ясен або носа"
+    action_ua: "Подзвоніть у клініку того ж дня — BTKi підвищують ризик кровотеч; уникайте антикоагулянтів"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Прискорене або нерівномірне серцебиття"
+    action_ua: "Подзвоніть у клініку того ж дня — можлива миготлива аритмія (пов'язана з BTKi)"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — обінутузумаб та акалабрутиніб посилюють імуносупресію"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-AMPLIFY-BROWN-2025
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Зменшення кількості сечі, набряки, біль у попереку — перші 5 тижнів венетоклаксу (цикл 3)"
+    action_ua: "Подзвоніть у клініку того ж дня — критичне вікно ризику синдрому розпаду пухлини при нарощуванні дози"
+    urgency: call_clinic_same_day
+    cycle_day_window: "Cycle 3 days 1-35 (venetoclax ramp)"
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Важка реакція на інфузію: різке утруднення дихання, набряк обличчя"
+    action_ua: "Якщо в клініці — повідомте медперсонал негайно. Якщо вдома — викликайте швидку"
+    urgency: er_now
+    cycle_day_window: "Day 1-2 of obinutuzumab cycle 2"
+    sources:
+      - SRC-NCCN-BCELL-2025
+  - trigger_ua: "Раптова сильна слабкість, аритмія, судоми — під час нарощування венетоклаксу"
+    action_ua: "Звертайтесь у лікарню негайно — ознаки тяжкого синдрому розпаду пухлини"
+    urgency: er_now
+    cycle_day_window: "Cycle 3 days 1-35"
+    sources:
+      - SRC-NCCN-BCELL-2025
+
+last_reviewed: "2026-05-07"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  AMPLIFY trial (Brown JR et al., NEJM 2025; NCT03836261): 3-arm 1:1:1 —
+  AV (acalabrutinib + venetoclax, cycles 1-14) vs AVO (AV + obinutuzumab
+  cycles 2-7) vs chemoimmunotherapy (FCR or BR, cycles 1-6). AVO arm: obi
+  starts cycle 2 (not cycle 1) to allow acalabrutinib lead-in; venetoclax
+  ramp begins cycle 3.
+  AVO 36-mo PFS 83.1% vs chemo 66.5% (HR 0.42 vs chemo).
+  Venetoclax ramp-up identical 5-week schedule to VenO (CLL14); TLS
+  protocol and HBV screening mandatory. Fixed-duration 14 cycles — no
+  indefinite therapy after cycle 14. STUB — pending Co-Lead sign-off.
+notes_ua: >
+  Дослідження AMPLIFY (Brown JR et al., NEJM 2025): AVO arm — акалабрутиніб
+  починається з циклу 1; обінутузумаб — цикли 2-7; венетоклакс рамп — цикл 3.
+  Фіксована тривалість 14 циклів. TLS протокол та HBV скринінг обов'язкові.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary
- `reg_avo_cll_1l.yaml`: NEW REG-AVO-CLL-1L (acalabrutinib + venetoclax + obinutuzumab; fixed-duration 14 cycles)
- `ind_cll_1l_avo.yaml`: NEW IND-CLL-1L-AVO; CLL/SLL 1L fit patients; AMPLIFY 3-arm RCT (SRC-AMPLIFY-BROWN-2025); PFS HR vs standard chemoimmunotherapy

## Quality gates
- Loader: schema 0 / ref 0 (confirmed by agent)
- audit_validator: no regression

🤖 Generated with [Claude Code](https://claude.ai/claude-code)