### PR TITLE
feat(heme): FL-2L — GADOLIN + AUGMENT sources, regimens, indications + algo wiring

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_fl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_fl_2l.yaml
@@ -1,63 +1,129 @@
 id: ALGO-FL-2L
 applicable_to_disease: DIS-FL
-applicable_to_line_of_therapy: 3
-purpose: 'Select 3L+ relapsed/refractory FL Indication. Three tracks driven by EZH2 status + CAR-T eligibility: (1) EZH2-mutated (Y641) → tazemetostat preferred (treatment-defining biomarker, ORR ~69% mut vs ~35% WT); (2) CAR-T-eligible non-EZH2 → axi-cel for durable remission; (3) transplant-ineligible / older / no CAR-T access → mosunetuzumab bispecific (off-the-shelf, manageable in standard heme unit). Note: although this algo is gated on line=3, it is the de-facto 2L+ relapsed routing for FL (no dedicated 2L algo wired).
+applicable_to_line_of_therapy: 2
+purpose: >
+  Select 2L and 3L+ relapsed/refractory FL Indication. Three routing tiers:
+  (1) First relapse (prior_lines ≤1): rituximab-refractoriness gate → OBG+Benda
+  (GADOLIN, standard) or R² (AUGMENT, aggressive/chemo-free); (2) EZH2-mutated
+  (Y641) at ≥2 prior lines → tazemetostat preferred; (3) ≥2 prior lines
+  non-EZH2: CAR-T-eligible → axi-cel, else mosunetuzumab bispecific.
 
-  '
 output_indications:
-- IND-FL-3L-TAZEMETOSTAT
-- IND-FL-3L-AXICEL-CART
-- IND-FL-3L-MOSUNETUZUMAB
-default_indication: IND-FL-3L-MOSUNETUZUMAB
-alternative_indication: IND-FL-3L-AXICEL-CART
-decision_tree:
-- step: 1
-  evaluate:
-    any_of:
-    - red_flag: RF-FL-EZH2-Y641-ACTIONABLE
-  if_true:
-    next_step: 11
-  if_false:
-    next_step: 2
-  notes: "Wired via RF-FL-EZH2-Y641-ACTIONABLE (CSD-9A): biomarker-gated branch fires on EZH2 hotspot mutation; sequential step 11 then checks ≥2 prior lines requirement before routing to tazemetostat."
-- step: 11
-  evaluate:
-    any_of:
-    - finding: "prior_lines"
-      threshold: 2
-      comparator: ">="
-  if_true:
-    result: IND-FL-3L-TAZEMETOSTAT
-  if_false:
-    next_step: 2
-  notes: "Sequential gate after EZH2 RF (step 1): tazemetostat is FDA-approved only for ≥2 prior systemic lines (Morschhauser 2020). EZH2-mut at <2 lines falls through to CAR-T / mosunetuzumab routing."
-- step: 2
-  evaluate:
-    all_of:
-    - condition: ≥2 prior systemic lines
-    - red_flag: RF-FITNESS-ECOG-FIT
-    - red_flag: RF-CAR-T-ELIGIBLE
-    - condition: Age 18-75
-    - condition: CD19+ disease confirmed
-  if_true:
-    result: IND-FL-3L-AXICEL-CART
-  if_false:
-    next_step: 3
-  notes: Partially wired - fitness/eligibility gates wired via CSD-7A pan-disease RFs; remaining condition(s) kept as MDT-evaluated text (no RF available for that criterion).
-- step: 3
-  evaluate:
-    any_of:
-    - condition: Transplant-ineligible OR CAR-T inaccessible
-    - condition: EZH2-WT and patient prefers chemo-free off-the-shelf
-  if_true:
-    result: IND-FL-3L-MOSUNETUZUMAB
-  if_false:
-    result: IND-FL-3L-MOSUNETUZUMAB
-  notes: Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring.
-sources:
-- SRC-NCCN-BCELL-2025
-- SRC-ESMO-FL-2024
-last_reviewed: '2026-04-26'
-notes: 'OOS / wiring gaps: (1) True 2L (post-1L BR/R-CHOP) routing — R2 (rituximab+lenalidomide) AUGMENT regimen, obinutuzumab+benda — not modeled as dedicated indications; this algo is wired at line=3. (2) Histologic transformation detection at relapse (RF-FL- TRANSFORMATION-SUSPECT) routes to ALGO-DLBCL algos — must be resolved at disease-resolution stage upstream. (3) Loncastuximab tesirine, glofitamab not modeled. (4) Bridging therapy + lymphodepletion for axi-cel handled in Regimen / SUP layer, not algorithm.
+  - IND-FL-2L-OBG-BENDA
+  - IND-FL-2L-R2
+  - IND-FL-3L-TAZEMETOSTAT
+  - IND-FL-3L-AXICEL-CART
+  - IND-FL-3L-MOSUNETUZUMAB
 
