### PR TITLE
W5c RF authoring — EV-pembro eligibility gate + endometrial dMMR gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ worktree merge conflict at integration time.
 
 - All six specs drafted at v0.1. Specs naming locked: OpenOnco.
 - KB scale: **78 diseases, 438 biomarker_actionability, 173 biomarkers, 383
-  sources, 251 drugs, 426 indications, 474 redflags, 361 regimens, 140
+  sources, 251 drugs, 426 indications, 476 redflags, 361 regimens, 140
   algorithms, 8 procedures, 5 radiation courses.** (updated 2026-05-09)
 - API clients live under `knowledge_base/clients/`.
 - RedFlag quality phases 1-7 done (2026-04-25/26): clinical sign-off received.

--- a/knowledge_base/hosted/content/algorithms/algo_endometrial_advanced_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_endometrial_advanced_1l.yaml
@@ -1,20 +1,74 @@
 id: ALGO-ENDOMETRIAL-ADVANCED-1L
 applicable_to_disease: DIS-ENDOMETRIAL
 applicable_to_line_of_therapy: 1
-purpose: "Select 1L advanced/recurrent endometrial by MMR status."
+purpose: >
+  Select 1L checkpoint inhibitor + chemotherapy combination for advanced or
+  recurrent endometrial carcinoma based on MMR/MSI status. dMMR/MSI-H
+  (RF-ENDOMETRIAL-DMMR) → dostarlimab+carbo/pac (RUBY; Mirza NEJM 2023,
+  dMMR PFS HR 0.28) as the aggressive plan. pMMR/MSS → pembrolizumab+carbo/pac
+  (KEYNOTE-868; Eskander NEJM 2023, overall PFS HR 0.54) as the standard plan.
+  Both carboplatin-paclitaxel backbones; carbo substituted for cisplatin in
+  most endometrial patients.
 output_indications: [IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO, IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO]
 default_indication: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO
 alternative_indication: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO
 decision_tree:
+  # Step 1 — dMMR/MSI-H gate (RF-ENDOMETRIAL-DMMR). dMMR patients benefit
+  # more from CPI+chemo than pMMR (PFS HR ~0.28-0.30 dMMR vs ~0.54-0.70
+  # pMMR). Both regimens are NCCN Category 1 regardless of MMR status.
   - step: 1
     evaluate:
       any_of:
+        - red_flag: RF-ENDOMETRIAL-DMMR
+        # Legacy finding-based evaluations for backward engine compatibility:
         - {finding: mmr_status, value: deficient}
+        - {finding: mmr_status, value: dMMR}
         - {finding: msi_status, value: MSI-H}
         - {finding: msi_status, value: MSI-high}
