### PR TITLE
feat(kb): W5c ET HU-resistance + Burkitt ifosfamide RFs + algo wiring

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_burkitt_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_burkitt_2l.yaml
@@ -60,6 +60,21 @@ decision_tree:
   - step: 3
     evaluate:
       any_of:
+        - red_flag: RF-BURKITT-IFOS-CONTRAINDICATED
+        - finding: "prior_hemorrhagic_cystitis"
+          value: true
+        - finding: "ifosfamide_contraindicated"
+          value: true
+        - finding: "pelvic_rt_bladder_field"
+          value: true
+        - finding: "neuropathy_grade"
+          threshold: 2
+          comparator: ">="
+        - finding: "peripheral_neuropathy_grade"
+          threshold: 2
+          comparator: ">="
+        - finding: "bladder_dysfunction"
+          value: true
         - condition: "Prior hemorrhagic cystitis OR pelvic RT field overlap"
         - condition: "Pre-existing grade ≥2 peripheral neuropathy"
         - condition: "Bladder dysfunction precluding mesna-protected ifosfamide"
@@ -67,7 +82,7 @@ decision_tree:
       result: IND-BURKITT-2L-RDHAP-ASCT
     if_false:
       next_step: 4
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: "Wired via RF-BURKITT-IFOS-CONTRAINDICATED (W5c): hemorrhagic cystitis history, pelvic RT field, grade ≥2 neuropathy, or bladder dysfunction → R-DHAP (CORAL trial: equivalent salvage, different toxicity profile). Legacy finding lookups + free-text retained."
 
   # Step 4 — default: R-ICE preferred (CORAL-equivalent salvage,
   # institutional familiarity > R-DHAP in most UA centers).
@@ -85,7 +100,7 @@ sources:
   - SRC-NCCN-BCELL-2025
   - SRC-ESMO-BURKITT-2024
 
-last_reviewed: "2026-04-27"
+last_reviewed: "2026-05-08"
 notes: >
   OOS / wiring gaps:
   (1) BEAM-autoSCT consolidation in CR2 is a procedure, not modeled

--- a/knowledge_base/hosted/content/algorithms/algo_et_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_et_2l.yaml
@@ -42,15 +42,27 @@ decision_tree:
   - step: 2
     evaluate:
       any_of:
+        - red_flag: RF-ET-HU-RESISTANT-INTOLERANT
+        - finding: "hu_resistance"
+          value: true
+        - finding: "hu_intolerance"
+          value: true
+        - finding: "thrombosis_on_hu"
+          value: true
+        - finding: "hu_status"
+          value: "resistant"
+        - finding: "hu_status"
+          value: "intolerant"
+        - red_flag: RF-PV-ET-HIGH-THROMBOSIS-RISK
         - condition: "HU resistance (platelets ≥600 ×10^9/L on max-tolerated HU ≥3mo)"
         - condition: "HU intolerance (cytopenia, mucocutaneous toxicity, leg ulcers, GI)"
         - condition: "Thrombotic event on HU therapy"
         - condition: "Age <60 preferring non-cytotoxic option"
-        - red_flag: RF-PV-ET-HIGH-THROMBOSIS-RISK
     if_true:
       result: IND-ET-2L-ANAGRELIDE
     if_false:
       next_step: 3
+    notes: "Wired via RF-ET-HU-RESISTANT-INTOLERANT (W5c): ELN HU resistance/intolerance criteria → switch to anagrelide (ANAHYDRET: non-inferior to HU in EFS, better arterial thrombosis rate). Legacy finding lookups + free-text retained."
 
   # Step 3 — default: anagrelide for any 2L+ ET indication.
   - step: 3
@@ -67,7 +79,7 @@ sources:
   - SRC-NCCN-MPN-2025
   - SRC-ESMO-MPN-2015
 