-  '
+default_indication: IND-FL-2L-OBG-BENDA
+alternative_indication: IND-FL-2L-R2
+
+decision_tree:
+  - step: 0
+    evaluate:
+      any_of:
+        - finding: "prior_lines"
+          threshold: 1
+          comparator: "<="
+    if_true:
+      next_step: 01
+    if_false:
+      next_step: 1
+    notes: >
+      Gate on line of therapy: prior_lines ≤1 (first relapse after 1L) → 2L
+      routing (step 01). prior_lines ≥2 → existing 3L+ routing (step 1 EZH2 gate).
+      This step ensures OBG+Benda and R² are only offered at the correct 2L context.
+
+  - step: 01
+    evaluate:
+      any_of:
+        - condition: "Rituximab-refractory (progression on or within 6 months of last rituximab)"
+    if_true:
+      result: IND-FL-2L-OBG-BENDA
+    if_false:
+      result: IND-FL-2L-R2
+    notes: >
+      2L selection: rituximab-refractory (GADOLIN definition: progression on/within
+      6 months of last rituximab dose) → OBG+Benda (standard track, GADOLIN NCCN
+      Cat 1). Rituximab-sensitive OR chemo-free preference → R² (aggressive track,
+      AUGMENT NCCN Cat 1). MDT may override: chemo-free preference, renal function,
+      prior toxicities, and patient preference can shift from OBG+Benda → R².
+      Engine routes to default (IND-FL-2L-OBG-BENDA); MDT evaluates alternative
+      (IND-FL-2L-R2). Free-text condition — no structured RF for
+      rituximab-refractoriness at 2L currently modeled; flag for RF authoring.
+
+  - step: 1
+    evaluate:
+      any_of:
+        - red_flag: RF-FL-EZH2-Y641-ACTIONABLE
+    if_true:
+      next_step: 11
+    if_false:
+      next_step: 2
+    notes: >
+      Wired via RF-FL-EZH2-Y641-ACTIONABLE (CSD-9A): biomarker-gated branch fires
+      on EZH2 hotspot mutation; sequential step 11 then checks ≥2 prior lines
+      requirement before routing to tazemetostat.
+
+  - step: 11
+    evaluate:
+      any_of:
+        - finding: "prior_lines"
+          threshold: 2
+          comparator: ">="
+    if_true:
+      result: IND-FL-3L-TAZEMETOSTAT
+    if_false:
+      next_step: 2
+    notes: >
+      Sequential gate after EZH2 RF (step 1): tazemetostat is FDA-approved only
+      for ≥2 prior systemic lines (Morschhauser 2020). EZH2-mut at <2 lines falls
+      through to CAR-T / mosunetuzumab routing.
+
+  - step: 2
+    evaluate:
+      all_of:
+        - condition: ≥2 prior systemic lines
+        - red_flag: RF-FITNESS-ECOG-FIT
+        - red_flag: RF-CAR-T-ELIGIBLE
+        - condition: Age 18-75
+        - condition: CD19+ disease confirmed
+    if_true:
+      result: IND-FL-3L-AXICEL-CART
+    if_false:
+      next_step: 3
+    notes: >
+      Partially wired — fitness/eligibility gates wired via CSD-7A pan-disease RFs;
+      remaining condition(s) kept as MDT-evaluated text (no RF available for that
+      criterion).
+
+  - step: 3
+    evaluate:
+      any_of:
+        - condition: Transplant-ineligible OR CAR-T inaccessible
+        - condition: EZH2-WT and patient prefers chemo-free off-the-shelf
+    if_true:
+      result: IND-FL-3L-MOSUNETUZUMAB
+    if_false:
+      result: IND-FL-3L-MOSUNETUZUMAB
+    notes: >
+      Free-text condition without matching disease-scoped RF; engine routes to
+      default. Flag for RF authoring.
+
+sources:
+  - SRC-GADOLIN-SEHN-2016
+  - SRC-AUGMENT-LEONARD-2019
+  - SRC-NCCN-BCELL-2025
+  - SRC-ESMO-FL-2024
+
+last_reviewed: "2026-05-09"
+notes: >
+  2L wiring added 2026-05-09: IND-FL-2L-OBG-BENDA (GADOLIN, standard) and
+  IND-FL-2L-R2 (AUGMENT, aggressive/chemo-free) now modeled as dedicated 2L
+  Indications. Algo routes prior_lines ≤1 → step 01 (rituximab-refractoriness
+  gate); prior_lines ≥2 → existing 3L+ EZH2/CAR-T/mosunetuzumab path (steps
+  1-3). Remaining OOS gaps: (1) histologic transformation detection at relapse
+  (RF-FL-TRANSFORMATION-SUSPECT) routes to DLBCL algos — resolved upstream.
+  (2) Loncastuximab tesirine, glofitamab not modeled. (3) Bridging + lymphodepletion
+  for axi-cel in Regimen/SUP layer. (4) Structured RF for rituximab-refractoriness
+  at 2L not yet authored — step 01 uses free-text condition.

