### PR TITLE
hotfix: normalize Citation.position primary/supporting → supports in 3 indication files

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_cll_2l_venr_murano.yaml
+++ b/knowledge_base/hosted/content/indications/ind_cll_2l_venr_murano.yaml
@@ -63,7 +63,7 @@ ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
   - source_id: SRC-MURANO-SEYMOUR-2018
-    position: primary
+    position: supports
     relevant_quote_paraphrase: "Venetoclax-rituximab vs BR in r/r CLL: PFS HR 0.17 (95% CI 0.11–0.25; p<0.001); 2-yr PFS 84.9% vs 36.3%; OS HR 0.48; 62% undetectable MRD at end of treatment (MURANO)"
   - source_id: SRC-NCCN-BCELL-2025
     position: supports

--- a/knowledge_base/hosted/content/indications/ind_dlbcl_1l_pola_r_chp.yaml
+++ b/knowledge_base/hosted/content/indications/ind_dlbcl_1l_pola_r_chp.yaml
@@ -76,7 +76,7 @@ ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
   - source_id: SRC-POLARIX-TILLY-2022
-    position: primary
+    position: supports
     relevant_quote_paraphrase: "Polatuzumab vedotin+R-CHP vs R-CHOP: PFS HR 0.73 (95% CI 0.57–0.95; p=0.02); 2-year PFS 76.7% vs 70.2% (POLARIX)"
   - source_id: SRC-NCCN-BCELL-2025
     position: supports

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_dvrd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_dvrd.yaml
@@ -68,10 +68,10 @@ ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 sources:
   - source_id: SRC-PERSEUS-SONNEVELD-2024
-    position: primary
+    position: supports
     relevant_quote_paraphrase: "D-VRd + ASCT + D-VRd + dara-len maintenance vs VRd + ASCT + VRd + len maintenance: PFS HR 0.42 (95% CI 0.30–0.59); 48-month PFS 84.3% vs 67.7%; MRD negativity (10⁻⁵) 75.2% vs 47.5% (PERSEUS)"
   - source_id: SRC-GRIFFIN-VOORHEES-2020
-    position: supporting
+    position: supports
     relevant_quote_paraphrase: "Phase 2 GRIFFIN trial established early D-VRd safety and efficacy data supporting quadruplet induction in ASCT-eligible NDMM"
   - source_id: SRC-NCCN-MM-2025
     position: supports


### PR DESCRIPTION
## Summary
Fixes 3 pre-existing schema errors that were cascading into E2E test failures via KB load errors.

- ind_cll_2l_venr_murano.yaml: `position: primary` → `position: supports`
- ind_dlbcl_1l_pola_r_chp.yaml: `position: primary` → `position: supports`
- ind_mm_1l_dvrd.yaml: `position: primary` → `position: supports` (PERSEUS); `position: supporting` → `position: supports` (GRIFFIN)

Citation schema only accepts `supports`, `contradicts`, `context`. No clinical content changes.

Generated with Claude Code