### PR TITLE
feat(kb): HEME-1 D1 — ALGO-MM-3L NEW + ALGO-CLL-1L AVO triple branch

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_cll_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_cll_1l.yaml
@@ -3,16 +3,20 @@ applicable_to_disease: DIS-CLL
 applicable_to_line_of_therapy: 1
 purpose: >
   Select default + alternative for first-line CLL based on cytogenetic
-  risk (TP53/del 17p/IGHV-unmutated/complex karyotype). Two tracks:
-  BTKi continuous (standard) vs VenO time-limited (preferred for high-risk).
+  risk (TP53/del 17p/IGHV-unmutated/complex karyotype) and fitness. Three
+  tracks: BTKi continuous (standard, acalabrutinib default / zanubrutinib
+  alternative) vs VenO time-limited (CLL14, high-risk ECOG 2 or anti-CD20
+  contraindication) vs AVO triple time-limited (AMPLIFY, aggressive-track
+  preferred for ECOG 0-1 high-risk CLL).
 
 output_indications:
   - IND-CLL-1L-BTKI
   - IND-CLL-1L-VENO
   - IND-CLL-1L-ZANUBRUTINIB
+  - IND-CLL-1L-AVO
 
 default_indication: IND-CLL-1L-BTKI
-alternative_indication: IND-CLL-1L-VENO
+alternative_indication: IND-CLL-1L-AVO
 
 decision_tree:
   - step: 1
@@ -21,10 +25,10 @@ decision_tree:
         - red_flag: RF-CLL-TP53-DELETION-ACTIONABLE
         - red_flag: RF-CLL-HIGH-RISK
     if_true:
-      result: IND-CLL-1L-VENO
+      next_step: 4
     if_false:
       next_step: 2
-    notes: "Wired via RF-CLL-TP53-DELETION-ACTIONABLE (CSD-9A) + RF-CLL-HIGH-RISK: TP53-disruption (del(17p)/TP53-mut) is the strongest single negative-prognostic factor and routes to fixed-duration venetoclax+obinutuzumab (CLL14, Fischer 2019); RF-CLL-HIGH-RISK still fires for IGHV-unmutated and complex-karyotype routing to the same VenO track."
+    notes: "Wired via RF-CLL-TP53-DELETION-ACTIONABLE (CSD-9A) + RF-CLL-HIGH-RISK: TP53-disruption (del(17p)/TP53-mut) is the strongest single negative-prognostic factor and routes high-risk to step 4 (AVO vs VenO fitness split); RF-CLL-HIGH-RISK still fires for IGHV-unmutated and complex-karyotype routing to the same AVO/VenO branch."
   - step: 2
     evaluate:
       any_of:
@@ -45,17 +49,31 @@ decision_tree:
     if_false:
       result: IND-CLL-1L-BTKI
     notes: "Wired via RF-BINET-A / RF-RAI-LOW (CSD-8A): early-stage CLL without iwCLL treatment indication — engine pins to BTKi as default but plan render surfaces watch-and-wait recommendation."
+  - step: 4
+    evaluate:
+      all_of:
+        - red_flag: RF-FITNESS-ECOG-FIT
+        - condition: "No major anti-CD20 or obinutuzumab contraindication (e.g., active HBV reactivation risk unmanaged, severe infusion history)"
+    if_true:
+      result: IND-CLL-1L-AVO
+    if_false:
+      result: IND-CLL-1L-VENO
+    notes: "MDT-only. High-risk CLL (TP53/del17p/IGHV-unmut from step 1) routed here. AVO (acalabrutinib+venetoclax+obinutuzumab; AMPLIFY, Brown NEJM 2025) shows superior PFS HR 0.42 vs chemoimmunotherapy and deeper uMRD vs VenO alone. Preferred for ECOG 0-1 fit patients seeking deepest response + finite duration. VenO (CLL14) preferred when ECOG 2, prior anti-CD20 reaction risk, or patient/MDT preference for lower-toxicity fixed-duration. Both are aggressive-track."
 
-sources: [SRC-NCCN-BCELL-2025]
-last_reviewed: "2026-04-30"
+sources: [SRC-NCCN-BCELL-2025, SRC-AMPLIFY-BROWN-2025]
+last_reviewed: "2026-05-09"
 notes: >
-  Both tracks are NCCN Cat 1; choice reflects risk + patient preference
-  (continuous vs finite-duration). IND-CLL-1L-ZANUBRUTINIB added to
-  output_indications 2026-04-30 (SEQUOIA 1L; ALPINE r/r superior to
-  ibrutinib HR 0.65 PFS, 5.2% vs 13.3% AF) — routes parallel to
-  IND-CLL-1L-BTKI (acalabrutinib) as Cat 1 second-generation BTKi
-  alternative. Engine continues to pin acalabrutinib via existing
-  step 2/3 result clauses (UA access default); render layer surfaces
-  zanubrutinib as alternative-track BTKi when applicable. Asymptomatic
-  CLL without iwCLL indication routes to active surveillance —
-  handled at higher level (no plan generated).
+  Three tracks: BTKi continuous (acalabrutinib default, zanubrutinib Cat 1
+  alternative per ALPINE/SEQUOIA) / VenO time-limited (CLL14 fixed-duration,
+  high-risk fallback when ECOG 2 or anti-CD20 contraindication) / AVO triple
+  time-limited (acalabrutinib+venetoclax+obinutuzumab; AMPLIFY Brown NEJM 2025,
+  preferred aggressive-track for ECOG 0-1 high-risk CLL). All tracks are NCCN
+  Cat 1; choice reflects cytogenetic risk, fitness, and patient preference
+  (continuous vs finite-duration). IND-CLL-1L-ZANUBRUTINIB added 2026-04-30
+  (SEQUOIA 1L; ALPINE r/r superior to ibrutinib HR 0.65 PFS, 5.2% vs 13.3% AF)
+  — routes parallel to IND-CLL-1L-BTKI (acalabrutinib) as Cat 1 second-generation
+  BTKi alternative. Engine pins acalabrutinib via step 2/3 result clauses (UA
+  access default); render surfaces zanubrutinib as alternative-track BTKi.
+  IND-CLL-1L-AVO added 2026-05-09 as aggressive-track alternative for high-risk
+  fit patients (step 4 AVO/VenO split). Asymptomatic CLL without iwCLL indication
+  routes to active surveillance — handled at higher level (no plan generated).