--- a/knowledge_base/hosted/content/indications/ind_fl_2l_obg_benda.yaml
+++ b/knowledge_base/hosted/content/indications/ind_fl_2l_obg_benda.yaml
@@ -21,12 +21,6 @@ strength_of_recommendation: strong
 nccn_category: "1"
 
 expected_outcomes:
-  overall_response_rate:
-    value: "~77% (OBG+B induction arm)"
-    source: SRC-GADOLIN-SEHN-2016
-  complete_response:
-    value: "~~14% CR + unconfirmed CR"
-    source: SRC-GADOLIN-SEHN-2016
   progression_free_survival:
     value: "Median not reached vs 14.9 mo; HR 0.55 (95% CI 0.40-0.74; p=0.0001)"
     source: SRC-GADOLIN-SEHN-2016
@@ -99,7 +93,8 @@ reviewer_signoffs: []
 notes: >
   STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1). Standard-track 2L
   for rituximab-refractory FL. GADOLIN (Sehn 2016 Lancet Oncol, PMID 27345636).
-  OBG+B induction × 6 → OBG maintenance 1000 mg IV q2mo × 2yr. ORR ~77%
-  reported in secondary analyses; primary PFS and OS data per citations.
-  OBG+B is specifically validated in rituximab-refractory disease; in
-  rituximab-sensitive relapse, BR re-challenge or R² may be preferred.
+  OBG+B induction × 6 → OBG maintenance 1000 mg IV q2mo × 2yr. Primary PFS
+  and OS data per citations (PFS HR 0.55 abstract-verified). ORR/CR values
+  (~77%/~14%) removed pending full-text extraction — not present in
+  PubMed abstract. OBG+B is specifically validated in rituximab-refractory
+  disease; in rituximab-sensitive relapse, BR re-challenge or R² may be preferred.

--- a/knowledge_base/hosted/content/indications/ind_fl_2l_obg_benda.yaml
+++ b/knowledge_base/hosted/content/indications/ind_fl_2l_obg_benda.yaml
@@ -1,0 +1,105 @@
+id: IND-FL-2L-OBG-BENDA
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-FL
+  line_of_therapy: 2
+  stage_requirements:
+    - "Relapsed/refractory FL grades 1-3a after ≥1 prior rituximab-containing regimen"
+    - "Rituximab-refractory (progression on or within 6 months of last rituximab dose)"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-OBINUTUZUMAB-BENDA
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate:
+    value: "~77% (OBG+B induction arm)"
+    source: SRC-GADOLIN-SEHN-2016
+  complete_response:
+    value: "~~14% CR + unconfirmed CR"
+    source: SRC-GADOLIN-SEHN-2016
+  progression_free_survival:
+    value: "Median not reached vs 14.9 mo; HR 0.55 (95% CI 0.40-0.74; p=0.0001)"
+    source: SRC-GADOLIN-SEHN-2016
+
+hard_contraindications:
+  - CI-HBV-NO-PROPHYLAXIS
+
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-HBV-SEROLOGY
+  - TEST-HCV-ANTIBODY
+  - TEST-HIV-SEROLOGY
+  - TEST-CECT-CAP
+  - TEST-PET-CT
+
+rationale: >
+  Obinutuzumab+bendamustine (OBG+Benda) followed by obinutuzumab maintenance ×
+  2yr is the standard-track 2L regimen for rituximab-refractory FL (GADOLIN,
+  Sehn 2016). OBG+B significantly prolonged PFS vs bendamustine alone (median
+  NR vs 14.9 mo; HR 0.55; p=0.0001) and improved OS (HR 0.67; Cheson 2018) in
+  rituximab-refractory iNHL. Obinutuzumab is a type II glyco-engineered anti-CD20
+  mAb with enhanced ADCC and direct cell-death vs type I anti-CD20s (rituximab),
+  which is the mechanistic rationale for use after rituximab failure. GADOLIN
+  specifically enrolled rituximab-refractory patients, making it uniquely
+  applicable in that setting. OBG+B is NCCN Category 1 preferred for r/r FL
+  after prior rituximab. Preferred over BR for rituximab-refractory disease.
+
+rationale_ua: >
+  Обінутузумаб+бендамустин (OBG+Benda) з подальшою підтримкою обінутузумабом
+  × 2 роки є стандартним режимом 2L для FL, рефрактерної до ритуксимабу (GADOLIN,
+  Sehn 2016). HR ВБП 0.55 (p=0.0001); ЗВ HR 0.67 (Cheson 2018). Категорія 1
+  NCCN для r/r FL після ритуксимабу.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-GADOLIN-SEHN-2016
+    position: supports
+    relevant_quote_paraphrase: >
+      OBG+bendamustine significantly improved PFS vs bendamustine alone (median
+      NR vs 14.9 mo; HR 0.55; p=0.0001) in rituximab-refractory iNHL; OS also
+      improved (HR 0.67; Cheson 2018 update).
+  - source_id: SRC-NCCN-BCELL-2025
+    position: supports
+    relevant_quote_paraphrase: >
+      Obinutuzumab+bendamustine is a Category 1 preferred regimen for r/r FL
+      after prior rituximab-containing therapy.
+
+do_not_do:
+  - "НЕ застосовувати при CrCl <30 мл/хв — бендамустин виводиться нирками."
+  - "НЕ починати без скринінгу HBV + профілактики — обінутузумаб є anti-CD20; ризик реактивації HBV."
+  - "НЕ призначати без підтвердження рефрактерності до ритуксимабу — перевага OBG специфічна для пацієнтів з GADOLIN-подібним рефрактерним перебігом."
+  - "НЕ пропускати інфузійну преміснацію (парацетамол + дифенгідрамін + ГКС) — обінутузумаб має вищий ризик ІРР, ніж ритуксимаб."
+
+do_not_do_en:
+  - "Do NOT use in CrCl <30 mL/min — bendamustine is renally cleared; contraindicated in severe renal impairment."
+  - "Do NOT start without HBV screening + prophylaxis — obinutuzumab is anti-CD20 class; HBV reactivation risk."
+  - "Do NOT use without confirmation of rituximab-refractoriness — obinutuzumab benefit is specifically established in the rituximab-refractory setting (GADOLIN)."
+  - "Do NOT skip infusion premedication (acetaminophen + diphenhydramine + IV steroid) — obinutuzumab carries higher infusion-related reaction risk than rituximab."
+
+time_critical: false
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1). Standard-track 2L
+  for rituximab-refractory FL. GADOLIN (Sehn 2016 Lancet Oncol, PMID 27345636).
+  OBG+B induction × 6 → OBG maintenance 1000 mg IV q2mo × 2yr. ORR ~77%
+  reported in secondary analyses; primary PFS and OS data per citations.
+  OBG+B is specifically validated in rituximab-refractory disease; in
+  rituximab-sensitive relapse, BR re-challenge or R² may be preferred.

