### PR TITLE
feat(kb): W5c RF-GIST-PDGFRA-D842V authoring + ALGO-GIST-1L wiring

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_gist_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gist_1l.yaml
@@ -20,12 +20,26 @@ decision_tree:
   - step: 1
     evaluate:
       any_of:
+        - red_flag: RF-GIST-PDGFRA-D842V
+        # Legacy finding-based evaluations for backward engine compatibility:
+        - {finding: BIO-PDGFRA, value: D842V}
+        - {finding: pdgfra_mutation, value: D842V}
+        - {finding: pdgfra_exon18_mutation, value: D842V}
+        - {finding: pdgfra_mutation_codon, value: D842V}
+        - {finding: pdgfra_d842v, value: "true"}
         - condition: "PDGFRA D842V mutation positive"
     if_true:
       result: IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V
+      notes: >
+        RF-GIST-PDGFRA-D842V fired (PDGFRA D842V confirmed) — avapritinib
+        preferred 1L (NAVIGATOR ORR ~88-91%). Imatinib is ineffective for
+        D842V (ORR <10%) and must NOT be used. NCCN GIST 2025 Category 1.
     if_false:
       next_step: 2
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      W5c RF wiring: RF-GIST-PDGFRA-D842V added as primary gate; legacy
+      finding lookups and free-text condition retained for backward
+      engine compatibility.
   - step: 2
     evaluate:
       any_of:
@@ -49,8 +63,9 @@ decision_tree:
 
 sources:
   - SRC-NCCN-GIST-2025
-  - SRC-ONCOKB
-last_reviewed: '2026-04-26'
+  - SRC-NAVIGATOR
+  - SRC-VOYAGER
+last_reviewed: '2026-05-08'
 notes: >
   Decision tree intentionally simplified for MVP: KIT/PDGFRA-WT
   (SDH-deficient or NF1-mutant) GIST is routed to imatinib as the