--- a/knowledge_base/hosted/content/algorithms/algo_mm_3l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mm_3l.yaml
@@ -1,0 +1,58 @@
+id: ALGO-MM-3L
+applicable_to_disease: DIS-MM
+applicable_to_line_of_therapy: 3
+purpose: >
+  Route line-3 RRMM to IND-MM-3L-ISA-KD (isatuximab+carfilzomib+dex, IKEMA;
+  carfilzomib-naive, ≥2 prior lines) vs IND-MM-4L-TECLISTAMAB (triple-class
+  refractory bispecific). Both are aggressive-track considerations; ISA-Kd is
+  default when carfilzomib-naive and not yet triple-class refractory.
+
+output_indications:
+  - IND-MM-3L-ISA-KD
+  - IND-MM-4L-TECLISTAMAB
+default_indication: IND-MM-3L-ISA-KD
+alternative_indication: IND-MM-4L-TECLISTAMAB
+
+decision_tree:
+  - step: 1
+    evaluate:
+      all_of:
+        - condition: "≥3 prior lines including ≥1 IMiD, ≥1 PI, ≥1 anti-CD38 monoclonal antibody"
+        - condition: "Refractory (progressed during or within 60 days of last line of each class)"
+    if_true:
+      result: IND-MM-4L-TECLISTAMAB
+    if_false:
+      next_step: 2
+    notes: "MDT-only — triple-class refractory definition. No RF for this composite criterion; evaluated as clinical MDT gate. If true, teclistamab BCMA bispecific (MajesTEC-1) is preferred (NCCN Cat 2A); ISA-Kd not indicated in triple-class refractory."
+  - step: 2
+    evaluate:
+      all_of:
+        - condition: "Carfilzomib-naive (no prior carfilzomib or carfilzomib-based regimen)"
+        - condition: "≥2 prior lines including ≥1 PI (non-carfilzomib) + ≥1 IMiD"
+        - red_flag: RF-FITNESS-ECOG-FIT
+    if_true:
+      result: IND-MM-3L-ISA-KD
+    if_false:
+      next_step: 3
+    notes: "Wired: RF-FITNESS-ECOG-FIT (CSD-7A). Remaining conditions (carfilzomib-naive, prior lines) are MDT-evaluated. IKEMA trial enrolled carfilzomib-naive RRMM ≥2 prior lines; PFS HR 0.531."
+  - step: 3
+    evaluate:
+      any_of:
+        - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+    if_true:
+      result: IND-MM-3L-ISA-KD
+    if_false:
+      result: IND-MM-3L-ISA-KD
+    notes: "Default ISA-Kd for carfilzomib-naive RRMM regardless of ECOG intermediate status; dose modifications available per IKEMA protocol. MDT surfaces carfilzomib cardiac monitoring requirement."
+
+sources:
+  - SRC-NCCN-MM-2025
+  - SRC-IKEMA-MOREAU-2021
+last_reviewed: "2026-05-09"
+notes: >
+  Coverage gaps: (1) Selinexor+dex (STORM, BOSTON) for penta-refractory — not
+  modeled. (2) Belantamab mafodotin withdrawn post DREAMM-3, not modeled.
+  (3) CAR-T (cilta-cel CARTITUDE-4, ide-cel KarMMa-3) for early-line — not modeled
+  (UA access near-zero). (4) DVRd (daratumumab+VRd) as 3L option for
+  lenalidomide-naive patients — not modeled in this algo. Overlap with ALGO-MM-2L
+  step 3-4 is expected; engine routes by line_of_therapy first.


### PR DESCRIPTION
## Summary
- `algo_mm_3l.yaml`: NEW ALGO-MM-3L; routes line-3 RRMM to IND-MM-3L-ISA-KD (carfilzomib-naive, IKEMA PFS HR 0.531) vs IND-MM-4L-TECLISTAMAB (triple-class refractory)
- `algo_cll_1l.yaml`: EDIT — add IND-CLL-1L-AVO (acalabrutinib+venetoclax+obi, AMPLIFY HR 0.42) as step 4 split from high-risk path; step 1 if_true now routes to new step 4 (AVO if ECOG fit / VenO otherwise); IND-CLL-1L-AVO added to output_indications + alternative_indication

## Quality gates
- audit_validator: schema 2 / ref 7 / contract 0 (unchanged from baseline)
- pytest: 228 passed, 1 pre-existing failure (bap1 escat_tier), 7 skipped — no regression
- test_algorithms_reference_existing_indications: PASSED
- test_no_unknown_red_flag_in_algorithms: PASSED

## Notes
- algo_cll_1l already had IND-CLL-1L-ZANUBRUTINIB from prior work; AVO added as 4th output_indication preserving existing content

🤖 Generated with [Claude Code](https://claude.ai/claude-code)