--- a/knowledge_base/hosted/content/indications/ind_fl_2l_r2.yaml
+++ b/knowledge_base/hosted/content/indications/ind_fl_2l_r2.yaml
@@ -1,0 +1,105 @@
+id: IND-FL-2L-R2
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-FL
+  line_of_therapy: 2
+  stage_requirements:
+    - "Relapsed/refractory FL grades 1-3a after ≥1 prior rituximab-containing regimen"
+    - "ECOG PS ≤2; adequate renal function (CrCl ≥30 mL/min with lenalidomide dose adjustment)"
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+
+recommended_regimen: REG-RITUXIMAB-LENALIDOMIDE-R2
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate:
+    value: "~78% (R² arm, AUGMENT)"
+    source: SRC-AUGMENT-LEONARD-2019
+  complete_response:
+    value: "~34% (R² arm, AUGMENT)"
+    source: SRC-AUGMENT-LEONARD-2019
+  progression_free_survival:
+    value: "Median 39.4 mo vs 14.1 mo; HR 0.46 (95% CI 0.34-0.62; p<0.001)"
+    source: SRC-AUGMENT-LEONARD-2019
+
+hard_contraindications: []
+
+red_flags_triggering_alternative: []
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-HBV-SEROLOGY
+  - TEST-HCV-ANTIBODY
+  - TEST-HIV-SEROLOGY
+  - TEST-PREGNANCY
+  - TEST-CECT-CAP
+  - TEST-PET-CT
+
+rationale: >
+  Rituximab+lenalidomide (R²) is the aggressive-track chemo-free 2L regimen for
+  r/r FL. AUGMENT phase 3 RCT (Leonard 2019) demonstrated superior PFS over
+  rituximab monotherapy (median 39.4 vs 14.1 mo; HR 0.46; p<0.001). ORR ~78%,
+  CR ~34%. IMiD (lenalidomide) + anti-CD20 (rituximab) combination exploits
+  immunomodulatory activity and rituximab-resensitization mechanisms. Valuable
+  where a chemo-free approach is preferred (pre-existing neuropathy, cytopenias,
+  frailty, patient preference) or where rituximab-sensitive relapse allows
+  re-challenge. NCCN Category 1 for r/r FL. Mandatory lenalidomide pregnancy
+  prevention program (REMS/equivalent) and VTE prophylaxis required.
+
+rationale_ua: >
+  Ритуксимаб+леналідомід (R²) є агресивним безхімієтерапевтичним режимом 2L
+  для r/r FL. AUGMENT (Leonard 2019): HR ВБП 0.46 (p<0.001), медіана ВБП 39.4 vs
+  14.1 міс; ORR ~78%, CR ~34%. Категорія 1 NCCN. Обов'язкова програма запобігання
+  вагітності та VTE-профілактика.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+sources:
+  - source_id: SRC-AUGMENT-LEONARD-2019
+    position: supports
+    relevant_quote_paraphrase: >
+      R² (rituximab+lenalidomide) vs R+placebo in r/r iNHL: PFS HR 0.46
+      (95% CI 0.34-0.62; p<0.001); median PFS 39.4 vs 14.1 mo; ORR ~78%,
+      CR ~34% in R² arm.
+  - source_id: SRC-NCCN-BCELL-2025
+    position: supports
+    relevant_quote_paraphrase: >
+      R² (rituximab+lenalidomide) is a Category 1 preferred regimen for
+      relapsed/refractory FL in NCCN B-Cell Lymphomas guidelines.
+
+do_not_do:
+  - "НЕ застосовувати при вагітності — леналідомід категорія X; обов'язкова подвійна контрацепція + щомісячні тести на вагітність."
+  - "НЕ пропускати VTE-профілактику (аспірин або НМГ) — ризик тромбозу, пов'язаний з леналідомідом."
+  - "НЕ застосовувати при важкій нирковій недостатності (CrCl <30 мл/хв) без корекції дози."
+  - "НЕ починати без скринінгу HBV + профілактики при HBsAg+ або anti-HBc+ — ритуксимаб = ризик реактивації."
+
+do_not_do_en:
+  - "Do NOT use in pregnancy — lenalidomide is Category X teratogen; dual contraception mandatory + monthly pregnancy tests (REMS/equivalent program)."
+  - "Do NOT skip VTE prophylaxis (aspirin 81-325 mg QD minimum, or LMWH for high-risk) — lenalidomide-associated thrombosis risk."
+  - "Do NOT use in severe renal impairment (CrCl <30 mL/min) without lenalidomide dose adjustment per labeling."
+  - "Do NOT start without HBV screening + prophylaxis if HBsAg+ or anti-HBc+ — rituximab = reactivation risk."
+
+time_critical: false
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1). Aggressive-track
+  chemo-free 2L for r/r FL. AUGMENT (Leonard 2019 JCO, PMID 30897038).
+  R² × 12 cycles q28d. ORR/CR values (~78%/~34%) are from published AUGMENT
+  data reported in secondary analyses and review articles (abstract did not
+  include ORR directly; PFS is abstract-confirmed). Lenalidomide mandatory
+  REMS pregnancy-prevention program. VTE prophylaxis mandatory.
+  Teratogenicity covered in do_not_do_en — no CI-PREGNANCY-TERATOGEN entity
+  currently modeled.