-    if_true: {result: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO}
-    if_false: {result: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO}
-    notes: "Gate replaced free-text condition with structured finding lookups for dMMR (mmr_status=deficient) and MSI-H (msi_status=MSI-H/MSI-high) — both label as eligible for dostarlimab arm."
-sources: [SRC-NCCN-UTERINE-2025, SRC-ESMO-ENDOMETRIAL-2022]
-last_reviewed: null
-notes: "Both pembro and dostarlimab approved; chemoimmuno superior to chemo alone regardless of MMR."
+        - {finding: msi_status, value: high}
+        - {finding: mlh1_ihc, value: loss}
+        - {finding: msh2_ihc, value: loss}
+        - {finding: msh6_ihc, value: loss}
+        - {finding: pms2_ihc, value: loss}
+    if_true:
+      result: IND-ENDOMETRIAL-ADVANCED-1L-DOSTARLIMAB-CHEMO
+      notes: >
+        dMMR/MSI-H confirmed (RF-ENDOMETRIAL-DMMR fired) — dostarlimab +
+        carbo/pac preferred (RUBY dMMR cohort 24-mo PFS HR 0.28,
+        95% CI 0.16–0.50; OS HR 0.28 interim). NCCN Cat 1. Pembrolizumab
+        + carbo/pac (KEYNOTE-868) is an equally acceptable alternative.
+    if_false:
+      result: IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO
+      notes: >
+        pMMR/MSS — pembrolizumab + carbo/pac (KEYNOTE-868 overall PFS HR 0.54,
+        95% CI 0.41–0.71). NCCN Cat 1 for all comers; pMMR cohort still
+        benefits. Dostarlimab + carbo/pac (RUBY) also acceptable. In Ukraine,
+        pembrolizumab access via НСЗУ oncology program preferred over
+        dostarlimab (not reimbursed).
+    notes: >
+      W5c RF wiring: added RF-ENDOMETRIAL-DMMR as primary gate; legacy
+      finding lookups retained for backward engine compatibility.
+sources:
+  - SRC-RUBY-MIRZA-2023
+  - SRC-GY018-MAKKER-2022
+  - SRC-NCCN-UTERINE-2025
+  - SRC-ESMO-ENDOMETRIAL-2022
+last_reviewed: "2026-05-09"
+notes: >
+  Both pembrolizumab + carbo/pac (KEYNOTE-868/NRG-GY018) and dostarlimab +
+  carbo/pac (RUBY) are NCCN Category 1 for advanced/recurrent endometrial
+  carcinoma regardless of MMR status. The dMMR subgroup shows approximately
+  double the PFS benefit (HR ~0.28-0.30) vs the pMMR subgroup (HR ~0.54-0.70).
+  dMMR status is defined by loss of MLH1, MSH2, MSH6, or PMS2 on IHC, or
+  MSI-H on PCR/NGS.
+
+  Ukraine context: pembrolizumab partially reimbursed via НСЗУ oncology
+  program for eligible patients; dostarlimab is not currently НСЗУ-reimbursed.
+  For dMMR patients where dostarlimab is unavailable, pembrolizumab + carbo/pac
+  (IND-ENDOMETRIAL-ADVANCED-1L-PEMBRO-CHEMO) is the standard-access alternative.
+
+  POLE/POLD1 ultra-mutated endometrial cancer: separate RF-POLE-POLD1-ENDOMETRIAL-
+  LOW-RISK; these patients may be candidates for de-escalation (omit
+  cytotoxic per ESMO 2022 for early-stage POLE). This algorithm covers
+  advanced/recurrent stage — POLE/POLD1 does not change systemic therapy
+  in advanced disease per current NCCN guidance.

--- a/knowledge_base/hosted/content/algorithms/algo_urothelial_metastatic_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_urothelial_metastatic_1l.yaml
@@ -16,50 +16,34 @@ default_indication: IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO
 alternative_indication: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
 
 decision_tree:
-  # Step 1 — EV+pembro eligibility. Main exclusions: severe pre-existing
-  # peripheral neuropathy (EV: MMAE-related neuropathy risk), uncontrolled
-  # diabetes mellitus (EV hyperglycemia risk), severe corneal/ocular disease
-  # (EV-associated keratopathy). No CrCl cutoff — EV+pembro works regardless
-  # of cisplatin eligibility (EV-302 enrolled both groups).
+  # Step 1 — EV+pembro ineligibility gate (RF-UROTHELIAL-EV-INELIGIBLE).
+  # Exclusions: grade ≥2 peripheral neuropathy, uncontrolled DM (HbA1c >9%),
+  # severe corneal/ocular disease, active autoimmune disease, prior ICI
+  # grade ≥3 irAE. CrCl alone is NOT an exclusion (EV-302 enrolled both
+  # cisplatin-eligible and cisplatin-ineligible patients).
   - step: 1
     evaluate:
       any_of:
-        - {finding: ev_pembro_eligible, value: true}
+        - red_flag: RF-UROTHELIAL-EV-INELIGIBLE
+        # Legacy finding-based evaluations kept for backward compatibility
+        # until engine fully adopts RF-based routing:
+        - {finding: ev_pembro_eligible, value: false}
+        - {finding: peripheral_neuropathy_grade, threshold: 2, comparator: ">="}
+        - {finding: diabetes_control, value: "uncontrolled"}
     if_true:
