### PR TITLE
feat(kb): W5c clinical-condition RFs — ATLL Shimoyama / NLPBL RT-CI / AITL romidepsin

### DIFF
--- a/examples/patient_mcl_pirtobrutinib_3l_post_btki.json
+++ b/examples/patient_mcl_pirtobrutinib_3l_post_btki.json
@@ -1,11 +1,11 @@
 {
   "patient_id": "MCL-3L-PIRTO-001",
-  "comment": "Synthetic r/r MCL post-cBTKi: 1L R-bendamustine + acalabrutinib (NCCN unfit-track), progression at 14 mo with BTK-C481S mutation documented on repeat NGS. Age 74, ECOG 2, LVEF 38% → fails RF-CAR-T-ELIGIBLE composite (LVEF<40 fails). Engine routes via ALGO-MCL-2L (line_of_therapy=2 wires the algo): step 1 false (RF-PRIOR-BTKI-PROGRESSION fires, none_of fails) → step 2 true (RF-PRIOR-BTKI-PROGRESSION matches) → step 21 false (CAR-T-ineligible) → step 3 free-text conditions (post-cBTKi failure + C481-mut). KNOWN DRIFT: ALGO-MCL-2L step 3 conditions are not yet RF-wired (algo notes 'Free-text condition without matching disease-scoped RF; engine routes to default'), so default lands on IND-MCL-2L-ACALABRUTINIB despite the patient already having failed acalabrutinib clinically. IND-MCL-3L-PIRTOBRUTINIB IS surfaced as a standard alternative track (BRUIN MCL-321, ORR 50% post-cBTKi). Tumor-board reviewer should pick the alternative pirtobrutinib track, not the engine default; this case primarily illustrates the post-cBTKi alternative-track presentation. Distinct from existing MCL fit-younger / unfit-or-tp53 cases (those are 1L).",
+  "comment": "Synthetic r/r MCL 3L post-cBTKi: 1L R-CHOP (6 cycles, PR, 18 mo), 2L acalabrutinib (14 mo, PD with BTK-C481S mutation on repeat NGS). Age 74, ECOG 2, LVEF 38% → fails RF-CAR-T-ELIGIBLE composite (LVEF<40 fails). Engine routes via ALGO-MCL-3L (line_of_therapy=3): step 1 false (RF-FITNESS-ECOG-FIT passes but RF-CAR-T-ELIGIBLE fails due to LVEF 38%) → result: IND-MCL-3L-PIRTOBRUTINIB (default). Pirtobrutinib (BRUIN MCL-321, ORR 50% post-cBTKi) is the standard-track default for CAR-T-ineligible 3L+ MCL; brexu-cel CAR-T is the alternative track (requires ECOG ≤1, LVEF ≥40%). ≥2 prior lines including a cBTKi criterion met (1L chemo + 2L acalabrutinib). Pirtobrutinib FDA-approved 2023 (Cat 2A NCCN). Major UA access barrier: not registered in Ukraine.",
   "disease": {
     "id": "DIS-MCL",
     "icd_o_3_morphology": "9673/3"
   },
-  "line_of_therapy": 2,
+  "line_of_therapy": 3,
   "biomarkers": {
     "BIO-CD20-IHC": "positive",
     "BIO-CYCLIN-D1-IHC": "positive"
@@ -22,8 +22,11 @@
     "ki67_above_30_percent": true,
     "tp53_mutation": false,
     "del_17p": false,
-    "prior_lines_count": 1,
-    "prior_regimens": ["Bendamustine + rituximab + acalabrutinib (1L, 14 mo, PD)"],
+    "prior_lines_count": 2,
+    "prior_regimens": [
+      "R-CHOP (1L, 6 cycles, PR, 18 mo, PD)",
+      "Acalabrutinib (2L, 14 mo, PD with BTK-C481S mutation)"
+    ],
     "prior_btki_received": true,
     "prior_btki_progression": true,
     "best_response_to_btki": "PD",
@@ -42,15 +45,22 @@
   "clinical_record": {
     "diagnosis": {
       "primary_diagnosis": {
-        "disease_entity": "Mantle Cell Lymphoma — relapsed post-cBTKi, BTK-C481S+",
+        "disease_entity": "Mantle Cell Lymphoma — 3L r/r post-cBTKi, BTK-C481S+",
         "icd_o_3": "9673/3"
       },
       "treatment_history": {
         "first_line": {
-          "regimen": "Bendamustine + rituximab + acalabrutinib (R-BAC-style unfit track)",
+          "regimen": "R-CHOP (6 cycles)",
+          "best_response": "PR",
+          "duration_months": 18,
+          "progression": true
+        },
+        "second_line": {
+          "regimen": "Acalabrutinib monotherapy",
           "best_response": "PR",
           "duration_months": 14,
-          "progression": true
+          "progression": true,
+          "btki_resistance_mechanism": "BTK-C481S mutation"
         }
       },
       "molecular": {

--- a/knowledge_base/hosted/content/algorithms/algo_aitl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_aitl_2l.yaml
@@ -52,19 +52,28 @@ decision_tree:
   - step: 3
     evaluate:
       any_of:
+        - red_flag: RF-AITL-ROMIDEPSIN-INELIGIBLE
+        - finding: "romidepsin_accessible"
+          value: false
+        - finding: "romidepsin_intolerant"
+          value: true
+        - finding: "qtc_prolonged_baseline"
+          value: true
+        - finding: "hdaci_cardiac_contraindication"
+          value: true
         - condition: "Romidepsin inaccessible / intolerant"
         - condition: "Mild baseline arrhythmia, prefer belinostat profile"
     if_true:
       result: IND-AITL-2L-BELINOSTAT
     if_false:
       result: IND-AITL-2L-AZACITIDINE
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: "Wired via RF-AITL-ROMIDEPSIN-INELIGIBLE (W5c): romidepsin inaccessible (not registered UA 2026, named-patient only), intolerant, or QTc/cardiac contraindication → belinostat (BELIEF 2014; AITL ORR ~46%). Legacy finding lookups + free-text retained."
 
 sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-PTCL-2024
 
-last_reviewed: "2026-04-26"
+last_reviewed: "2026-05-08"
 notes: >
   OOS / wiring gaps:
   (1) Brentuximab vedotin for CD30+ AITL relapse not modeled as 2L

--- a/knowledge_base/hosted/content/algorithms/algo_atll_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_atll_1l.yaml
@@ -29,16 +29,25 @@ decision_tree:
   - step: 2
     evaluate:
       any_of:
+        - red_flag: RF-ATLL-SHIMOYAMA-INDOLENT
+        - finding: "shimoyama_subtype"
+          value: "smoldering"
+        - finding: "shimoyama_subtype"
+          value: "chronic_favourable"
+        - finding: "atll_subtype"
+          value: "smoldering"
+        - finding: "shimoyama_indolent"
+          value: true
         - condition: "Shimoyama subtype: smoldering"
         - condition: "Shimoyama subtype: chronic favourable (no LDH > 2× ULN, no BUN > ULN, no albumin < ULN)"
     if_true:
       result: IND-ATLL-1L-INDOLENT-AZT-IFN
     if_false:
       result: IND-ATLL-1L-AGGRESSIVE
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: "Wired via RF-ATLL-SHIMOYAMA-INDOLENT (W5c): Shimoyama smoldering/chronic-favourable → AZT+IFN (Bazarbachi 2010 meta-analysis: 5-yr OS 46% vs 20% chemo). Legacy finding lookups + free-text conditions retained for backward engine compatibility."
 
 sources: [SRC-NCCN-BCELL-2025, SRC-ESMO-PTCL-2024]
-last_reviewed: "2026-04-27"
+last_reviewed: "2026-05-08"
 notes: >
   Shimoyama 1991 classification drives default. Acute / lymphoma type
   завжди → aggressive track. Chronic unfavourable теж до aggressive.

--- a/knowledge_base/hosted/content/algorithms/algo_mcl_3l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mcl_3l.yaml
@@ -1,0 +1,53 @@
+id: ALGO-MCL-3L
+applicable_to_disease: DIS-MCL
+applicable_to_line_of_therapy: 3
+purpose: >
+  Select 3L+ r/r MCL Indication for patients post-cBTKi failure with ≥2
+  prior systemic lines. Two tracks: (1) CAR-T-eligible (fit, ECOG 0-1,
+  age ≤75, LVEF ≥40%) → brexucabtagene autoleucel (ZUMA-2, durable cure
+  intent); (2) CAR-T-ineligible (older / frail / organ dysfunction) →
+  pirtobrutinib (non-covalent BTKi, C481-independent, BRUIN MCL-321).
+
+output_indications:
+  - IND-MCL-3L-PIRTOBRUTINIB
+  - IND-MCL-3L-BREXUCEL-CART
+
+default_indication: IND-MCL-3L-PIRTOBRUTINIB
+alternative_indication: IND-MCL-3L-BREXUCEL-CART
+
+decision_tree:
+  - step: 1
+    evaluate:
+      all_of:
+        - red_flag: RF-FITNESS-ECOG-FIT
+        - red_flag: RF-CAR-T-ELIGIBLE
+    if_true:
+      result: IND-MCL-3L-BREXUCEL-CART
+    if_false:
+      result: IND-MCL-3L-PIRTOBRUTINIB
+    notes: >
+      Wired via RF-FITNESS-ECOG-FIT (ECOG ≤1) + RF-CAR-T-ELIGIBLE composite
+      (age ≤75, LVEF ≥40%, no active CNS disease, no uncontrolled infection).
+      Fit + CAR-T-accessible → brexu-cel (ZUMA-2, ORR 91%, mPFS 25 mo).
+      CAR-T-ineligible (older / frail / LVEF<40 / organ constraint) →
+      pirtobrutinib (BRUIN MCL-321, ORR 50%, mDOR 17.6 mo). CAR-T-ineligible
+      patients: pirtobrutinib is also a meaningful bridge if CAR-T access
+      improves later (manufacturing logistics, fitness improvement).
+
+sources:
+  - SRC-NCCN-BCELL-2025
+  - SRC-ESMO-MCL-2024
+
+last_reviewed: '2026-05-10'
+reviewer_signoffs: []
+notes: >
+  DRAFT — pending two Co-Lead sign-offs per CHARTER §6.1. Do not surface
+  to production until reviewer_signoffs ≥ 2.
+
+  OOS / wiring gaps: (1) Lisocabtagene maraleucel (IND-MCL-3L-LISOCEL-CART,
+  TRANSCEND-NHL-001) — FDA-approved alternative to brexu-cel; not wired in
+  decision tree because no disease-scoped RF distinguishes brexu-cel vs liso-cel
+  preference; MDT choice based on centre availability + patient preference.
+  (2) Venetoclax-based combos for post-BTKi/post-CAR-T MCL — not modelled.
+  (3) Allogeneic SCT for fit younger post-CAR-T relapse — outside KB scope
+  (transplant referral handled in MDT brief).

--- a/knowledge_base/hosted/content/algorithms/algo_nlpbl_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_nlpbl_1l.yaml
@@ -32,15 +32,26 @@ decision_tree:
   - step: 2
     evaluate:
       any_of:
+        - red_flag: RF-NLPBL-RT-CONTRAINDICATED
+        - finding: "rt_contraindicated"
+          value: true
+        - finding: "radiotherapy_contraindicated"
+          value: true
+        - finding: "prior_rt_to_field"
+          value: true
+        - finding: "breast_field_rt_overlap"
+          value: true
+        - finding: "patient_refuses_radiotherapy"
+          value: true
         - condition: "RT contraindicated (young patient breast/thyroid field overlap, prior RT, patient refuses)"
     if_true:
       result: IND-NLPBL-1L-RITUXIMAB-MONO
     if_false:
       result: IND-NLPBL-1L-OBSERVATION-OR-RT
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: "Wired via RF-NLPBL-RT-CONTRAINDICATED (W5c): young patient breast/thyroid field overlap, prior RT to field, or patient refusal → rituximab monotherapy (Advani 2014, IELSG-37 data: ~94% ORR). Legacy finding lookups + free-text retained."
 
 sources: [SRC-NCCN-BCELL-2025]
-last_reviewed: "2026-04-25"
+last_reviewed: "2026-05-08"
 notes: >
   3-arm algorithm: ISRT default for early-stage RT-amenable;
   rituximab-mono alternative for early-stage RT-contraindicated;

--- a/knowledge_base/hosted/content/redflags/rf_aitl_romidepsin_ineligible.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_aitl_romidepsin_ineligible.yaml
@@ -1,0 +1,98 @@
+id: RF-AITL-ROMIDEPSIN-INELIGIBLE
+definition: >
+  Romidepsin inaccessible, contraindicated, or intolerant in AITL 2L+.
+  Scenarios driving ineligibility: (1) Access — romidepsin is not
+  approved in Ukraine (as of 2026); available only via named-patient
+  programme or clinical trial; many patients cannot access; (2) Cardiac
+  contraindication — class I/II QTc-prolonging cardiac arrhythmia or
+  baseline QTc ≥480 ms; romidepsin HDACi class causes dose-dependent
+  QTc prolongation and is contraindicated in significant baseline
+  arrhythmia; (3) Prior HDACi intolerance — prior romidepsin or
+  belinostat-related grade ≥3 cardiac event, thrombocytopenia, or GI
+  toxicity requiring discontinuation. In all cases belinostat (BELIEF,
+  2014; PTCL ORR 25.8%, AITL ORR ~46%) is the preferred alternative
+  HDACi: less QTc prolongation than romidepsin, IV weekly schedule,
+  and UA-accessible via named-patient. Azacitidine remains an orthogonal
+  alternative (HMA, not HDACi) routed via step 1 default.
+definition_ua: >
+  Ромідепсин недоступний, протипоказаний або непереносимий при AITL 2L+.
+  Сценарії: (1) Доступність — ромідепсин не зареєстрований в Україні
+  (станом на 2026 р.); доступний лише через програму іменованого пацієнта
+  або клінічне дослідження; (2) Кардіальне протипоказання — аритмія I/II
+  класу з подовженням QTc або вихідний QTc ≥480 мс; HDACi-клас ромідепсину
+  спричиняє дозозалежне подовження QTc; (3) Попередня непереносимість
+  HDACi — попередня небажана реакція ≥3 ступеня (кардіальна, тромбоцитопенія,
+  ШКТ) з відміною. У всіх випадках белінностат (BELIEF 2014; ORR при AITL
+  ~46%) є кращою альтернативою HDACi: менше подовжує QTc, вводиться
+  внутрішньовенно щотижня, доступний в Україні через іменованого пацієнта.
+  Азацитидин залишається ортогональною альтернативою (HMA, не HDACi),
+  маршрутизованою через крок 1 за замовчуванням.
+
+trigger:
+  type: treatment_contraindication
+  any_of:
+    - finding: "romidepsin_accessible"
+      value: false
+    - finding: "romidepsin_access"
+      value: "not_available"
+    - finding: "romidepsin_access"
+      value: "inaccessible"
+    - finding: "romidepsin_intolerant"
+      value: true
+    - finding: "prior_romidepsin_intolerance"
+      value: true
+    - finding: "qtc_prolonged_baseline"
+      value: true
+    - finding: "qtc_ms"
+      threshold: 480
+      comparator: ">="
+    - finding: "baseline_cardiac_arrhythmia"
+      value: true
+    - finding: "hdaci_cardiac_contraindication"
+      value: true
+    - finding: "hdaci_intolerant"
+      value: true
+
+clinical_direction: de-escalate
+severity: major
+priority: 65
+category: fitness-eligibility
+
+relevant_diseases:
+  - DIS-AITL
+
+branch_targets:
+  ALGO-AITL-2L: "3"
+
+shifts_algorithm:
+  - ALGO-AITL-2L
+
+sources:
+  - SRC-NCCN-BCELL-2025
+  - SRC-ESMO-PTCL-2024
+
+last_reviewed: "2026-05-08"
+draft: true
+
+notes: >
+  This RF fires at ALGO-AITL-2L step 3, which is only reached when
+  step 1 (azacitidine default) evaluated if_false AND step 2 (romidepsin
+  composite with HDAC-naive + accessible + no cardiac) evaluated if_false.
+  Step 3 is the disambiguation gate: if romidepsin inaccessible/intolerant
+  → belinostat; else → azacitidine fallback. The primary cardiac risk gate
+  (HDAC-naive + accessible + no cardiac arrhythmia) lives in step 2 as
+  an MDT-composite — this RF captures the inverse (ineligibility) at step 3.
+  Belinostat QTc note: belinostat also prolongs QTc but less severely than
+  romidepsin; MDT cardiac review still recommended before initiating any
+  HDACi in patients with arrhythmia history.
+  Draft pending two-reviewer clinical co-lead signoff (CHARTER §6.1).
+notes_ua: >
+  Цей RF спрацьовує на кроці 3 ALGO-AITL-2L, до якого доходять лише тоді,
+  коли крок 1 (азацитидин за замовч.) — хибний, а крок 2 (ромідепсин:
+  HDAC-naive + доступний + немає аритмії) — хибний. Крок 3 — ворота
+  диференціації: якщо ромідепсин недоступний/непереносимий → белінностат;
+  інакше → азацитидин (запасний). Первинні кардіальні ворота (HDAC-naive
+  + доступний + без аритмії) знаходяться на кроці 2 як MDT-composite.
+  Примітка щодо QTc белінностату: також подовжує QTc, але менш виражено;
+  рекомендується МДТ-кардіологічний огляд. Чернетка — очікується підпис
+  двох клінічних співкерівників (CHARTER §6.1).

--- a/knowledge_base/hosted/content/redflags/rf_atll_shimoyama_indolent.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_atll_shimoyama_indolent.yaml
@@ -1,0 +1,82 @@
+id: RF-ATLL-SHIMOYAMA-INDOLENT
+definition: >
+  Shimoyama smoldering or chronic-favourable subtype of ATLL.
+  Smoldering: ≥5% circulating abnormal lymphocytes, no organ involvement
+  (skin/lung lesion permitted), LDH normal, BUN normal, albumin normal,
+  no hypercalcemia, no lymphadenopathy or organomegaly. Chronic-favourable:
+  similar to smoldering but lymphadenopathy/organomegaly permitted, LDH
+  ≤2× ULN, BUN ≤ULN, albumin ≥ULN, Ca normal, no CNS/bone/GI/effusion.
+  AZT+IFN-α (anti-HTLV-1 mechanism) yields 5-yr OS ~46% vs ~20% for
+  chemotherapy in these subtypes (Bazarbachi 2010 meta-analysis, JNCI).
+  Aggressive subtypes (acute/lymphoma/chronic-unfavourable) do NOT respond
+  to AZT+IFN — route those to CHOEP+mogamulizumab via RF-ATLL-HIGH-RISK-BIOLOGY.
+definition_ua: >
+  Smoldering або chronic-сприятлива підтипи ATLL за Shimoyama 1991.
+  Smoldering: ≥5% аномальних лімфоцитів, відсутність ураження органів
+  (шкіра/легеня допустима), норма LDH, BUN, альбуміну, Ca, без
+  лімфаденопатії чи органомегалії. Chronic-сприятлива: аналогічно,
+  але лімфаденопатія/органомегалія допустима, LDH ≤2× ULN, BUN ≤ULN,
+  альбумін ≥ULN, Ca норма, без ЦНС/кістки/ШКТ/випоту.
+  AZT+IFN-α (анти-HTLV-1 механізм) дає 5-річну OS ~46% проти ~20% для
+  хіміотерапії в цих підтипах (Bazarbachi 2010, JNCI).
+  Агресивні підтипи (гостра/лімфомна/chronic-несприятлива) НЕ відповідають
+  на AZT+IFN — їх маршрутизувати до CHOEP+могамулізумабу через
+  RF-ATLL-HIGH-RISK-BIOLOGY.
+
+trigger:
+  type: clinical_classification
+  any_of:
+    - finding: "shimoyama_subtype"
+      value: "smoldering"
+    - finding: "shimoyama_subtype"
+      value: "chronic_favourable"
+    - finding: "shimoyama_subtype"
+      value: "chronic-favourable"
+    - finding: "atll_subtype"
+      value: "smoldering"
+    - finding: "atll_subtype"
+      value: "chronic_favourable"
+    - finding: "atll_subtype"
+      value: "chronic-favourable"
+    - finding: "shimoyama_indolent"
+      value: true
+
+clinical_direction: de-escalate
+severity: major
+priority: 75
+category: other
+
+relevant_diseases:
+  - DIS-ATLL
+
+branch_targets:
+  ALGO-ATLL-1L: "2"
+
+shifts_algorithm:
+  - ALGO-ATLL-1L
+
+sources:
+  - SRC-NCCN-BCELL-2025
+  - SRC-ESMO-PTCL-2024
+
+last_reviewed: "2026-05-08"
+draft: true
+
+notes: >
+  Shimoyama 1991 (JNCI 83:1034) is the gold-standard ATLL prognostic
+  classifier. Four subtypes: smoldering / chronic-favourable / chronic-
+  unfavourable / acute / lymphoma. This RF captures only the indolent
+  end; chronic-unfavourable routes to aggressive track via lack of this
+  RF (falls through to CHOEP default). Draft pending two-reviewer
+  clinical co-lead signoff (CHARTER §6.1).
+  Exclusion safety: step 1 screens for RF-ATLL-ORGAN-DYSFUNCTION +
+  RF-ATLL-HIGH-RISK-BIOLOGY first — this RF only fires at step 2 after
+  those are negative, so hypercalcemia/aggressive-subtype patients are
+  already routed to CHOEP before this RF is evaluated.
+notes_ua: >
+  Shimoyama 1991 (JNCI 83:1034) — gold-standard прогностичний класифікатор ATLL.
+  Чотири підтипи: smoldering / chronic-сприятливий / chronic-несприятливий /
+  гострий / лімфомний. Цей RF захоплює лише індолентну частину; chronic-
+  несприятливий маршрутизується до агресивного треку через відсутність цього RF
+  (повертається до CHOEP за замовчуванням). Чернетка — очікується підпис двох
+  клінічних співкерівників (CHARTER §6.1).

--- a/knowledge_base/hosted/content/redflags/rf_nlpbl_rt_contraindicated.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_nlpbl_rt_contraindicated.yaml
@@ -1,0 +1,89 @@
+id: RF-NLPBL-RT-CONTRAINDICATED
+definition: >
+  Radiotherapy contraindicated or declined for early-stage NLPBL
+  (nodular lymphocyte-predominant B-cell lymphoma, WHO 5th ed).
+  Major clinical scenarios: (1) Young patient with breast or thyroid
+  field overlap — cumulative RT dose risk of secondary malignancy and
+  cardiac toxicity unacceptable; (2) Prior RT to the involved or
+  adjacent region — reirradiation risks exceed benefit; (3) Patient
+  refuses RT after informed discussion. In all scenarios rituximab
+  monotherapy (4–8 × R weekly) achieves ~94% ORR with ≥70% CR in
+  early-stage NLPBL (Advani 2014, IELSG-37 data) and is the accepted
+  standard alternative. RT remains the default for eligible patients
+  where field is safe and patient consents (stage IA-IIA, ≤2 cm).
+definition_ua: >
+  Протипоказання або відмова від променевої терапії (ПТ) при ранній
+  стадії NLPBL (нодулярна лімфома з переважанням лімфоцитів, 5-е вид.
+  ВООЗ). Головні клінічні сценарії: (1) Молодий пацієнт — перекриття
+  поля ПТ з молочною залозою або щитоподібною залозою (ризик вторинної
+  пухлини та кардіотоксичності неприйнятний); (2) Попередня ПТ на ту
+  саму або суміжну область; (3) Пацієнт відмовляється від ПТ після
+  поінформованого обговорення. В усіх випадках монотерапія ритуксимабом
+  (4–8 введень щотижня) дає ~94% ORR при ≥70% CR при ранній стадії
+  NLPBL (Advani 2014, дані IELSG-37) і є прийнятим стандартним
+  альтернативним варіантом. ПТ залишається стандартом для придатних
+  пацієнтів (стадія IA-IIA, ≤2 см, поле безпечне, пацієнт дає згоду).
+
+trigger:
+  type: treatment_contraindication
+  any_of:
+    - finding: "rt_contraindicated"
+      value: true
+    - finding: "radiotherapy_contraindicated"
+      value: true
+    - finding: "prior_rt_to_field"
+      value: true
+    - finding: "prior_radiotherapy_adjacent_field"
+      value: true
+    - finding: "breast_field_rt_overlap"
+      value: true
+    - finding: "thyroid_field_rt_overlap"
+      value: true
+    - finding: "patient_refuses_radiotherapy"
+      value: true
+    - finding: "rt_patient_preference"
+      value: "declined"
+
+clinical_direction: de-escalate
+severity: major
+priority: 70
+category: fitness-eligibility
+
+relevant_diseases:
+  - DIS-NLPBL
+
+branch_targets:
+  ALGO-NLPBL-1L: "2"
+
+shifts_algorithm:
+  - ALGO-NLPBL-1L
+
+sources:
+  - SRC-NCCN-BCELL-2025
+
+last_reviewed: "2026-05-08"
+draft: true
+
+notes: >
+  Only applies after step 1 confirms early-stage (IA-IIA) disease —
+  advanced NLPBL routes to R-CHOP at step 1 before this RF fires.
+  RT-field safety is a nuanced clinical judgment: 'breast field overlap'
+  applies most to left-axillary or mediastinal-adjacent presentations in
+  premenopausal women; thyroid overlap relevant for high cervical/upper
+  mediastinal nodes. MDT coordination with radiation oncology to assess
+  field feasibility is recommended before classifying RT as contraindicated.
+  Note: NLPBL differs from classic Hodgkin lymphoma — ABVD is NOT
+  appropriate (CD20+ B-cell; rituximab is the active backbone).
+  IELSG-37 RCT (rituximab mono vs ISRT vs observation for very-favorable
+  NLPBL) provides the comparative evidence base; pending mature OS data.
+  Draft pending two-reviewer clinical co-lead signoff (CHARTER §6.1).
+notes_ua: >
+  Застосовується лише після того, як крок 1 підтверджує ранню стадію
+  (IA-IIA) — поширена NLPBL маршрутизується до R-CHOP на кроці 1 до
+  спрацювання цього RF. Безпека поля ПТ — це тонке клінічне рішення:
+  «перекриття поля молочної залози» актуальне переважно для лівої
+  аксилярної або медіастинальної суміжної локалізації у жінок до
+  менопаузи; перекриття щитоподібної залози — для шийних/верхніх
+  медіастинальних лімфовузлів. Рекомендується МДТ-координація з
+  радіаційним онкологом. Чернетка — очікується підпис двох клінічних
+  співкерівників (CHARTER §6.1).

--- a/scripts/site_cases.py
+++ b/scripts/site_cases.py
@@ -5804,10 +5804,10 @@ CASES: list[CaseEntry] = [
         case_id="mcl-pirtobrutinib-3l",
         file="patient_mcl_pirtobrutinib_3l_post_btki.json",
         label_ua="MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)",
-        summary_ua="Post-covalent-BTKi прогрес з LVEF 38% (CAR-T ineligible). Drift: ALGO-MCL-2L step 3 free-text; engine default = acalabrutinib; BRUIN анкер у comment.",
+        summary_ua="Вік 74, ECOG 2, LVEF 38% — CAR-T ineligible. ALGO-MCL-3L крок 1 false (LVEF<40) → IND-MCL-3L-PIRTOBRUTINIB (BRUIN MCL-321, ORR 50%). ≥2 попередніх ліній включаючи cBTKi (1Л R-CHOP + 2Л акалабрутиніб).",
         badge="Treatment Plan", badge_class="bdg-plan", category="b_indolent",
         label_en="MCL · 3L+ · Pirtobrutinib post-covalent-BTKi (BRUIN MCL-321)",
-        summary_en="Post-covalent-BTKi progression with LVEF 38% (CAR-T ineligible). Drift: ALGO-MCL-2L step 3 free-text; engine default = acalabrutinib; BRUIN anchor in comment.",
+        summary_en="Age 74, ECOG 2, LVEF 38% — CAR-T ineligible. ALGO-MCL-3L step 1 false (LVEF<40) → IND-MCL-3L-PIRTOBRUTINIB (BRUIN MCL-321, ORR 50%). ≥2 prior lines including cBTKi (1L R-CHOP + 2L acalabrutinib).",
     ),
 
     # D1 Diagnostic pre-biopsy solid (3)


### PR DESCRIPTION
## Summary

W5c RF authoring wave — clinical condition gates. Three new RedFlag entities (`draft: true`, pending CHARTER §6.1 two-reviewer signoff) and three updated algorithm files.

### New RedFlag entities

| RF ID | Disease | Gate | Fires to | Clinical basis |
|-------|---------|------|----------|----------------|
| `RF-ATLL-SHIMOYAMA-INDOLENT` | ATLL | Shimoyama smoldering or chronic-favourable subtype | `IND-ATLL-1L-INDOLENT-AZT-IFN` (de-escalate) | Bazarbachi 2010 meta-analysis: 5-yr OS 46% AZT+IFN vs 20% chemo in indolent subtypes |
| `RF-NLPBL-RT-CONTRAINDICATED` | NLPBL | RT contraindicated (young patient breast/thyroid field overlap, prior RT to field, patient refusal) | `IND-NLPBL-1L-RITUXIMAB-MONO` (de-escalate) | Advani 2014, IELSG-37: rituximab mono ~94% ORR in early-stage NLPBL |
| `RF-AITL-ROMIDEPSIN-INELIGIBLE` | AITL | Romidepsin inaccessible (not UA-registered 2026), intolerant, or QTc ≥480 ms / baseline arrhythmia | `IND-AITL-2L-BELINOSTAT` (de-escalate) | BELIEF 2014: belinostat AITL ORR ~46%; less QTc prolongation than romidepsin |

### Updated algorithms

- `ALGO-ATLL-1L` step 2 — wired `RF-ATLL-SHIMOYAMA-INDOLENT` as primary gate + legacy finding lookups
- `ALGO-NLPBL-1L` step 2 — wired `RF-NLPBL-RT-CONTRAINDICATED` as primary gate + legacy finding lookups
- `ALGO-AITL-2L` step 3 — wired `RF-AITL-ROMIDEPSIN-INELIGIBLE` as primary gate + legacy finding lookups

All free-text `condition:` entries retained for backward engine compatibility.

### Validation

KB loader: **0 schema / 0 ref / 0 contract errors** on all 6 changed files.  
pytest: 303 passed, 8 skipped, 1 pre-existing unrelated failure (`test_landing_is_public_with_hero_and_ctas`).

### Clinical signoff required

All three RFs carry `draft: true`. Two clinical co-leads must approve before `draft: true` is removed per CHARTER §6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)