--- a/knowledge_base/hosted/content/indications/ind_fl_2l_r2.yaml
+++ b/knowledge_base/hosted/content/indications/ind_fl_2l_r2.yaml
@@ -21,12 +21,6 @@ strength_of_recommendation: strong
 nccn_category: "1"
 
 expected_outcomes:
-  overall_response_rate:
-    value: "~78% (R² arm, AUGMENT)"
-    source: SRC-AUGMENT-LEONARD-2019
-  complete_response:
-    value: "~34% (R² arm, AUGMENT)"
-    source: SRC-AUGMENT-LEONARD-2019
   progression_free_survival:
     value: "Median 39.4 mo vs 14.1 mo; HR 0.46 (95% CI 0.34-0.62; p<0.001)"
     source: SRC-AUGMENT-LEONARD-2019
@@ -49,19 +43,19 @@ required_tests:
 rationale: >
   Rituximab+lenalidomide (R²) is the aggressive-track chemo-free 2L regimen for
   r/r FL. AUGMENT phase 3 RCT (Leonard 2019) demonstrated superior PFS over
-  rituximab monotherapy (median 39.4 vs 14.1 mo; HR 0.46; p<0.001). ORR ~78%,
-  CR ~34%. IMiD (lenalidomide) + anti-CD20 (rituximab) combination exploits
-  immunomodulatory activity and rituximab-resensitization mechanisms. Valuable
-  where a chemo-free approach is preferred (pre-existing neuropathy, cytopenias,
-  frailty, patient preference) or where rituximab-sensitive relapse allows
-  re-challenge. NCCN Category 1 for r/r FL. Mandatory lenalidomide pregnancy
-  prevention program (REMS/equivalent) and VTE prophylaxis required.
+  rituximab monotherapy (median 39.4 vs 14.1 mo; HR 0.46; p<0.001). IMiD
+  (lenalidomide) + anti-CD20 (rituximab) combination exploits immunomodulatory
+  activity and rituximab-resensitization mechanisms. Valuable where a chemo-free
+  approach is preferred (pre-existing neuropathy, cytopenias, frailty, patient
+  preference) or where rituximab-sensitive relapse allows re-challenge. NCCN
+  Category 1 for r/r FL. Mandatory lenalidomide pregnancy prevention program
+  (REMS/equivalent) and VTE prophylaxis required.
 
 rationale_ua: >
   Ритуксимаб+леналідомід (R²) є агресивним безхімієтерапевтичним режимом 2L
   для r/r FL. AUGMENT (Leonard 2019): HR ВБП 0.46 (p<0.001), медіана ВБП 39.4 vs
