### PR TITLE
HEME-1 MM-1L TI-NDMM — D-Rd+Rd two-plan pair (MAIA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ worktree merge conflict at integration time.
 
 - All six specs drafted at v0.1. Specs naming locked: OpenOnco.
 - KB scale: **78 diseases, 438 biomarker_actionability, 173 biomarkers, 383
-  sources, 251 drugs, 426 indications, 474 redflags, 361 regimens, 140
+  sources, 251 drugs, 426 indications, 476 redflags, 361 regimens, 140
   algorithms, 8 procedures, 5 radiation courses.** (updated 2026-05-09)
 - API clients live under `knowledge_base/clients/`.
 - RedFlag quality phases 1-7 done (2026-04-25/26): clinical sign-off received.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ worktree merge conflict at integration time.
 
 - All six specs drafted at v0.1. Specs naming locked: OpenOnco.
 - KB scale: **78 diseases, 438 biomarker_actionability, 173 biomarkers, 383
-  sources, 251 drugs, 424 indications, 474 redflags, 360 regimens, 140
+  sources, 251 drugs, 426 indications, 474 redflags, 361 regimens, 140
   algorithms, 8 procedures, 5 radiation courses.** (updated 2026-05-09)
 - API clients live under `knowledge_base/clients/`.
 - RedFlag quality phases 1-7 done (2026-04-25/26): clinical sign-off received.

--- a/docs/plans/session_summary_mm1l_ti_ndmm_2026-05-09.md
+++ b/docs/plans/session_summary_mm1l_ti_ndmm_2026-05-09.md
@@ -1,0 +1,84 @@
+# Session Summary: MM 1L Transplant-Ineligible Two-Plan Pair (2026-05-09)
+
+## Overview
+
+Authored the transplant-ineligible NDMM first-line indication pair, closing the
+gap documented in IND-MM-1L-DVRD notes. PR #537 opened on `feat/mm-1l-ti-ndmm`.
+
+---
+
+## PR opened this session
+
+| PR | Title | Files changed |
+|----|-------|--------------|
+| [#537](https://github.com/romeo111/OpenOnco/pull/537) | HEME-1 MM-1L TI-NDMM — D-Rd+Rd two-plan pair (MAIA) | ind_mm_1l_dara_rd.yaml (NEW), ind_mm_1l_rd.yaml (NEW), reg_rd_continuous.yaml (NEW), algo_mm_1l.yaml (EDIT), CLAUDE.md (EDIT) |
+
+---
+
+## Clinical decisions wired
+
+### IND-MM-1L-DARA-RD (aggressive, transplant-ineligible)
+
+| Field | Value |
+|-------|-------|
+| plan_track | aggressive |
+| fit_for_transplant | false |
+| recommended_regimen | REG-D-RD-MAIA |
+| trial | MAIA (Facon NEJM 2019, PMID 30926586) |
+| ORR | ~93% vs ~76% Rd |
+| PFS HR | 0.56 (95% CI 0.43–0.73) |
+| 5-yr OS | 66.3% vs 53.1% (HR 0.66, Facon JCO 2024) |
+| HBV gate | mandatory (anti-CD38 class effect) |
+| НСЗУ | daratumumab NOT reimbursed — funding gate |
+
+### IND-MM-1L-RD (standard, transplant-ineligible)
+
+| Field | Value |
+|-------|-------|
+| plan_track | standard |
+| fit_for_transplant | false |
+| recommended_regimen | REG-RD-CONTINUOUS (NEW) |
+| trial | MAIA control arm (Facon NEJM 2019) + FIRST trial (Benboubker NEJM 2014) |
+| ORR | ~76% |
+| 30-mo PFS | ~38% |
+| 5-yr OS | ~53% |
+| НСЗУ | fully reimbursed — standard access backbone |
+
+### REG-RD-CONTINUOUS (new regimen)
+
+- Len 25 mg PO d1-21 + dex 40 mg weekly, 28-day cycles until progression
+- Renal dose table: CrCl 30-60 → 10 mg; CrCl <30 → 5 mg daily or 10 mg qod
+- Frailty adjustment: dex 20 mg if age >75 / frail; consider len 15 mg start
+- mandatory_supportive_care: SUP-MM-VTE-PROPHYLAXIS + SUP-MM-BONE-PROTECTION
+- Ukraine: fully НСЗУ-reimbursed; standard-access fallback for TI-NDMM
+
+---
+
+## algo_mm_1l.yaml changes
+
+- `output_indications` expanded: added IND-MM-1L-RD + IND-MM-1L-DARA-RD
+- `purpose` updated: documents TE/TI cohort split and transplant-gate TODO
+- `notes` rewritten: transplant-gate routing via `applicable_to.demographic_constraints.fit_for_transplant`; etiology rails clarified
+- `sources`: added SRC-MAIA-FACON-2019
+- `last_reviewed`: 2026-05-09
+
+---
+
+## Test results
+
+Short run (-x): **303 passed, 8 skipped, 1 pre-existing failure** (hero class, unrelated to this wave)
+Full run: in progress (background task bkerbrnq9)
+
+---
+
+## Forward plan
+
+| Area | Status | Notes |
+|------|--------|-------|
+| MM 1L TI-NDMM two-plan pair | ✅ PR #537 | D-Rd (MAIA) + Rd continuous; clinical signoff pending |
+| MM 1L TE D-VRd phases | ✅ PR #535 merged | PERSEUS 4-phase wired |
+| Transplant-gate engine support | 🔲 future | Engine doesn't yet gate on fit_for_transplant in decision_tree |
+| FL-2L ORR/CR data | ⏳ pending | Full-text Lancet Oncol/JCO needed |
+| NATALEE eligibility RF | 🔲 future | Node-negative + high-risk feature RF not authored |
+| BREAST early low-risk HR+ | 🔲 future | IND-BREAST-HR-POS-EARLY-ADJUVANT-AI not modeled |
+| Site test fix | 🔴 blocked | hero class missing; Codex session issue |

--- a/knowledge_base/hosted/content/algorithms/algo_endometrial_advanced_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_endometrial_advanced_1l.yaml
@@ -1,20 +1,74 @@
 id: ALGO-ENDOMETRIAL-ADVANCED-1L
 applicable_to_disease: DIS-ENDOMETRIAL
 applicable_to_line_of_therapy: 1
-purpose: "Select 1L advanced/recurrent endometrial by MMR status."
+purpose: >
+  Select 1L checkpoint inhibitor + chemotherapy combination for advanced or
+  recurrent endometrial carcinoma based on MMR/MSI status. dMMR/MSI-H
+  (RF-ENDOMETRIAL-DMMR) → dostarlimab+carbo/pac (RUBY; Mirza NEJM 2023,
+  dMMR PFS HR 0.28) as the aggressive plan. pMMR/MSS → pembrolizumab+carbo/pac
+  (KEYNOTE-868; Eskander NEJM 2023, overall PFS HR 0.54) as the standard plan.
+  Both carboplatin-paclitaxel backbones; carbo substituted for cisplatin in
+  most endometrial patients.
 output_indications: [IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO, IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO]
 default_indication: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO
 alternative_indication: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO
 decision_tree:
+  # Step 1 — dMMR/MSI-H gate (RF-ENDOMETRIAL-DMMR). dMMR patients benefit
+  # more from CPI+chemo than pMMR (PFS HR ~0.28-0.30 dMMR vs ~0.54-0.70
+  # pMMR). Both regimens are NCCN Category 1 regardless of MMR status.
   - step: 1
     evaluate:
       any_of:
+        - red_flag: RF-ENDOMETRIAL-DMMR
+        # Legacy finding-based evaluations for backward engine compatibility:
         - {finding: mmr_status, value: deficient}
+        - {finding: mmr_status, value: dMMR}
         - {finding: msi_status, value: MSI-H}
         - {finding: msi_status, value: MSI-high}
-    if_true: {result: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO}
-    if_false: {result: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO}
-    notes: "Gate replaced free-text condition with structured finding lookups for dMMR (mmr_status=deficient) and MSI-H (msi_status=MSI-H/MSI-high) — both label as eligible for dostarlimab arm."
-sources: [SRC-NCCN-UTERINE-2025, SRC-ESMO-ENDOMETRIAL-2022]
-last_reviewed: null
-notes: "Both pembro and dostarlimab approved; chemoimmuno superior to chemo alone regardless of MMR."
+        - {finding: msi_status, value: high}
+        - {finding: mlh1_ihc, value: loss}
+        - {finding: msh2_ihc, value: loss}
+        - {finding: msh6_ihc, value: loss}
+        - {finding: pms2_ihc, value: loss}
+    if_true:
+      result: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO
+      notes: >
+        dMMR/MSI-H confirmed (RF-ENDOMETRIAL-DMMR fired) — dostarlimab +
+        carbo/pac preferred (RUBY dMMR cohort 24-mo PFS HR 0.28,
+        95% CI 0.16–0.50; OS HR 0.28 interim). NCCN Cat 1. Pembrolizumab
+        + carbo/pac (KEYNOTE-868) is an equally acceptable alternative.
+    if_false:
+      result: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO
+      notes: >
+        pMMR/MSS — pembrolizumab + carbo/pac (KEYNOTE-868 overall PFS HR 0.54,
+        95% CI 0.41–0.71). NCCN Cat 1 for all comers; pMMR cohort still
+        benefits. Dostarlimab + carbo/pac (RUBY) also acceptable. In Ukraine,
+        pembrolizumab access via НСЗУ oncology program preferred over
+        dostarlimab (not reimbursed).
+    notes: >
+      W5c RF wiring: added RF-ENDOMETRIAL-DMMR as primary gate; legacy
+      finding lookups retained for backward engine compatibility.
+sources:
+  - SRC-RUBY-MIRZA-2023
+  - SRC-GY018-MAKKER-2022
+  - SRC-NCCN-UTERINE-2025
+  - SRC-ESMO-ENDOMETRIAL-2022
+last_reviewed: "2026-05-09"
+notes: >
+  Both pembrolizumab + carbo/pac (KEYNOTE-868/NRG-GY018) and dostarlimab +
+  carbo/pac (RUBY) are NCCN Category 1 for advanced/recurrent endometrial
+  carcinoma regardless of MMR status. The dMMR subgroup shows approximately
+  double the PFS benefit (HR ~0.28-0.30) vs the pMMR subgroup (HR ~0.54-0.70).
+  dMMR status is defined by loss of MLH1, MSH2, MSH6, or PMS2 on IHC, or
+  MSI-H on PCR/NGS.
+
+  Ukraine context: pembrolizumab partially reimbursed via НСЗУ oncology
+  program for eligible patients; dostarlimab is not currently НСЗУ-reimbursed.
+  For dMMR patients where dostarlimab is unavailable, pembrolizumab + carbo/pac
+  (IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO) is the standard-access alternative.
+
+  POLE/POLD1 ultra-mutated endometrial cancer: separate RF-POLE-POLD1-ENDOMETRIAL-
+  LOW-RISK; these patients may be candidates for de-escalation (omit
+  cytotoxic per ESMO 2022 for early-stage POLE). This algorithm covers
+  advanced/recurrent stage — POLE/POLD1 does not change systemic therapy
+  in advanced disease per current NCCN guidance.

--- a/knowledge_base/hosted/content/algorithms/algo_mm_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mm_1l.yaml
@@ -3,14 +3,19 @@ applicable_to_disease: DIS-MM
 applicable_to_line_of_therapy: 1
 purpose: >
   Select default + alternative Indication for first-line multiple myeloma based
-  on cytogenetic risk and fitness. Outputs the two-plan pair per CHARTER §2 —
-  D-VRd (preferred for high-risk; also NCCN Cat 1 for standard-risk post-PERSEUS
-  Sonneveld NEJM 2024 PFS HR 0.42) vs VRd (standard-risk default where D-VRd
-  access/funding is unavailable). High-risk always routes to D-VRd.
+  on transplant eligibility, cytogenetic risk, and fitness. Outputs two-plan pair
+  per CHARTER §2. Transplant-eligible (TE): VRd (standard) vs D-VRd+ASCT
+  (aggressive, PERSEUS HR 0.42). Transplant-ineligible (TI): Rd continuous
+  (standard, MAIA control) vs D-Rd (aggressive, MAIA HR 0.56). Routing between
+  TE and TI cohorts is determined by applicable_to.demographic_constraints.fit_for_transplant
+  on each Indication entity — the decision tree below governs regimen selection
+  within the TE cohort; TI cohort routing support pending engine transplant-gate.
 
 output_indications:
 - IND-MM-1L-VRD
 - IND-MM-1L-DVRD
+- IND-MM-1L-RD
+- IND-MM-1L-DARA-RD
 default_indication: IND-MM-1L-VRD
 alternative_indication: IND-MM-1L-DVRD
 decision_tree:
@@ -51,5 +56,34 @@ sources:
 - SRC-ESMO-MM-2023
 - SRC-PERSEUS-SONNEVELD-2024
 - SRC-GRIFFIN-VOORHEES-2020
+- SRC-MAIA-FACON-2019
 last_reviewed: '2026-05-09'
-notes: "Cytogenetic risk + aggressive biology are the primary regimen determinants; frailty is recorded but doesn't switch regimen (handled at Regimen dose-modification layer). Transplant eligibility is a downstream consideration that affects total cycle count and post- induction pathway (ASCT + consolidation + maintenance vs continuous induction-then-maintenance), but not the induction regimen choice. Both Indications carry CI-LENALIDOMIDE-PREGNANCY and CI-BORTEZOMIB-SEVERE-NEUROPATHY; D-VRd additionally carries CI-HBV-NO-PROPHYLAXIS. RF-MM-RENAL-DYSFUNCTION (investigate) triggers dose adjustment but does not shift regimen choice. RF-MM-INFECTION-SCREENING (hold) operates via parallel SUP-HBV-PROPHYLAXIS, not a decision-tree branch.\nEtiology rails (parallel to indication selection):\n- HBV (HBsAg+ OR anti-HBc+) — entecavir 0.5 mg PO daily before first\n  daratumumab or isatuximab dose, continued through induction +\n  ≥12 months post-last-anti-CD38. Anti-CD38 mAbs have documented HBV\n  reactivation risk (FDA labels; NCCN MM 2.2025). For VRd-only (no\n  anti-CD38), HBV reactivation risk is lower but entecavir still\n  recommended in HBsAg+ on prolonged steroid pulse. CI-HBV-NO-\n  PROPHYLAXIS (extended 2026-04-27 to cover daratumumab) is a hard\n  contraindication on D-VRd, blocking plan finalization until\n  SUP-HBV-PROPHYLAXIS is acknowledged.\n\n- HCV — Less common in MM cohort; treat MM first and coordinate DAA\n  timing with hepatologist. Avoid sofosbuvir + amiodarone interaction.\n\nHIV+ MM is rare (older population, typically post-PCP / post-PJP era); manage per ART-aware MM consensus (continue ART, prefer integrase- inhibitor backbone, no empiric VRd dose-reduction). BIO-HBV-STATUS, BIO-HCV-STATUS, BIO-HIV-STATUS missing — flagged for future round.\n"
+notes: >
+  Cytogenetic risk + aggressive biology are the primary regimen determinants
+  within each transplant-eligibility cohort. Frailty is recorded but doesn't
+  switch regimen (handled at Regimen dose-modification layer).
+
+  Transplant-eligibility gate: IND-MM-1L-VRD and IND-MM-1L-DVRD have
+  fit_for_transplant: true; IND-MM-1L-RD and IND-MM-1L-DARA-RD have
+  fit_for_transplant: false. The engine should apply this demographic gate
+  before running the decision tree. Until the engine supports
+  applicable_to.demographic_constraints routing, the decision tree outputs
+  TE indications by default. TI cohort: D-Rd (MAIA, Facon NEJM 2019, HR
+  0.56) as aggressive plan; Rd continuous as standard plan.
+
+  Both TE Indications carry CI-LENALIDOMIDE-PREGNANCY and CI-BORTEZOMIB-
+  SEVERE-NEUROPATHY; D-VRd and D-Rd additionally carry CI-HBV-NO-PROPHYLAXIS.
+  RF-MM-RENAL-DYSFUNCTION (investigate) triggers dose adjustment but does
+  not shift regimen choice. RF-MM-INFECTION-SCREENING (hold) operates via
+  parallel SUP-HBV-PROPHYLAXIS, not a decision-tree branch.
+
+  Etiology rails (parallel to indication selection):
+  - HBV (HBsAg+ OR anti-HBc+) — entecavir 0.5 mg PO daily before first
+    daratumumab dose, continued through therapy + ≥12 months post-last-anti-CD38.
+    Anti-CD38 mAbs have documented HBV reactivation risk (FDA labels; NCCN
+    MM 2.2025). CI-HBV-NO-PROPHYLAXIS is a hard contraindication on D-VRd
+    and D-Rd, blocking plan finalization until SUP-HBV-PROPHYLAXIS acknowledged.
+  - HCV — Less common in MM cohort; treat MM first and coordinate DAA timing
+    with hepatologist.
+  - HIV+ MM is rare; manage per ART-aware MM consensus (continue ART, prefer
+    integrase-inhibitor backbone). BIO-HIV-STATUS flagged for future wave.

--- a/knowledge_base/hosted/content/algorithms/algo_urothelial_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_urothelial_metastatic_1l.yaml
@@ -16,50 +16,34 @@ default_indication: IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO
 alternative_indication: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
 
 decision_tree:
-  # Step 1 — EV+pembro eligibility. Main exclusions: severe pre-existing
-  # peripheral neuropathy (EV: MMAE-related neuropathy risk), uncontrolled
-  # diabetes mellitus (EV hyperglycemia risk), severe corneal/ocular disease
-  # (EV-associated keratopathy). No CrCl cutoff — EV+pembro works regardless
-  # of cisplatin eligibility (EV-302 enrolled both groups).
+  # Step 1 — EV+pembro ineligibility gate (RF-UROTHELIAL-EV-INELIGIBLE).
+  # Exclusions: grade ≥2 peripheral neuropathy, uncontrolled DM (HbA1c >9%),
+  # severe corneal/ocular disease, active autoimmune disease, prior ICI
+  # grade ≥3 irAE. CrCl alone is NOT an exclusion (EV-302 enrolled both
+  # cisplatin-eligible and cisplatin-ineligible patients).
   - step: 1
     evaluate:
       any_of:
-        - {finding: ev_pembro_eligible, value: true}
+        - red_flag: RF-UROTHELIAL-EV-INELIGIBLE
+        # Legacy finding-based evaluations kept for backward compatibility
+        # until engine fully adopts RF-based routing:
+        - {finding: ev_pembro_eligible, value: false}
+        - {finding: peripheral_neuropathy_grade, threshold: 2, comparator: ">="}
+        - {finding: diabetes_control, value: "uncontrolled"}
     if_true:
+      result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
+      notes: >
+        RF-UROTHELIAL-EV-INELIGIBLE fired — route to platinum-based chemotherapy
+        + avelumab maintenance (JAVELIN Bladder 100; mOS 21.4 vs 14.3 mo,
+        HR 0.69). Both cisplatin-eligible (GC/MVAC) and cisplatin-ineligible
+        (gem+carbo) patients covered by IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB.
+    if_false:
       result: IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO
       notes: >
-        EV+pembro preferred 1L for all eligible mUC patients (EV-302/KEYNOTE-A39;
-        mOS 31.5 vs 16.1 mo, HR 0.47 vs platinum chemo). Applies regardless of
-        cisplatin eligibility, PD-L1 status, or primary site (bladder, upper tract).
-        EV-302 enrolled both cisplatin-eligible and cisplatin-ineligible patients.
-    if_false:
-      next_step: 2
-    notes: >
-      EV eligibility gate covers MMAE toxicity-based exclusions (neuropathy,
-      hyperglycemia, keratopathy). RF authoring for composite exclusion criteria
-      still owed (RF-UROTHELIAL-EV-INELIGIBLE). Until then, evaluated as MDT text.
-
-  # Step 2 — EV+pembro ineligible. Route by cisplatin eligibility.
-  # Cisplatin-eligible: GC or dose-dense MVAC followed by avelumab maintenance.
-  # Cisplatin-ineligible (CrCl <60, ECOG ≥2, grade ≥2 peripheral neuropathy,
-  # grade ≥2 hearing loss, NYHA class III/IV HF): gem+carboplatin → avelumab.
-  - step: 2
-    evaluate:
-      all_of:
-        - condition: "Cisplatin-eligible: CrCl ≥60 mL/min, ECOG PS 0-1, no significant hearing loss, no neuropathy Grade ≥2, no HF NYHA III/IV"
-    if_true:
-      result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
-      notes: >
-        Cisplatin-eligible + EV-pembro ineligible: gemcitabine+cisplatin (4-6 cycles)
-        → avelumab maintenance until progression (JAVELIN Bladder 100;
-        mOS 21.4 vs 14.3 mo, HR 0.69). MVAC (dose-dense) is an alternative backbone.
-    if_false:
-      result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
-      notes: >
-        Cisplatin-ineligible + EV-pembro ineligible: gemcitabine+carboplatin (4-6
-        cycles) → avelumab maintenance. IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-
-        AVELUMAB covers both cisplatin and carboplatin backbone — regimen selection
-        guided by CrCl and patient fitness within the indication.
+        No EV exclusion criteria — EV+pembro preferred 1L for all eligible mUC
+        patients (EV-302/KEYNOTE-A39; mOS 31.5 vs 16.1 mo, HR 0.47 vs platinum
+        chemo). Applies regardless of cisplatin eligibility, PD-L1 status, or
+        primary site (bladder, upper tract, urethra).
 
 sources:
   - SRC-EV302-POWLES-2024
@@ -67,7 +51,7 @@ sources:
   - SRC-NCCN-BLADDER-2025
   - SRC-EAU-BLADDER-2024
 
-last_reviewed: "2026-05-03"
+last_reviewed: "2026-05-09"
 notes: >
   Post-EV-302 (2024): EV+pembro has replaced platinum-based chemotherapy as
   the preferred 1L for most patients, including cisplatin-ineligible (EV-302

--- a/knowledge_base/hosted/content/drugs/lomustine.yaml
+++ b/knowledge_base/hosted/content/drugs/lomustine.yaml
@@ -24,6 +24,19 @@ black_box_warnings:
 
 absolute_contraindications: []
 
+regulatory_status:
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-09"
+    notes: >
+      Lomustine (CCNU) not currently registered or reimbursed in Ukraine.
+      PCV chemotherapy is rarely administered in Ukraine; lomustine typically
+      requires compassionate-use import if needed for REG-RT-PCV-LGG.
+      Named-patient import or cross-border procurement required.
+
 last_reviewed: "2026-05-08"
 review_status: stub
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_dara_rd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_dara_rd.yaml
@@ -1,0 +1,145 @@
+id: IND-MM-1L-DARA-RD
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-MM
+  line_of_therapy: 1
+  stage_requirements: []
+  biomarker_requirements_required:
+    - biomarker_id: BIO-HBV-STATUS
+      required: true
+      value_constraint: "any value valid (categorical etiology gate; HBsAg+ or anti-HBc+ → entecavir prophylaxis mandatory before first daratumumab dose; anti-CD38 class effect — fulminant reactivation reported)"
+    - biomarker_id: BIO-HCV-STATUS
+      required: true
+      value_constraint: "any value valid (categorical etiology gate; anti-HCV+ → reflex BIO-HCV-RNA; coordinate DAA with hepatology)"
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+    fit_for_transplant: false
+
+recommended_regimen: REG-D-RD-MAIA
+phases: []
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~93% (MAIA D-Rd arm; vs ~76% Rd control, P<0.001)"
+  complete_response: "~48% ≥VGPR post-induction; ~24% sCR/CR (MAIA 30-month update)"
+  progression_free_survival: "30-month PFS ~53% (D-Rd); HR 0.56 (95% CI 0.43–0.73) vs Rd alone (MAIA)"
+  overall_survival_5y: "60-month OS ~66.3% D-Rd vs ~53.1% Rd (MAIA 5-yr update, Facon JCO 2024)"
+
+hard_contraindications:
+  - CI-LENALIDOMIDE-PREGNANCY
+  - CI-HBV-NO-PROPHYLAXIS
+red_flags_triggering_alternative:
+  - RF-MM-CORD-COMPRESSION
+  - RF-MM-HYPERCALCEMIA
+  - RF-MM-HYPERVISCOSITY
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-B2-MICROGLOBULIN
+  - TEST-IMMUNOGLOBULINS
+  - TEST-SPEP-UPEP
+  - TEST-FREE-LIGHT-CHAINS
+  - TEST-FISH-PANEL
+  - TEST-BM-ASPIRATE
+  - TEST-BM-TREPHINE
+  - TEST-WHOLE-BODY-MRI
+  - TEST-HBV-SEROLOGY
+  - TEST-ECHO
+desired_tests: []
+
+rationale: >
+  Aggressive-plan default for newly-diagnosed transplant-ineligible multiple
+  myeloma (ECOG ≤2, fit_for_transplant: false). The MAIA trial (Facon NEJM
+  2019, PMID 30926586) demonstrated that adding daratumumab to Rd (D-Rd)
+  significantly improves ORR (~93% vs ~76%), PFS (HR 0.56), and OS (5-yr
+  ~66% vs ~53%) vs Rd alone in transplant-ineligible NDMM. D-Rd is given
+  until progression — no transplant, no consolidation phase. Anti-CD38
+  class HBV reactivation risk mandates pre-treatment HBV serology +
+  entecavir prophylaxis if HBsAg+ or anti-HBc+. Red-cell phenotyping
+  before first daratumumab dose is mandatory (anti-CD38 crossmatching
+  interference). НСЗУ reimbursement for daratumumab not currently available
+  in Ukraine — funding pathway must be confirmed before plan announcement.
+
+rationale_ua: >
+  агресивний-plan default for newly-diagnosed непридатний до трансплантації
+  множинна мієлома (ECOG ≤2, fit_for_transplant: false). Дослідження MAIA
+  (Facon NEJM 2019, PMID 30926586) продемонструвало, що додавання
+  даратумумабу до Rd (D-Rd) значно покращує ЗВВ (~93% проти ~76%), ВБП
+  (ВР 0.56) та ЗВ (5-річна ~66% проти ~53%) порівняно з Rd у непридатних
+  до трансплантації пацієнтів. D-Rd призначається до прогресування.
+  HBV реактивація на анти-CD38 — обов'язковий скринінг + ентекавір при
+  HBsAg+ або anti-HBc+. Феротипування еритроцитів перед першою дозою
+  даратумумабу є обов'язковим. НСЗУ не відшкодовує даратумумаб — шлях
+  фінансування має бути підтверджений до оголошення плану.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+sources:
+  - source_id: SRC-MAIA-FACON-2019
+    position: supports
+    relevant_quote_paraphrase: "MAIA: D-Rd vs Rd in transplant-ineligible NDMM; PFS HR 0.56 (95% CI 0.43–0.73); ORR 92.9% vs 75.8%; 30-month PFS 52.9% vs 37.9%; 5-yr OS 66.3% vs 53.1% (Facon JCO 2024 update)"
+  - source_id: SRC-NCCN-MM-2025
+    position: supports
+    relevant_quote_paraphrase: "D-Rd is a Category 1 preferred regimen for transplant-ineligible NDMM; MAIA data support daratumumab addition to Rd backbone"
+
+do_not_do:
+  - "Не призначати daratumumab без попереднього red-cell phenotyping (type and screen) — анти-CD38 інтерферує з прямим Coombs та crossmatching."
+  - "Не починати без HBV скринінгу + entecavir prophylaxis при HBsAg+ або anti-HBc+ — ризик HBV реактивації значно підвищений на анти-CD38."
+  - "Не підтверджувати D-Rd план без верифікованого funding pathway — daratumumab НЕ реімбурсується через НСЗУ; пацієнт повинен бути попереджений до оголошення плану."
+  - "Не пропускати VTE профілактику (aspirin/LMWH) — IMiD-induced VTE ризик не зменшується від додавання даратумумабу."
+  - "Не пропускати HSV/VZV профілактику — даратумумаб додає до immunosuppression леналідоміду."
+  - "Не пропускати PJP профілактику — анти-CD38 + IMiD + steroid = підвищений ризик опортуністичних інфекцій."
+  - "Не розпочинати у жінок репродуктивного віку без двох методів контрацепції (леналідомід — тератоген)."
+  - "Не призначати у transplant-eligible пацієнтів — D-VRd (IND-MM-1L-DVRD) є відповідним планом для придатних до трансплантації."
+  - "Не скорочувати дексаметазон без клінічної підстави у перших 6 циклах — зниження дози стероїду у цей момент може знизити ефективність анти-CD38."
+
+do_not_do_en:
+  - "Do not prescribe daratumumab without prior red-cell phenotyping (type and screen) — anti-CD38 interferes with direct Coombs and crossmatching."
+  - "Do not start without HBV screening + entecavir prophylaxis in HBsAg+ or anti-HBc+ — risk of HBV reactivation significantly elevated on anti-CD38."
+  - "Do not confirm D-Rd plan without verified funding pathway — daratumumab is NOT reimbursed via NSZU; patient must be informed before the plan is announced."
+  - "Do not skip VTE prophylaxis (aspirin/LMWH) — IMiD-induced VTE risk is not reduced by adding daratumumab."
+  - "Do not skip HSV/VZV prophylaxis — daratumumab adds to lenalidomide immunosuppression."
+  - "Do not skip PJP prophylaxis — anti-CD38 + IMiD + steroid = elevated risk of opportunistic infections."
+  - "Do not start in women of reproductive age without two methods of contraception (lenalidomide is teratogenic)."
+  - "Do not use in transplant-eligible patients — D-VRd (IND-MM-1L-DVRD) is the appropriate plan for transplant-eligible patients."
+  - "Do not reduce dexamethasone without clinical indication in first 6 cycles — steroid dose reduction at this point may reduce anti-CD38 efficacy."
+known_controversies:
+  - "Frail TI patients (IMWG frailty ≥2, age >80): D-Rd vs DRd-lite (attenuated Rd) debated. MAIA enrolled broadly fit TI-NDMM; frail subgroup analysis suggests benefit maintained but toxicity higher. Some centers use attenuated doses (len 10 mg, dex 20 mg) upfront in frailest patients."
+  - "D-VRd continuous (GRIFFIN-style, 6+ cycles without ASCT) vs D-Rd for TI-NDMM: no head-to-head RCT; bortezomib adds neuropathy risk in older TI population. MAIA D-Rd is current NCCN Cat 1 standard for TI-NDMM."
+
+time_critical: false  # outpatient cancer planning, not time-critical (FDA non-device CDS criterion 4)
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: 0
+notes: >
+  STUB — requires clinical co-lead signoff before publication. Aggressive
+  counterpart to IND-MM-1L-RD for two-plan output in transplant-ineligible
+  NDMM (CHARTER §2). Major access constraint in Ukraine: daratumumab is
+  not currently НСЗУ-reimbursed — funding pathway (clinical trial /
+  charitable / out-of-pocket) MUST be confirmed BEFORE this Plan is
+  finalized. Red-cell phenotyping (type and screen) BEFORE first
+  daratumumab dose is mandatory due to anti-CD38 interference with
+  crossmatching.
+
+  MAIA trial (Facon NEJM 2019, PMID 30926586): 737 transplant-ineligible
+  NDMM patients randomized D-Rd vs Rd. Primary endpoint PFS: HR 0.56
+  (95% CI 0.43–0.73), p<0.001. 5-year OS update (Facon JCO 2024):
+  66.3% vs 53.1% (HR 0.66, p<0.0001) — first OS benefit for an anti-CD38
+  doublet addition in TI-NDMM.
+
+  Scope gate: fit_for_transplant: false restricts IND-MM-1L-DARA-RD to
+  transplant-ineligible patients. For transplant-eligible aggressive-plan
+  patients, see IND-MM-1L-DVRD (D-VRd + ASCT + dara-len maintenance).
+
+  Treatment is continuous until progression or unacceptable toxicity —
+  no fixed-duration transplant pathway. No phases block needed (single
+  continuous regimen, no ASCT step).

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_dara_rd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_dara_rd.yaml
@@ -113,8 +113,20 @@ do_not_do_en:
   - "Do not use in transplant-eligible patients — D-VRd (IND-MM-1L-DVRD) is the appropriate plan for transplant-eligible patients."
   - "Do not reduce dexamethasone without clinical indication in first 6 cycles — steroid dose reduction at this point may reduce anti-CD38 efficacy."
 known_controversies:
-  - "Frail TI patients (IMWG frailty ≥2, age >80): D-Rd vs DRd-lite (attenuated Rd) debated. MAIA enrolled broadly fit TI-NDMM; frail subgroup analysis suggests benefit maintained but toxicity higher. Some centers use attenuated doses (len 10 mg, dex 20 mg) upfront in frailest patients."
-  - "D-VRd continuous (GRIFFIN-style, 6+ cycles without ASCT) vs D-Rd for TI-NDMM: no head-to-head RCT; bortezomib adds neuropathy risk in older TI population. MAIA D-Rd is current NCCN Cat 1 standard for TI-NDMM."
+  - topic: "D-Rd vs attenuated Rd in frail transplant-ineligible NDMM"
+    positions:
+      - position: "D-Rd for frail patients (IMWG frailty ≥2, age >80) — MAIA frail subgroup analysis suggests PFS benefit maintained; daratumumab adds limited additional toxicity beyond Rd"
+        sources: [SRC-MAIA-FACON-2019, SRC-NCCN-MM-2025]
+      - position: "Attenuated Rd-lite upfront (len 10 mg, dex 20 mg weekly) — reduce toxicity in frailest patients; standard D-Rd doses may cause excess cytopenias/infections in IMWG frailty ≥2"
+        sources: [SRC-NCCN-MM-2025]
+    our_default: "D-Rd with standard doses per MAIA; attenuate len/dex per dose_adjustment rules if IMWG frailty ≥2 or age >75"
+  - topic: "D-VRd continuous (no ASCT) vs D-Rd for transplant-ineligible NDMM"
+    positions:
+      - position: "D-Rd (MAIA) — NCCN Cat 1; prospective RCT data; favourable toxicity profile in older/frail patients; no bortezomib neuropathy"
+        sources: [SRC-MAIA-FACON-2019, SRC-NCCN-MM-2025]
+      - position: "D-VRd continuous (GRIFFIN-style 6+ cycles without ASCT) — higher MRD-negativity rate but no RCT vs D-Rd; bortezomib adds neuropathy risk in older TI population"
+        sources: [SRC-NCCN-MM-2025]
+    our_default: "D-Rd (MAIA) as the TI-NDMM aggressive plan; D-VRd-continuous not recommended outside clinical trial for TI patients given neuropathy burden"
 
 time_critical: false  # outpatient cancer planning, not time-critical (FDA non-device CDS criterion 4)
 last_reviewed: "2026-05-09"

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_rd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_rd.yaml
@@ -1,0 +1,124 @@
+id: IND-MM-1L-RD
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-MM
+  line_of_therapy: 1
+  stage_requirements: []
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+    fit_for_transplant: false
+
+recommended_regimen: REG-RD-CONTINUOUS
+phases: []
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~76% (MAIA Rd control arm; Facon NEJM 2019)"
+  complete_response: "~34% ≥VGPR; ~9% sCR/CR (MAIA Rd arm 30-month update)"
+  progression_free_survival: "30-month PFS ~38% (Rd alone, MAIA control); median PFS ~31.9 months"
+  overall_survival_5y: "~53% (MAIA Rd 5-yr update, Facon JCO 2024)"
+
+hard_contraindications:
+  - CI-LENALIDOMIDE-PREGNANCY
+red_flags_triggering_alternative:
+  - RF-MM-CORD-COMPRESSION
+  - RF-MM-HYPERCALCEMIA
+  - RF-MM-HYPERVISCOSITY
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-B2-MICROGLOBULIN
+  - TEST-IMMUNOGLOBULINS
+  - TEST-SPEP-UPEP
+  - TEST-FREE-LIGHT-CHAINS
+  - TEST-FISH-PANEL
+  - TEST-BM-ASPIRATE
+  - TEST-BM-TREPHINE
+  - TEST-WHOLE-BODY-MRI
+  - TEST-HBV-SEROLOGY
+desired_tests: []
+
+rationale: >
+  Standard-plan default for newly-diagnosed transplant-ineligible multiple
+  myeloma (ECOG ≤2, fit_for_transplant: false) when daratumumab funding
+  is unavailable or patient is not a candidate for anti-CD38 therapy.
+  Rd continuous (lenalidomide 25 mg d1-21 + dexamethasone 40 mg weekly,
+  28-day cycles until progression) was established by the MAIA control
+  arm (Facon NEJM 2019) and the FIRST trial (Benboubker NEJM 2014) as
+  the standard-access backbone for TI-NDMM. ORR ~76%, 30-month PFS ~38%.
+  No HBV prophylaxis required for Rd (no anti-CD38), but HBV serology
+  still recommended per NCCN given immunosuppression from IMiD+steroid.
+  No red-cell phenotyping required (no daratumumab).
+
+rationale_ua: >
+  стандарт-plan default for newly-diagnosed непридатний до трансплантації
+  множинна мієлома (ECOG ≤2, fit_for_transplant: false) коли фінансування
+  даратумумабу недоступне або пацієнт не є кандидатом на анти-CD38 терапію.
+  Rd безперервно (леналідомід 25 мг д1-21 + дексаметазон 40 мг щотижня,
+  28-денні цикли до прогресування) встановлений дослідженнями MAIA (Facon
+  NEJM 2019) та FIRST (Benboubker NEJM 2014) як стандартний доступний
+  режим для непридатних до трансплантації НДММ. ЗВВ ~76%, 30-місячна ВБП
+  ~38%. Схема повністю фінансується через НСЗУ — є стандартом доступу в
+  Україні при недоступності даратумумабу.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+sources:
+  - source_id: SRC-MAIA-FACON-2019
+    position: supports
+    relevant_quote_paraphrase: "MAIA Rd control arm: ORR 75.8%, 30-month PFS 37.9%, 5-yr OS 53.1%; establishes Rd continuous as TI-NDMM standard backbone"
+  - source_id: SRC-NCCN-MM-2025
+    position: supports
+    relevant_quote_paraphrase: "Rd continuous is a Category 1 preferred regimen for transplant-ineligible NDMM; standard-access option where anti-CD38 funding is unavailable"
+
+do_not_do:
+  - "Не пропускати VTE профілактику (aspirin 81-100 mg або LMWH) — ризик тромбозу на леналідоміді 10-20% без профілактики."
+  - "Не пропускати HSV/VZV профілактику (acyclovir 400 mg BID) — IMiD + steroid підвищують ризик оперізуючого герпесу."
+  - "Не починати у жінок репродуктивного віку без підтверджених двох методів контрацепції + негативного тесту на вагітність (леналідомід — тератоген)."
+  - "Не пропускати редукцію дози леналідоміду при CrCl 30-60 mL/min (10 mg) — повна доза значно токсична при нирковій недостатності."
+  - "Не призначати zoledronate без попередньої стоматологічної оцінки — ризик osteonecrosis of the jaw."
+  - "Не використовувати IND-MM-1L-RD якщо daratumumab фінансується — агресивний план (IND-MM-1L-DARA-RD) має кращі результати виживаності."
+
+do_not_do_en:
+  - "Do not skip VTE prophylaxis (aspirin 81-100 mg or LMWH) — IMiD-induced VTE risk 10-20% without prophylaxis."
+  - "Do not skip HSV/VZV prophylaxis (acyclovir 400 mg BID) — IMiD + steroid elevates herpes zoster reactivation risk."
+  - "Do not start in women of reproductive age without two methods of contraception + negative pregnancy test (lenalidomide is teratogenic)."
+  - "Do not skip lenalidomide dose reduction at CrCl 30-60 mL/min (use 10 mg) — full dose significantly toxic in renal impairment."
+  - "Do not prescribe zoledronate without prior dental evaluation — osteonecrosis of the jaw risk."
+  - "Do not use IND-MM-1L-RD if daratumumab is funded — aggressive plan (IND-MM-1L-DARA-RD) has superior survival outcomes."
+known_controversies: []
+
+time_critical: false  # outpatient cancer planning, not time-critical (FDA non-device CDS criterion 4)
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: 0
+notes: >
+  STUB — requires clinical co-lead signoff before publication. Standard
+  counterpart to IND-MM-1L-DARA-RD for two-plan output in transplant-
+  ineligible NDMM (CHARTER §2). Rd continuous is the standard-access
+  option when daratumumab funding is unavailable (common in Ukraine
+  where НСЗУ does not currently reimburse daratumumab).
+
+  MAIA trial context (Facon NEJM 2019, PMID 30926586): this indication
+  represents the control arm — Rd alone. D-Rd improved PFS HR 0.56 and
+  5-yr OS HR 0.66 vs Rd. In a well-resourced setting, D-Rd is preferred;
+  Rd is the fallback when daratumumab is inaccessible.
+
+  FIRST trial (Benboubker NEJM 2014, PMID 25184863): Rd continuous vs
+  Rd18 (18 cycles fixed) vs MPT — Rd continuous showed superior PFS
+  (26 months) vs MPT (21.9 months). Established the "until progression"
+  strategy.
+
+  Scope gate: fit_for_transplant: false restricts IND-MM-1L-RD to
+  transplant-ineligible patients. For transplant-eligible standard-plan
+  patients, see IND-MM-1L-VRD (VRd backbone + ASCT pathway).

--- a/knowledge_base/hosted/content/redflags/rf_endometrial_dmmr.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_endometrial_dmmr.yaml
@@ -1,0 +1,122 @@
+id: RF-ENDOMETRIAL-DMMR
+definition: >
+  Deficient mismatch repair (dMMR) or microsatellite instability-high
+  (MSI-H) status in advanced or recurrent endometrial carcinoma. dMMR
+  endometrial cancer is defined by loss of at least one MMR protein (MLH1,
+  MSH2, MSH6, PMS2) on IHC or MSI-H on PCR or NGS. Approximately 25-30%
+  of advanced endometrial cancers are dMMR/MSI-H (higher in endometrioid
+  histology, lower in serous/CCCC).
+
+  Fires to route ALGO-ENDOMETRIAL-ADVANCED-1L to checkpoint inhibitor
+  + chemotherapy combinations (dostarlimab + carbo/paclitaxel per RUBY
+  trial, Mirza NEJM 2023 PMID 37395437; or pembrolizumab + carbo/paclitaxel
+  per KEYNOTE-868 / NRG-GY018, Eskander NEJM 2023 PMID 36972026). Both
+  are NCCN Category 1 for dMMR/MSI-H advanced endometrial cancer.
+
+  dMMR status is the strongest predictive biomarker for immunotherapy
+  benefit in endometrial cancer: hazard ratio for PFS with CPI+chemo vs
+  chemo alone is approximately 0.28 (RUBY dostarlimab arm, dMMR cohort)
+  and 0.30 (KEYNOTE-868 pembro arm, dMMR/MSI-H cohort), versus ~0.70 for
+  the pMMR cohort with the same regimens — about double the relative PFS
+  benefit in dMMR vs pMMR. The OS benefit is similarly pronounced in
+  dMMR (HR ~0.28 RUBY 24-mo update; NRG-GY018 OS data maturing).
+
+  Lynch syndrome (germline MLH1/MSH2/MSH6/PMS2 mutation) accounts for
+  approximately 2-3% of endometrial cancers; somatic MLH1 promoter
+  hypermethylation accounts for most sporadic dMMR cases. The RF fires
+  regardless of germline vs somatic mechanism.
+definition_ua: >
+  Дефіцит системи репарації помилок (dMMR) або висока мікросателітна
+  нестабільність (MSI-H) при поширеному або рецидивуючому раку ендометрія.
+  Приблизно 25-30% поширеного раку ендометрія є dMMR/MSI-H. Спрацьовує для
+  маршрутизації до схем хіміоімунотерапії: достарлімаб + карбо/паклітаксел
+  (RUBY; Mirza NEJM 2023) або пембролізумаб + карбо/паклітаксел (KEYNOTE-868;
+  Eskander NEJM 2023). Обидва — NCCN категорія 1 для dMMR/MSI-H. Відношення
+  ризику ВБП при dMMR ~0.28-0.30 порівняно з ~0.70 при pMMR — подвоєний
+  виграш від імунотерапії при dMMR. Синдром Лінча (зародкова мутація
+  MLH1/MSH2/MSH6/PMS2) відповідає за ~2-3% випадків.
+
+trigger:
+  type: biomarker_status
+  any_of:
+    - finding: "mmr_status"
+      value: "deficient"
+    - finding: "mmr_status"
+      value: "dMMR"
+    - finding: "msi_status"
+      value: "MSI-H"
+    - finding: "msi_status"
+      value: "MSI-high"
+    - finding: "msi_status"
+      value: "high"
+    - finding: "mlh1_ihc"
+      value: "loss"
+    - finding: "msh2_ihc"
+      value: "loss"
+    - finding: "msh6_ihc"
+      value: "loss"
+    - finding: "pms2_ihc"
+      value: "loss"
+
+clinical_direction: intensify
+severity: major
+priority: 50
+category: high-risk-biology
+
+branch_targets:
+  ALGO-ENDOMETRIAL-ADVANCED-1L: "1"
+
+relevant_diseases:
+  - DIS-ENDOMETRIAL
+
+shifts_algorithm:
+  - ALGO-ENDOMETRIAL-ADVANCED-1L
+
+sources:
+  - SRC-RUBY-MIRZA-2023
+  - SRC-GY018-MAKKER-2022
+  - SRC-NCCN-UTERINE-2025
+
+last_reviewed: "2026-05-09"
+reviewer_signoffs: []
+draft: true
+notes: >
+  W5c RF authoring. Converts the free-text `{finding: mmr_status, value:
+  deficient}` condition in ALGO-ENDOMETRIAL-ADVANCED-1L step 1 into a
+  formal RF entity. The algo already uses structured finding lookups;
+  this RF provides the named entity that coverage tooling and the render
+  layer can reference.
+
+  RUBY trial (Mirza NEJM 2023, PMID 37395437): dostarlimab + carbo/pac
+  vs carbo/pac in advanced/recurrent endometrial. dMMR cohort 24-month
+  PFS HR 0.28 (95% CI 0.16–0.50); overall cohort PFS HR 0.64. OS data
+  reported at 2024 SGO (dMMR HR 0.28, CI 0.16–0.50, interim OS
+  analysis with 46% events).
+
+  KEYNOTE-868 / NRG-GY018 (Eskander NEJM 2023, PMID 36972026): pembrolizumab
+  + carbo/pac vs carbo/pac. dMMR/MSI-H cohort PFS HR 0.30 (95% CI
+  0.19–0.48); pMMR cohort PFS HR 0.54 (95% CI 0.41–0.71). OS data
+  maturing.
+
+  POLE/POLD1 ultra-mutated endometrial (see RF-POLE-POLD1-ENDOMETRIAL-LOW-RISK):
+  POLE exonuclease domain mutations confer MSI-H-like hypermutation but with
+  EXCELLENT prognosis — do not conflate with dMMR. POLE/POLD1 status is
+  assessed separately and typically warrants de-escalation (no cytotoxic
+  needed per ESMO 2022 for POLE/POLD1 early stage). dMMR ≠ POLE ultra-mutated.
+
+  Lynch syndrome genetic counselling: all dMMR endometrial cancers should
+  have germline MMR gene testing (reflex IHC → MLH1 methylation if MLH1 loss
+  → germline testing if methylation negative or other MMR protein loss).
+  This RF triggers the treatment routing; Lynch genetic referral is a
+  parallel care requirement not modelled in this RF.
+
+  Ukraine availability: pembrolizumab partially reimbursed for dMMR tumours
+  via НСЗУ oncology package (oncology drug access program 2024);
+  dostarlimab not currently НСЗУ-reimbursed. Practical default in Ukraine:
+  pembrolizumab + carbo/pac (KEYNOTE-868) when ICI funded; carbo/pac alone
+  when ICI access unavailable.
+
+  Sources confirmed in KB: SRC-RUBY-MIRZA-2023 (dostarlimab RUBY trial),
+  SRC-GY018-MAKKER-2022 (NRG-GY018/KEYNOTE-868 pembro+chemo trial),
+  SRC-NCCN-UTERINE-2025. All IDs verified present in
+  knowledge_base/hosted/content/sources/.

--- a/knowledge_base/hosted/content/redflags/rf_urothelial_ev_ineligible.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_urothelial_ev_ineligible.yaml
@@ -1,0 +1,112 @@
+id: RF-UROTHELIAL-EV-INELIGIBLE
+definition: >
+  Enfortumab vedotin + pembrolizumab (EV+pembro) exclusion criteria in
+  locally advanced or metastatic urothelial carcinoma. EV+pembro (EV-302 /
+  KEYNOTE-A39; Powles NEJM 2024, PMID 37840257) is NCCN Category 1 preferred
+  1L for all eligible patients regardless of cisplatin eligibility or PD-L1
+  status. This flag fires when ANY of the following EV-specific toxicity
+  exclusions are present, routing the algorithm to platinum-based chemotherapy
+  → avelumab maintenance instead:
+
+  (1) Grade ≥2 pre-existing peripheral neuropathy — MMAE (monomethyl
+  auristatin E) payload induces dose-limiting sensory-motor neuropathy;
+  baseline impairment is the primary safety exclusion in all EV trials.
+  (2) Uncontrolled diabetes mellitus (HbA1c >9% or active hyperglycaemia
+  requiring IV insulin) — EV causes hyperglycaemia through a mechanism
+  distinct from immunotherapy; uncontrolled DM amplifies risk of severe
+  hyperglycaemic events (grade ≥3 in ~4% EV-302).
+  (3) Severe corneal/ocular surface disease — EV-associated keratopathy
+  (microcyst-like epithelial changes) is class-wide for MMAE-ADCs; severe
+  baseline corneal disease or active keratitis is an exclusion.
+  (4) Active autoimmune disease requiring systemic immunosuppression —
+  pembrolizumab component; cross-references RF-ACTIVE-AUTOIMMUNE-DISEASE-ICI-RISK.
+  (5) Unresolved irAE from prior checkpoint inhibitor therapy — pembrolizumab
+  component; prior immune toxicity Grade ≥3 from any ICI is a standard
+  re-challenge exclusion.
+
+  Does NOT include CrCl <60 mL/min (cisplatin-ineligible) — EV+pembro was
+  tested in both cisplatin-eligible and cisplatin-ineligible cohorts in EV-302;
+  renal impairment alone is NOT an exclusion for EV+pembro.
+definition_ua: >
+  Критерії виключення для енфортумаб ведотин + пембролізумаб (EV+пембро)
+  при місцево-поширеному або метастатичному уротеліальному раку. EV+пембро
+  (EV-302/KEYNOTE-A39; Powles NEJM 2024) — NCCN категорія 1, переважний
+  режим 1Л для всіх придатних пацієнтів незалежно від придатності до
+  цисплатину або статусу PD-L1. Цей прапор спрацьовує при наявності
+  БУДЬ-ЯКОГО з таких критеріїв виключення, специфічних для EV:
+  (1) Периферична нейропатія ≥2 ступеня — ММАЕ індукує нейротоксичність;
+  (2) Неконтрольований цукровий діабет (HbA1c >9%) — EV викликає гіперглікемію;
+  (3) Тяжке захворювання рогівки/поверхні ока — ММАЕ-ADC кератопатія;
+  (4) Активне аутоімунне захворювання — компонент пембролізумабу;
+  (5) Невирішена іАНЖ від попереднього ІКТ ≥3 ступеня.
+  НЕ включає CrCl <60 мл/хв — EV+пембро тестувався в обох когортах.
+
+trigger:
+  type: composite_eligibility
+  any_of:
+    - finding: "peripheral_neuropathy_grade"
+      threshold: 2
+      comparator: ">="
+    - finding: "baseline_neuropathy"
+      value: "grade2"
+    - finding: "baseline_neuropathy"
+      value: "grade3"
+    - finding: "baseline_neuropathy"
+      value: "grade4"
+    - finding: "diabetes_control"
+      value: "uncontrolled"
+    - finding: "hba1c"
+      threshold: 9.0
+      comparator: ">"
+    - finding: "ev_pembro_eligible"
+      value: false
+    - finding: "corneal_disease_severe"
+      value: true
+    - finding: "active_autoimmune_disease"
+      value: true
+    - finding: "prior_ici_grade3_irae"
+      value: true
+
+clinical_direction: de-escalate
+severity: major
+priority: 60
+category: fitness-eligibility
+
+branch_targets:
+  ALGO-UROTHELIAL-METASTATIC-1L: "1"
+
+relevant_diseases:
+  - DIS-UROTHELIAL
+
+shifts_algorithm:
+  - ALGO-UROTHELIAL-METASTATIC-1L
+
+sources:
+  - SRC-NCCN-BLADDER-2025
+  - SRC-EV302-POWLES-2024
+
+last_reviewed: "2026-05-09"
+reviewer_signoffs: []
+draft: true
+notes: >
+  W5c RF authoring. Closes the RF authoring gap noted in
+  ALGO-UROTHELIAL-METASTATIC-1L step 1 (comment: "RF authoring for
+  composite exclusion criteria still owed — RF-UROTHELIAL-EV-INELIGIBLE.
+  Until then, evaluated as MDT text.").
+
+  EV-302 key data (Powles NEJM 2024, PMID 37840257): EV+pembro vs
+  platinum-based chemotherapy in 1L la/mUC. mOS 31.5 vs 16.1 months
+  (HR 0.47, p<0.001); mPFS 12.5 vs 6.3 months (HR 0.45). Benefit
+  consistent regardless of cisplatin eligibility, PD-L1 CPS status,
+  primary site, or prior BCG. EV-specific safety (grade ≥3): peripheral
+  neuropathy 6%, hyperglycaemia 4%, skin reactions 10%.
+
+  Rationale for `de-escalate` direction: firing this RF means EV+pembro
+  (the preferred aggressive regimen) is contraindicated — the patient
+  must de-escalate to the alternative (platinum chemo + avelumab
+  maintenance). The flag does not modify dosing; it routes to a
+  different regimen.
+
+  SRC-EV302-POWLES-2024: Powles T et al. Enfortumab vedotin and
+  pembrolizumab in untreated advanced urothelial cancer. N Engl J Med.
+  2024;390(10):875-888. PMID 37840257. Source stub confirmed in KB.

--- a/knowledge_base/hosted/content/regimens/reg_rd_continuous.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_rd_continuous.yaml
@@ -1,0 +1,128 @@
+id: REG-RD-CONTINUOUS
+name: "Lenalidomide + Dexamethasone continuous (Rd, MAIA control arm — MM 1L transplant-ineligible)"
+name_ua: "Леналідомід + Дексаметазон безперервно (Rd, контрольна група MAIA — MM 1Л непридатні до трансплантації)"
+alternate_names:
+  - "Rd continuous"
+  - "Len-Dex"
+  - "Lenalidomide-Dex until progression"
+  - "MAIA control arm"
+  - "CALGB 100104 backbone"
+
+# MAIA control arm (Facon NEJM 2019, PMID 30926586):
+# Lenalidomide 25 mg PO days 1-21 + dexamethasone 40 mg PO weekly, 28-day cycles
+# until progression. Standard-of-care triplet-ineligible or access-limited option.
+components:
+  - drug_id: DRUG-LENALIDOMIDE
+    dose: "25 mg PO daily (10 mg if CrCl 30-60 mL/min)"
+    schedule: "Days 1-21 of each 28-day cycle; continuous until progression"
+    route: PO
+  - drug_id: DRUG-DEXAMETHASONE
+    dose: "40 mg PO weekly (20 mg if age >75 or frail)"
+    schedule: "Days 1, 8, 15, 22 of each 28-day cycle"
+    route: PO
+
+cycle_length_days: 28
+total_cycles: "Continuous until progression or unacceptable toxicity"
+toxicity_profile: low-moderate
+
+premedication:
+  - "Acyclovir 400 mg PO BID (HSV/VZV prophylaxis per NCCN MM)"
+  - "Aspirin 81-100 mg PO daily for VTE prophylaxis (IMiD class); LMWH if prior VTE or high-risk profile"
+  - "Confirm two reliable contraceptive methods (women of reproductive potential) — REMS/iPLEDGE-equivalent required for lenalidomide"
+
+mandatory_supportive_care:
+  - SUP-MM-VTE-PROPHYLAXIS
+  - SUP-MM-BONE-PROTECTION
+
+monitoring_schedule_id: MON-VRD-REGIMEN
+
+dose_adjustments:
+  - condition: "CrCl 30-60 mL/min"
+    modification: "Lenalidomide 10 mg daily; dexamethasone unchanged"
+    rationale: "Lenalidomide ~80% renally cleared; dose-interval extension recommended"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "CrCl <30 mL/min (no dialysis)"
+    modification: "Lenalidomide 5 mg daily or 10 mg every other day; reassess if <15 mL/min"
+    rationale: "Major lenalidomide exposure increase"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "Age >75 OR frail (IMWG frailty ≥2)"
+    modification: "Dexamethasone 20 mg weekly; consider lenalidomide 15 mg starting dose"
+    rationale: "Frail patients have increased steroid toxicity (infections, delirium, hyperglycemia)"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "ANC <1000 OR platelets <50K"
+    modification: "Hold lenalidomide; resume at 20 mg → 15 mg → 10 mg → 5 mg on recovery"
+    rationale: "Cumulative lenalidomide myelosuppression; dose ladder per NCCN"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "Grade ≥3 rash"
+    modification: "Withhold lenalidomide; systemic corticosteroids; resume at next-lower dose if resolves ≤Grade 1"
+    rationale: "Lenalidomide dermatological toxicity (Stevens-Johnson rarely)"
+    source_refs: [SRC-NCCN-MM-2025]
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: true
+  notes: >
+    Lenalidomide reimbursed via НСЗУ for myeloma. Dexamethasone widely
+    available. Rd is the standard-access backbone for transplant-ineligible
+    NDMM in Ukraine when daratumumab funding is unavailable.
+
+between_visit_watchpoints:
+  - trigger_ua: "Втома або слабкість під час леналідоміду"
+    action_ua: "Часто зустрічається — занотовуйте; не зупиняйте без консультації"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MM-2025
+  - trigger_ua: "Біль або набряк в одній нозі"
+    action_ua: "Подзвоніть у клініку того ж дня — леналідомід підвищує ризик тромбозу; антикоагулянти призначаються профілактично"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MM-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — можлива нейтропенія або інфекція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова задишка, біль у грудях або кровохаркання"
+    action_ua: "Звертайтесь у лікарню негайно — можлива легенева тромбоемболія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MM-2025
+
+sources:
+  - SRC-MAIA-FACON-2019
+  - SRC-NCCN-MM-2025
+
+last_reviewed: "2026-05-09"
+notes: >
+  Rd continuous (lenalidomide + low-dose dexamethasone until progression)
+  was the MAIA control arm (Facon NEJM 2019, PMID 30926586) and represents
+  the standard-access first-line regimen for transplant-ineligible NDMM.
+  MAIA control arm outcomes: ORR 75.8%, PFS HR (D-Rd vs Rd) 0.56 (95% CI
+  0.43–0.73), 30-month PFS ~53.3% for D-Rd vs ~37.8% for Rd.
+
+  Rd continuous showed superiority over MPT and melphalan-prednisone in the
+  FIRST trial (Benboubker NEJM 2014, PMID 25184863): PFS 26 months vs 21.9
+  months for MPT.
+
+  Dose of dexamethasone: low-dose (40 mg weekly = "Ld schedule") is
+  preferred over high-dose (480 mg/cycle); ECOG E4A03 showed equivalent
+  efficacy and better tolerability with low-dose dex in NDMM (Rajkumar
+  LANCET ONCOL 2010).
+
+  Renal adjustment is critical: lenalidomide is ~80% renally cleared.
+  CrCl 30-60 → 10 mg daily; CrCl <30 → 5 mg daily or 10 mg qod.
+  Myeloma renal impairment often improves with therapy — recheck CrCl
+  monthly and escalate dose when GFR recovers.
+
+  Second primary malignancy (SPM) risk: CALGB 100104 and IFM 2005-02
+  documented elevated SPM (MDS/AML) with lenalidomide maintenance
+  post-ASCT; risk applies to continuous Rd as well at smaller magnitude.
+  Must be included in informed consent discussion.
+notes_ua: >
+  Rd безперервно (леналідомід + низькодозовий дексаметазон до прогресування)
+  була контрольною групою у дослідженні MAIA (Facon NEJM 2019, PMID 30926586)
+  і є стандартною схемою першої лінії для непридатних до трансплантації пацієнтів
+  з НДММ. Схема фінансується через НСЗУ — є стандартом доступу в Україні.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary

- **IND-MM-1L-DARA-RD** (aggressive, `fit_for_transplant: false`): D-Rd until progression per MAIA trial (Facon NEJM 2019, PMID 30926586); PFS HR 0.56 vs Rd; 5-yr OS 66.3% vs 53.1%; NCCN Cat 1 for TI-NDMM
- **IND-MM-1L-RD** (standard, `fit_for_transplant: false`): Rd continuous (MAIA control arm / FIRST trial backbone); standard-access НСЗУ-reimbursed fallback when daratumumab unavailable
- **REG-RD-CONTINUOUS** (NEW): Rd backbone regimen — len 25 mg d1-21 + dex 40 mg weekly until progression; renal dose table, Ukraine availability wired
- **algo_mm_1l.yaml**: adds both TI indications to `output_indications`; documents TE/TI cohort split + transplant-gate engine TODO; adds SRC-MAIA-FACON-2019
- **CLAUDE.md**: KB scale updated (426 indications, 361 regimens)

Closes the transplant-ineligible gap documented in IND-MM-1L-DVRD notes (CHARTER §2 two-plan output).

## Clinical content wired
- HBV/HCV biomarker gates on IND-MM-1L-DARA-RD (anti-CD38 class effect)
- `CI-HBV-NO-PROPHYLAXIS` hard contraindication on D-Rd
- VTE + HSV/VZV + PJP prophylaxis `do_not_do` items (UA + EN)
- НСЗУ funding warning: daratumumab not reimbursed → funding pathway must be confirmed before D-Rd plan announced
- Red-cell phenotyping mandatory note (anti-CD38 crossmatching interference)
- `do_not_do` gate preventing IND-MM-1L-DARA-RD use in transplant-eligible patients (should use DVRD)

## Test plan
- [ ] KB loader validates all 5 changed files without schema errors
- [ ] No new test failures (only pre-existing `test_landing_is_public_with_hero_and_ctas` fails)
- [ ] `ind_mm_1l_dara_rd.yaml` — `recommended_regimen: REG-D-RD-MAIA` FK resolves
- [ ] `ind_mm_1l_rd.yaml` — `recommended_regimen: REG-RD-CONTINUOUS` FK resolves
- [ ] `algo_mm_1l.yaml` — all 4 `output_indications` FKs resolve
- [ ] Clinical co-lead signoff required before publication (CHARTER §6.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)