+      result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
+      notes: >
+        RF-UROTHELIAL-EV-INELIGIBLE fired — route to platinum-based chemotherapy
+        + avelumab maintenance (JAVELIN Bladder 100; mOS 21.4 vs 14.3 mo,
+        HR 0.69). Both cisplatin-eligible (GC/MVAC) and cisplatin-ineligible
+        (gem+carbo) patients covered by IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB.
+    if_false:
       result: IND-UROTHELIAL-METASTATIC-1L-EV-PEMBRO
       notes: >
-        EV+pembro preferred 1L for all eligible mUC patients (EV-302/KEYNOTE-A39;
-        mOS 31.5 vs 16.1 mo, HR 0.47 vs platinum chemo). Applies regardless of
-        cisplatin eligibility, PD-L1 status, or primary site (bladder, upper tract).
-        EV-302 enrolled both cisplatin-eligible and cisplatin-ineligible patients.
-    if_false:
-      next_step: 2
-    notes: >
-      EV eligibility gate covers MMAE toxicity-based exclusions (neuropathy,
-      hyperglycemia, keratopathy). RF authoring for composite exclusion criteria
-      still owed (RF-UROTHELIAL-EV-INELIGIBLE). Until then, evaluated as MDT text.
-
-  # Step 2 — EV+pembro ineligible. Route by cisplatin eligibility.
-  # Cisplatin-eligible: GC or dose-dense MVAC followed by avelumab maintenance.
-  # Cisplatin-ineligible (CrCl <60, ECOG ≥2, grade ≥2 peripheral neuropathy,
-  # grade ≥2 hearing loss, NYHA class III/IV HF): gem+carboplatin → avelumab.
-  - step: 2
-    evaluate:
-      all_of:
-        - condition: "Cisplatin-eligible: CrCl ≥60 mL/min, ECOG PS 0-1, no significant hearing loss, no neuropathy Grade ≥2, no HF NYHA III/IV"
-    if_true:
-      result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
-      notes: >
-        Cisplatin-eligible + EV-pembro ineligible: gemcitabine+cisplatin (4-6 cycles)
-        → avelumab maintenance until progression (JAVELIN Bladder 100;
-        mOS 21.4 vs 14.3 mo, HR 0.69). MVAC (dose-dense) is an alternative backbone.
-    if_false:
-      result: IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-AVELUMAB
-      notes: >
-        Cisplatin-ineligible + EV-pembro ineligible: gemcitabine+carboplatin (4-6
-        cycles) → avelumab maintenance. IND-UROTHELIAL-METASTATIC-1L-PLATINUM-CHEMO-
-        AVELUMAB covers both cisplatin and carboplatin backbone — regimen selection
-        guided by CrCl and patient fitness within the indication.
+        No EV exclusion criteria — EV+pembro preferred 1L for all eligible mUC
+        patients (EV-302/KEYNOTE-A39; mOS 31.5 vs 16.1 mo, HR 0.47 vs platinum
+        chemo). Applies regardless of cisplatin eligibility, PD-L1 status, or
+        primary site (bladder, upper tract, urethra).
 
 sources:
   - SRC-EV302-POWLES-2024
@@ -67,7 +51,7 @@ sources:
   - SRC-NCCN-BLADDER-2025
   - SRC-EAU-BLADDER-2024
 