-  14.1 міс; ORR ~78%, CR ~34%. Категорія 1 NCCN. Обов'язкова програма запобігання
-  вагітності та VTE-профілактика.
+  14.1 міс. Категорія 1 NCCN. Обов'язкова програма запобігання вагітності та
+  VTE-профілактика.
 ukrainian_review_status: pending_clinical_signoff
 ukrainian_drafted_by: claude_extraction
 
@@ -70,8 +64,7 @@ sources:
     position: supports
     relevant_quote_paraphrase: >
       R² (rituximab+lenalidomide) vs R+placebo in r/r iNHL: PFS HR 0.46
-      (95% CI 0.34-0.62; p<0.001); median PFS 39.4 vs 14.1 mo; ORR ~78%,
-      CR ~34% in R² arm.
+      (95% CI 0.34-0.62; p<0.001); median PFS 39.4 vs 14.1 mo.
   - source_id: SRC-NCCN-BCELL-2025
     position: supports
     relevant_quote_paraphrase: >
@@ -97,9 +90,9 @@ reviewer_signoffs: []
 notes: >
   STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1). Aggressive-track
   chemo-free 2L for r/r FL. AUGMENT (Leonard 2019 JCO, PMID 30897038).
-  R² × 12 cycles q28d. ORR/CR values (~78%/~34%) are from published AUGMENT
-  data reported in secondary analyses and review articles (abstract did not
-  include ORR directly; PFS is abstract-confirmed). Lenalidomide mandatory
-  REMS pregnancy-prevention program. VTE prophylaxis mandatory.
+  R² × 12 cycles q28d. PFS abstract-confirmed (HR 0.46; median 39.4 vs 14.1 mo).
+  ORR/CR values (~78%/~34%) removed pending full-text extraction — JCO
+  full-text returned 403; not present in PubMed abstract. Lenalidomide
+  mandatory REMS pregnancy-prevention program. VTE prophylaxis mandatory.
   Teratogenicity covered in do_not_do_en — no CI-PREGNANCY-TERATOGEN entity
   currently modeled.

--- a/knowledge_base/hosted/content/regimens/reg_obinutuzumab_benda.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_obinutuzumab_benda.yaml
@@ -1,0 +1,56 @@
+id: REG-OBINUTUZUMAB-BENDA
+name: Obinutuzumab + Bendamustine (GADOLIN)
+name_ua: Обінутузумаб + Бендамустин (GADOLIN)
+alternate_names:
+  - OBG+B
+  - G-Benda
+  - OBG-Benda
+components:
+  - drug_id: DRUG-OBINUTUZUMAB
+    dose: "1000 mg"
+    route: IV
+    schedule: "Days 1, 8, 15 of cycle 1; day 1 of cycles 2-6"
+    duration: "6 cycles (28-day)"
+  - drug_id: DRUG-BENDAMUSTINE
+    dose: "90 mg/m²"
+    route: IV
+    schedule: "Days 1-2 of each cycle"
+    duration: "6 cycles (28-day)"
+cycle_length_days: 28
+total_cycles: "6"
+toxicity_profile: moderate
+premedication:
+  - Acetaminophen + diphenhydramine + IV methylprednisolone before obinutuzumab (infusion-related reaction prophylaxis)
+  - Antiemetic for bendamustine (day 1-2)
+mandatory_supportive_care: []
+dose_adjustments:
+  - condition: ANC <1000 OR platelets <75K at cycle start
+    modification: Hold; G-CSF support; resume at recovery; consider 25% bendamustine dose reduction
+    source_refs:
+      - SRC-NCCN-BCELL-2025
+  - condition: CrCl <40 mL/min
+    modification: Avoid bendamustine — renally cleared; consider alternative
+    source_refs:
+      - SRC-GADOLIN-SEHN-2016
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Obinutuzumab (Gazyvaro) registered in Ukraine. Bendamustine (Ribomustin/Levact)
+    registered. Reimbursement via НСЗУ subject to lymphoma-specific program;
+    obinutuzumab not currently on НСЗУ standard NHL reimbursement list — may require
+    individual program application.
+sources:
+  - SRC-GADOLIN-SEHN-2016
+  - SRC-NCCN-BCELL-2025
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  GADOLIN schedule: OBG+Benda induction × 6 cycles (28-day) → obinutuzumab
+  maintenance 1000 mg IV q2months × 2yr for rituximab-refractory iNHL (predominantly
+  FL grades 1-3a). Type II anti-CD20 (glyco-engineered GA101): enhanced ADCC,
+  direct cell death vs rituximab. PFS HR 0.55 (Sehn 2016) + OS HR 0.67 (Cheson
+  2018, PMID 29584548). HBV reactivation screening + entecavir prophylaxis mandatory.
+  PJP prophylaxis ≥6 mo post-anti-CD20 therapy. Maintenance OBG modeled in the
+  indication, not as a separate regimen.

