### PR TITLE
feat(kb): HEME-1 C1 — backfill MURANO primary source into CLL 2L VenR indication

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_cll_2l_venr_murano.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cll_2l_venr_murano.yaml
@@ -62,16 +62,15 @@ rationale_ua: >
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
+  - source_id: SRC-MURANO-SEYMOUR-2018
+    position: primary
+    relevant_quote_paraphrase: "Venetoclax-rituximab vs BR in r/r CLL: PFS HR 0.17 (95% CI 0.11–0.25; p<0.001); 2-yr PFS 84.9% vs 36.3%; OS HR 0.48; 62% undetectable MRD at end of treatment (MURANO)"
   - source_id: SRC-NCCN-BCELL-2025
     position: supports
     relevant_quote_paraphrase: "Venetoclax + rituximab (24-month MURANO schedule) is a Category 1 preferred regimen for r/r CLL after 1+ prior lines"
   - source_id: SRC-ESMO-CLL-2024
     position: supports
     relevant_quote_paraphrase: "VenR fixed-duration 24-month regimen is recommended for r/r CLL with substantial PFS + OS benefit over chemoimmunotherapy"
-
-  - source_id: SRC-CLL14-FISCHER-2019
-    position: supports
-    relevant_quote_paraphrase: CLL14 trial — see referenced publication for primary outcome data.
 known_controversies:
   - topic: "Continued BTKi vs switch to VenR after 1L BTKi progression"
     positions:
@@ -101,7 +100,7 @@ do_not_do_en:
   - "Do NOT forget PJP prophylaxis on prolonged therapy."
   - "Do NOT use in prior BCL2i resistance — low efficacy; consider pirtobrutinib or CAR-T."
 time_critical: false
-last_reviewed: "2026-04-25"
+last_reviewed: "2026-05-09"
 reviewers: []
 reviewer_signoffs: 0
 notes: >


### PR DESCRIPTION
Add SRC-MURANO-SEYMOUR-2018 as position:primary to IND-CLL-2L-VENR-MURANO (was missing; only had NCCN/ESMO). Remove incorrectly placed SRC-CLL14-FISCHER-2019 (VenO 1L trial, not VenR 2L). PFS HR 0.17, 2-yr PFS 84.9% vs 36.3%. Audit: schema 0 / ref 0 / contract 0.