### PR TITLE
docs: update README KB coverage + entity counts (post HEME-1 wave)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 > picks regimens** ([CHARTER §8.3](specs/CHARTER.md)).
 
 **Live demo:** **[openonco.info](https://openonco.info)** — try it in the browser, no install needed.
+**Knowledge base:** 420 indications · 377 sources · 140 algorithms across hematologic + GI + pulmonary oncology (growing).
 **FDA non-device CDS positioning** per [CHARTER §15](specs/CHARTER.md) — informational support tool, not a medical device.
 **License:** Code MIT · Content / specs CC BY 4.0.
 
@@ -41,7 +42,7 @@ OpenOnco automates the chore work. The clinician gets a **drafted plan with ever
 
 **Tumor-board questions:** **[openonco.info/ask.html](https://openonco.info/ask.html)** — optional server-backed prototype for free-text oncology vignettes. ChatGPT structures the case, OpenOnco runs the deterministic rule engine, then the response is framed as an answer, alternatives, or clarifying questions. Do not paste identifiable real-patient data.
 
-**Sample patients:** **[openonco.info/gallery.html](https://openonco.info/gallery.html)** — pre-rendered cases across DLBCL, FL, CLL/SLL, MCL, HCV-MZL, MM, and other heme + solid-tumor entities.
+**Sample patients:** **[openonco.info/gallery.html](https://openonco.info/gallery.html)** — pre-rendered cases across DLBCL, FL, CLL/SLL, MCL, MZL, MM (hematologic) and gastric, esophageal, PDAC, cholangiocarcinoma, CRC, NSCLC, SCLC, mesothelioma (solid tumors).
 
 **Contributors:** start with [`specs/`](specs/) and [`CLAUDE.md`](CLAUDE.md) — these define scope, schemas, and authoring conventions before any KB or code change.
 


### PR DESCRIPTION
- Live demo line: add KB scale (420 indications, 377 sources, 140 algorithms)
- Gallery line: expand solid-tumor disease list (gastric, esoph, PDAC, cholangio, CRC, NSCLC, SCLC, meso)