--- a/knowledge_base/hosted/content/redflags/rf_gist_pdgfra_d842v.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_gist_pdgfra_d842v.yaml
@@ -1,0 +1,104 @@
+id: RF-GIST-PDGFRA-D842V
+definition: >
+  PDGFRA D842V substitution mutation in advanced or metastatic GIST. The
+  PDGFRA D842V variant accounts for approximately 6-7% of all GIST and is
+  the most common PDGFRA exon 18 mutation (~65-70% of PDGFRA-mutant GIST).
+  D842V confers primary resistance to imatinib, sunitinib, and regorafenib
+  due to steric interference with drug binding at the activation loop. The
+  type I kinase inhibitor avapritinib binds the active conformation of
+  PDGFRA D842V and achieves ORR ~88% (NAVIGATOR phase 1; Heinrich CANCER
+  DISCOV 2020) and confirmed ORR ~91% in the phase 3 NAVIGATOR expansion
+  cohort. Imatinib is ineffective (historical ORR <10% for D842V) and must
+  not be used as 1L for confirmed D842V-mutant GIST.
+
+  Fires to route ALGO-GIST-1L step 1 to avapritinib (IND-GIST-1L-
+  AVAPRITINIB-PDGFRA-D842V) instead of imatinib (IND-GIST-1L-IMATINIB).
+  NCCN GIST 2025 Category 1 preferred: avapritinib 300 mg PO QD for
+  PDGFRA D842V-mutant unresectable/metastatic GIST.
+
+  Detection: PDGFRA D842V is detectable on targeted NGS, hotspot PCR, or
+  PDGFRA-specific IHC (D842V antibody). Tissue or ctDNA-based molecular
+  testing of all GIST at diagnosis is standard of care per NCCN GIST 2025.
+
+  PDGFRA non-D842V exon 18 mutations (e.g., D842del, DI842-843IM):
+  intermediate imatinib sensitivity — these are NOT covered by this RF.
+  The RF fires exclusively on the D842V substitution. Non-D842V exon 18
+  PDGFRA mutations route to imatinib (ALGO-GIST-1L step 2 default path).
+
+definition_ua: >
+  Мутація PDGFRA D842V при поширеній або метастатичній ГІСТ. D842V наявна
+  приблизно у 6-7% всіх ГІСТ і є найпоширенішою мутацією PDGFRA екзону 18.
+  D842V конферує первинну резистентність до іматинібу, сунітинібу та
+  регорафенібу. Авапритиніб — інгібітор тирозинкінази I типу, ефективний
+  при D842V: ЗВВ ~88-91% (NAVIGATOR). Іматиніб неефективний (ЗВВ <10%)
+  і не повинен застосовуватись при підтвердженій D842V-мутації ГІСТ.
+  Категорія 1 NCCN GIST 2025: авапритиніб 300 мг перорально 1 раз на добу.
+
+trigger:
+  type: biomarker_status
+  any_of:
+    - finding: BIO-PDGFRA
+      value: D842V
+    - finding: pdgfra_mutation
+      value: D842V
+    - finding: pdgfra_exon18_mutation
+      value: D842V
+    - finding: pdgfra_mutation_codon
+      value: D842V
+    - finding: pdgfra_d842v
+      value: "true"
+
+clinical_direction: intensify
+severity: major
+priority: 80
+category: high-risk-biology
+
+branch_targets:
+  ALGO-GIST-1L: "1"
+
+relevant_diseases:
+  - DIS-GIST
+
+shifts_algorithm:
+  - ALGO-GIST-1L
+
+sources:
+  - SRC-NCCN-GIST-2025
+  - SRC-NAVIGATOR
+  - SRC-VOYAGER
+
+last_reviewed: "2026-05-08"
+reviewer_signoffs: []
+draft: true
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+notes: >
+  W5c RF authoring. Converts free-text `{condition: "PDGFRA D842V mutation
+  positive"}` in ALGO-GIST-1L step 1 into a formal RF entity.
+
+  Clinical rationale: PDGFRA D842V confers primary resistance to all
+  approved TKIs except avapritinib. NAVIGATOR phase 3 expansion cohort
+  (Heinrich et al, CANCER DISCOV 2020; trial NCT02508532) demonstrated
+  ORR 88-91% with avapritinib 300 mg QD; median PFS not reached at
+  data cutoff. VOYAGER (NCT03465722) was designed as avapritinib vs
+  regorafenib in 3L+ GIST (mixed genotype); primary endpoint (PFS) did
+  not meet statistical significance but was confounded by inclusion of
+  non-D842V GIST. NAVIGATOR remains the key evidence base for D842V 1L.
+
+  Trigger: uses BIO-PDGFRA/D842V pattern consistent with BMA entity
+  bma_pdgfra_d842v_gist.yaml (ESCAT IA). Legacy finding name variants
+  retained for backward engine compatibility until biomarker normalization
+  pass completes.
+
+  PDGFRA non-D842V exon 18 mutations (D842del, DI842-843IM, N659K, etc.)
+  are NOT within this RF scope — those have intermediate imatinib
+  sensitivity and route via ALGO-GIST-1L step 2 imatinib path.
+
+  Source stubs: SRC-NAVIGATOR and SRC-VOYAGER are auto-stubs with
+  pending citation verification (PMID + DOI to be confirmed by clinical
+  co-lead). SRC-NCCN-GIST-2025 is the primary guideline authority
+  (NCCN Category 1 for avapritinib 1L in D842V GIST).
+
+  CHARTER §6.1: Two-reviewer clinical co-lead signoff required before
+  removing draft: true.


### PR DESCRIPTION
## Summary

- New entity: RF-GIST-PDGFRA-D842V — formal RedFlag for PDGFRA D842V substitution in GIST, replacing the free-text condition gate in ALGO-GIST-1L step 1
- Wired into: ALGO-GIST-1L step 1 any_of — primary RF gate + legacy finding-based lookups for backward engine compatibility
- Clinical impact: Routes PDGFRA D842V patients to avapritinib (IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V) instead of imatinib. D842V confers primary imatinib resistance (ORR <10%); avapritinib ORR 88-91% (NAVIGATOR)
- Sources: SRC-NCCN-GIST-2025 (Category 1 preferred), SRC-NAVIGATOR, SRC-VOYAGER; SRC-ONCOKB legacy reference removed from algo
- All new content ships draft: true per CHARTER Section 6.1

## Test plan

- [ ] KB loader load_content: zero schema/ref/contract errors for GIST entities (verified locally: 0 errors, 1 expected draft: true contract warning)
- [ ] YAML syntax: both files pass yaml.safe_load with UTF-8 encoding
- [ ] Pre-existing test failure test_all_bma_cells_have_valid_escat_tier (bma_bap1_mut_rcc_prognostic.yaml escat_tier: III) is NOT caused by this PR - confirmed via git diff master --name-only
- [ ] Clinical co-lead: verify NAVIGATOR ORR data (88-91%); confirm SRC-NAVIGATOR/SRC-VOYAGER citation stubs; sign off per CHARTER Section 6.1 before removing draft: true
- [ ] Confirm PDGFRA non-D842V exon 18 mutations (D842del, DI842-843IM) are NOT covered by this RF (intentional - they have intermediate imatinib sensitivity)

Generated with Claude Code (https://claude.com/claude-code)