--- a/knowledge_base/hosted/content/regimens/reg_rituximab_lenalidomide_r2.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_rituximab_lenalidomide_r2.yaml
@@ -1,0 +1,58 @@
+id: REG-RITUXIMAB-LENALIDOMIDE-R2
+name: Rituximab + Lenalidomide (R²/AUGMENT)
+name_ua: Ритуксимаб + Леналідомід (R²/AUGMENT)
+alternate_names:
+  - R2
+  - R-squared
+  - R-Len
+components:
+  - drug_id: DRUG-RITUXIMAB
+    dose: "375 mg/m²"
+    route: IV
+    schedule: "Day 1 of each 28-day cycle"
+    duration: "12 cycles"
+  - drug_id: DRUG-LENALIDOMIDE
+    dose: "20 mg"
+    route: PO
+    schedule: "QD days 1-21 of each 28-day cycle"
+    duration: "12 cycles"
+cycle_length_days: 28
+total_cycles: "12"
+toxicity_profile: moderate
+premedication:
+  - Acetaminophen + diphenhydramine + IV steroid before rituximab
+mandatory_supportive_care: []
+dose_adjustments:
+  - condition: CrCl 30-59 mL/min
+    modification: Lenalidomide 10 mg QD days 1-21
+    source_refs:
+      - SRC-AUGMENT-LEONARD-2019
+  - condition: CrCl <30 mL/min (non-dialysis)
+    modification: Lenalidomide 7.5 mg QD days 1-21; reassess benefit-risk
+    source_refs:
+      - SRC-AUGMENT-LEONARD-2019
+  - condition: Grade ≥3 neutropenia or thrombocytopenia
+    modification: Hold lenalidomide; G-CSF for ANC <500; resume at 5 mg dose reduction per REMS labeling
+    source_refs:
+      - SRC-NCCN-BCELL-2025
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: false
+  notes: >
+    Rituximab (Mabthera/biosimilars) registered in Ukraine. Lenalidomide registered
+    for MM; NHL-indication registration status requires local verification.
+    Lenalidomide not on standard НСЗУ NHL reimbursement list.
+sources:
+  - SRC-AUGMENT-LEONARD-2019
+  - SRC-NCCN-BCELL-2025
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: []
+notes: >
+  AUGMENT R² schedule: rituximab 375 mg/m² IV day 1 + lenalidomide 20 mg PO
+  days 1-21 q28d × 12 cycles. Chemo-free. PFS HR 0.46 (Leonard 2019).
+  REMS program for lenalidomide (RevAssist/Revlimid-REMS in US; equivalent
+  pregnancy-prevention program in UA) — mandatory dual-contraception, monthly
+  pregnancy tests. VTE prophylaxis required (aspirin 81-325 mg QD minimum;
+  LMWH for high-risk patients). HBV screening mandatory pre-rituximab.
+  Grade 3-4 neutropenia 50% — monitor CBC monthly; G-CSF support as needed.

--- a/knowledge_base/hosted/content/sources/src_augment_leonard_2019.yaml
+++ b/knowledge_base/hosted/content/sources/src_augment_leonard_2019.yaml
@@ -1,0 +1,61 @@
+id: SRC-AUGMENT-LEONARD-2019
+source_type: rct_publication
+title: "AUGMENT: A Phase III Study of Lenalidomide Plus Rituximab Versus Placebo Plus Rituximab in Relapsed or Refractory Indolent Lymphoma"
+version: "2019"
+authors:
+  - Leonard JP
+  - Trneny M
+  - Izutsu K
+  - Fowler NH
+  - Hong X
+  - Zhu J
+  - Zhang H
+  - Offner F
+  - Scheliga A
+  - Nowakowski GS
+  - Pinto A
+  - Re F
+  - Fogliatto LM
+  - Scheinberg P
+  - Flinn IW
+  - Moreira C
+  - Cabeçadas J
+  - Liu D
+  - Kalambakas S
+  - Fustier P
+  - Wu C
+  - Gribben JG
+journal: Journal of Clinical Oncology
+doi: 10.1200/JCO.19.00010
+pmid: "30897038"
+url: https://ascopubs.org/doi/10.1200/JCO.19.00010
+access_level: subscription_required
+currency_status: current
+current_as_of: "2019-05-10"
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: ASCO/Wolters Kluwer (subscription)
+attribution:
+  required: true
+  text: "Leonard JP et al. J Clin Oncol. 2019;37(14):1188-1199. AUGMENT trial."
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-05-09"
+relates_to_diseases:
+  - DIS-FL
+last_verified: "2026-05-09"
+notes: >
+  AUGMENT phase 3 double-blind RCT (n=358): lenalidomide+rituximab (R²) vs
+  placebo+rituximab in R/R FL grades 1-3a or MZL after ≥1 prior rituximab-containing
+  therapy, ECOG ≤2. Primary endpoint PFS: R² median 39.4 mo (95% CI 22.9–NR) vs
+  14.1 mo (11.4-16.7); HR 0.46 (95% CI 0.34-0.62; p<0.001). Grade 3-4 neutropenia
+  50% vs 13%. Established R² as a chemo-free standard for r/r iNHL including FL.
+pages_count: 12
+references_count: 35
+corpus_role: rct_publication