-last_reviewed: "2026-05-03"
+last_reviewed: "2026-05-09"
 notes: >
   Post-EV-302 (2024): EV+pembro has replaced platinum-based chemotherapy as
   the preferred 1L for most patients, including cisplatin-ineligible (EV-302

--- a/knowledge_base/hosted/content/redflags/rf_endometrial_dmmr.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_endometrial_dmmr.yaml
@@ -1,0 +1,122 @@
+id: RF-ENDOMETRIAL-DMMR
+definition: >
+  Deficient mismatch repair (dMMR) or microsatellite instability-high
+  (MSI-H) status in advanced or recurrent endometrial carcinoma. dMMR
+  endometrial cancer is defined by loss of at least one MMR protein (MLH1,
+  MSH2, MSH6, PMS2) on IHC or MSI-H on PCR or NGS. Approximately 25-30%
+  of advanced endometrial cancers are dMMR/MSI-H (higher in endometrioid
+  histology, lower in serous/CCCC).
+
+  Fires to route ALGO-ENDOMETRIAL-ADVANCED-1L to checkpoint inhibitor
+  + chemotherapy combinations (dostarlimab + carbo/paclitaxel per RUBY
+  trial, Mirza NEJM 2023 PMID 37395437; or pembrolizumab + carbo/paclitaxel
+  per KEYNOTE-868 / NRG-GY018, Eskander NEJM 2023 PMID 36972026). Both
+  are NCCN Category 1 for dMMR/MSI-H advanced endometrial cancer.
+
+  dMMR status is the strongest predictive biomarker for immunotherapy
+  benefit in endometrial cancer: hazard ratio for PFS with CPI+chemo vs
+  chemo alone is approximately 0.28 (RUBY dostarlimab arm, dMMR cohort)
+  and 0.30 (KEYNOTE-868 pembro arm, dMMR/MSI-H cohort), versus ~0.70 for
+  the pMMR cohort with the same regimens — about double the relative PFS
+  benefit in dMMR vs pMMR. The OS benefit is similarly pronounced in
+  dMMR (HR ~0.28 RUBY 24-mo update; NRG-GY018 OS data maturing).
+
+  Lynch syndrome (germline MLH1/MSH2/MSH6/PMS2 mutation) accounts for
+  approximately 2-3% of endometrial cancers; somatic MLH1 promoter
+  hypermethylation accounts for most sporadic dMMR cases. The RF fires
+  regardless of germline vs somatic mechanism.
+definition_ua: >
+  Дефіцит системи репарації помилок (dMMR) або висока мікросателітна
+  нестабільність (MSI-H) при поширеному або рецидивуючому раку ендометрія.
+  Приблизно 25-30% поширеного раку ендометрія є dMMR/MSI-H. Спрацьовує для
+  маршрутизації до схем хіміоімунотерапії: достарлімаб + карбо/паклітаксел
+  (RUBY; Mirza NEJM 2023) або пембролізумаб + карбо/паклітаксел (KEYNOTE-868;
+  Eskander NEJM 2023). Обидва — NCCN категорія 1 для dMMR/MSI-H. Відношення
+  ризику ВБП при dMMR ~0.28-0.30 порівняно з ~0.70 при pMMR — подвоєний
+  виграш від імунотерапії при dMMR. Синдром Лінча (зародкова мутація
+  MLH1/MSH2/MSH6/PMS2) відповідає за ~2-3% випадків.
+
+trigger:
+  type: biomarker_status
+  any_of:
+    - finding: "mmr_status"
+      value: "deficient"
+    - finding: "mmr_status"
+      value: "dMMR"
+    - finding: "msi_status"
+      value: "MSI-H"
+    - finding: "msi_status"
+      value: "MSI-high"
+    - finding: "msi_status"
+      value: "high"
+    - finding: "mlh1_ihc"
+      value: "loss"
+    - finding: "msh2_ihc"
+      value: "loss"
+    - finding: "msh6_ihc"
+      value: "loss"
+    - finding: "pms2_ihc"
+      value: "loss"
+
+clinical_direction: intensify
+severity: major
+priority: 50
+category: high-risk-biology
+
+branch_targets:
+  ALGO-ENDOMETRIAL-ADVANCED-1L: "1"
+
+relevant_diseases:
+  - DIS-ENDOMETRIAL
+
+shifts_algorithm:
+  - ALGO-ENDOMETRIAL-ADVANCED-1L
+
+sources:
+  - SRC-RUBY-MIRZA-2023
+  - SRC-GY018-MAKKER-2022
+  - SRC-NCCN-UTERINE-2025
+
+last_reviewed: "2026-05-09"
+reviewer_signoffs: []
+draft: true
+notes: >
+  W5c RF authoring. Converts the free-text `{finding: mmr_status, value:
+  deficient}` condition in ALGO-ENDOMETRIAL-ADVANCED-1L step 1 into a
+  formal RF entity. The algo already uses structured finding lookups;
+  this RF provides the named entity that coverage tooling and the render
+  layer can reference.
+
+  RUBY trial (Mirza NEJM 2023, PMID 37395437): dostarlimab + carbo/pac
+  vs carbo/pac in advanced/recurrent endometrial. dMMR cohort 24-month
+  PFS HR 0.28 (95% CI 0.16–0.50); overall cohort PFS HR 0.64. OS data
+  reported at 2024 SGO (dMMR HR 0.28, CI 0.16–0.50, interim OS
+  analysis with 46% events).
+
+  KEYNOTE-868 / NRG-GY018 (Eskander NEJM 2023, PMID 36972026): pembrolizumab
+  + carbo/pac vs carbo/pac. dMMR/MSI-H cohort PFS HR 0.30 (95% CI
+  0.19–0.48); pMMR cohort PFS HR 0.54 (95% CI 0.41–0.71). OS data
+  maturing.
+
+  POLE/POLD1 ultra-mutated endometrial (see RF-POLE-POLD1-ENDOMETRIAL-LOW-RISK):
+  POLE exonuclease domain mutations confer MSI-H-like hypermutation but with
+  EXCELLENT prognosis — do not conflate with dMMR. POLE/POLD1 status is
+  assessed separately and typically warrants de-escalation (no cytotoxic
+  needed per ESMO 2022 for POLE/POLD1 early stage). dMMR ≠ POLE ultra-mutated.
+
+  Lynch syndrome genetic counselling: all dMMR endometrial cancers should
+  have germline MMR gene testing (reflex IHC → MLH1 methylation if MLH1 loss
+  → germline testing if methylation negative or other MMR protein loss).
+  This RF triggers the treatment routing; Lynch genetic referral is a
+  parallel care requirement not modelled in this RF.
+
+  Ukraine availability: pembrolizumab partially reimbursed for dMMR tumours
+  via НСЗУ oncology package (oncology drug access program 2024);
+  dostarlimab not currently НСЗУ-reimbursed. Practical default in Ukraine:
+  pembrolizumab + carbo/pac (KEYNOTE-868) when ICI funded; carbo/pac alone
+  when ICI access unavailable.
+
+  Sources confirmed in KB: SRC-RUBY-MIRZA-2023 (dostarlimab RUBY trial),
+  SRC-GY018-MAKKER-2022 (NRG-GY018/KEYNOTE-868 pembro+chemo trial),
+  SRC-NCCN-UTERINE-2025. All IDs verified present in
+  knowledge_base/hosted/content/sources/.

--- a/knowledge_base/hosted/content/redflags/rf_urothelial_ev_ineligible.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_urothelial_ev_ineligible.yaml
@@ -1,0 +1,112 @@
+id: RF-UROTHELIAL-EV-INELIGIBLE
+definition: >
+  Enfortumab vedotin + pembrolizumab (EV+pembro) exclusion criteria in
+  locally advanced or metastatic urothelial carcinoma. EV+pembro (EV-302 /
+  KEYNOTE-A39; Powles NEJM 2024, PMID 37840257) is NCCN Category 1 preferred
+  1L for all eligible patients regardless of cisplatin eligibility or PD-L1
+  status. This flag fires when ANY of the following EV-specific toxicity
+  exclusions are present, routing the algorithm to platinum-based chemotherapy
+  → avelumab maintenance instead:
+
+  (1) Grade ≥2 pre-existing peripheral neuropathy — MMAE (monomethyl
+  auristatin E) payload induces dose-limiting sensory-motor neuropathy;
+  baseline impairment is the primary safety exclusion in all EV trials.
+  (2) Uncontrolled diabetes mellitus (HbA1c >9% or active hyperglycaemia
+  requiring IV insulin) — EV causes hyperglycaemia through a mechanism
+  distinct from immunotherapy; uncontrolled DM amplifies risk of severe
+  hyperglycaemic events (grade ≥3 in ~4% EV-302).
+  (3) Severe corneal/ocular surface disease — EV-associated keratopathy
+  (microcyst-like epithelial changes) is class-wide for MMAE-ADCs; severe
+  baseline corneal disease or active keratitis is an exclusion.
+  (4) Active autoimmune disease requiring systemic immunosuppression —
+  pembrolizumab component; cross-references RF-ACTIVE-AUTOIMMUNE-DISEASE-ICI-RISK.
+  (5) Unresolved irAE from prior checkpoint inhibitor therapy — pembrolizumab
+  component; prior immune toxicity Grade ≥3 from any ICI is a standard
+  re-challenge exclusion.
+
+  Does NOT include CrCl <60 mL/min (cisplatin-ineligible) — EV+pembro was
+  tested in both cisplatin-eligible and cisplatin-ineligible cohorts in EV-302;
+  renal impairment alone is NOT an exclusion for EV+pembro.
+definition_ua: >
+  Критерії виключення для енфортумаб ведотин + пембролізумаб (EV+пембро)
+  при місцево-поширеному або метастатичному уротеліальному раку. EV+пембро
+  (EV-302/KEYNOTE-A39; Powles NEJM 2024) — NCCN категорія 1, переважний
+  режим 1Л для всіх придатних пацієнтів незалежно від придатності до
+  цисплатину або статусу PD-L1. Цей прапор спрацьовує при наявності
+  БУДЬ-ЯКОГО з таких критеріїв виключення, специфічних для EV:
+  (1) Периферична нейропатія ≥2 ступеня — ММАЕ індукує нейротоксичність;
+  (2) Неконтрольований цукровий діабет (HbA1c >9%) — EV викликає гіперглікемію;
+  (3) Тяжке захворювання рогівки/поверхні ока — ММАЕ-ADC кератопатія;
+  (4) Активне аутоімунне захворювання — компонент пембролізумабу;
+  (5) Невирішена іАНЖ від попереднього ІКТ ≥3 ступеня.
+  НЕ включає CrCl <60 мл/хв — EV+пембро тестувався в обох когортах.
+
+trigger:
+  type: composite_eligibility
+  any_of:
+    - finding: "peripheral_neuropathy_grade"
+      threshold: 2
+      comparator: ">="
+    - finding: "baseline_neuropathy"
+      value: "grade2"
+    - finding: "baseline_neuropathy"
+      value: "grade3"
+    - finding: "baseline_neuropathy"
+      value: "grade4"
+    - finding: "diabetes_control"
+      value: "uncontrolled"
+    - finding: "hba1c"
+      threshold: 9.0
+      comparator: ">"
+    - finding: "ev_pembro_eligible"
+      value: false
+    - finding: "corneal_disease_severe"
+      value: true
+    - finding: "active_autoimmune_disease"
+      value: true
+    - finding: "prior_ici_grade3_irae"
+      value: true
+
+clinical_direction: de-escalate
+severity: major
+priority: 60
+category: fitness-eligibility
+
+branch_targets:
+  ALGO-UROTHELIAL-METASTATIC-1L: "1"
+
+relevant_diseases:
+  - DIS-UROTHELIAL
+
+shifts_algorithm:
+  - ALGO-UROTHELIAL-METASTATIC-1L
+
+sources:
+  - SRC-NCCN-BLADDER-2025
+  - SRC-EV302-POWLES-2024
+
+last_reviewed: "2026-05-09"
+reviewer_signoffs: []
+draft: true
+notes: >
+  W5c RF authoring. Closes the RF authoring gap noted in
+  ALGO-UROTHELIAL-METASTATIC-1L step 1 (comment: "RF authoring for
+  composite exclusion criteria still owed — RF-UROTHELIAL-EV-INELIGIBLE.
+  Until then, evaluated as MDT text.").
+
+  EV-302 key data (Powles NEJM 2024, PMID 37840257): EV+pembro vs
+  platinum-based chemotherapy in 1L la/mUC. mOS 31.5 vs 16.1 months
+  (HR 0.47, p<0.001); mPFS 12.5 vs 6.3 months (HR 0.45). Benefit
+  consistent regardless of cisplatin eligibility, PD-L1 CPS status,
+  primary site, or prior BCG. EV-specific safety (grade ≥3): peripheral
+  neuropathy 6%, hyperglycaemia 4%, skin reactions 10%.
+
+  Rationale for `de-escalate` direction: firing this RF means EV+pembro
+  (the preferred aggressive regimen) is contraindicated — the patient
+  must de-escalate to the alternative (platinum chemo + avelumab
+  maintenance). The flag does not modify dosing; it routes to a
+  different regimen.
+
+  SRC-EV302-POWLES-2024: Powles T et al. Enfortumab vedotin and
+  pembrolizumab in untreated advanced urothelial cancer. N Engl J Med.
+  2024;390(10):875-888. PMID 37840257. Source stub confirmed in KB.


### PR DESCRIPTION
## Summary

Closes W5c gap from `docs/plans/biomarker_expansion_roadmap_2026-04-30-1500.md`: two RedFlags converting free-text algorithm conditions to formal RF entities.

- **RF-UROTHELIAL-EV-INELIGIBLE** — composite EV+pembro exclusion gate (`de-escalate / fitness-eligibility`): grade ≥2 peripheral neuropathy, uncontrolled DM (HbA1c >9%), severe corneal disease, active autoimmune disease, prior ICI grade ≥3 irAE. Closes "RF authoring still owed" TODO in ALGO-UROTHELIAL-METASTATIC-1L. CrCl is NOT an exclusion.
- **RF-ENDOMETRIAL-DMMR** — dMMR/MSI-H gate (`intensify / high-risk-biology`): fires on IHC MMR protein loss or MSI-H on PCR/NGS. Routes to dostarlimab+carbo/pac (RUBY dMMR PFS HR 0.28) vs pembro+carbo/pac for pMMR.

**Algo updates:**
- `algo_urothelial_metastatic_1l.yaml`: restructures step 1 to check `RF-UROTHELIAL-EV-INELIGIBLE` (ineligible → platinum chemo; no flag → EV+pembro); collapses two steps to one
- `algo_endometrial_advanced_1l.yaml`: adds `RF-ENDOMETRIAL-DMMR` as primary gate; expands purpose/notes/sources

**Note:** Base set to `feat/mm-1l-ti-ndmm` (PR #537, pending merge) — depends on that PR merging first. W5c diff is clean (2 new RF files + 2 algo updates).

## Test plan
- [ ] KB loader validates without schema errors (confirmed: loader tests pass)
- [ ] Both RFs: `trigger`, `clinical_direction`, `severity`, `category` conform to schema
- [ ] `RF-UROTHELIAL-EV-INELIGIBLE` — `de-escalate`, `fitness-eligibility`, sources resolved
- [ ] `RF-ENDOMETRIAL-DMMR` — `intensify`, `high-risk-biology`, sources resolved
- [ ] Algo step 1 wired correctly: urothelial (EV-ineligible → platinum; else → EV+pembro)
- [ ] Algo step 1 wired correctly: endometrial (dMMR RF fires → dostarlimab-chemo; else → pembro-chemo)
- [ ] Pre-existing curated test failures unchanged (CRC/DLBCL/MCL/NSCLC routing bugs pre-exist on master)
- [ ] Clinical co-lead signoff required before `draft: true` is removed (CHARTER §6.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)