-last_reviewed: "2026-04-27"
+last_reviewed: "2026-05-08"
 notes: >
   OOS / wiring gaps:
   (1) IND-ET-2L-PEG-IFN (pegylated interferon α-2a / ropeginterferon

--- a/knowledge_base/hosted/content/redflags/rf_burkitt_ifos_contraindicated.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_burkitt_ifos_contraindicated.yaml
@@ -1,0 +1,109 @@
+id: RF-BURKITT-IFOS-CONTRAINDICATED
+definition: >
+  Ifosfamide contraindicated or high-risk in relapsed/refractory Burkitt
+  lymphoma 2L salvage, routing to R-DHAP (cisplatin-based) over R-ICE
+  (ifosfamide-based). Three clinical scenarios: (1) Prior hemorrhagic
+  cystitis — any prior ifosfamide- or cyclophosphamide-related hemorrhagic
+  cystitis is a contraindication to further ifosfamide even with mesna;
+  residual mucosal damage increases bleeding risk; (2) Pelvic RT field
+  overlap — prior irradiation to bladder field dramatically increases
+  ifosfamide-related bladder toxicity; avoid; (3) Pre-existing peripheral
+  neuropathy grade ≥2 — ifosfamide causes both peripheral and central
+  neuropathy; additional neurotoxicity risk unacceptable when baseline
+  neuropathy already impairs function; (4) Bladder outlet obstruction,
+  single kidney, or other bladder structural contraindication to mesna-
+  protected ifosfamide.
+  In these scenarios R-DHAP (dexamethasone 40 mg d1-4 + cytarabine
+  2 g/m² q12h d2 + cisplatin 100 mg/m² d1) is the preferred platinum
+  salvage — equivalent salvage activity to R-ICE (CORAL trial subgroup)
+  with different toxicity profile (renal/ototoxicity from cisplatin vs
+  bladder/neuropathy from ifosfamide).
+definition_ua: >
+  Іфосфамід протипоказаний або високоризикований при рецидиві/рефрактерній
+  лімфомі Беркіта 2L, що переключає на R-DHAP (цисплатин) замість R-ICE
+  (іфосфамід). Три клінічні сценарії: (1) Попередній геморагічний цистит —
+  будь-який попередній геморагічний цистит після іфосфаміду або
+  циклофосфаміду є протипоказанням до повторного застосування іфосфаміду
+  навіть із месною; (2) Перекриття поля опромінення малого таза — попереднє
+  опромінення в ділянці сечового міхура різко підвищує токсичність іфосфаміду;
+  (3) Периферична нейропатія ≥2 ст. — іфосфамід спричиняє периферичну та
+  центральну нейропатію; (4) Обструкція вихідного відділу сечового міхура,
+  одна нирка або інша структурна перешкода для месна-захисту.
+  У цих сценаріях R-DHAP (дексаметазон 40 мг д1-4 + цитарабін 2 г/м²
+  кожні 12 год д2 + цисплатин 100 мг/м² д1) — кращий платиновий режим
+  порятунку (CORAL trial subgroup: еквівалентна активність R-ICE).
+
+trigger:
+  type: treatment_contraindication
+  any_of:
+    - finding: "prior_hemorrhagic_cystitis"
+      value: true
+    - finding: "hemorrhagic_cystitis_history"
+      value: true
+    - finding: "ifosfamide_contraindicated"
+      value: true
+    - finding: "pelvic_rt_bladder_field"
+      value: true
+    - finding: "prior_pelvic_radiotherapy"
+      value: true
+    - finding: "peripheral_neuropathy_grade"
+      threshold: 2
+      comparator: ">="
+    - finding: "neuropathy_grade"
+      threshold: 2
+      comparator: ">="
+    - finding: "baseline_neuropathy"
+      value: "grade2"
+    - finding: "baseline_neuropathy"
+      value: "grade3"
+    - finding: "bladder_dysfunction"
+      value: true
+    - finding: "bladder_outlet_obstruction"
+      value: true
+    - finding: "single_kidney"
+      value: true
+
+clinical_direction: de-escalate
+severity: major
+priority: 75
+category: fitness-eligibility
+
+relevant_diseases:
+  - DIS-BURKITT
+
+branch_targets:
+  ALGO-BURKITT-2L: "3"
+
+shifts_algorithm:
+  - ALGO-BURKITT-2L
+
+sources:
+  - SRC-NCCN-BCELL-2025
+  - SRC-ESMO-BURKITT-2024
+
+last_reviewed: "2026-05-08"
+draft: true
+
+notes: >
+  Step 2 handles the reverse routing: CrCl <50 mL/min / hearing loss /
+  prior cisplatin toxicity → R-ICE preferred (uses carboplatin AUC-dose).
+  Step 3 (this RF) handles the inverse: ifosfamide-specific
+  contraindications → R-DHAP preferred. Both steps reference
+  RF-BURKITT-ORGAN-DYSFUNCTION (which already fires on renal/hepatic
+  dysfunction) — this RF captures the ifosfamide-specific history and
+  neuropathy sub-criteria not covered by the organ-dysfunction RF.
+  Step 1 pre-screens for transplant-ineligible patients (frailty +
+  organ dysfunction + infection); this RF only fires after step 1 is
+  negative (patient IS eligible for salvage).
+  CORAL trial note: R-ICE and R-DHAP showed similar overall salvage
+  rates (~63% ORR); the choice is driven purely by toxicity avoidance.
+  Draft pending two-reviewer clinical co-lead signoff (CHARTER §6.1).
+notes_ua: >
+  Крок 2 обробляє зворотне маршрутизування: CrCl <50 мл/хв / втрата
+  слуху → R-ICE (карбоплатин AUC). Крок 3 (цей RF) обробляє обернений
+  варіант: специфічні протипоказання до іфосфаміду → R-DHAP.
+  RF-BURKITT-ORGAN-DYSFUNCTION вже охоплює ниркову/печінкову дисфункцію —
+  цей RF захоплює специфічний анамнез іфосфаміду та нейропатію,
+  які не охоплені RF органної дисфункції. CORAL trial: R-ICE та
+  R-DHAP — еквівалентні (~63% ORR); вибір визначається уникненням
+  токсичності. Чернетка — очікується підпис двох КСК (CHARTER §6.1).

--- a/knowledge_base/hosted/content/redflags/rf_et_hu_resistant_intolerant.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_et_hu_resistant_intolerant.yaml
@@ -1,0 +1,100 @@
+id: RF-ET-HU-RESISTANT-INTOLERANT
+definition: >
+  Hydroxyurea (HU) resistance or intolerance in essential thrombocythemia
+  (ET), triggering switch to 2L cytoreduction. ELN/BCSH resistance criteria:
+  platelets ≥600 ×10⁹/L despite HU ≥2 g/day for ≥3 months; failure to
+  achieve platelet <400 ×10⁹/L AND WBC <10 ×10⁹/L on adequate HU dose;
+  thrombotic event occurring on HU therapy. ELN intolerance criteria:
+  ANC <1 ×10⁹/L or Hgb <10 g/dL on any dose of HU; HU-related
+  mucocutaneous toxicity (oral ulcers, leg ulcers, skin atrophy) grade ≥2
+  at any dose; fever ≥38°C attributable to HU.
+  Anagrelide is the ELN/NCCN 2L standard after HU failure — platelet-
+  selective, non-leukemogenic, preferred in younger patients (ANAHYDRET
+  trial: anagrelide non-inferior to HU in event-free survival, better
+  arterial thrombosis rate). Pegylated IFN (ropeginterferon) is the
+  preferred alternative in pregnancy/planning or JAK2-V617F dominant
+  disease but is not yet a separate KB Indication.
+definition_ua: >
+  Резистентність або непереносимість гідроксисечовини (HU) при есенціальній
+  тромбоцитемії (ET), що зумовлює перехід до 2L цитредукції.
+  Критерії резистентності ELN/BCSH: тромбоцити ≥600 ×10⁹/л попри HU
+  ≥2 г/добу ≥3 місяці; неможливість досягти тромбоцитів <400 ×10⁹/л
+  та ЛПК <10 ×10⁹/л на адекватній дозі HU; тромботичний епізод на фоні HU.
+  Критерії непереносимості ELN: АНЧ <1 ×10⁹/л або Hgb <10 г/дл на
+  будь-якій дозі HU; мукошкірна токсичність (виразки рота/ніг, атрофія
+  шкіри) ≥2 ст. на будь-якій дозі; лихоманка ≥38°С, пов'язана з HU.
+  Анагрелід — стандарт 2L за ELN/NCCN після відмови HU (ANAHYDRET:
+  анагрелід не поступається HU за event-free survival, краща ставка
+  артеріального тромбозу). Пег-ІФН (ропегінтерферон) — альтернатива при
+  вагітності/плануванні або JAK2-V617F-домінуючій хворобі, але поки не
+  є окремою KB Indication.
+
+trigger:
+  type: prior_therapy_failure
+  any_of:
+    - finding: "hu_resistance"
+      value: true
+    - finding: "hydroxyurea_resistance"
+      value: true
+    - finding: "hu_intolerance"
+      value: true
+    - finding: "hydroxyurea_intolerance"
+      value: true
+    - finding: "cytoreduction_failure_class"
+      value: "HU"
+    - finding: "cytoreduction_failure_class"
+      value: "hydroxyurea"
+    - finding: "hu_status"
+      value: "resistant"
+    - finding: "hu_status"
+      value: "intolerant"
+    - finding: "thrombosis_on_hu"
+      value: true
+    - finding: "platelet_on_hu"
+      threshold: 600
+      comparator: ">="
+      condition_context: "on_max_tolerated_hu_3mo"
+
+clinical_direction: de-escalate
+severity: major
+priority: 70
+category: prior-therapy-class
+
+relevant_diseases:
+  - DIS-ET
+
+branch_targets:
+  ALGO-ET-2L: "2"
+
+shifts_algorithm:
+  - ALGO-ET-2L
+
+sources:
+  - SRC-NCCN-MPN-2025
+  - SRC-ESMO-MPN-2015
+
+last_reviewed: "2026-05-08"
+draft: true
+
+notes: >
+  Note: ALGO-ET-2L step 2 already includes RF-PV-ET-HIGH-THROMBOSIS-RISK
+  in its any_of — this RF augments (not replaces) that gate, adding the
+  explicit HU-failure criterion. Since anagrelide is the only 2L IND
+  in the KB, both true and false branches at step 2 route to anagrelide;
+  the RF primarily provides trace evidence for why the switch was made.
+  Age <60 preferring non-cytotoxic option is a clinical preference
+  condition not mapped to a finding — retained as free-text in the algo.
+  Step 3 is degenerate (both → anagrelide) and intentionally not wired.
+  Missing IND-ET-2L-PEG-IFN: peg-IFN α-2a / ropeginterferon is the
+  preferred 2L in pregnancy or JAK2-driven disease (ELN 2018, BSH 2024)
+  but is not modeled — flagged as OOS gap in the algo notes.
+  Draft pending two-reviewer clinical co-lead signoff (CHARTER §6.1).
+notes_ua: >
+  ALGO-ET-2L крок 2 вже містить RF-PV-ET-HIGH-THROMBOSIS-RISK у
+  any_of — цей RF доповнює (не замінює) цей критерій, додаючи явний
+  критерій відмови HU. Оскільки анагрелід — єдина 2L IND у KB, обидві
+  гілки кроку 2 маршрутизуються до анагреліду; RF переважно надає
+  trace-доказ переходу. Degenerate крок 3 навмисно не прив'язаний.
+  Відсутня IND-ET-2L-PEG-IFN — ropeginterferon є кращою альтернативою
+  при вагітності або JAK2-домінуючій хворобі, але не змодельована
+  (gap у notes алго). Чернетка — очікується підпис двох КСК (CHARTER §6.1).


### PR DESCRIPTION
## Summary

W5c RF authoring wave — ET + Burkitt clinical condition gates. Two new RedFlag entities (`draft: true`, pending CHARTER §6.1 two-reviewer signoff) and two updated algorithm files.

### New RedFlag entities

| RF ID | Disease | Gate | Fires to | Clinical basis |
|-------|---------|------|----------|----------------|
| `RF-ET-HU-RESISTANT-INTOLERANT` | ET | ELN HU resistance (platelets ≥600 ×10⁹/L on max-tolerated HU ≥3mo) or intolerance (cytopenia, mucocutaneous toxicity, thrombosis on HU) | `IND-ET-2L-ANAGRELIDE` (prior-therapy-class switch) | ANAHYDRET trial: anagrelide non-inferior to HU in EFS, better arterial thrombosis rate |
| `RF-BURKITT-IFOS-CONTRAINDICATED` | Burkitt | Ifosfamide contraindicated: prior hemorrhagic cystitis, pelvic RT field overlap, grade ≥2 peripheral neuropathy, or bladder dysfunction | `IND-BURKITT-2L-RDHAP-ASCT` (de-escalate from ifosfamide) | CORAL trial: R-ICE and R-DHAP equivalent salvage ORR; toxicity profile drives choice |

### Updated algorithms

- `ALGO-ET-2L` step 2 — wired `RF-ET-HU-RESISTANT-INTOLERANT` as primary gate alongside existing `RF-PV-ET-HIGH-THROMBOSIS-RISK`
- `ALGO-BURKITT-2L` step 3 — wired `RF-BURKITT-IFOS-CONTRAINDICATED` as primary gate

All free-text `condition:` entries retained for backward engine compatibility. Legacy finding lookups added for engine-traversal path.

### Validation

KB loader: **0 schema / 0 ref / 0 contract errors** on all 4 changed files.

### Clinical signoff required

Both RFs carry `draft: true`. Two clinical co-leads must approve before `draft: true` is removed per CHARTER §6.1.

### Related PRs (W5c RF authoring wave)
- #540 GIST PDGFRA D842V
- #541 MTC RET-mutant
- #542 WM CXCR4 WHIM
- #543 AdvSM KIT D816V
- #544 Breast TNBC + stage gates
- #545 ATLL Shimoyama / NLPBL RT-CI / AITL romidepsin

🤖 Generated with [Claude Code](https://claude.com/claude-code)