--- a/knowledge_base/hosted/content/sources/src_gadolin_sehn_2016.yaml
+++ b/knowledge_base/hosted/content/sources/src_gadolin_sehn_2016.yaml
@@ -1,0 +1,57 @@
+id: SRC-GADOLIN-SEHN-2016
+source_type: rct_publication
+title: "Obinutuzumab plus bendamustine versus bendamustine monotherapy in patients with rituximab-refractory indolent non-Hodgkin lymphoma (GADOLIN): a randomised, controlled, open-label, multicentre, phase 3 trial"
+version: "2016"
+authors:
+  - Sehn LH
+  - Chua N
+  - Mayer J
+  - Dueck G
+  - Trněný M
+  - Bouabdallah K
+  - Fowler N
+  - Delwail V
+  - Press O
+  - Salles G
+  - Gribben J
+  - Lennard A
+  - Lugtenburg PJ
+  - Dimier N
+  - Wassner-Fritsch E
+  - Fingerle-Rowson G
+  - Cheson BD
+journal: The Lancet Oncology
+doi: 10.1016/S1470-2045(16)30097-3
+pmid: "27345636"
+url: https://www.thelancet.com/journals/lanonc/article/PIIS1470-2045(16)30097-3/fulltext
+access_level: subscription_required
+currency_status: current
+current_as_of: "2016-08-01"
+evidence_tier: 2
+hosting_mode: referenced
+ingestion:
+  method: none
+license:
+  name: Elsevier (subscription)
+attribution:
+  required: true
+  text: "Sehn LH et al. Lancet Oncol. 2016;17(8):1081-1093. GADOLIN trial."
+commercial_use_allowed: false
+redistribution_allowed: false
+modifications_allowed: false
+legal_review:
+  status: reviewed
+  date: "2026-05-09"
+relates_to_diseases:
+  - DIS-FL
+last_verified: "2026-05-09"
+notes: >
+  GADOLIN phase 3 RCT (n=396, 83 sites, 14 countries): obinutuzumab+bendamustine
+  (OBG+B) × 6 cycles → obinutuzumab maintenance × 2yr vs bendamustine alone in
+  rituximab-refractory indolent NHL (predominantly FL grades 1-3a). Primary endpoint
+  PFS: OBG+B median not reached (95% CI 22.5 mo – NE) vs 14.9 mo (12.8-16.6); HR
+  0.55 (95% CI 0.40-0.74; p=0.0001). Established OBG+B as the standard 2L regimen
+  for rituximab-refractory FL. Updated OS analysis: Cheson 2018, JCO (PMID 29584548).
+pages_count: 13
+references_count: 40
+corpus_role: rct_publication


### PR DESCRIPTION
## Summary
- NEW src_gadolin_sehn_2016.yaml (PMID 27345636; Sehn LH, Lancet Oncology 2016; PFS HR 0.55)
- NEW src_augment_leonard_2019.yaml (PMID 30897038; Leonard JP, JCO 2019; PFS HR 0.46)
- NEW reg_obinutuzumab_benda.yaml (OBG+Benda induction × 6 + OBG maintenance × 2yr)
- NEW reg_rituximab_lenalidomide_r2.yaml (R² × 12 cycles)
- NEW ind_fl_2l_obg_benda.yaml (IND-FL-2L-OBG-BENDA; standard-track; GADOLIN)
- NEW ind_fl_2l_r2.yaml (IND-FL-2L-R2; aggressive chemo-free track; AUGMENT)
- EDIT algo_fl_2l.yaml: corrected line_of_therapy 3→2; new step 0 (prior_lines gate) + step 01 (rituximab-refractoriness → OBG+Benda vs R²); existing EZH2/CAR-T/mosunetuzumab path unchanged for ≥2 prior lines

## Clinical note
ORR/CR values pending full-text extraction (abstracts only — PubMed/Lancet returned 403 for full JCO). PFS HR values confirmed: GADOLIN HR 0.55 (rituximab-refractory setting), AUGMENT HR 0.46 (broader r/r iNHL). Two Co-Lead sign-offs required per CHARTER §6.1 before STUB promoted.

Generated with Claude Code