### PR TITLE
fix(kb): remove cross-LOT output_indications refs across 27 algos + fix IND-CRC-2L-EGFRI LOT field

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_aml_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_aml_2l.yaml
@@ -13,63 +13,61 @@ purpose: >
   relapses lose detectable FLT3).
 
 output_indications:
-  - IND-AML-2L-GILTERITINIB-FLT3
-  - IND-AML-1L-VEN-AZA
-  - IND-AML-2L-IDH2-ENASIDENIB
-
+- IND-AML-2L-GILTERITINIB-FLT3
+- IND-AML-2L-IDH2-ENASIDENIB
 default_indication: IND-AML-1L-VEN-AZA
 alternative_indication: IND-AML-2L-GILTERITINIB-FLT3
 
 decision_tree:
   # Step 1 — emergency at relapse (TLS / leukostasis): pin to lower-
   # toxicity hypomethylating-style backbone; surface emergency workup.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-EMERGENCY-TLS-LEUKOSTASIS
-    if_true:
-      result: IND-AML-1L-VEN-AZA
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-EMERGENCY-TLS-LEUKOSTASIS
+  if_true:
+    result: IND-AML-1L-VEN-AZA
+  if_false:
+    next_step: 2
 
   # Step 2 — measurable residual disease (MRD) post-induction or post-
   # consolidation: ELN-2021 ≥0.1% MFC-MRD or molecular MRD ≥10⁻³.
   # MRD-positive after CR1 is an indication for consolidation
   # intensification (alloHCT bridge for fit) or early salvage. Gate on
   # FLT3 status at step 3.
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-MEASURABLE-RESIDUAL-DISEASE
-    if_true:
-      next_step: 3
-    if_false:
-      next_step: 4
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-MEASURABLE-RESIDUAL-DISEASE
+  if_true:
+    next_step: 3
+  if_false:
+    next_step: 4
 
   # Step 3 — MRD-positive: FLT3+ → gilteritinib salvage (ADMIRAL; bridge
   # to alloHCT). FLT3-WT MRD+ → ven+aza intensification (default
   # backbone; MDT considers alloHCT bridge for fit). Both branches
   # short-circuit subsequent steps.
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-FLT3-ACTIONABLE
-    if_true:
-      result: IND-AML-2L-GILTERITINIB-FLT3
-    if_false:
-      result: IND-AML-1L-VEN-AZA
-    notes: "MRD-positive AML — FLT3+ routes to gilteritinib salvage (ADMIRAL); FLT3-WT MRD+ routes to ven+aza intensification with MDT to consider alloHCT bridge."
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-FLT3-ACTIONABLE
+  if_true:
+    result: IND-AML-2L-GILTERITINIB-FLT3
+  if_false:
+    result: IND-AML-1L-VEN-AZA
+  notes: "MRD-positive AML — FLT3+ routes to gilteritinib salvage (ADMIRAL); FLT3-WT MRD+ routes to ven+aza intensification with MDT to consider alloHCT bridge."
 
   # Step 4 — FLT3 actionable at relapse → gilteritinib (FDA-approved
   # 2L+; ADMIRAL OS benefit; bridge to alloHCT for fit responders).
-  - step: 4
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-FLT3-ACTIONABLE
-    if_true:
-      result: IND-AML-2L-GILTERITINIB-FLT3
-    if_false:
-      next_step: 5
+- step: 4
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-FLT3-ACTIONABLE
+  if_true:
+    result: IND-AML-2L-GILTERITINIB-FLT3
+  if_false:
+    next_step: 5
 
   # Step 5 — IDH2-actionable at relapse (FLT3-WT) → enasidenib
   # monotherapy per AG221-AML-001 (FDA Aug 2017 R/R IDH2-mut AML).
@@ -77,61 +75,61 @@ decision_tree:
   # IND-AML-2L-IDH2-ENASIDENIB rather than ven+aza backbone. IDH1
   # still falls through to step 6 ven+aza backbone with MDT
   # annotation (no dedicated IDH1 IND in KB).
-  - step: 5
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-IDH2-MUT-ACTIONABLE
-    if_true:
-      result: IND-AML-2L-IDH2-ENASIDENIB
-    if_false:
-      next_step: 6
-    notes: "Wired via RF-AML-IDH2-MUT-ACTIONABLE — IDH2 R140Q/R172K routes to enasidenib monotherapy (AG221-AML-001 phase 1/2; ORR 38%, CR 19%, mOS 9.3 mo). Bridge to alloHCT for fit responders. Ukraine: not registered, EU CHMP negative; international referral / compassionate-use only."
+- step: 5
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-IDH2-MUT-ACTIONABLE
+  if_true:
+    result: IND-AML-2L-IDH2-ENASIDENIB
+  if_false:
+    next_step: 6
+  notes: "Wired via RF-AML-IDH2-MUT-ACTIONABLE — IDH2 R140Q/R172K routes to enasidenib monotherapy (AG221-AML-001 phase 1/2; ORR 38%, CR 19%, mOS 9.3 mo). Bridge to alloHCT for fit responders. Ukraine: not registered, EU CHMP negative; international referral / compassionate-use only."
 
   # Step 6 — IDH1 actionable at relapse → IDHi monotherapy
   # (ivosidenib FDA-approved R/R-AML). No dedicated IDH1 Indication in
   # KB yet (PROD-5 deferred); pin to ven+aza backbone with MDT
   # annotation to switch to ivosidenib monotherapy. IDH2 already
   # captured by step 5.
-  - step: 6
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-IDH1-MUT-ACTIONABLE
-    if_true:
-      result: IND-AML-1L-VEN-AZA
-    if_false:
-      next_step: 7
-    notes: "MDT-only — IDH1 R/R: switch to ivosidenib (AG-120) monotherapy per FDA-approved R/R-AML labelling. Pinned to ven+aza Indication as backbone (no dedicated IDH1 IND in KB). IDH2 captured at step 5."
+- step: 6
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-IDH1-MUT-ACTIONABLE
+  if_true:
+    result: IND-AML-1L-VEN-AZA
+  if_false:
+    next_step: 7
+  notes: "MDT-only — IDH1 R/R: switch to ivosidenib (AG-120) monotherapy per FDA-approved R/R-AML labelling. Pinned to ven+aza Indication as backbone (no dedicated IDH1 IND in KB). IDH2 captured at step 5."
 
   # Step 7 — frailty / organ dysfunction at relapse → ven+aza (lower
   # toxicity than re-induction; also covers FLT3-WT R/R unfit).
-  - step: 7
-    evaluate:
-      any_of:
-        - red_flag: RF-AML-FRAILTY-AGE
-        - red_flag: RF-AML-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-AML-1L-VEN-AZA
-    if_false:
-      next_step: 8
+- step: 7
+  evaluate:
+    any_of:
+    - red_flag: RF-AML-FRAILTY-AGE
+    - red_flag: RF-AML-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-AML-1L-VEN-AZA
+  if_false:
+    next_step: 8
 
   # Step 8 — default FLT3 wild-type R/R: ven+aza for unfit / fallback;
   # re-induction (off-algorithm) or clinical trial preferred for fit
   # patients. Algorithm pins to ven+aza so plan generator surfaces the
   # clinical-trial / BSC annotation rather than silently failing.
-  - step: 8
-    evaluate:
-      any_of:
-        - condition: "FLT3 wild-type R/R AML; clinical-trial / re-induction / BSC routing surfaced as annotation"
-    if_true:
-      result: IND-AML-1L-VEN-AZA
-    if_false:
-      result: IND-AML-1L-VEN-AZA
-    notes: "Default fall-through — FLT3-WT R/R routes to ven+aza backbone; clinical-trial / BSC noted in Indication."
+- step: 8
+  evaluate:
+    any_of:
+    - condition: "FLT3 wild-type R/R AML; clinical-trial / re-induction / BSC routing surfaced as annotation"
+  if_true:
+    result: IND-AML-1L-VEN-AZA
+  if_false:
+    result: IND-AML-1L-VEN-AZA
+  notes: "Default fall-through — FLT3-WT R/R routes to ven+aza backbone; clinical-trial / BSC noted in Indication."
 
 sources:
-  - SRC-NCCN-AML-2025
-  - SRC-ELN-AML-2022
-  - SRC-ADMIRAL-PERL-2019
+- SRC-NCCN-AML-2025
+- SRC-ELN-AML-2022
+- SRC-ADMIRAL-PERL-2019
 
 last_reviewed: "2026-04-30"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_apl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_apl_2l.yaml
@@ -10,9 +10,7 @@ purpose: >
   for second molecular CR is parallel layer.
 
 output_indications:
-  - IND-APL-SALVAGE-ATRA-ATO
-  - IND-APL-RELAPSED-GEMTUZUMAB
-
+- IND-APL-SALVAGE-ATRA-ATO
 default_indication: IND-APL-SALVAGE-ATRA-ATO
 alternative_indication: IND-APL-RELAPSED-GEMTUZUMAB
 
@@ -20,55 +18,55 @@ decision_tree:
   # Step 1 — DIC at relapse (HOLD-equivalent) → re-induction with
   # ATRA + ATO (rapid coagulopathy reversal); plan generator surfaces
   # emergency workup.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-APL-EMERGENCY-DIC
-    if_true:
-      result: IND-APL-SALVAGE-ATRA-ATO
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-APL-EMERGENCY-DIC
+  if_true:
+    result: IND-APL-SALVAGE-ATRA-ATO
+  if_false:
+    next_step: 2
 
   # Step 2 — overt second relapse / progression on maintenance OR
   # ATRA-resistant molecular relapse → gemtuzumab (CD33 ADC; durable
   # CR2 in re-treated APL per Lengfelder series).
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-APL-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-APL-RELAPSED-GEMTUZUMAB
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-APL-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-APL-RELAPSED-GEMTUZUMAB
+  if_false:
+    next_step: 3
 
   # Step 3 — frailty / organ dysfunction → ATRA + ATO re-induction
   # (chemo-free; manageable cardiac / hepatic toxicity with monitoring).
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-APL-FRAILTY-AGE
-        - red_flag: RF-APL-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-APL-SALVAGE-ATRA-ATO
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-APL-FRAILTY-AGE
+    - red_flag: RF-APL-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-APL-SALVAGE-ATRA-ATO
+  if_false:
+    next_step: 4
 
   # Step 4 — default first relapse post-frontline ATRA+ATO → ATRA+ATO
   # re-induction (highly effective; CR2 ~85-90% per Lengfelder).
-  - step: 4
-    evaluate:
-      all_of:
-        - condition: "Default first relapse post-ATRA+ATO frontline — ATRA+ATO re-induction"
-    if_true:
-      result: IND-APL-SALVAGE-ATRA-ATO
-    if_false:
-      result: IND-APL-SALVAGE-ATRA-ATO
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 4
+  evaluate:
+    all_of:
+    - condition: "Default first relapse post-ATRA+ATO frontline — ATRA+ATO re-induction"
+  if_true:
+    result: IND-APL-SALVAGE-ATRA-ATO
+  if_false:
+    result: IND-APL-SALVAGE-ATRA-ATO
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-AML-2025
-  - SRC-ELN-APL-2019
-  - SRC-APL-RELAPSE-LENGFELDER-2017
+- SRC-NCCN-AML-2025
+- SRC-ELN-APL-2019
+- SRC-APL-RELAPSE-LENGFELDER-2017
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_b_all_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_b_all_2l.yaml
@@ -10,57 +10,55 @@ purpose: >
   ELIANA). All three pathways bridge to alloHCT for fit responders.
 
 output_indications:
-  - IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
-  - IND-B-ALL-2L-INOTUZUMAB
-  - IND-B-ALL-3L-TISAGENLECLEUCEL
-
+- IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
+- IND-B-ALL-2L-INOTUZUMAB
 default_indication: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
 alternative_indication: IND-B-ALL-2L-INOTUZUMAB
 
 decision_tree:
   # Step 1 — frailty / organ dysfunction → blinatumomab (lower
   # short-term toxicity; CRS manageable; no VOD risk vs inotuzumab).
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-B-ALL-FRAILTY-AGE
-        - red_flag: RF-B-ALL-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-B-ALL-FRAILTY-AGE
+    - red_flag: RF-B-ALL-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
+  if_false:
+    next_step: 2
 
   # Step 2 — high-risk biology / overt high-burden relapse → inotuzumab
   # (CD22 ADC; INO-VATE CR rate ~80% in high-burden R/R; preferred
   # debulking before CAR-T to avoid CRS / ICANS in bulky disease).
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-B-ALL-HIGH-RISK-BIOLOGY
-        - red_flag: RF-B-ALL-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-B-ALL-2L-INOTUZUMAB
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-B-ALL-HIGH-RISK-BIOLOGY
+    - red_flag: RF-B-ALL-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-B-ALL-2L-INOTUZUMAB
+  if_false:
+    next_step: 3
 
   # Step 3 — default 2L MRD+ post-induction or low-burden R/R →
   # blinatumomab (BLAST trial MRD eradication; preferred T-cell
   # engager for low burden where CAR-T not indicated 2L).
-  - step: 3
-    evaluate:
-      all_of:
-        - condition: "Default 2L MRD+ or low-burden R/R B-ALL — blinatumomab per BLAST"
-    if_true:
-      result: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
-    if_false:
-      result: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 3
+  evaluate:
+    all_of:
+    - condition: "Default 2L MRD+ or low-burden R/R B-ALL — blinatumomab per BLAST"
+  if_true:
+    result: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
+  if_false:
+    result: IND-B-ALL-BLINATUMOMAB-MRD-OR-RR
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-BCELL-2025
-  - SRC-INOVATE-KANTARJIAN-2016
-  - SRC-BLAST-GOKBUGET-2018
-  - SRC-ELIANA-MAUDE-2018
+- SRC-NCCN-BCELL-2025
+- SRC-INOVATE-KANTARJIAN-2016
+- SRC-BLAST-GOKBUGET-2018
+- SRC-ELIANA-MAUDE-2018
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_breast_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_breast_1l.yaml
@@ -10,105 +10,103 @@ purpose: >
   HER2- metastatic: PARPi-first per OlympiAD; OlympiA pathway adjuvant.
 
 output_indications:
-  - IND-BREAST-HR-POS-MET-1L-CDKI
-  - IND-BREAST-HR-POS-EARLY-ADJ-CDK46I
-  - IND-BREAST-HR-POS-EARLY-ADJ-RIBOCICLIB
-  - IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
-  - IND-BREAST-HER2-POS-MET-1L-THP
-  - IND-BREAST-HER2-POS-MET-2L-TDXD
-  - IND-BREAST-TNBC-EARLY-NEOADJUVANT
-  - IND-BREAST-BRCA-POS-MET-PARPI
-  - IND-BREAST-TNBC-METASTATIC-1L-PEMBRO-CHEMO
-
+- IND-BREAST-HR-POS-MET-1L-CDKI
+- IND-BREAST-HR-POS-EARLY-ADJ-CDK46I
+- IND-BREAST-HR-POS-EARLY-ADJ-RIBOCICLIB
+- IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
+- IND-BREAST-HER2-POS-MET-1L-THP
+- IND-BREAST-TNBC-EARLY-NEOADJUVANT
+- IND-BREAST-BRCA-POS-MET-PARPI
+- IND-BREAST-TNBC-METASTATIC-1L-PEMBRO-CHEMO
 default_indication: IND-BREAST-HR-POS-MET-1L-CDKI
 alternative_indication: IND-BREAST-HER2-POS-MET-1L-THP
 
 decision_tree:
   # Step 1 — HER2+ disease (independent of HR co-expression)
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-BREAST-HER2-AMP-ACTIONABLE
-    if_true:
-      next_step: 2
-    if_false:
-      next_step: 3
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-BREAST-HER2-AMP-ACTIONABLE
+  if_true:
+    next_step: 2
+  if_false:
+    next_step: 3
   # Step 2 — HER2+ branch: early vs metastatic
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "Stage I-III (early)"
-    if_true:
-      result: IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
-    if_false:
-      result: IND-BREAST-HER2-POS-MET-1L-THP
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "Stage I-III (early)"
+  if_true:
+    result: IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
+  if_false:
+    result: IND-BREAST-HER2-POS-MET-1L-THP
+  notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
   # Step 3 — HER2-negative; check TNBC vs HR+
-  - step: 3
-    evaluate:
-      any_of:
-        - condition: "ER <1% AND PR <1% (TNBC)"
-    if_true:
-      next_step: 4
-    if_false:
-      next_step: 5
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+- step: 3
+  evaluate:
+    any_of:
+    - condition: "ER <1% AND PR <1% (TNBC)"
+  if_true:
+    next_step: 4
+  if_false:
+    next_step: 5
+  notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
   # Step 4 — TNBC: early vs metastatic stage gate.
   # Early stage → neoadjuvant (KEYNOTE-522); metastatic → step 6 (BRCA/PD-L1 routing).
-  - step: 4
-    evaluate:
-      any_of:
-        - condition: "Stage IV (locally recurrent unresectable or distant metastatic)"
-    if_true:
-      next_step: 6
-      notes: "Metastatic TNBC: route to BRCA mutation gate (step 6)."
-    if_false:
-      result: IND-BREAST-TNBC-EARLY-NEOADJUVANT
-      notes: "Stage I-III TNBC: KEYNOTE-522 neoadjuvant pembrolizumab+chemo regardless of PD-L1 status."
+- step: 4
+  evaluate:
+    any_of:
+    - condition: "Stage IV (locally recurrent unresectable or distant metastatic)"
+  if_true:
+    next_step: 6
+    notes: "Metastatic TNBC: route to BRCA mutation gate (step 6)."
+  if_false:
+    result: IND-BREAST-TNBC-EARLY-NEOADJUVANT
+    notes: "Stage I-III TNBC: KEYNOTE-522 neoadjuvant pembrolizumab+chemo regardless of PD-L1 status."
   # Step 5 — HR+/HER2- branch: early-stage high-risk → adjuvant CDK4/6i; metastatic → CDK4/6i 1L.
   # monarchE (Johnston, Lancet Oncol 2023): abemaciclib 2yr adjuvant; high-risk = ≥4+ nodes
   # OR 1-3 nodes + Ki67 ≥20% or grade 3. NATALEE (ribociclib 3yr) broadens eligibility.
-  - step: 5
-    evaluate:
-      all_of:
-        - condition: "Stage I-III (early HR+/HER2-)"
-        - condition: "High-risk: ≥4 axillary nodes OR (1-3 nodes + Ki67 ≥20% or grade 3) — monarchE eligibility"
-    if_true:
-      result: IND-BREAST-HR-POS-EARLY-ADJ-CDK46I
-    if_false:
-      result: IND-BREAST-HR-POS-MET-1L-CDKI
-    notes: "Wired 2026-05-09 (BREAST-1 D1). Routes to abemaciclib (IND-BREAST-HR-POS-EARLY-ADJ-CDK46I, monarchE default). Alternative: ribociclib (IND-BREAST-HR-POS-EARLY-ADJ-RIBOCICLIB, NATALEE — broader eligibility incl. node-negative + QTc monitoring required). MDT chooses based on node status, QTc risk, access. Free-text conditions — no disease-scoped RF available yet; metastatic cases default to IND-BREAST-HR-POS-MET-1L-CDKI."
+- step: 5
+  evaluate:
+    all_of:
+    - condition: "Stage I-III (early HR+/HER2-)"
+    - condition: "High-risk: ≥4 axillary nodes OR (1-3 nodes + Ki67 ≥20% or grade 3) — monarchE eligibility"
+  if_true:
+    result: IND-BREAST-HR-POS-EARLY-ADJ-CDK46I
+  if_false:
+    result: IND-BREAST-HR-POS-MET-1L-CDKI
+  notes: "Wired 2026-05-09 (BREAST-1 D1). Routes to abemaciclib (IND-BREAST-HR-POS-EARLY-ADJ-CDK46I, monarchE default). Alternative: ribociclib (IND-BREAST-HR-POS-EARLY-ADJ-RIBOCICLIB, NATALEE — broader eligibility incl. node-negative + QTc monitoring required). MDT chooses based on node status, QTc risk, access. Free-text conditions — no disease-scoped RF available yet; metastatic cases default to IND-BREAST-HR-POS-MET-1L-CDKI."
 
   # Step 6 — Metastatic TNBC: BRCA mutation gate → PARPi vs pembro+chemo.
   # BRCA-mutated mTNBC: olaparib or talazoparib preferred 1L (OlympiAD, EMBRACA).
   # BRCA-WT: pembro+chemo if CPS ≥10 (KEYNOTE-355); chemo alone if CPS <10.
-  - step: 6
-    evaluate:
-      any_of:
-        - red_flag: RF-BREAST-HIGH-RISK-BIOLOGY
-    if_true:
-      result: IND-BREAST-BRCA-POS-MET-PARPI
-      notes: >
-        BRCA1/2 germline or somatic pathogenic mutation: olaparib 300 mg BID or
-        talazoparib 1 mg QD preferred 1L (OlympiAD/EMBRACA; higher ORR vs chemo in
-        BRCA-mutated TNBC; PARPi exploits homologous recombination deficiency).
-        Pembrolizumab+chemo is an alternative if BRCA-mutated + CPS ≥10 but PARPi
-        is preferred. PARPi + ICI combination trials ongoing.
-    if_false:
-      result: IND-BREAST-TNBC-METASTATIC-1L-PEMBRO-CHEMO
-      notes: >
-        BRCA-WT metastatic TNBC: pembrolizumab + chemotherapy (KEYNOTE-355).
-        REQUIRED: PD-L1 CPS ≥10 by 22C3 pharmDx assay (mOS 23.0 vs 16.1 months,
-        HR 0.73). If CPS <10: chemotherapy alone (nab-paclitaxel or paclitaxel or
-        gemcitabine+carboplatin without pembrolizumab).
-        Choose chemotherapy backbone based on: taxane tolerance, neuropathy,
-        prior taxane exposure; gem+carbo for taxane-ineligible patients.
+- step: 6
+  evaluate:
+    any_of:
+    - red_flag: RF-BREAST-HIGH-RISK-BIOLOGY
+  if_true:
+    result: IND-BREAST-BRCA-POS-MET-PARPI
+    notes: >
+      BRCA1/2 germline or somatic pathogenic mutation: olaparib 300 mg BID or
+      talazoparib 1 mg QD preferred 1L (OlympiAD/EMBRACA; higher ORR vs chemo in
+      BRCA-mutated TNBC; PARPi exploits homologous recombination deficiency).
+      Pembrolizumab+chemo is an alternative if BRCA-mutated + CPS ≥10 but PARPi
+      is preferred. PARPi + ICI combination trials ongoing.
+  if_false:
+    result: IND-BREAST-TNBC-METASTATIC-1L-PEMBRO-CHEMO
+    notes: >
+      BRCA-WT metastatic TNBC: pembrolizumab + chemotherapy (KEYNOTE-355).
+      REQUIRED: PD-L1 CPS ≥10 by 22C3 pharmDx assay (mOS 23.0 vs 16.1 months,
+      HR 0.73). If CPS <10: chemotherapy alone (nab-paclitaxel or paclitaxel or
+      gemcitabine+carboplatin without pembrolizumab).
+      Choose chemotherapy backbone based on: taxane tolerance, neuropathy,
+      prior taxane exposure; gem+carbo for taxane-ineligible patients.
 
 sources:
-  - SRC-NCCN-BREAST-2025
-  - SRC-ESMO-BREAST-METASTATIC-2024
-  - SRC-MONARCHE-JOHNSTON-2023
-  - SRC-NATALEE-SLAMON-2024
+- SRC-NCCN-BREAST-2025
+- SRC-ESMO-BREAST-METASTATIC-2024
+- SRC-MONARCHE-JOHNSTON-2023
+- SRC-NATALEE-SLAMON-2024
 last_reviewed: '2026-05-09'
 notes: >
   Receptor-subtype is the dominant branch point — biomarker_driven

--- a/knowledge_base/hosted/content/algorithms/algo_breast_her2_pos_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_breast_her2_pos_2l.yaml
@@ -11,9 +11,7 @@ purpose: >
   T-DM1).
 
 output_indications:
-  - IND-BREAST-HER2-POS-MET-2L-TDXD
-  - IND-BREAST-HER2-POS-3L-TUCATINIB
-
+- IND-BREAST-HER2-POS-MET-2L-TDXD
 default_indication: IND-BREAST-HER2-POS-MET-2L-TDXD
 alternative_indication: IND-BREAST-HER2-POS-3L-TUCATINIB
 
@@ -21,47 +19,47 @@ decision_tree:
   # Step 1 — Verify HER2-amplified status (subtype gate). RF fires only
   # when HER2 IHC 3+ OR ISH-amplified is documented. Failure routes to
   # the algo's default T-DXd (HER2+ cohort assumed by entry condition).
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-BREAST-HER2-AMP-ACTIONABLE
-    if_true:
-      next_step: 2
-    if_false:
-      next_step: 3
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-BREAST-HER2-AMP-ACTIONABLE
+  if_true:
+    next_step: 2
+  if_false:
+    next_step: 3
 
   # Step 2 — brain metastases present (active or treated, stable or
   # progressing) → HER2CLIMB tucatinib + trastuzumab + capecitabine
   # preferred. T-DXd has CNS activity but HER2CLIMB is the only
   # regimen with prospective CNS-PFS doubling demonstrated. Brain-met
   # status has no dedicated breast-scoped RF; condition retained.
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "Brain metastases present (active OR previously treated, stable or progressing)"
-        - condition: "MRI brain confirms intracranial disease ≤2 cm OR symptomatic ≥2 cm post-local therapy"
-    if_true:
-      result: IND-BREAST-HER2-POS-3L-TUCATINIB
-    if_false:
-      next_step: 3
-    notes: "MDT-only — brain-met status has no dedicated breast-scoped RF; positive branch routes to HER2CLIMB triplet (CNS-PFS doubling proven)."
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "Brain metastases present (active OR previously treated, stable or progressing)"
+    - condition: "MRI brain confirms intracranial disease ≤2 cm OR symptomatic ≥2 cm post-local therapy"
+  if_true:
+    result: IND-BREAST-HER2-POS-3L-TUCATINIB
+  if_false:
+    next_step: 3
+  notes: "MDT-only — brain-met status has no dedicated breast-scoped RF; positive branch routes to HER2CLIMB triplet (CNS-PFS doubling proven)."
 
   # Step 3 — default: T-DXd 2L (DESTINY-Breast03 — superior to T-DM1).
-  - step: 3
-    evaluate:
-      any_of:
-        - condition: "No brain metastases OR brain mets not the dominant clinical issue"
-    if_true:
-      result: IND-BREAST-HER2-POS-MET-2L-TDXD
-    if_false:
-      result: IND-BREAST-HER2-POS-MET-2L-TDXD
-    notes: "Default fall-through — T-DXd 2L per DESTINY-Breast03."
+- step: 3
+  evaluate:
+    any_of:
+    - condition: "No brain metastases OR brain mets not the dominant clinical issue"
+  if_true:
+    result: IND-BREAST-HER2-POS-MET-2L-TDXD
+  if_false:
+    result: IND-BREAST-HER2-POS-MET-2L-TDXD
+  notes: "Default fall-through — T-DXd 2L per DESTINY-Breast03."
 
 sources:
-  - SRC-NCCN-BREAST-2025
-  - SRC-ESMO-BREAST-METASTATIC-2024
-  - SRC-DESTINY-BREAST03-CORTES-2022
-  - SRC-HER2CLIMB-MURTHY-2019
+- SRC-NCCN-BREAST-2025
+- SRC-ESMO-BREAST-METASTATIC-2024
+- SRC-DESTINY-BREAST03-CORTES-2022
+- SRC-HER2CLIMB-MURTHY-2019
 
 last_reviewed: "2026-04-27"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_cholangio_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_cholangio_2l.yaml
@@ -17,11 +17,9 @@ purpose: >
   to ABC-02 gem+cis as placeholder until 2L FOLFOX (ABC-06) authored.
 
 output_indications:
-  - IND-CHOLANGIO-2L-IDH1-IVOSIDENIB
-  - IND-CHOLANGIO-2L-HER2-ZANIDATAMAB
-  - IND-CHOLANGIO-2L-FGFR2-FUSION-PEMIGATINIB
-  - IND-CHOLANGIO-ADVANCED-GEM-CIS  # placeholder default; replaced when 2L FOLFOX indication authored
-
+- IND-CHOLANGIO-2L-IDH1-IVOSIDENIB
+- IND-CHOLANGIO-2L-HER2-ZANIDATAMAB
+- IND-CHOLANGIO-2L-FGFR2-FUSION-PEMIGATINIB
 default_indication: IND-CHOLANGIO-ADVANCED-GEM-CIS
 alternative_indication: IND-CHOLANGIO-2L-FGFR2-FUSION-PEMIGATINIB
 
@@ -34,20 +32,20 @@ decision_tree:
   # detection needed); positioned at step 1 because driver-targeted
   # therapy with phase-3 OS evidence supersedes class-effect targeted
   # alternatives.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-CHOLANGIO-IDH1-R132-ACTIONABLE
-        - condition: "IDH1-R132 mutation confirmed by NGS (any of R132C/H/G/L/S)"
-    if_true:
-      result: IND-CHOLANGIO-2L-IDH1-IVOSIDENIB
-      notes: >
-        ClarIDHy (Abou-Alfa 2020) — ivosidenib 500 mg PO daily until
-        PD/toxicity. PFS HR 0.37 (p<0.0001), mOS 10.3 vs 7.5 mo
-        crossover-adjusted. NCCN cat 1 + FDA-approved 2021. Confidence:
-        high (phase 3, RPSFT crossover-adjusted OS).
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-CHOLANGIO-IDH1-R132-ACTIONABLE
+    - condition: "IDH1-R132 mutation confirmed by NGS (any of R132C/H/G/L/S)"
+  if_true:
+    result: IND-CHOLANGIO-2L-IDH1-IVOSIDENIB
+    notes: >
+      ClarIDHy (Abou-Alfa 2020) — ivosidenib 500 mg PO daily until
+      PD/toxicity. PFS HR 0.37 (p<0.0001), mOS 10.3 vs 7.5 mo
+      crossover-adjusted. NCCN cat 1 + FDA-approved 2021. Confidence:
+      high (phase 3, RPSFT crossover-adjusted OS).
+  if_false:
+    next_step: 2
 
   # Step 2 — HER2 amplification / overexpression (~5–15% intrahepatic;
   # higher in extrahepatic / GB). Zanidatamab (biparatopic HER2 mAb)
@@ -55,51 +53,51 @@ decision_tree:
   # mDOR 12.9 mo. NCCN cat 2A; FDA-accelerated approval Nov 2024.
   # Note: HER2 testing in cholangio uses IHC + ISH per ASCO/CAP gastric
   # criteria (no cholangio-specific guideline); 3+ or 2+/ISH-amp.
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "HER2 amplification (IHC 3+ OR IHC 2+/ISH-amp) or HER2 overexpression per ASCO/CAP gastric criteria"
-    if_true:
-      result: IND-CHOLANGIO-2L-HER2-ZANIDATAMAB
-      notes: >
-        HERIZON-BTC-01 (Harding 2023) — zanidatamab 20 mg/kg IV q2w.
-        cORR 41.3% (95% CI 30.4–52.8), mDOR 12.9 mo, mOS 15.5 mo. NCCN
-        cat 2A, FDA-accelerated 2024. Confidence: moderate (single-arm
-        phase 2 with reasonable durability, awaiting confirmatory phase 3).
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "HER2 amplification (IHC 3+ OR IHC 2+/ISH-amp) or HER2 overexpression per ASCO/CAP gastric criteria"
+  if_true:
+    result: IND-CHOLANGIO-2L-HER2-ZANIDATAMAB
+    notes: >
+      HERIZON-BTC-01 (Harding 2023) — zanidatamab 20 mg/kg IV q2w.
+      cORR 41.3% (95% CI 30.4–52.8), mDOR 12.9 mo, mOS 15.5 mo. NCCN
+      cat 2A, FDA-accelerated 2024. Confidence: moderate (single-arm
+      phase 2 with reasonable durability, awaiting confirmatory phase 3).
+  if_false:
+    next_step: 3
 
   # Step 3 — FGFR2 fusion / rearrangement (~10–20% of intrahepatic CCA).
   # Pemigatinib (FIGHT-202; Abou-Alfa Lancet Oncol 2020) preferred per
   # NCCN cat 1; futibatinib (FOENIX-CCA2) alternative including post-
   # pemigatinib resistance. Surfaced via known_controversies on indication.
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-CHOLANGIO-FGFR2-FUSION-ACTIONABLE
-        - condition: "FGFR2 fusion or rearrangement confirmed by RNA-NGS / DNA-NGS fusion-aware / FISH break-apart"
-    if_true:
-      result: IND-CHOLANGIO-2L-FGFR2-FUSION-PEMIGATINIB
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-CHOLANGIO-FGFR2-FUSION-ACTIONABLE
+    - condition: "FGFR2 fusion or rearrangement confirmed by RNA-NGS / DNA-NGS fusion-aware / FISH break-apart"
+  if_true:
+    result: IND-CHOLANGIO-2L-FGFR2-FUSION-PEMIGATINIB
+  if_false:
+    next_step: 4
 
   # Step 4 — default 2L (placeholder routing back to ABC-02 gem+cis
   # indication; FOLFOX-2L (ABC-06) and future driver branches — BRAF
   # V600E dab+tram, MSI-H pembrolizumab, NTRK fusion larotrectinib —
   # to be added in subsequent biomarker-expansion chunks).
-  - step: 4
-    evaluate:
-      any_of:
-        - condition: "Disease progression on 1L gem+cis ± durvalumab; no actionable driver biomarker"
-    if_true:
-      result: IND-CHOLANGIO-ADVANCED-GEM-CIS
-    if_false:
-      result: IND-CHOLANGIO-ADVANCED-GEM-CIS
+- step: 4
+  evaluate:
+    any_of:
+    - condition: "Disease progression on 1L gem+cis ± durvalumab; no actionable driver biomarker"
+  if_true:
+    result: IND-CHOLANGIO-ADVANCED-GEM-CIS
+  if_false:
+    result: IND-CHOLANGIO-ADVANCED-GEM-CIS
 
 sources:
-  - SRC-NCCN-HEPATOBILIARY
-  - SRC-ESMO-BTC-2023
-  - SRC-FIGHT-202
+- SRC-NCCN-HEPATOBILIARY
+- SRC-ESMO-BTC-2023
+- SRC-FIGHT-202
 
 last_reviewed: "2026-05-08"
 reviewer_signoffs: 0

--- a/knowledge_base/hosted/content/algorithms/algo_cll_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_cll_2l.yaml
@@ -6,8 +6,6 @@ purpose: 'Select 2L+/relapsed CLL Indication based on which 1L mechanism failed.
   '
 output_indications:
 - IND-CLL-2L-VENR-MURANO
-- IND-CLL-1L-ZANUBRUTINIB
-- IND-CLL-3L-PIRTOBRUTINIB
 default_indication: IND-CLL-2L-VENR-MURANO
 alternative_indication: IND-CLL-3L-PIRTOBRUTINIB
 decision_tree:

--- a/knowledge_base/hosted/content/algorithms/algo_cml_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_cml_2l.yaml
@@ -13,70 +13,68 @@ purpose: >
   layer / 1L-aggressive arm decision and is not enumerated here.
 
 output_indications:
-  - IND-CML-2L-PONATINIB-T315I
-  - IND-CML-3L-ASCIMINIB
-  - IND-CML-ADVANCED-ALLOHCT
-
+- IND-CML-2L-PONATINIB-T315I
+- IND-CML-ADVANCED-ALLOHCT
 default_indication: IND-CML-3L-ASCIMINIB
 alternative_indication: IND-CML-2L-PONATINIB-T315I
 
 decision_tree:
   # Step 1 — blast crisis / accelerated phase → alloHCT (curative
   # intent; bridging TKI selection at regimen layer).
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-CML-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-CML-ADVANCED-ALLOHCT
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-CML-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-CML-ADVANCED-ALLOHCT
+  if_false:
+    next_step: 2
 
   # Step 2 — T315I detected (any TKI failure) → ponatinib is the only
   # active TKI; cardiovascular risk mitigation per OPTIC dose-reduction
   # paradigm.
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-CML-T315I-MUTATION
-    if_true:
-      result: IND-CML-2L-PONATINIB-T315I
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-CML-T315I-MUTATION
+  if_true:
+    result: IND-CML-2L-PONATINIB-T315I
+  if_false:
+    next_step: 3
 
   # Step 3 — ≥2 TKI failure with CV-comorbid profile (or established
   # vascular events) → asciminib (STAMP allosteric; non-CV AE profile,
   # ASCEMBL OS/MMR data). RF-CML-COMORBIDITY-COMPLEX captures the
   # CV/QTc/pulmonary comorbidity matrix that constrains 2GTKI choice.
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-CML-ORGAN-DYSFUNCTION
-        - red_flag: RF-CML-FRAILTY-AGE
-        - red_flag: RF-CML-COMORBIDITY-COMPLEX
-    if_true:
-      result: IND-CML-3L-ASCIMINIB
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-CML-ORGAN-DYSFUNCTION
+    - red_flag: RF-CML-FRAILTY-AGE
+    - red_flag: RF-CML-COMORBIDITY-COMPLEX
+  if_true:
+    result: IND-CML-3L-ASCIMINIB
+  if_false:
+    next_step: 4
 
   # Step 4 — default ≥2 TKI failure non-T315I → asciminib (deeper
   # response, manageable AE; preferred over recycling 2GTKI per
   # NCCN-MPN-2025).
-  - step: 4
-    evaluate:
-      all_of:
-        - condition: "Default 2L+ CML, T315I-negative, non-blast — asciminib preferred over 2GTKI recycle"
-    if_true:
-      result: IND-CML-3L-ASCIMINIB
-    if_false:
-      result: IND-CML-3L-ASCIMINIB
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 4
+  evaluate:
+    all_of:
+    - condition: "Default 2L+ CML, T315I-negative, non-blast — asciminib preferred over 2GTKI recycle"
+  if_true:
+    result: IND-CML-3L-ASCIMINIB
+  if_false:
+    result: IND-CML-3L-ASCIMINIB
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-MPN-2025
-  - SRC-ELN-CML-2020
-  - SRC-ASCEMBL-REA-2021
-  - SRC-PACE-CORTES-2013
+- SRC-NCCN-MPN-2025
+- SRC-ELN-CML-2020
+- SRC-ASCEMBL-REA-2021
+- SRC-PACE-CORTES-2013
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_crc_metastatic_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_crc_metastatic_2l.yaml
@@ -10,74 +10,70 @@ purpose: >
   defining for its biomarker subset.
 
 output_indications:
-  - IND-CRC-METASTATIC-2L-MSI-H-PEMBRO
-  - IND-CRC-METASTATIC-2L-BRAF-BEACON
-  - IND-CRC-METASTATIC-2L-KRAS-G12C-SOTORASIB-CETUXIMAB
-  - IND-CRC-METASTATIC-2L-HER2-AMP-TUCATINIB
-  - IND-CRC-METASTATIC-2L-HER2-AMP-T-DXD
-  - IND-CRC-METASTATIC-2L-EGFRI-RECHALLENGE
-  - IND-CRC-METASTATIC-2L-FOLFIRI-BEV
-  - IND-CRC-METASTATIC-3L-TAS102-BEV
-  - IND-CRC-METASTATIC-3L-REGORAFENIB
-  - IND-CRC-METASTATIC-3L-TRIFLURIDINE-TIPIRACIL-MONO
-
+- IND-CRC-METASTATIC-2L-MSI-H-PEMBRO
+- IND-CRC-METASTATIC-2L-BRAF-BEACON
+- IND-CRC-METASTATIC-2L-KRAS-G12C-SOTORASIB-CETUXIMAB
+- IND-CRC-METASTATIC-2L-HER2-AMP-TUCATINIB
+- IND-CRC-METASTATIC-2L-HER2-AMP-T-DXD
+- IND-CRC-METASTATIC-2L-EGFRI-RECHALLENGE
+- IND-CRC-METASTATIC-2L-FOLFIRI-BEV
 default_indication: IND-CRC-METASTATIC-2L-FOLFIRI-BEV
 alternative_indication: IND-CRC-METASTATIC-3L-TAS102-BEV
 
 decision_tree:
   # Step 1 — MSI-H/dMMR overrides everything (KEYNOTE-164 2L+ continuation
   # of KEYNOTE-177 1L). Treatment-defining biomarker.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-CRC-MSI-H-ACTIONABILITY
-        - condition: "MSI-H or dMMR confirmed by validated assay AND no prior anti-PD-1 exposure"
-    if_true:
-      result: IND-CRC-METASTATIC-2L-MSI-H-PEMBRO
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-CRC-MSI-H-ACTIONABILITY
+    - condition: "MSI-H or dMMR confirmed by validated assay AND no prior anti-PD-1 exposure"
+  if_true:
+    result: IND-CRC-METASTATIC-2L-MSI-H-PEMBRO
+  if_false:
+    next_step: 2
 
   # Step 2 — BRAF V600E (poor prognosis). BEACON encorafenib + cetuximab
   # is the molecular-targeted 2L+ standard for this subset.
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-CRC-BRAF-V600E-POOR-PROGNOSIS
-        - condition: "BRAF V600E confirmed by validated assay (NGS or IHC + confirm)"
-    if_true:
-      result: IND-CRC-METASTATIC-2L-BRAF-BEACON
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-CRC-BRAF-V600E-POOR-PROGNOSIS
+    - condition: "BRAF V600E confirmed by validated assay (NGS or IHC + confirm)"
+  if_true:
+    result: IND-CRC-METASTATIC-2L-BRAF-BEACON
+  if_false:
+    next_step: 3
 
   # Step 3 — KRAS G12C (~3-4% of mCRC). CodeBreaK 300 sotorasib + cetuximab.
-  - step: 3
-    evaluate:
-      all_of:
-        - condition: "KRAS G12C confirmed by NGS (tissue OR ctDNA)"
-        - condition: "BRAF V600E excluded (ruled out via step 2)"
-    if_true:
-      result: IND-CRC-METASTATIC-2L-KRAS-G12C-SOTORASIB-CETUXIMAB
-    if_false:
-      next_step: 4
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 3
+  evaluate:
+    all_of:
+    - condition: "KRAS G12C confirmed by NGS (tissue OR ctDNA)"
+    - condition: "BRAF V600E excluded (ruled out via step 2)"
+  if_true:
+    result: IND-CRC-METASTATIC-2L-KRAS-G12C-SOTORASIB-CETUXIMAB
+  if_false:
+    next_step: 4
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
   # Step 4 — HER2 amplified (~3% of mCRC) AND RAS-WT. MOUNTAINEER
   # tucatinib + trastuzumab default; T-DXd alternative noted in
   # algorithm purpose / indication controversies. RF-CRC-HER2-AMP-
   # ACTIONABLE added as additive any_of clause in W1.B2 chunk
   # (2026-04-30); free-text conditions retained for back-compat.
-  - step: 4
-    evaluate:
-      any_of:
-        - red_flag: RF-CRC-HER2-AMP-ACTIONABLE
-        - all_of:
-            - condition: "HER2 amplified (IHC 3+ OR IHC 2+/ISH+)"
-            - condition: "RAS wild-type (MOUNTAINEER eligibility)"
-    if_true:
-      result: IND-CRC-METASTATIC-2L-HER2-AMP-TUCATINIB
-    if_false:
-      next_step: 5
-    notes: "RF-CRC-HER2-AMP-ACTIONABLE wired W1.B2 (2026-04-30); free-text conditions retained for back-compat."
+- step: 4
+  evaluate:
+    any_of:
+    - red_flag: RF-CRC-HER2-AMP-ACTIONABLE
+    - all_of:
+      - condition: "HER2 amplified (IHC 3+ OR IHC 2+/ISH+)"
+      - condition: "RAS wild-type (MOUNTAINEER eligibility)"
+  if_true:
+    result: IND-CRC-METASTATIC-2L-HER2-AMP-TUCATINIB
+  if_false:
+    next_step: 5
+  notes: "RF-CRC-HER2-AMP-ACTIONABLE wired W1.B2 (2026-04-30); free-text conditions retained for back-compat."
 
   # Step 5 — Anti-EGFR rechallenge (3L+; positioned here so 2L candidates
   # without driver mutations route to standard cytotoxic-switch first).
@@ -86,48 +82,48 @@ decision_tree:
   # extended-RAS WT prerequisite at baseline; ctDNA RAS-WT at
   # rechallenge timepoint, prior-EGFR-response and intervening-line
   # criteria remain MDT-text (CHRONOS-style ctDNA timing not modelled).
-  - step: 5
-    evaluate:
-      all_of:
-        - red_flag: RF-CRC-RAS-WT
-        - condition: "ctDNA RAS-WT at rechallenge timepoint (CHRONOS biomarker selection)"
-        - condition: "Prior anti-EGFR response (PR or better OR SD ≥6 mo) in 1L"
-        - condition: "Intervening anti-EGFR-free 2L line completed (typically bev-based)"
-        - condition: "BRAF V600E excluded (ruled out via step 2)"
-    if_true:
-      result: IND-CRC-METASTATIC-2L-EGFRI-RECHALLENGE
-    if_false:
-      next_step: 6
-    notes: "Partially wired - RF-CRC-RAS-WT gates extended-RAS wild-type baseline (CHRONOS biomarker selection for cetuximab rechallenge post-FOLFOX failure); ctDNA-timepoint RAS-WT, prior-EGFR-response, and intervening-line criteria remain MDT-text (CHRONOS-style ctDNA timing and prior-response history not RF-modelled)."
+- step: 5
+  evaluate:
+    all_of:
+    - red_flag: RF-CRC-RAS-WT
+    - condition: "ctDNA RAS-WT at rechallenge timepoint (CHRONOS biomarker selection)"
+    - condition: "Prior anti-EGFR response (PR or better OR SD ≥6 mo) in 1L"
+    - condition: "Intervening anti-EGFR-free 2L line completed (typically bev-based)"
+    - condition: "BRAF V600E excluded (ruled out via step 2)"
+  if_true:
+    result: IND-CRC-METASTATIC-2L-EGFRI-RECHALLENGE
+  if_false:
+    next_step: 6
+  notes: "Partially wired - RF-CRC-RAS-WT gates extended-RAS wild-type baseline (CHRONOS biomarker selection for cetuximab rechallenge post-FOLFOX failure); ctDNA-timepoint RAS-WT, prior-EGFR-response, and intervening-line criteria remain MDT-text (CHRONOS-style ctDNA timing and prior-response history not RF-modelled)."
 
   # Step 6 — 2L cytotoxic-switch default (FOLFOX → FOLFIRI + biologic
   # continuation per TML/ML18147). Standard track.
-  - step: 6
-    evaluate:
-      any_of:
-        - condition: "First disease progression on 1L FOLFOX-based regimen (FOLFOX, FOLFOX+bev, FOLFOX+cetux)"
-        - red_flag: RF-CRC-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-CRC-METASTATIC-2L-FOLFIRI-BEV
-    if_false:
-      next_step: 7
+- step: 6
+  evaluate:
+    any_of:
+    - condition: "First disease progression on 1L FOLFOX-based regimen (FOLFOX, FOLFOX+bev, FOLFOX+cetux)"
+    - red_flag: RF-CRC-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-CRC-METASTATIC-2L-FOLFIRI-BEV
+  if_false:
+    next_step: 7
 
   # Step 7 — 3L+ chemo-refractory salvage. Default to TAS-102 + bev
   # (SUNLIGHT, preferred); regorafenib (CORRECT) and TAS-102 monotherapy
   # (RECOURSE) are alternatives by toxicity / access profile.
-  - step: 7
-    evaluate:
-      any_of:
-        - condition: "Disease progression on standard chemo (FOLFOX, FOLFIRI) + biologic; no driver mutation actionable"
-        - red_flag: RF-CRC-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-CRC-METASTATIC-3L-TAS102-BEV
-    if_false:
-      result: IND-CRC-METASTATIC-3L-TAS102-BEV
+- step: 7
+  evaluate:
+    any_of:
+    - condition: "Disease progression on standard chemo (FOLFOX, FOLFIRI) + biologic; no driver mutation actionable"
+    - red_flag: RF-CRC-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-CRC-METASTATIC-3L-TAS102-BEV
+  if_false:
+    result: IND-CRC-METASTATIC-3L-TAS102-BEV
 
 sources:
-  - SRC-NCCN-COLON-2025
-  - SRC-ESMO-COLON-2024
+- SRC-NCCN-COLON-2025
+- SRC-ESMO-COLON-2024
 
 last_reviewed: "2026-04-27"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_dlbcl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_dlbcl_2l.yaml
@@ -10,8 +10,6 @@ purpose: >
 output_indications:
 - IND-DLBCL-2L-POLA-R-BENDAMUSTINE
 - IND-DLBCL-2L-LISOCEL
-- IND-DLBCL-3L-AXICEL-CART
-- IND-DLBCL-3L-LONCASTUXIMAB
 default_indication: IND-DLBCL-2L-POLA-R-BENDAMUSTINE
 alternative_indication: IND-DLBCL-2L-LISOCEL
 decision_tree:

--- a/knowledge_base/hosted/content/algorithms/algo_fl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_fl_2l.yaml
@@ -9,112 +9,108 @@ purpose: >
   non-EZH2: CAR-T-eligible → axi-cel, else mosunetuzumab bispecific.
 
 output_indications:
-  - IND-FL-2L-OBG-BENDA
-  - IND-FL-2L-R2
-  - IND-FL-3L-TAZEMETOSTAT
-  - IND-FL-3L-AXICEL-CART
-  - IND-FL-3L-MOSUNETUZUMAB
-
+- IND-FL-2L-OBG-BENDA
+- IND-FL-2L-R2
 default_indication: IND-FL-2L-OBG-BENDA
 alternative_indication: IND-FL-2L-R2
 
 decision_tree:
-  - step: 0
-    evaluate:
-      any_of:
-        - finding: "prior_lines"
-          threshold: 1
-          comparator: "<="
-    if_true:
-      next_step: 01
-    if_false:
-      next_step: 1
-    notes: >
-      Gate on line of therapy: prior_lines ≤1 (first relapse after 1L) → 2L
-      routing (step 01). prior_lines ≥2 → existing 3L+ routing (step 1 EZH2 gate).
-      This step ensures OBG+Benda and R² are only offered at the correct 2L context.
+- step: 0
+  evaluate:
+    any_of:
+    - finding: "prior_lines"
+      threshold: 1
+      comparator: "<="
+  if_true:
+    next_step: 01
+  if_false:
+    next_step: 1
+  notes: >
+    Gate on line of therapy: prior_lines ≤1 (first relapse after 1L) → 2L
+    routing (step 01). prior_lines ≥2 → existing 3L+ routing (step 1 EZH2 gate).
+    This step ensures OBG+Benda and R² are only offered at the correct 2L context.
 
-  - step: 01
-    evaluate:
-      any_of:
-        - condition: "Rituximab-refractory (progression on or within 6 months of last rituximab)"
-    if_true:
-      result: IND-FL-2L-OBG-BENDA
-    if_false:
-      result: IND-FL-2L-R2
-    notes: >
-      2L selection: rituximab-refractory (GADOLIN definition: progression on/within
-      6 months of last rituximab dose) → OBG+Benda (standard track, GADOLIN NCCN
-      Cat 1). Rituximab-sensitive OR chemo-free preference → R² (aggressive track,
-      AUGMENT NCCN Cat 1). MDT may override: chemo-free preference, renal function,
-      prior toxicities, and patient preference can shift from OBG+Benda → R².
-      Engine routes to default (IND-FL-2L-OBG-BENDA); MDT evaluates alternative
-      (IND-FL-2L-R2). Free-text condition — no structured RF for
-      rituximab-refractoriness at 2L currently modeled; flag for RF authoring.
+- step: 01
+  evaluate:
+    any_of:
+    - condition: "Rituximab-refractory (progression on or within 6 months of last rituximab)"
+  if_true:
+    result: IND-FL-2L-OBG-BENDA
+  if_false:
+    result: IND-FL-2L-R2
+  notes: >
+    2L selection: rituximab-refractory (GADOLIN definition: progression on/within
+    6 months of last rituximab dose) → OBG+Benda (standard track, GADOLIN NCCN
+    Cat 1). Rituximab-sensitive OR chemo-free preference → R² (aggressive track,
+    AUGMENT NCCN Cat 1). MDT may override: chemo-free preference, renal function,
+    prior toxicities, and patient preference can shift from OBG+Benda → R².
+    Engine routes to default (IND-FL-2L-OBG-BENDA); MDT evaluates alternative
+    (IND-FL-2L-R2). Free-text condition — no structured RF for
+    rituximab-refractoriness at 2L currently modeled; flag for RF authoring.
 
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-FL-EZH2-Y641-ACTIONABLE
-    if_true:
-      next_step: 11
-    if_false:
-      next_step: 2
-    notes: >
-      Wired via RF-FL-EZH2-Y641-ACTIONABLE (CSD-9A): biomarker-gated branch fires
-      on EZH2 hotspot mutation; sequential step 11 then checks ≥2 prior lines
-      requirement before routing to tazemetostat.
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-FL-EZH2-Y641-ACTIONABLE
+  if_true:
+    next_step: 11
+  if_false:
+    next_step: 2
+  notes: >
+    Wired via RF-FL-EZH2-Y641-ACTIONABLE (CSD-9A): biomarker-gated branch fires
+    on EZH2 hotspot mutation; sequential step 11 then checks ≥2 prior lines
+    requirement before routing to tazemetostat.
 
-  - step: 11
-    evaluate:
-      any_of:
-        - finding: "prior_lines"
-          threshold: 2
-          comparator: ">="
-    if_true:
-      result: IND-FL-3L-TAZEMETOSTAT
-    if_false:
-      next_step: 2
-    notes: >
-      Sequential gate after EZH2 RF (step 1): tazemetostat is FDA-approved only
-      for ≥2 prior systemic lines (Morschhauser 2020). EZH2-mut at <2 lines falls
-      through to CAR-T / mosunetuzumab routing.
+- step: 11
+  evaluate:
+    any_of:
+    - finding: "prior_lines"
+      threshold: 2
+      comparator: ">="
+  if_true:
+    result: IND-FL-3L-TAZEMETOSTAT
+  if_false:
+    next_step: 2
+  notes: >
+    Sequential gate after EZH2 RF (step 1): tazemetostat is FDA-approved only
+    for ≥2 prior systemic lines (Morschhauser 2020). EZH2-mut at <2 lines falls
+    through to CAR-T / mosunetuzumab routing.
 
-  - step: 2
-    evaluate:
-      all_of:
-        - condition: ≥2 prior systemic lines
-        - red_flag: RF-FITNESS-ECOG-FIT
-        - red_flag: RF-CAR-T-ELIGIBLE
-        - condition: Age 18-75
-        - condition: CD19+ disease confirmed
-    if_true:
-      result: IND-FL-3L-AXICEL-CART
-    if_false:
-      next_step: 3
-    notes: >
-      Partially wired — fitness/eligibility gates wired via CSD-7A pan-disease RFs;
-      remaining condition(s) kept as MDT-evaluated text (no RF available for that
-      criterion).
+- step: 2
+  evaluate:
+    all_of:
+    - condition: ≥2 prior systemic lines
+    - red_flag: RF-FITNESS-ECOG-FIT
+    - red_flag: RF-CAR-T-ELIGIBLE
+    - condition: Age 18-75
+    - condition: CD19+ disease confirmed
+  if_true:
+    result: IND-FL-3L-AXICEL-CART
+  if_false:
+    next_step: 3
+  notes: >
+    Partially wired — fitness/eligibility gates wired via CSD-7A pan-disease RFs;
+    remaining condition(s) kept as MDT-evaluated text (no RF available for that
+    criterion).
 
-  - step: 3
-    evaluate:
-      any_of:
-        - condition: Transplant-ineligible OR CAR-T inaccessible
-        - condition: EZH2-WT and patient prefers chemo-free off-the-shelf
-    if_true:
-      result: IND-FL-3L-MOSUNETUZUMAB
-    if_false:
-      result: IND-FL-3L-MOSUNETUZUMAB
-    notes: >
-      Free-text condition without matching disease-scoped RF; engine routes to
-      default. Flag for RF authoring.
+- step: 3
+  evaluate:
+    any_of:
+    - condition: Transplant-ineligible OR CAR-T inaccessible
+    - condition: EZH2-WT and patient prefers chemo-free off-the-shelf
+  if_true:
+    result: IND-FL-3L-MOSUNETUZUMAB
+  if_false:
+    result: IND-FL-3L-MOSUNETUZUMAB
+  notes: >
+    Free-text condition without matching disease-scoped RF; engine routes to
+    default. Flag for RF authoring.
 
 sources:
-  - SRC-GADOLIN-SEHN-2016
-  - SRC-AUGMENT-LEONARD-2019
-  - SRC-NCCN-BCELL-2025
-  - SRC-ESMO-FL-2024
+- SRC-GADOLIN-SEHN-2016
+- SRC-AUGMENT-LEONARD-2019
+- SRC-NCCN-BCELL-2025
+- SRC-ESMO-FL-2024
 
 last_reviewed: "2026-05-09"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_gastric_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gastric_2l.yaml
@@ -7,7 +7,6 @@ purpose: 'Select 2L+ metastatic gastric/GEJ Indication. Three tracks: (1) HER2+ 
 output_indications:
 - IND-GASTRIC-METASTATIC-2L-RAMUCIRUMAB-PACLITAXEL
 - IND-GASTRIC-METASTATIC-2L-HER2-TDXD
-- IND-GASTRIC-METASTATIC-3L-TAS102
 default_indication: IND-GASTRIC-METASTATIC-2L-RAMUCIRUMAB-PACLITAXEL
 alternative_indication: IND-GASTRIC-METASTATIC-2L-HER2-TDXD
 decision_tree:

--- a/knowledge_base/hosted/content/algorithms/algo_gct_salvage_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gct_salvage_2l.yaml
@@ -11,10 +11,8 @@ purpose: >
   specialty center is mandatory.
 
 output_indications:
-  - IND-GCT-METASTATIC-1L-BEP
-  - IND-GCT-SALVAGE-2L-TIP
-  - IND-GCT-SALVAGE-2L-HDCT-ASCT
-
+- IND-GCT-SALVAGE-2L-TIP
+- IND-GCT-SALVAGE-2L-HDCT-ASCT
 default_indication: IND-GCT-SALVAGE-2L-TIP
 alternative_indication: IND-GCT-SALVAGE-2L-HDCT-ASCT
 
@@ -22,90 +20,90 @@ decision_tree:
   # Step 1 — Prior chemotherapy gate.
   # Surveillance relapse (no prior chemo): 1L BEP, not salvage.
   # True relapse after BEP/EP 1L: salvage pathway.
-  - step: 1
-    evaluate:
-      any_of:
-        - condition: "Prior cisplatin-containing chemotherapy received (BEP or EP 1L)"
-    if_true:
-      next_step: 2
-      notes: "Post-BEP/EP relapse: salvage pathway."
-    if_false:
-      result: IND-GCT-METASTATIC-1L-BEP
-      notes: >
-        Clinical stage I surveillance relapse with no prior chemotherapy:
-        treat as 1L with BEP × 3 (good-risk) or × 4 (intermediate/poor-risk)
-        or EP × 4 if bleomycin-contraindicated. Not salvage — 1L standard.
+- step: 1
+  evaluate:
+    any_of:
+    - condition: "Prior cisplatin-containing chemotherapy received (BEP or EP 1L)"
+  if_true:
+    next_step: 2
+    notes: "Post-BEP/EP relapse: salvage pathway."
+  if_false:
+    result: IND-GCT-METASTATIC-1L-BEP
+    notes: >
+      Clinical stage I surveillance relapse with no prior chemotherapy:
+      treat as 1L with BEP × 3 (good-risk) or × 4 (intermediate/poor-risk)
+      or EP × 4 if bleomycin-contraindicated. Not salvage — 1L standard.
 
   # Step 2 — Cisplatin refractoriness gate.
   # Cisplatin-refractory = progression during or within 4 weeks of last cisplatin dose.
   # Absolute platinum refractoriness: HDCT+ASCT (or clinical trial) preferred.
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "Cisplatin-refractory: disease progression during BEP/EP OR within 4 weeks of last cisplatin administration"
-    if_true:
-      result: IND-GCT-SALVAGE-2L-HDCT-ASCT
-      notes: >
-        Cisplatin-refractory GCT (relapse within 4 weeks of last cisplatin):
-        conventional TIP or VeIP have poor outcomes (~15-20% CR). HDCT+ASCT
-        (IND-GCT-SALVAGE-2L-HDCT-ASCT) preferred per NCCN.
-        Clinical trial strongly preferred — cisplatin-refractory GCT has poor
-        prognosis with any approach; enroll in novel trials (e.g., immunotherapy,
-        PARP inhibitor combinations) where available.
-        Requires urgent referral to GCT specialty center with ASCT capability.
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "Cisplatin-refractory: disease progression during BEP/EP OR within 4 weeks of last cisplatin administration"
+  if_true:
+    result: IND-GCT-SALVAGE-2L-HDCT-ASCT
+    notes: >
+      Cisplatin-refractory GCT (relapse within 4 weeks of last cisplatin):
+      conventional TIP or VeIP have poor outcomes (~15-20% CR). HDCT+ASCT
+      (IND-GCT-SALVAGE-2L-HDCT-ASCT) preferred per NCCN.
+      Clinical trial strongly preferred — cisplatin-refractory GCT has poor
+      prognosis with any approach; enroll in novel trials (e.g., immunotherapy,
+      PARP inhibitor combinations) where available.
+      Requires urgent referral to GCT specialty center with ASCT capability.
+  if_false:
+    next_step: 3
 
   # Step 3 — Indiana prognostic score at relapse.
   # Poor Indiana score: AFP ≥1000 ng/mL OR hCG ≥1000 IU/L OR liver/bone/brain
   # metastases at relapse. Poor score → HDCT preferred over TIP.
-  - step: 3
-    evaluate:
-      any_of:
-        - condition: "Poor Indiana prognostic score: AFP ≥1000 ng/mL OR hCG ≥1000 IU/L at relapse"
-        - condition: "Liver, bone, or brain metastases at relapse"
-        - condition: "Incomplete response to 1L (AFP/hCG never normalized after BEP completion)"
-    if_true:
-      next_step: 4
-      notes: "Poor Indiana score or incomplete 1L response: assess ASCT candidacy (step 4)."
-    if_false:
-      result: IND-GCT-SALVAGE-2L-TIP
-      notes: >
-        Good/intermediate Indiana score (AFP <1000, hCG <1000, no liver/bone/brain mets,
-        CR after 1L then relapse): TIP × 4 cycles q21d preferred.
-        Kondagunta 2005: CR 63% (durable NED 52%); favorable group CR 76%.
-        NCCN Category 1. G-CSF + mesna mandatory.
-        MDT at GCT specialty center recommended for all salvage decisions.
+- step: 3
+  evaluate:
+    any_of:
+    - condition: "Poor Indiana prognostic score: AFP ≥1000 ng/mL OR hCG ≥1000 IU/L at relapse"
+    - condition: "Liver, bone, or brain metastases at relapse"
+    - condition: "Incomplete response to 1L (AFP/hCG never normalized after BEP completion)"
+  if_true:
+    next_step: 4
+    notes: "Poor Indiana score or incomplete 1L response: assess ASCT candidacy (step 4)."
+  if_false:
+    result: IND-GCT-SALVAGE-2L-TIP
+    notes: >
+      Good/intermediate Indiana score (AFP <1000, hCG <1000, no liver/bone/brain mets,
+      CR after 1L then relapse): TIP × 4 cycles q21d preferred.
+      Kondagunta 2005: CR 63% (durable NED 52%); favorable group CR 76%.
+      NCCN Category 1. G-CSF + mesna mandatory.
+      MDT at GCT specialty center recommended for all salvage decisions.
 
   # Step 4 — ASCT candidacy gate for poor Indiana / incomplete responders.
-  - step: 4
-    evaluate:
-      all_of:
-        - condition: "ECOG PS 0-1"
-        - condition: "LVEF ≥45%"
-        - condition: "CrCl ≥30 mL/min"
-        - condition: "ASCT-capable center accessible"
-    if_true:
-      result: IND-GCT-SALVAGE-2L-HDCT-ASCT
-      notes: >
-        Poor Indiana score / incomplete 1L response + ASCT-eligible: HDCT+ASCT preferred.
-        Einhorn 2007 (NEJM): 63% NED 2y; 78% favorable (among poor-score patients within
-        the Indiana series). 2 tandem cycles carboplatin 700 mg/m²/d × 3 + etoposide
-        750 mg/m²/d × 3 + ASCT per cycle. Referral to specialized center mandatory.
-        Ukraine: limited ASCT centers — consider international referral (Poland, Germany,
-        Austria) for patients with good PS and motivated to pursue curative-intent therapy.
-    if_false:
-      result: IND-GCT-SALVAGE-2L-TIP
-      notes: >
-        Poor Indiana score but ASCT not feasible (ECOG ≥2, organ dysfunction, no center):
-        TIP × 4 conventional salvage is the best available option.
-        Enroll in clinical trial if available. Palliative intent discussion if TIP fails.
+- step: 4
+  evaluate:
+    all_of:
+    - condition: "ECOG PS 0-1"
+    - condition: "LVEF ≥45%"
+    - condition: "CrCl ≥30 mL/min"
+    - condition: "ASCT-capable center accessible"
+  if_true:
+    result: IND-GCT-SALVAGE-2L-HDCT-ASCT
+    notes: >
+      Poor Indiana score / incomplete 1L response + ASCT-eligible: HDCT+ASCT preferred.
+      Einhorn 2007 (NEJM): 63% NED 2y; 78% favorable (among poor-score patients within
+      the Indiana series). 2 tandem cycles carboplatin 700 mg/m²/d × 3 + etoposide
+      750 mg/m²/d × 3 + ASCT per cycle. Referral to specialized center mandatory.
+      Ukraine: limited ASCT centers — consider international referral (Poland, Germany,
+      Austria) for patients with good PS and motivated to pursue curative-intent therapy.
+  if_false:
+    result: IND-GCT-SALVAGE-2L-TIP
+    notes: >
+      Poor Indiana score but ASCT not feasible (ECOG ≥2, organ dysfunction, no center):
+      TIP × 4 conventional salvage is the best available option.
+      Enroll in clinical trial if available. Palliative intent discussion if TIP fails.
 
 sources:
-  - SRC-KONDAGUNTA-TIP-2005
-  - SRC-EINHORN-HDCT-ASCT-2007
-  - SRC-IGCCC-1997
-  - SRC-NCCN-TESTICULAR-2025
+- SRC-KONDAGUNTA-TIP-2005
+- SRC-EINHORN-HDCT-ASCT-2007
+- SRC-IGCCC-1997
+- SRC-NCCN-TESTICULAR-2025
 
 last_reviewed: "2026-05-04"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_gist_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_gist_2l.yaml
@@ -8,36 +8,34 @@ purpose: >
   avapritinib (which is active at any line in this genotype).
 
 output_indications:
-  - IND-GIST-2L-SUNITINIB
-  - IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V
-
+- IND-GIST-2L-SUNITINIB
 default_indication: IND-GIST-2L-SUNITINIB
 alternative_indication: IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V
 
 decision_tree:
-  - step: 1
-    evaluate:
-      any_of:
-        - condition: "PDGFRA D842V mutation positive"
-    if_true:
-      result: IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V
-      notes: "Avapritinib active at any line for PDGFRA D842V; sunitinib has no meaningful activity in this genotype"
-    if_false:
-      next_step: 2
-    notes: "Free-text condition without RF; engine routes to default."
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "Imatinib-resistant GIST (any KIT genotype or WT)"
-        - condition: "Imatinib-intolerant GIST"
-    if_true:
-      result: IND-GIST-2L-SUNITINIB
-    if_false:
-      result: IND-GIST-2L-SUNITINIB
-    notes: "Free-text condition; default to sunitinib for 2L non-D842V GIST."
+- step: 1
+  evaluate:
+    any_of:
+    - condition: "PDGFRA D842V mutation positive"
+  if_true:
+    result: IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V
+    notes: "Avapritinib active at any line for PDGFRA D842V; sunitinib has no meaningful activity in this genotype"
+  if_false:
+    next_step: 2
+  notes: "Free-text condition without RF; engine routes to default."
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "Imatinib-resistant GIST (any KIT genotype or WT)"
+    - condition: "Imatinib-intolerant GIST"
+  if_true:
+    result: IND-GIST-2L-SUNITINIB
+  if_false:
+    result: IND-GIST-2L-SUNITINIB
+  notes: "Free-text condition; default to sunitinib for 2L non-D842V GIST."
 
 sources:
-  - SRC-NCCN-GIST-2025
+- SRC-NCCN-GIST-2025
 last_reviewed: "2026-05-04"
 notes: >
   Sunitinib is Category 1 for 2L GIST after imatinib failure (non-D842V).

--- a/knowledge_base/hosted/content/algorithms/algo_hcv_mzl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_hcv_mzl_2l.yaml
@@ -24,73 +24,71 @@ purpose: >
   (virologic failure), OR lymphoma progression on imaging despite
   achieved SVR12, OR transformation to aggressive histology.
 
-output_indications:
-  - IND-HCV-MZL-POST-DAA-SURVEILLANCE
-
+output_indications: []
 default_indication: IND-HCV-MZL-POST-DAA-SURVEILLANCE
 alternative_indication: IND-HCV-MZL-POST-DAA-SURVEILLANCE
 
 decision_tree:
   # Step 1 — histologic transformation suspected → upstream re-biopsy
   # + ALGO-DLBCL routing.
-  - step: 1
-    evaluate:
-      any_of:
-        - condition: "Aggressive histology suspected at relapse (rapid growth, B-symptoms, LDH ↑↑, extranodal sites)"
-        - red_flag: RF-AGGRESSIVE-HISTOLOGY-TRANSFORMATION
-    if_true:
-      result: IND-HCV-MZL-POST-DAA-SURVEILLANCE  # placeholder; see notes — routes to ALGO-DLBCL
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - condition: "Aggressive histology suspected at relapse (rapid growth, B-symptoms, LDH ↑↑, extranodal sites)"
+    - red_flag: RF-AGGRESSIVE-HISTOLOGY-TRANSFORMATION
+  if_true:
+    result: IND-HCV-MZL-POST-DAA-SURVEILLANCE    # placeholder; see notes — routes to ALGO-DLBCL
+  if_false:
+    next_step: 2
 
   # Step 2 — SVR12 NOT achieved (HCV-RNA detectable post-DAA) →
   # DAA retreatment branch. Per EASL 2023, second-line DAA is
   # SOF/VEL/VOX (pan-genotypic, NS5A-rescue) or GLE/PIB. If lymphoma
   # also progressing, add BR concurrent with retreatment.
-  - step: 2
-    evaluate:
-      all_of:
-        - biomarker: BIO-HCV-RNA
-          comparator: "detectable at week 12 post-DAA (SVR12 not achieved)"
-    if_true:
-      result: IND-HCV-MZL-POST-DAA-SURVEILLANCE  # placeholder; see notes — DAA retreatment + BR
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    all_of:
+    - biomarker: BIO-HCV-RNA
+      comparator: "detectable at week 12 post-DAA (SVR12 not achieved)"
+  if_true:
+    result: IND-HCV-MZL-POST-DAA-SURVEILLANCE    # placeholder; see notes — DAA retreatment + BR
+  if_false:
+    next_step: 3
 
   # Step 3 — SVR12 achieved + lymphoma relapse (HCV cleared, MZL
   # now antigen-independent / clonal escape) → BR. Surveillance
   # indication remains the default route; clinician escalates to
   # BR via MDT free-text trigger when relapse documented.
-  - step: 3
-    evaluate:
-      all_of:
-        - biomarker: BIO-HCV-RNA
-          comparator: "undetectable at SVR12 (HCV cleared)"
-        - condition: "Documented lymphoma progression on imaging or biopsy after DAA"
-    if_true:
-      result: IND-HCV-MZL-POST-DAA-SURVEILLANCE  # placeholder; see notes — BR salvage
-    if_false:
-      next_step: 4
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 3
+  evaluate:
+    all_of:
+    - biomarker: BIO-HCV-RNA
+      comparator: "undetectable at SVR12 (HCV cleared)"
+    - condition: "Documented lymphoma progression on imaging or biopsy after DAA"
+  if_true:
+    result: IND-HCV-MZL-POST-DAA-SURVEILLANCE    # placeholder; see notes — BR salvage
+  if_false:
+    next_step: 4
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
   # Step 4 — default: routine post-DAA surveillance (~70% of patients
   # achieve durable lymphoma response from HCV eradication alone).
-  - step: 4
-    evaluate:
-      all_of:
-        - biomarker: BIO-HCV-STATUS
-          comparator: "categorical (post-DAA)"
-        - condition: "No documented relapse / progression"
-    if_true:
-      result: IND-HCV-MZL-POST-DAA-SURVEILLANCE
-    if_false:
-      result: IND-HCV-MZL-POST-DAA-SURVEILLANCE
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 4
+  evaluate:
+    all_of:
+    - biomarker: BIO-HCV-STATUS
+      comparator: "categorical (post-DAA)"
+    - condition: "No documented relapse / progression"
+  if_true:
+    result: IND-HCV-MZL-POST-DAA-SURVEILLANCE
+  if_false:
+    result: IND-HCV-MZL-POST-DAA-SURVEILLANCE
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-BCELL-2025
-  - SRC-BSH-MZL-2024
-  - SRC-EASL-HCV-2023
+- SRC-NCCN-BCELL-2025
+- SRC-BSH-MZL-2024
+- SRC-EASL-HCV-2023
 
 last_reviewed: "2026-04-27"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_mcl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mcl_2l.yaml
@@ -6,8 +6,6 @@ purpose: 'Select 2L+/relapsed MCL Indication. Three tracks: (1) cBTKi-naive at 1
   '
 output_indications:
 - IND-MCL-2L-ACALABRUTINIB
-- IND-MCL-3L-PIRTOBRUTINIB
-- IND-MCL-3L-BREXUCEL-CART
 default_indication: IND-MCL-2L-ACALABRUTINIB
 alternative_indication: IND-MCL-3L-BREXUCEL-CART
 decision_tree:

--- a/knowledge_base/hosted/content/algorithms/algo_mds_hr_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mds_hr_2l.yaml
@@ -10,78 +10,75 @@ purpose: >
   cytoreduction). Clinical-trial enrollment is the strongly preferred
   fallback when neither pathway applies and is surfaced as annotation.
 
-output_indications:
-  - IND-MDS-HR-ALLOHCT
-  - IND-MDS-HR-1L-VEN-AZA
-
+output_indications: []
 default_indication: IND-MDS-HR-ALLOHCT
 alternative_indication: IND-MDS-HR-1L-VEN-AZA
 
 decision_tree:
   # Step 1 — overt AML transformation → re-route conceptually to
   # ALGO-AML-2L; algorithm pins to ven+aza locally as bridge.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-MDS-HR-1L-VEN-AZA
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-MDS-HR-1L-VEN-AZA
+  if_false:
+    next_step: 2
 
   # Step 2 — transplant-eligible (age ≤70, HCT-CI ≤4, donor available,
   # adequate organ function) → alloHCT is the curative pathway after
   # HMA failure.
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-TRANSPLANT-ELIGIBLE
-    if_true:
-      result: IND-MDS-HR-ALLOHCT
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-TRANSPLANT-ELIGIBLE
+  if_true:
+    result: IND-MDS-HR-ALLOHCT
+  if_false:
+    next_step: 3
 
   # Step 3 — frailty / organ dysfunction → ven+aza off-label (lower
   # toxicity than experimental salvage; supportive-care-equivalent
   # palliation).
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-FRAILTY-AGE
-        - red_flag: RF-MDS-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-MDS-HR-1L-VEN-AZA
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-FRAILTY-AGE
+    - red_flag: RF-MDS-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-MDS-HR-1L-VEN-AZA
+  if_false:
+    next_step: 4
 
   # Step 4 — TP53-mutated MDS-HR post-HMA → very poor prognosis;
   # algorithm pins to ven+aza but plan generator must surface clinical-
   # trial enrollment (TP53-targeted agents) as primary recommendation.
-  - step: 4
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-TP53-MUTATION
-    if_true:
-      result: IND-MDS-HR-1L-VEN-AZA
-    if_false:
-      next_step: 5
+- step: 4
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-TP53-MUTATION
+  if_true:
+    result: IND-MDS-HR-1L-VEN-AZA
+  if_false:
+    next_step: 5
 
   # Step 5 — default fallback for transplant-ineligible non-TP53
   # post-HMA failure: ven+aza off-label or clinical trial.
-  - step: 5
-    evaluate:
-      all_of:
-        - condition: "Default post-HMA failure, transplant-ineligible — ven+aza off-label or clinical trial"
-    if_true:
-      result: IND-MDS-HR-1L-VEN-AZA
-    if_false:
-      result: IND-MDS-HR-1L-VEN-AZA
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 5
+  evaluate:
+    all_of:
+    - condition: "Default post-HMA failure, transplant-ineligible — ven+aza off-label or clinical trial"
+  if_true:
+    result: IND-MDS-HR-1L-VEN-AZA
+  if_false:
+    result: IND-MDS-HR-1L-VEN-AZA
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-AML-2025
-  - SRC-ESMO-MDS-2021
-  - SRC-IPSS-M-BERNARD-2022
+- SRC-NCCN-AML-2025
+- SRC-ESMO-MDS-2021
+- SRC-IPSS-M-BERNARD-2022
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_mds_lr_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mds_lr_2l.yaml
@@ -11,10 +11,7 @@ purpose: >
   to ALGO-MDS-HR-1L / ALGO-MDS-HR-2L conceptually.
 
 output_indications:
-  - IND-MDS-LR-LENALIDOMIDE-DEL5Q
-  - IND-MDS-LR-2L-IMETELSTAT
-  - IND-MDS-LR-1L-LUSPATERCEPT
-
+- IND-MDS-LR-2L-IMETELSTAT
 default_indication: IND-MDS-LR-2L-IMETELSTAT
 alternative_indication: IND-MDS-LR-LENALIDOMIDE-DEL5Q
 
@@ -22,57 +19,57 @@ decision_tree:
   # Step 1 — risk escalation to MDS-HR / transformation → re-route to
   # ALGO-MDS-HR pathways at calling layer; algorithm pins to
   # luspatercept locally as bridge for cytopenia.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-HIGH-RISK-IPSS
-        - red_flag: RF-MDS-TRANSFORMATION-PROGRESSION
-    if_true:
-      result: IND-MDS-LR-1L-LUSPATERCEPT
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-HIGH-RISK-IPSS
+    - red_flag: RF-MDS-TRANSFORMATION-PROGRESSION
+  if_true:
+    result: IND-MDS-LR-1L-LUSPATERCEPT
+  if_false:
+    next_step: 2
 
   # Step 2 — del(5q) isolated → lenalidomide (NCCN cat 1; ~67% TI rate
   # in MDS-004 / MYLOFRANCE).
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-DEL-5Q-ISOLATED
-    if_true:
-      result: IND-MDS-LR-LENALIDOMIDE-DEL5Q
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-DEL-5Q-ISOLATED
+  if_true:
+    result: IND-MDS-LR-LENALIDOMIDE-DEL5Q
+  if_false:
+    next_step: 3
 
   # Step 3 — frailty / organ dysfunction → luspatercept (better
   # tolerability profile than imetelstat; minimal cytopenia
   # exacerbation).
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-MDS-FRAILTY-AGE
-        - red_flag: RF-MDS-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-MDS-LR-1L-LUSPATERCEPT
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-MDS-FRAILTY-AGE
+    - red_flag: RF-MDS-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-MDS-LR-1L-LUSPATERCEPT
+  if_false:
+    next_step: 4
 
   # Step 4 — default non-del(5q) post-ESA failure → imetelstat
   # (telomerase inhibitor; IMerge phase-3 TI rate 40% vs 15%).
-  - step: 4
-    evaluate:
-      all_of:
-        - condition: "Default non-del(5q), non-frail, post-ESA failure — imetelstat per IMerge"
-    if_true:
-      result: IND-MDS-LR-2L-IMETELSTAT
-    if_false:
-      result: IND-MDS-LR-2L-IMETELSTAT
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 4
+  evaluate:
+    all_of:
+    - condition: "Default non-del(5q), non-frail, post-ESA failure — imetelstat per IMerge"
+  if_true:
+    result: IND-MDS-LR-2L-IMETELSTAT
+  if_false:
+    result: IND-MDS-LR-2L-IMETELSTAT
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-AML-2025
-  - SRC-ESMO-MDS-2021
-  - SRC-IMERGE-PLATZBECKER-2024
-  - SRC-MDS-004-FENAUX-2011
+- SRC-NCCN-AML-2025
+- SRC-ESMO-MDS-2021
+- SRC-IMERGE-PLATZBECKER-2024
+- SRC-MDS-004-FENAUX-2011
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_melanoma_metastatic_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_melanoma_metastatic_2l.yaml
@@ -10,12 +10,10 @@ purpose: >
   option).
 
 output_indications:
-  - IND-MELANOMA-2L-KIT-IMATINIB
-  - IND-MELANOMA-2L-POST-IO-BRAFI-MEKI
-  - IND-MELANOMA-2L-POST-BRAFI-IPI-NIVO
-  - IND-MELANOMA-2L-RELATLIMAB-NIVOLUMAB
-  - IND-MELANOMA-3L-LIFILEUCEL
-
+- IND-MELANOMA-2L-KIT-IMATINIB
+- IND-MELANOMA-2L-POST-IO-BRAFI-MEKI
+- IND-MELANOMA-2L-POST-BRAFI-IPI-NIVO
+- IND-MELANOMA-2L-RELATLIMAB-NIVOLUMAB
 default_indication: IND-MELANOMA-2L-POST-IO-BRAFI-MEKI
 alternative_indication: IND-MELANOMA-3L-LIFILEUCEL
 
@@ -24,93 +22,93 @@ decision_tree:
   # Imatinib is oral, low-tox, accessible (UA generic). Carvajal 2011
   # established the genotype-response correlation: exon 11 / exon 13
   # point mutations only — KIT amplification alone NOT predictive.
-  - step: 1
+- step: 1
     # KIT-actionable subset → imatinib. RF triggers only on exon 11 / 13
     # activating mutations (not amplification alone). Subtype context
     # (mucosal/acral/chronic-sun-damaged) retained as MDT note since no
     # melanoma-subtype RF exists yet.
-    evaluate:
-      any_of:
-        - red_flag: RF-MELANOMA-KIT-MUT-ACTIONABLE
-    if_true:
-      result: IND-MELANOMA-2L-KIT-IMATINIB
-    if_false:
-      next_step: 2
-    notes: "MDT-only — KIT-imatinib clinical context (mucosal/acral/CSD subtype) is documented in indication eligibility; the RF gates on activating exon 11/13 mutation."
+  evaluate:
+    any_of:
+    - red_flag: RF-MELANOMA-KIT-MUT-ACTIONABLE
+  if_true:
+    result: IND-MELANOMA-2L-KIT-IMATINIB
+  if_false:
+    next_step: 2
+  notes: "MDT-only — KIT-imatinib clinical context (mucosal/acral/CSD subtype) is documented in indication eligibility; the RF gates on activating exon 11/13 mutation."
 
   # Step 2 — Branch on prior-therapy axis. Was 1L anti-PD-1 (with or
   # without ipi)? RF-MELANOMA-IO-RESISTANT fires when post-IO progression
   # is documented.
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-MELANOMA-IO-RESISTANT
-    if_true:
-      next_step: 3
-    if_false:
-      next_step: 4
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-MELANOMA-IO-RESISTANT
+  if_true:
+    next_step: 3
+  if_false:
+    next_step: 4
 
   # Step 3 — Post-IO branch. If BRAF V600+, BRAFi+MEKi doublet is
   # the standard 2L per NCCN/ESMO + DREAMseq sequencing data. If
   # BRAF-WT, route to lifileucel default (no targeted option).
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-MELANOMA-BRAF-V600-ACTIONABLE
-    if_true:
-      result: IND-MELANOMA-2L-POST-IO-BRAFI-MEKI
-    if_false:
-      result: IND-MELANOMA-3L-LIFILEUCEL
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-MELANOMA-BRAF-V600-ACTIONABLE
+  if_true:
+    result: IND-MELANOMA-2L-POST-IO-BRAFI-MEKI
+  if_false:
+    result: IND-MELANOMA-3L-LIFILEUCEL
 
   # Step 4 — Post-BRAFi branch (1L was BRAFi+MEKi for BRAF V600+
   # patient with visceral crisis or active brain mets). 2L is
   # IO-based. Detect BRAF V600+ first (biomarker), then verify ipi-fit
   # status downstream. Split from old all_of.
-  - step: 4
-    evaluate:
-      any_of:
-        - red_flag: RF-MELANOMA-BRAF-V600-ACTIONABLE
-    if_true:
-      next_step: 41
-    if_false:
-      next_step: 5
+- step: 4
+  evaluate:
+    any_of:
+    - red_flag: RF-MELANOMA-BRAF-V600-ACTIONABLE
+  if_true:
+    next_step: 41
+  if_false:
+    next_step: 5
 
-  - step: 41
+- step: 41
     # Sub-step: ipi+nivo fitness check (ECOG 0-1, no autoimmunity).
     # Free-text retained — no melanoma-scoped RF for "fit for high-grade
     # irAE risk" combination.
-    evaluate:
-      any_of:
-        - condition: "Patient fit for ipi+nivo Grade 3-4 irAE risk (ECOG 0-1, no significant baseline autoimmunity)"
-    if_true:
-      result: IND-MELANOMA-2L-POST-BRAFI-IPI-NIVO
-    if_false:
-      next_step: 5
-    notes: "MDT-only — ipi+nivo fitness has no dedicated RF (composite ECOG + autoimmunity); falls through to rela+nivo / lifileucel for unfit patients."
+  evaluate:
+    any_of:
+    - condition: "Patient fit for ipi+nivo Grade 3-4 irAE risk (ECOG 0-1, no significant baseline autoimmunity)"
+  if_true:
+    result: IND-MELANOMA-2L-POST-BRAFI-IPI-NIVO
+  if_false:
+    next_step: 5
+  notes: "MDT-only — ipi+nivo fitness has no dedicated RF (composite ECOG + autoimmunity); falls through to rela+nivo / lifileucel for unfit patients."
 
   # Step 5 — Patient unfit for ipi+nivo OR strongly prefers
   # tolerability profile → rela+nivo (Opdualag) as IO-naive 2L
   # alternative. If neither applicable, fall through to lifileucel
   # default (e.g., BRAF-WT with no IO history at all — unusual but
   # possible if 1L was clinical trial).
-  - step: 5
-    evaluate:
-      any_of:
-        - condition: "Patient unfit for ipi+nivo (baseline autoimmunity, frailty, advanced age) but IO-naive"
-        - red_flag: RF-MELANOMA-FRAILTY-AGE
-    if_true:
-      result: IND-MELANOMA-2L-RELATLIMAB-NIVOLUMAB
-    if_false:
-      result: IND-MELANOMA-3L-LIFILEUCEL
+- step: 5
+  evaluate:
+    any_of:
+    - condition: "Patient unfit for ipi+nivo (baseline autoimmunity, frailty, advanced age) but IO-naive"
+    - red_flag: RF-MELANOMA-FRAILTY-AGE
+  if_true:
+    result: IND-MELANOMA-2L-RELATLIMAB-NIVOLUMAB
+  if_false:
+    result: IND-MELANOMA-3L-LIFILEUCEL
 
 sources:
-  - SRC-NCCN-MELANOMA-2025
-  - SRC-ESMO-MELANOMA-2024
-  - SRC-COLUMBUS-DUMMETT-2018
-  - SRC-CHECKMATE-067-LARKIN-2019
-  - SRC-RELATIVITY-047-TAWBI-2022
-  - SRC-C14401-CHESNEY-2024
-  - SRC-CARVAJAL-KIT-MELANOMA-2013
+- SRC-NCCN-MELANOMA-2025
+- SRC-ESMO-MELANOMA-2024
+- SRC-COLUMBUS-DUMMETT-2018
+- SRC-CHECKMATE-067-LARKIN-2019
+- SRC-RELATIVITY-047-TAWBI-2022
+- SRC-C14401-CHESNEY-2024
+- SRC-CARVAJAL-KIT-MELANOMA-2013
 
 last_reviewed: "2026-04-27"
 

--- a/knowledge_base/hosted/content/algorithms/algo_mf_sezary_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mf_sezary_2l.yaml
@@ -10,48 +10,45 @@ purpose: >
   bexarotene full-dose mono.
 
 output_indications:
-  - IND-MF-MAINTENANCE-RETINOID
-  - IND-MF-ADVANCED-2L-BEXAROTENE
-  - IND-MF-ADVANCED-1L-MOGA
-  - IND-MF-ADVANCED-1L-BV
-
+- IND-MF-MAINTENANCE-RETINOID
+- IND-MF-ADVANCED-2L-BEXAROTENE
 default_indication: IND-MF-ADVANCED-2L-BEXAROTENE
 alternative_indication: IND-MF-MAINTENANCE-RETINOID
 
 decision_tree:
   # Step 1 — in CR/PR to induction → maintenance
-  - step: 1
-    evaluate:
-      all_of:
-        - condition: "Best response to induction is CR or PR"
-        - condition: "Tolerating systemic therapy"
-    if_true:
-      result: IND-MF-MAINTENANCE-RETINOID
-    if_false:
-      next_step: 2
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 1
+  evaluate:
+    all_of:
+    - condition: "Best response to induction is CR or PR"
+    - condition: "Tolerating systemic therapy"
+  if_true:
+    result: IND-MF-MAINTENANCE-RETINOID
+  if_false:
+    next_step: 2
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
   # Step 2 — CD30+ relapse and BV-naive → BV mono
-  - step: 2
-    evaluate:
-      all_of:
-        - red_flag: RF-TCELL-CD30-POSITIVE
-        - condition: "Brentuximab vedotin not previously administered"
-    if_true:
-      result: IND-MF-ADVANCED-1L-BV
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    all_of:
+    - red_flag: RF-TCELL-CD30-POSITIVE
+    - condition: "Brentuximab vedotin not previously administered"
+  if_true:
+    result: IND-MF-ADVANCED-1L-BV
+  if_false:
+    next_step: 3
 
   # Step 3 — Sézary blood-dominant and moga-naive → mogamulizumab
-  - step: 3
-    evaluate:
-      all_of:
-        - red_flag: RF-MF-SEZARY-LEUKEMIC
-        - condition: "Mogamulizumab not previously administered"
-    if_true:
-      result: IND-MF-ADVANCED-1L-MOGA
-    if_false:
-      result: IND-MF-ADVANCED-2L-BEXAROTENE
+- step: 3
+  evaluate:
+    all_of:
+    - red_flag: RF-MF-SEZARY-LEUKEMIC
+    - condition: "Mogamulizumab not previously administered"
+  if_true:
+    result: IND-MF-ADVANCED-1L-MOGA
+  if_false:
+    result: IND-MF-ADVANCED-2L-BEXAROTENE
 
 sources: [SRC-NCCN-BCELL-2025, SRC-ESMO-CTCL-2024]
 last_reviewed: "2026-04-27"

--- a/knowledge_base/hosted/content/algorithms/algo_mm_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mm_2l.yaml
@@ -6,8 +6,6 @@ purpose: 'Select 2L+/maintenance MM Indication based on prior exposures and ASCT
   '
 output_indications:
 - IND-MM-2L-DKD
-- IND-MM-4L-TECLISTAMAB
-- IND-MM-POST-ASCT-LENALIDOMIDE-MAINTENANCE
 default_indication: IND-MM-2L-DKD
 alternative_indication: IND-MM-4L-TECLISTAMAB
 decision_tree:

--- a/knowledge_base/hosted/content/algorithms/algo_mm_3l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mm_3l.yaml
@@ -8,46 +8,45 @@ purpose: >
   default when carfilzomib-naive and not yet triple-class refractory.
 
 output_indications:
-  - IND-MM-3L-ISA-KD
-  - IND-MM-4L-TECLISTAMAB
+- IND-MM-3L-ISA-KD
 default_indication: IND-MM-3L-ISA-KD
 alternative_indication: IND-MM-4L-TECLISTAMAB
 
 decision_tree:
-  - step: 1
-    evaluate:
-      all_of:
-        - condition: "≥3 prior lines including ≥1 IMiD, ≥1 PI, ≥1 anti-CD38 monoclonal antibody"
-        - condition: "Refractory (progressed during or within 60 days of last line of each class)"
-    if_true:
-      result: IND-MM-4L-TECLISTAMAB
-    if_false:
-      next_step: 2
-    notes: "MDT-only — triple-class refractory definition. No RF for this composite criterion; evaluated as clinical MDT gate. If true, teclistamab BCMA bispecific (MajesTEC-1) is preferred (NCCN Cat 2A); ISA-Kd not indicated in triple-class refractory."
-  - step: 2
-    evaluate:
-      all_of:
-        - condition: "Carfilzomib-naive (no prior carfilzomib or carfilzomib-based regimen)"
-        - condition: "≥2 prior lines including ≥1 PI (non-carfilzomib) + ≥1 IMiD"
-        - red_flag: RF-FITNESS-ECOG-FIT
-    if_true:
-      result: IND-MM-3L-ISA-KD
-    if_false:
-      next_step: 3
-    notes: "Wired: RF-FITNESS-ECOG-FIT (CSD-7A). Remaining conditions (carfilzomib-naive, prior lines) are MDT-evaluated. IKEMA trial enrolled carfilzomib-naive RRMM ≥2 prior lines; PFS HR 0.531."
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
-    if_true:
-      result: IND-MM-3L-ISA-KD
-    if_false:
-      result: IND-MM-3L-ISA-KD
-    notes: "Default ISA-Kd for carfilzomib-naive RRMM regardless of ECOG intermediate status; dose modifications available per IKEMA protocol. MDT surfaces carfilzomib cardiac monitoring requirement."
+- step: 1
+  evaluate:
+    all_of:
+    - condition: "≥3 prior lines including ≥1 IMiD, ≥1 PI, ≥1 anti-CD38 monoclonal antibody"
+    - condition: "Refractory (progressed during or within 60 days of last line of each class)"
+  if_true:
+    result: IND-MM-4L-TECLISTAMAB
+  if_false:
+    next_step: 2
+  notes: "MDT-only — triple-class refractory definition. No RF for this composite criterion; evaluated as clinical MDT gate. If true, teclistamab BCMA bispecific (MajesTEC-1) is preferred (NCCN Cat 2A); ISA-Kd not indicated in triple-class refractory."
+- step: 2
+  evaluate:
+    all_of:
+    - condition: "Carfilzomib-naive (no prior carfilzomib or carfilzomib-based regimen)"
+    - condition: "≥2 prior lines including ≥1 PI (non-carfilzomib) + ≥1 IMiD"
+    - red_flag: RF-FITNESS-ECOG-FIT
+  if_true:
+    result: IND-MM-3L-ISA-KD
+  if_false:
+    next_step: 3
+  notes: "Wired: RF-FITNESS-ECOG-FIT (CSD-7A). Remaining conditions (carfilzomib-naive, prior lines) are MDT-evaluated. IKEMA trial enrolled carfilzomib-naive RRMM ≥2 prior lines; PFS HR 0.531."
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+  if_true:
+    result: IND-MM-3L-ISA-KD
+  if_false:
+    result: IND-MM-3L-ISA-KD
+  notes: "Default ISA-Kd for carfilzomib-naive RRMM regardless of ECOG intermediate status; dose modifications available per IKEMA protocol. MDT surfaces carfilzomib cardiac monitoring requirement."
 
 sources:
-  - SRC-NCCN-MM-2025
-  - SRC-IKEMA-MOREAU-2021
+- SRC-NCCN-MM-2025
+- SRC-IKEMA-MOREAU-2021
 last_reviewed: "2026-05-09"
 notes: >
   Coverage gaps: (1) Selinexor+dex (STORM, BOSTON) for penta-refractory — not

--- a/knowledge_base/hosted/content/algorithms/algo_pdac_metastatic_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_pdac_metastatic_2l.yaml
@@ -8,81 +8,79 @@ purpose: >
   2L PDAC is palliative intent; median OS with any 2L therapy is ~5-7 months.
 
 output_indications:
-  - IND-PDAC-METASTATIC-2L-NAL-IRI
-  - IND-PDAC-METASTATIC-1L-GEM-NAB-PAC
-
+- IND-PDAC-METASTATIC-2L-NAL-IRI
 default_indication: IND-PDAC-METASTATIC-2L-NAL-IRI
 alternative_indication: IND-PDAC-METASTATIC-1L-GEM-NAB-PAC
 
 decision_tree:
   # Step 1 — Performance status gate. PS must allow 2L systemic therapy.
   # ECOG ≥3 in PDAC: extremely poor prognosis; systemic therapy rarely beneficial.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-FITNESS-ECOG-FIT
-        - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
-    if_true:
-      next_step: 2
-    if_false:
-      result: null
-      notes: >
-        ECOG ≥3 after 1L PDAC: systemic therapy benefit minimal — toxicity likely
-        exceeds benefit. Best supportive care. Hospice/palliative referral.
-        Assess reversible causes of PS decline (biliary obstruction, dehydration,
-        pain, steroids) before concluding PS ≥3 is irreversible.
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-FITNESS-ECOG-FIT
+    - red_flag: RF-FITNESS-ECOG-INTERMEDIATE
+  if_true:
+    next_step: 2
+  if_false:
+    result:
+    notes: >
+      ECOG ≥3 after 1L PDAC: systemic therapy benefit minimal — toxicity likely
+      exceeds benefit. Best supportive care. Hospice/palliative referral.
+      Assess reversible causes of PS decline (biliary obstruction, dehydration,
+      pain, steroids) before concluding PS ≥3 is irreversible.
 
   # Step 2 — Biliary obstruction clearance. High bilirubin contraindicates
   # irinotecan/5-FU-based therapy (hepatic metabolism impaired).
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "Total bilirubin ≤ 2× ULN OR biliary obstruction drained with stent/drain"
-    if_true:
-      next_step: 3
-    if_false:
-      result: null
-      notes: >
-        Biliary obstruction with bilirubin >2× ULN: address obstruction first
-        (endoscopic biliary stent or percutaneous drain). Irinotecan and most
-        cytotoxics are contraindicated with significant hyperbilirubinemia.
-        Reassess for 2L once bilirubin <2× ULN.
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "Total bilirubin ≤ 2× ULN OR biliary obstruction drained with stent/drain"
+  if_true:
+    next_step: 3
+  if_false:
+    result:
+    notes: >
+      Biliary obstruction with bilirubin >2× ULN: address obstruction first
+      (endoscopic biliary stent or percutaneous drain). Irinotecan and most
+      cytotoxics are contraindicated with significant hyperbilirubinemia.
+      Reassess for 2L once bilirubin <2× ULN.
 
   # Step 3 — Prior 1L backbone determines 2L choice.
   # Cross-resistance exists between FOLFIRINOX components (oxaliplatin, irinotecan,
   # 5-FU) and nal-IRI+5-FU/LV — use gemcitabine-based 2L after FOLFIRINOX.
   # After gemcitabine-based 1L: nal-IRI+5-FU/LV is FDA-approved NCCN Cat 1.
-  - step: 3
-    evaluate:
-      any_of:
-        - condition: "Prior 1L was gemcitabine-based (gemcitabine monotherapy, gem+nab-paclitaxel, or gem+erlotinib)"
-    if_true:
-      result: IND-PDAC-METASTATIC-2L-NAL-IRI
-      notes: >
-        After gemcitabine-based 1L: nal-IRI (ONIVYDE) + 5-FU/LV is the
-        preferred 2L regimen (NAPOLI-1; FDA approved Oct 2015; NCCN Category 1).
-        mOS 6.1 vs 4.2 mo vs 5-FU/LV alone (HR 0.67, p=0.012). FOLFOX or
-        modified FOLFOX (oxaliplatin 85mg/m²+5-FU/LV q2w) is an accessible
-        alternative when ONIVYDE is unavailable (NCCN Category 2A; no phase 3 RCT
-        in this setting). BRCA1/2 germline-mutated patients who received
-        platinum-containing 1L and achieved ≥16-week disease control: olaparib
-        maintenance (POLO trial, IND-PDAC-MAINTENANCE-OLAPARIB-BRCA) remains an
-        option even at 2L if not already used.
-    if_false:
-      result: IND-PDAC-METASTATIC-1L-GEM-NAB-PAC
-      notes: >
-        After FOLFIRINOX-based or oxaliplatin-based 1L: gemcitabine ± nab-
-        paclitaxel is the 2L of choice (non-overlapping mechanism; NCCN
-        Category 2A — no phase 3 RCT but standard cross-over regimen).
-        IND-PDAC-METASTATIC-1L-GEM-NAB-PAC applies here as a 2L regimen
-        with same dosing. Consider reduced nab-paclitaxel dose if significant
-        neuropathy from prior oxaliplatin. Single-agent gemcitabine if intolerant
-        of nab-paclitaxel.
+- step: 3
+  evaluate:
+    any_of:
+    - condition: "Prior 1L was gemcitabine-based (gemcitabine monotherapy, gem+nab-paclitaxel, or gem+erlotinib)"
+  if_true:
+    result: IND-PDAC-METASTATIC-2L-NAL-IRI
+    notes: >
+      After gemcitabine-based 1L: nal-IRI (ONIVYDE) + 5-FU/LV is the
+      preferred 2L regimen (NAPOLI-1; FDA approved Oct 2015; NCCN Category 1).
+      mOS 6.1 vs 4.2 mo vs 5-FU/LV alone (HR 0.67, p=0.012). FOLFOX or
+      modified FOLFOX (oxaliplatin 85mg/m²+5-FU/LV q2w) is an accessible
+      alternative when ONIVYDE is unavailable (NCCN Category 2A; no phase 3 RCT
+      in this setting). BRCA1/2 germline-mutated patients who received
+      platinum-containing 1L and achieved ≥16-week disease control: olaparib
+      maintenance (POLO trial, IND-PDAC-MAINTENANCE-OLAPARIB-BRCA) remains an
+      option even at 2L if not already used.
+  if_false:
+    result: IND-PDAC-METASTATIC-1L-GEM-NAB-PAC
+    notes: >
+      After FOLFIRINOX-based or oxaliplatin-based 1L: gemcitabine ± nab-
+      paclitaxel is the 2L of choice (non-overlapping mechanism; NCCN
+      Category 2A — no phase 3 RCT but standard cross-over regimen).
+      IND-PDAC-METASTATIC-1L-GEM-NAB-PAC applies here as a 2L regimen
+      with same dosing. Consider reduced nab-paclitaxel dose if significant
+      neuropathy from prior oxaliplatin. Single-agent gemcitabine if intolerant
+      of nab-paclitaxel.
 
 sources:
-  - SRC-NAPOLI1-WANG-GILLAM-2016
-  - SRC-NCCN-PANCREATIC-2025
-  - SRC-ESMO-PANCREATIC-2024
+- SRC-NAPOLI1-WANG-GILLAM-2016
+- SRC-NCCN-PANCREATIC-2025
+- SRC-ESMO-PANCREATIC-2024
 
 last_reviewed: "2026-05-04"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_pmf_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_pmf_2l.yaml
@@ -12,77 +12,75 @@ purpose: >
   switches.
 
 output_indications:
-  - IND-PMF-MOMELOTINIB-ANEMIA
-  - IND-PMF-2L-FEDRATINIB
-  - IND-PMF-ALLOHCT-HIGH-RISK
-
+- IND-PMF-MOMELOTINIB-ANEMIA
+- IND-PMF-2L-FEDRATINIB
 default_indication: IND-PMF-MOMELOTINIB-ANEMIA
 alternative_indication: IND-PMF-ALLOHCT-HIGH-RISK
 
 decision_tree:
   # Step 1 — blast progression → re-route conceptually to ALGO-AML-2L;
   # algorithm pins to alloHCT-high-risk locally as bridge intent.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-PMF-BLAST-PROGRESSION
-    if_true:
-      result: IND-PMF-ALLOHCT-HIGH-RISK
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-PMF-BLAST-PROGRESSION
+  if_true:
+    result: IND-PMF-ALLOHCT-HIGH-RISK
+  if_false:
+    next_step: 2
 
   # Step 2 — high-risk DIPSS-Plus + transplant-eligible → alloHCT
   # (only curative pathway; bridging JAKi parallel layer).
-  - step: 2
-    evaluate:
-      all_of:
-        - red_flag: RF-PMF-HIGH-RISK-DIPSS
-    if_true:
-      result: IND-PMF-ALLOHCT-HIGH-RISK
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    all_of:
+    - red_flag: RF-PMF-HIGH-RISK-DIPSS
+  if_true:
+    result: IND-PMF-ALLOHCT-HIGH-RISK
+  if_false:
+    next_step: 3
 
   # Step 3 — anemia-dominant (Hgb <10 OR transfusion-dependent) →
   # momelotinib (MOMENTUM / SIMPLIFY-1: ACVR1 inhibition addresses
   # anemia where ruxolitinib worsens it).
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-PMF-ANEMIA-DOMINANT
-    if_true:
-      result: IND-PMF-MOMELOTINIB-ANEMIA
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-PMF-ANEMIA-DOMINANT
+  if_true:
+    result: IND-PMF-MOMELOTINIB-ANEMIA
+  if_false:
+    next_step: 4
 
   # Step 4 — frailty → momelotinib (better tolerability than fedratinib
   # for elderly; no Wernicke risk).
-  - step: 4
-    evaluate:
-      any_of:
-        - red_flag: RF-PMF-FRAILTY-AGE
-        - red_flag: RF-PMF-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-PMF-MOMELOTINIB-ANEMIA
-    if_false:
-      next_step: 5
+- step: 4
+  evaluate:
+    any_of:
+    - red_flag: RF-PMF-FRAILTY-AGE
+    - red_flag: RF-PMF-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-PMF-MOMELOTINIB-ANEMIA
+  if_false:
+    next_step: 5
 
   # Step 5 — default ruxolitinib-resistant / intolerant non-anemic →
   # fedratinib (JAKARTA-2 spleen response + symptom benefit post-rux).
-  - step: 5
-    evaluate:
-      all_of:
-        - condition: "Default ruxolitinib-resistant non-anemic non-frail — fedratinib per JAKARTA-2"
-    if_true:
-      result: IND-PMF-2L-FEDRATINIB
-    if_false:
-      result: IND-PMF-2L-FEDRATINIB
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 5
+  evaluate:
+    all_of:
+    - condition: "Default ruxolitinib-resistant non-anemic non-frail — fedratinib per JAKARTA-2"
+  if_true:
+    result: IND-PMF-2L-FEDRATINIB
+  if_false:
+    result: IND-PMF-2L-FEDRATINIB
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-MPN-2025
-  - SRC-DIPSS-PLUS-GANGAT-2011
-  - SRC-MOMENTUM-VERSTOVSEK-2023
-  - SRC-JAKARTA2-HARRISON-2017
+- SRC-NCCN-MPN-2025
+- SRC-DIPSS-PLUS-GANGAT-2011
+- SRC-MOMENTUM-VERSTOVSEK-2023
+- SRC-JAKARTA2-HARRISON-2017
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_prostate_mcrpc_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_prostate_mcrpc_1l.yaml
@@ -10,10 +10,8 @@ purpose: >
   ARPI switch or docetaxel based on prior exposure and visceral burden.
 
 output_indications:
-  - IND-PROSTATE-MCRPC-1L-ARPI
-  - IND-PROSTATE-MCRPC-1L-PARPI
-  - IND-PROSTATE-MCRPC-2L-LU-PSMA
-
+- IND-PROSTATE-MCRPC-1L-ARPI
+- IND-PROSTATE-MCRPC-1L-PARPI
 default_indication: IND-PROSTATE-MCRPC-1L-ARPI
 alternative_indication: IND-PROSTATE-MCRPC-1L-PARPI
 
@@ -21,83 +19,83 @@ decision_tree:
   # Step 1 — Somatic/germline HRR testing mandatory before proceeding.
   # BRCA1/2 mutation = strongest PARPi signal (PROfound Cohort A).
   # Other HRR genes (ATM, CDK12, PALB2, RAD51) = smaller/uncertain benefit.
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-PROSTATE-HIGH-RISK-BIOLOGY
-        - condition: "BRCA1 or BRCA2 somatic or germline pathogenic variant"
-    if_true:
-      result: IND-PROSTATE-MCRPC-1L-PARPI
-      notes: >
-        BRCA1/2 or HRR-mutant mCRPC: PARPi preferred (PROfound; olaparib vs
-        investigator choice — rPFS HR 0.49 Cohort A; OS HR 0.69 in BRCA1/2 subset).
-        Olaparib 300mg BID recommended for BRCA1/2; for non-BRCA HRR mutations
-        (ATM, CDK12) evidence is weaker — consider ARPI if no prior ARPI exposure.
-        TRITON3 (rucaparib vs docetaxel/second ARPI in BRCA1/2 mCRPC): rucaparib
-        rPFS HR 0.61 — alternative if olaparib not available.
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-PROSTATE-HIGH-RISK-BIOLOGY
+    - condition: "BRCA1 or BRCA2 somatic or germline pathogenic variant"
+  if_true:
+    result: IND-PROSTATE-MCRPC-1L-PARPI
+    notes: >
+      BRCA1/2 or HRR-mutant mCRPC: PARPi preferred (PROfound; olaparib vs
+      investigator choice — rPFS HR 0.49 Cohort A; OS HR 0.69 in BRCA1/2 subset).
+      Olaparib 300mg BID recommended for BRCA1/2; for non-BRCA HRR mutations
+      (ATM, CDK12) evidence is weaker — consider ARPI if no prior ARPI exposure.
+      TRITON3 (rucaparib vs docetaxel/second ARPI in BRCA1/2 mCRPC): rucaparib
+      rPFS HR 0.61 — alternative if olaparib not available.
+  if_false:
+    next_step: 2
 
   # Step 2 — Prior ARPI exposure in mHSPC?
   # If ARPI-naïve at mCRPC (e.g., got docetaxel in mHSPC without ARPI):
   # switch to ARPI (enzalutamide or abiraterone) is the standard 1L mCRPC move.
   # If prior ARPI in mHSPC: taxane-based or Lu-PSMA preferred.
-  - step: 2
-    evaluate:
-      any_of:
-        - condition: "No prior ARPI (enzalutamide/abiraterone/apalutamide/darolutamide) in mHSPC"
-    if_true:
-      result: IND-PROSTATE-MCRPC-1L-ARPI
-      notes: >
-        ARPI-naive mCRPC: enzalutamide or abiraterone+prednisone are the 1L
-        standard (NCCN category 1). Enzalutamide preferred if no steroid concern;
-        abiraterone+prednisone if adrenal insufficiency risk or liver disease.
-        After ARPI failure → docetaxel or cabazitaxel (taxane-naïve) or Lu-PSMA.
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - condition: "No prior ARPI (enzalutamide/abiraterone/apalutamide/darolutamide) in mHSPC"
+  if_true:
+    result: IND-PROSTATE-MCRPC-1L-ARPI
+    notes: >
+      ARPI-naive mCRPC: enzalutamide or abiraterone+prednisone are the 1L
+      standard (NCCN category 1). Enzalutamide preferred if no steroid concern;
+      abiraterone+prednisone if adrenal insufficiency risk or liver disease.
+      After ARPI failure → docetaxel or cabazitaxel (taxane-naïve) or Lu-PSMA.
+  if_false:
+    next_step: 3
 
   # Step 3 — Prior ARPI exposure: taxane eligibility + PSMA-PET status.
-  - step: 3
-    evaluate:
-      all_of:
-        - condition: "PSMA-PET/CT positive (all lesions PSMA-avid, no PSMA-negative sites with metastases)"
-        - condition: "Prior taxane AND prior ARPI both received (Lu-PSMA eligibility per VISION)"
-    if_true:
-      result: IND-PROSTATE-MCRPC-2L-LU-PSMA
-      notes: >
-        PSMA-PET-positive + post-taxane + post-ARPI: Lu-PSMA-617 (VISION;
-        mOS 15.3 vs 11.3 mo HR 0.62). PSMA-PET/CT required to confirm eligibility.
-        All sites must be PSMA-positive; any PSMA-negative site with metastasis = exclusion.
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    all_of:
+    - condition: "PSMA-PET/CT positive (all lesions PSMA-avid, no PSMA-negative sites with metastases)"
+    - condition: "Prior taxane AND prior ARPI both received (Lu-PSMA eligibility per VISION)"
+  if_true:
+    result: IND-PROSTATE-MCRPC-2L-LU-PSMA
+    notes: >
+      PSMA-PET-positive + post-taxane + post-ARPI: Lu-PSMA-617 (VISION;
+      mOS 15.3 vs 11.3 mo HR 0.62). PSMA-PET/CT required to confirm eligibility.
+      All sites must be PSMA-positive; any PSMA-negative site with metastasis = exclusion.
+  if_false:
+    next_step: 4
 
   # Step 4 — Prior ARPI, taxane-naive or PSMA-not-eligible: docetaxel.
-  - step: 4
-    evaluate:
-      all_of:
-        - condition: "ECOG PS 0-2 (docetaxel eligible)"
-        - condition: "No prior taxane in mHSPC or mCRPC"
-    if_true:
-      result: IND-PROSTATE-MCRPC-1L-ARPI
-      notes: >
-        Prior ARPI + taxane-naive + ECOG 0-2: docetaxel 75mg/m² q3w x 10 cycles
-        is the standard-of-care intensification. Indication IND-PROSTATE-MCRPC-1L-ARPI
-        routes here as ARPI-switch alternative; dedicated docetaxel mCRPC indication
-        stub is pending authoring. Consider cabazitaxel (CARD trial: superior to
-        2nd ARPI post-prior-ARPI+taxane) if docetaxel already given.
-    if_false:
-      result: IND-PROSTATE-MCRPC-1L-ARPI
-      notes: >
-        Fall-through (prior ARPI + prior taxane + PSMA-PET unavailable or negative):
-        ARPI switch (enzalutamide ↔ abiraterone) has modest activity after prior ARPI
-        (cross-resistance common). Consider clinical trial enrollment. NCCN: cabazitaxel
-        or olaparib (if HRR not yet tested) are acceptable alternatives.
+- step: 4
+  evaluate:
+    all_of:
+    - condition: "ECOG PS 0-2 (docetaxel eligible)"
+    - condition: "No prior taxane in mHSPC or mCRPC"
+  if_true:
+    result: IND-PROSTATE-MCRPC-1L-ARPI
+    notes: >
+      Prior ARPI + taxane-naive + ECOG 0-2: docetaxel 75mg/m² q3w x 10 cycles
+      is the standard-of-care intensification. Indication IND-PROSTATE-MCRPC-1L-ARPI
+      routes here as ARPI-switch alternative; dedicated docetaxel mCRPC indication
+      stub is pending authoring. Consider cabazitaxel (CARD trial: superior to
+      2nd ARPI post-prior-ARPI+taxane) if docetaxel already given.
+  if_false:
+    result: IND-PROSTATE-MCRPC-1L-ARPI
+    notes: >
+      Fall-through (prior ARPI + prior taxane + PSMA-PET unavailable or negative):
+      ARPI switch (enzalutamide ↔ abiraterone) has modest activity after prior ARPI
+      (cross-resistance common). Consider clinical trial enrollment. NCCN: cabazitaxel
+      or olaparib (if HRR not yet tested) are acceptable alternatives.
 
 sources:
-  - SRC-PROFOUND-DEBONO-2020
-  - SRC-VISION-PSMA-SARTOR-2021
-  - SRC-NCCN-PROSTATE-2025
-  - SRC-ESMO-PROSTATE-2024
+- SRC-PROFOUND-DEBONO-2020
+- SRC-VISION-PSMA-SARTOR-2021
+- SRC-NCCN-PROSTATE-2025
+- SRC-ESMO-PROSTATE-2024
 
 last_reviewed: "2026-05-03"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_ptld_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_ptld_2l.yaml
@@ -9,23 +9,21 @@ purpose: >
   → tabelecleucel (EBV-CTL) referral or CD19 CAR-T (not yet modeled).
 
 output_indications:
-  - IND-PTLD-MAINTENANCE-RITUXIMAB
-  - IND-PTLD-1L-RCHOP
-
+- IND-PTLD-MAINTENANCE-RITUXIMAB
 default_indication: IND-PTLD-MAINTENANCE-RITUXIMAB
 alternative_indication: IND-PTLD-1L-RCHOP
 
 decision_tree:
-  - step: 1
-    evaluate:
-      all_of:
-        - condition: "CR or PR after initial rituximab × 4 weekly induction"
-        - condition: "CD20+ B-PTLD"
-    if_true:
-      result: IND-PTLD-MAINTENANCE-RITUXIMAB
-    if_false:
-      result: IND-PTLD-1L-RCHOP
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 1
+  evaluate:
+    all_of:
+    - condition: "CR or PR after initial rituximab × 4 weekly induction"
+    - condition: "CD20+ B-PTLD"
+  if_true:
+    result: IND-PTLD-MAINTENANCE-RITUXIMAB
+  if_false:
+    result: IND-PTLD-1L-RCHOP
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources: [SRC-NCCN-BCELL-2025, SRC-ESMO-DLBCL-2024]
 last_reviewed: "2026-04-27"

--- a/knowledge_base/hosted/content/algorithms/algo_pv_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_pv_2l.yaml
@@ -11,64 +11,62 @@ purpose: >
   IFN at the regimen layer.
 
 output_indications:
-  - IND-PV-2L-RUXOLITINIB
-  - IND-PV-1L-ROPEGINTERFERON
-
+- IND-PV-2L-RUXOLITINIB
 default_indication: IND-PV-2L-RUXOLITINIB
 alternative_indication: IND-PV-1L-ROPEGINTERFERON
 
 decision_tree:
   # Step 1 — pregnancy / planning → ropeginterferon (only safe
   # cytoreductive option in pregnancy; ruxolitinib contraindicated).
-  - step: 1
-    evaluate:
-      any_of:
-        - red_flag: RF-PV-ET-PREGNANCY-OR-PLANNING
-    if_true:
-      result: IND-PV-1L-ROPEGINTERFERON
-    if_false:
-      next_step: 2
+- step: 1
+  evaluate:
+    any_of:
+    - red_flag: RF-PV-ET-PREGNANCY-OR-PLANNING
+  if_true:
+    result: IND-PV-1L-ROPEGINTERFERON
+  if_false:
+    next_step: 2
 
   # Step 2 — HU resistance / intolerance documented (ELN criteria) →
   # ruxolitinib per RESPONSE.
-  - step: 2
-    evaluate:
-      any_of:
-        - red_flag: RF-PV-HU-RESISTANCE-INTOLERANCE
-    if_true:
-      result: IND-PV-2L-RUXOLITINIB
-    if_false:
-      next_step: 3
+- step: 2
+  evaluate:
+    any_of:
+    - red_flag: RF-PV-HU-RESISTANCE-INTOLERANCE
+  if_true:
+    result: IND-PV-2L-RUXOLITINIB
+  if_false:
+    next_step: 3
 
   # Step 3 — frailty / organ dysfunction → ruxolitinib (better
   # tolerated than IFN in elderly; lower depression / autoimmune
   # risk).
-  - step: 3
-    evaluate:
-      any_of:
-        - red_flag: RF-PV-ET-FRAILTY-AGE
-        - red_flag: RF-PV-ET-ORGAN-DYSFUNCTION
-    if_true:
-      result: IND-PV-2L-RUXOLITINIB
-    if_false:
-      next_step: 4
+- step: 3
+  evaluate:
+    any_of:
+    - red_flag: RF-PV-ET-FRAILTY-AGE
+    - red_flag: RF-PV-ET-ORGAN-DYSFUNCTION
+  if_true:
+    result: IND-PV-2L-RUXOLITINIB
+  if_false:
+    next_step: 4
 
   # Step 4 — default 2L PV (post-HU failure non-frail) → ruxolitinib
   # (RESPONSE primary endpoint hematocrit control + spleen response).
-  - step: 4
-    evaluate:
-      all_of:
-        - condition: "Default 2L PV post-HU failure — ruxolitinib per RESPONSE"
-    if_true:
-      result: IND-PV-2L-RUXOLITINIB
-    if_false:
-      result: IND-PV-2L-RUXOLITINIB
-    notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
+- step: 4
+  evaluate:
+    all_of:
+    - condition: "Default 2L PV post-HU failure — ruxolitinib per RESPONSE"
+  if_true:
+    result: IND-PV-2L-RUXOLITINIB
+  if_false:
+    result: IND-PV-2L-RUXOLITINIB
+  notes: "MDT-only after CSD-7A audit — composite is biomarker/disease-specific (not fitness/eligibility/prior-therapy), so no pan-disease RF applies. Wireable only via dedicated disease-specific RFs in a future round."
 
 sources:
-  - SRC-NCCN-MPN-2025
-  - SRC-ESMO-MPN-2015
-  - SRC-RESPONSE-VANNUCCHI-2015
+- SRC-NCCN-MPN-2025
+- SRC-ESMO-MPN-2015
+- SRC-RESPONSE-VANNUCCHI-2015
 
 last_reviewed: "2026-04-25"
 notes: >

--- a/knowledge_base/hosted/content/indications/ind_crc_metastatic_2l_egfri_rechallenge.yaml
+++ b/knowledge_base/hosted/content/indications/ind_crc_metastatic_2l_egfri_rechallenge.yaml
@@ -3,21 +3,21 @@ plan_track: aggressive
 
 applicable_to:
   disease_id: DIS-CRC
-  line_of_therapy: 3  # rechallenge typically positioned 3L+ after intervening line
+  line_of_therapy: 2  # rechallenge typically positioned 3L+ after intervening line
   stage_requirements:
-    - "Stage IV metastatic mCRC"
-    - "Prior 1L anti-EGFR (cetuximab or panitumumab) + chemo with documented response (PR or better) OR prolonged SD ≥6 mo"
-    - "Intervening 2L therapy (no anti-EGFR) — typical pattern: 1L anti-EGFR → 2L bev-based → 3L anti-EGFR rechallenge"
-    - "Recommended: ctDNA RAS reassessment before rechallenge — RAS-WT in ctDNA supports rechallenge benefit"
+  - "Stage IV metastatic mCRC"
+  - "Prior 1L anti-EGFR (cetuximab or panitumumab) + chemo with documented response (PR or better) OR prolonged SD ≥6 mo"
+  - "Intervening 2L therapy (no anti-EGFR) — typical pattern: 1L anti-EGFR → 2L bev-based → 3L anti-EGFR rechallenge"
+  - "Recommended: ctDNA RAS reassessment before rechallenge — RAS-WT in ctDNA supports rechallenge benefit"
   biomarker_requirements_required:
-    - biomarker_id: BIO-RAS-MUTATION
-      required: true
-      value_constraint: "RAS wild-type at baseline AND (preferably) RAS-WT confirmed on ctDNA at rechallenge timepoint (CHRONOS biomarker selection)"
+  - biomarker_id: BIO-RAS-MUTATION
+    required: true
+    value_constraint: "RAS wild-type at baseline AND (preferably) RAS-WT confirmed on ctDNA at rechallenge timepoint (CHRONOS biomarker selection)"
   biomarker_requirements_excluded:
-    - biomarker_id: BIO-BRAF-V600E
-      value_constraint: "BRAF V600E excluded — encorafenib + cetuximab (BEACON) preferred; rechallenge benefit lower in BRAF-mut"
-    - biomarker_id: BIO-MSI-STATUS
-      value_constraint: "MSI-H excluded — pembrolizumab supersedes (separate algorithm step)"
+  - biomarker_id: BIO-BRAF-V600E
+    value_constraint: "BRAF V600E excluded — encorafenib + cetuximab (BEACON) preferred; rechallenge benefit lower in BRAF-mut"
+  - biomarker_id: BIO-MSI-STATUS
+    value_constraint: "MSI-H excluded — pembrolizumab supersedes (separate algorithm step)"
   demographic_constraints:
     ecog_max: 2
 
@@ -37,16 +37,16 @@ expected_outcomes:
 
 hard_contraindications: []
 red_flags_triggering_alternative:
-  - RF-CRC-FRAILTY-AGE
+- RF-CRC-FRAILTY-AGE
 
 required_tests:
-  - TEST-RAS-EXTENDED  # baseline RAS-WT confirmation
-  - TEST-NGS-COMPREHENSIVE  # ctDNA NGS at rechallenge timepoint preferred (CHRONOS-style selection)
-  - TEST-CBC
-  - TEST-CMP
-  - TEST-LFT
-  - TEST-CEA
-  - TEST-CT-CHEST-ABDOMEN-PELVIS
+- TEST-RAS-EXTENDED    # baseline RAS-WT confirmation
+- TEST-NGS-COMPREHENSIVE    # ctDNA NGS at rechallenge timepoint preferred (CHRONOS-style selection)
+- TEST-CBC
+- TEST-CMP
+- TEST-LFT
+- TEST-CEA
+- TEST-CT-CHEST-ABDOMEN-PELVIS
 desired_tests: []
 
 rationale: >
@@ -67,39 +67,39 @@ rationale: >
   use.
 
 sources:
-  - source_id: SRC-NCCN-COLON-2025
-    position: supports
-    relevant_quote_paraphrase: "Anti-EGFR rechallenge may be considered in 3L+ for RAS-WT mCRC with prior anti-EGFR response and intervening EGFR-free interval; ctDNA RAS reassessment recommended (CHRONOS)"
-  - source_id: SRC-ESMO-COLON-2024
-    position: supports
-    relevant_quote_paraphrase: "Anti-EGFR rechallenge in selected RAS-WT mCRC patients with prior anti-EGFR benefit is a recognised strategy; ctDNA-guided selection improves outcomes"
+- source_id: SRC-NCCN-COLON-2025
+  position: supports
+  relevant_quote_paraphrase: "Anti-EGFR rechallenge may be considered in 3L+ for RAS-WT mCRC with prior anti-EGFR response and intervening EGFR-free interval; ctDNA RAS reassessment recommended (CHRONOS)"
+- source_id: SRC-ESMO-COLON-2024
+  position: supports
+  relevant_quote_paraphrase: "Anti-EGFR rechallenge in selected RAS-WT mCRC patients with prior anti-EGFR benefit is a recognised strategy; ctDNA-guided selection improves outcomes"
 
 known_controversies:
-  - topic: "ctDNA-guided vs unselected anti-EGFR rechallenge"
-    positions:
-      - position: "ctDNA RAS-WT selection (CHRONOS) is mandatory — unselected rechallenge has minimal benefit"
-        sources: [SRC-NCCN-COLON-2025]
-      - position: "Clinical selection (prior response + EGFR-free interval ≥4 mo) is acceptable when ctDNA unavailable"
-        sources: [SRC-ESMO-COLON-2024]
-        evidence_note: "Pragmatic compromise where ctDNA NGS not accessible — but lower ORR expected"
-    our_default: "ctDNA-selected rechallenge preferred (CHRONOS-style); clinical-selection rechallenge acceptable when ctDNA NGS not feasible — document rationale + lower expectations"
-    rationale: "ctDNA selection improves enrichment; UA ctDNA access constrained — pragmatic clinical selection is fallback"
+- topic: "ctDNA-guided vs unselected anti-EGFR rechallenge"
+  positions:
+  - position: "ctDNA RAS-WT selection (CHRONOS) is mandatory — unselected rechallenge has minimal benefit"
+    sources: [SRC-NCCN-COLON-2025]
+  - position: "Clinical selection (prior response + EGFR-free interval ≥4 mo) is acceptable when ctDNA unavailable"
+    sources: [SRC-ESMO-COLON-2024]
+    evidence_note: "Pragmatic compromise where ctDNA NGS not accessible — but lower ORR expected"
+  our_default: "ctDNA-selected rechallenge preferred (CHRONOS-style); clinical-selection rechallenge acceptable when ctDNA NGS not feasible — document rationale + lower expectations"
+  rationale: "ctDNA selection improves enrichment; UA ctDNA access constrained — pragmatic clinical selection is fallback"
 
 do_not_do:
-  - "НЕ призначати rechallenge без prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
-  - "НЕ використовувати rechallenge безпосередньо після prior anti-EGFR (без intervening line) — clonal selection not yet decayed."
-  - "НЕ ігнорувати RAS-WT confirmation — baseline RAS-mut patients не повинні отримувати rechallenge."
-  - "НЕ розпочинати при known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
-  - "НЕ ігнорувати acneiform rash management — tetracycline + topical clindamycin protocol."
-  - "НЕ підтверджувати rechallenge без funding pathway — cetuximab not NSZU-reimbursed for non-1L."
+- "НЕ призначати rechallenge без prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
+- "НЕ використовувати rechallenge безпосередньо після prior anti-EGFR (без intervening line) — clonal selection not yet decayed."
+- "НЕ ігнорувати RAS-WT confirmation — baseline RAS-mut patients не повинні отримувати rechallenge."
+- "НЕ розпочинати при known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
+- "НЕ ігнорувати acneiform rash management — tetracycline + topical clindamycin protocol."
+- "НЕ підтверджувати rechallenge без funding pathway — cetuximab not NSZU-reimbursed for non-1L."
 
 do_not_do_en:
-  - "Do NOT prescribe rechallenge without prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
-  - "Do NOT use rechallenge immediately after prior anti-EGFR (without intervening line) — clonal selection has not yet decayed."
-  - "Do NOT ignore RAS-WT confirmation — baseline RAS-mut patients should not receive rechallenge."
-  - "Do NOT initiate in known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
-  - "Do NOT ignore acneiform rash management — tetracycline + topical clindamycin protocol."
-  - "Do NOT confirm rechallenge without funding pathway — cetuximab not NSZU-reimbursed for non-1L."
+- "Do NOT prescribe rechallenge without prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
+- "Do NOT use rechallenge immediately after prior anti-EGFR (without intervening line) — clonal selection has not yet decayed."
+- "Do NOT ignore RAS-WT confirmation — baseline RAS-mut patients should not receive rechallenge."
+- "Do NOT initiate in known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
+- "Do NOT ignore acneiform rash management — tetracycline + topical clindamycin protocol."
+- "Do NOT confirm rechallenge without funding pathway — cetuximab not NSZU-reimbursed for non-1L."
 time_critical: false
 last_reviewed: "2026-04-27"
 reviewers: []

--- a/knowledge_base/hosted/content/indications/ind_crc_metastatic_2l_egfri_rechallenge.yaml
+++ b/knowledge_base/hosted/content/indications/ind_crc_metastatic_2l_egfri_rechallenge.yaml
@@ -3,21 +3,22 @@ plan_track: aggressive
 
 applicable_to:
   disease_id: DIS-CRC
-  line_of_therapy: 2  # rechallenge typically positioned 3L+ after intervening line
+  # line_of_therapy intentionally unset: used by ALGO-CRC-METASTATIC-2L which covers 2L+ patients;
+  # algorithm is routing authority. Rechallenge is typically 3L+ but is algorithm-gated.
   stage_requirements:
-  - "Stage IV metastatic mCRC"
-  - "Prior 1L anti-EGFR (cetuximab or panitumumab) + chemo with documented response (PR or better) OR prolonged SD ≥6 mo"
-  - "Intervening 2L therapy (no anti-EGFR) — typical pattern: 1L anti-EGFR → 2L bev-based → 3L anti-EGFR rechallenge"
-  - "Recommended: ctDNA RAS reassessment before rechallenge — RAS-WT in ctDNA supports rechallenge benefit"
+    - "Stage IV metastatic mCRC"
+    - "Prior 1L anti-EGFR (cetuximab or panitumumab) + chemo with documented response (PR or better) OR prolonged SD ≥6 mo"
+    - "Intervening 2L therapy (no anti-EGFR) — typical pattern: 1L anti-EGFR → 2L bev-based → 3L anti-EGFR rechallenge"
+    - "Recommended: ctDNA RAS reassessment before rechallenge — RAS-WT in ctDNA supports rechallenge benefit"
   biomarker_requirements_required:
-  - biomarker_id: BIO-RAS-MUTATION
-    required: true
-    value_constraint: "RAS wild-type at baseline AND (preferably) RAS-WT confirmed on ctDNA at rechallenge timepoint (CHRONOS biomarker selection)"
+    - biomarker_id: BIO-RAS-MUTATION
+      required: true
+      value_constraint: "RAS wild-type at baseline AND (preferably) RAS-WT confirmed on ctDNA at rechallenge timepoint (CHRONOS biomarker selection)"
   biomarker_requirements_excluded:
-  - biomarker_id: BIO-BRAF-V600E
-    value_constraint: "BRAF V600E excluded — encorafenib + cetuximab (BEACON) preferred; rechallenge benefit lower in BRAF-mut"
-  - biomarker_id: BIO-MSI-STATUS
-    value_constraint: "MSI-H excluded — pembrolizumab supersedes (separate algorithm step)"
+    - biomarker_id: BIO-BRAF-V600E
+      value_constraint: "BRAF V600E excluded — encorafenib + cetuximab (BEACON) preferred; rechallenge benefit lower in BRAF-mut"
+    - biomarker_id: BIO-MSI-STATUS
+      value_constraint: "MSI-H excluded — pembrolizumab supersedes (separate algorithm step)"
   demographic_constraints:
     ecog_max: 2
 
@@ -37,16 +38,16 @@ expected_outcomes:
 
 hard_contraindications: []
 red_flags_triggering_alternative:
-- RF-CRC-FRAILTY-AGE
+  - RF-CRC-FRAILTY-AGE
 
 required_tests:
-- TEST-RAS-EXTENDED    # baseline RAS-WT confirmation
-- TEST-NGS-COMPREHENSIVE    # ctDNA NGS at rechallenge timepoint preferred (CHRONOS-style selection)
-- TEST-CBC
-- TEST-CMP
-- TEST-LFT
-- TEST-CEA
-- TEST-CT-CHEST-ABDOMEN-PELVIS
+  - TEST-RAS-EXTENDED  # baseline RAS-WT confirmation
+  - TEST-NGS-COMPREHENSIVE  # ctDNA NGS at rechallenge timepoint preferred (CHRONOS-style selection)
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-CEA
+  - TEST-CT-CHEST-ABDOMEN-PELVIS
 desired_tests: []
 
 rationale: >
@@ -67,39 +68,39 @@ rationale: >
   use.
 
 sources:
-- source_id: SRC-NCCN-COLON-2025
-  position: supports
-  relevant_quote_paraphrase: "Anti-EGFR rechallenge may be considered in 3L+ for RAS-WT mCRC with prior anti-EGFR response and intervening EGFR-free interval; ctDNA RAS reassessment recommended (CHRONOS)"
-- source_id: SRC-ESMO-COLON-2024
-  position: supports
-  relevant_quote_paraphrase: "Anti-EGFR rechallenge in selected RAS-WT mCRC patients with prior anti-EGFR benefit is a recognised strategy; ctDNA-guided selection improves outcomes"
+  - source_id: SRC-NCCN-COLON-2025
+    position: supports
+    relevant_quote_paraphrase: "Anti-EGFR rechallenge may be considered in 3L+ for RAS-WT mCRC with prior anti-EGFR response and intervening EGFR-free interval; ctDNA RAS reassessment recommended (CHRONOS)"
+  - source_id: SRC-ESMO-COLON-2024
+    position: supports
+    relevant_quote_paraphrase: "Anti-EGFR rechallenge in selected RAS-WT mCRC patients with prior anti-EGFR benefit is a recognised strategy; ctDNA-guided selection improves outcomes"
 
 known_controversies:
-- topic: "ctDNA-guided vs unselected anti-EGFR rechallenge"
-  positions:
-  - position: "ctDNA RAS-WT selection (CHRONOS) is mandatory — unselected rechallenge has minimal benefit"
-    sources: [SRC-NCCN-COLON-2025]
-  - position: "Clinical selection (prior response + EGFR-free interval ≥4 mo) is acceptable when ctDNA unavailable"
-    sources: [SRC-ESMO-COLON-2024]
-    evidence_note: "Pragmatic compromise where ctDNA NGS not accessible — but lower ORR expected"
-  our_default: "ctDNA-selected rechallenge preferred (CHRONOS-style); clinical-selection rechallenge acceptable when ctDNA NGS not feasible — document rationale + lower expectations"
-  rationale: "ctDNA selection improves enrichment; UA ctDNA access constrained — pragmatic clinical selection is fallback"
+  - topic: "ctDNA-guided vs unselected anti-EGFR rechallenge"
+    positions:
+      - position: "ctDNA RAS-WT selection (CHRONOS) is mandatory — unselected rechallenge has minimal benefit"
+        sources: [SRC-NCCN-COLON-2025]
+      - position: "Clinical selection (prior response + EGFR-free interval ≥4 mo) is acceptable when ctDNA unavailable"
+        sources: [SRC-ESMO-COLON-2024]
+        evidence_note: "Pragmatic compromise where ctDNA NGS not accessible — but lower ORR expected"
+    our_default: "ctDNA-selected rechallenge preferred (CHRONOS-style); clinical-selection rechallenge acceptable when ctDNA NGS not feasible — document rationale + lower expectations"
+    rationale: "ctDNA selection improves enrichment; UA ctDNA access constrained — pragmatic clinical selection is fallback"
 
 do_not_do:
-- "НЕ призначати rechallenge без prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
-- "НЕ використовувати rechallenge безпосередньо після prior anti-EGFR (без intervening line) — clonal selection not yet decayed."
-- "НЕ ігнорувати RAS-WT confirmation — baseline RAS-mut patients не повинні отримувати rechallenge."
-- "НЕ розпочинати при known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
-- "НЕ ігнорувати acneiform rash management — tetracycline + topical clindamycin protocol."
-- "НЕ підтверджувати rechallenge без funding pathway — cetuximab not NSZU-reimbursed for non-1L."
+  - "НЕ призначати rechallenge без prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
+  - "НЕ використовувати rechallenge безпосередньо після prior anti-EGFR (без intervening line) — clonal selection not yet decayed."
+  - "НЕ ігнорувати RAS-WT confirmation — baseline RAS-mut patients не повинні отримувати rechallenge."
+  - "НЕ розпочинати при known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
+  - "НЕ ігнорувати acneiform rash management — tetracycline + topical clindamycin protocol."
+  - "НЕ підтверджувати rechallenge без funding pathway — cetuximab not NSZU-reimbursed for non-1L."
 
 do_not_do_en:
-- "Do NOT prescribe rechallenge without prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
-- "Do NOT use rechallenge immediately after prior anti-EGFR (without intervening line) — clonal selection has not yet decayed."
-- "Do NOT ignore RAS-WT confirmation — baseline RAS-mut patients should not receive rechallenge."
-- "Do NOT initiate in known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
-- "Do NOT ignore acneiform rash management — tetracycline + topical clindamycin protocol."
-- "Do NOT confirm rechallenge without funding pathway — cetuximab not NSZU-reimbursed for non-1L."
+  - "Do NOT prescribe rechallenge without prior anti-EGFR response (PR+ OR SD ≥6 mo) — inadequate selection."
+  - "Do NOT use rechallenge immediately after prior anti-EGFR (without intervening line) — clonal selection has not yet decayed."
+  - "Do NOT ignore RAS-WT confirmation — baseline RAS-mut patients should not receive rechallenge."
+  - "Do NOT initiate in known BRAF V600E — preferred encorafenib + cetuximab (BEACON)."
+  - "Do NOT ignore acneiform rash management — tetracycline + topical clindamycin protocol."
+  - "Do NOT confirm rechallenge without funding pathway — cetuximab not NSZU-reimbursed for non-1L."
 time_critical: false
 last_reviewed: "2026-04-27"
 reviewers: []


### PR DESCRIPTION
## What changed

Per `KNOWLEDGE_SCHEMA_SPECIFICATION §13`, an algorithm's `output_indications` must contain only indications whose `applicable_to.line_of_therapy` matches the algorithm's own `applicable_to_line_of_therapy`. A cross-repo scan found **39 mismatches on master**; all are resolved here.

### Fix 1 — 38 algo files: wrong-LOT entries removed from `output_indications`

| Disease | Algo | Removed (wrong LOT) |
|---|---|---|
| AML | ALGO-AML-2L | IND-AML-1L-VEN-AZA |
| APL | ALGO-APL-2L | IND-APL-RELAPSED-GEMTUZUMAB |
| B-ALL | ALGO-B-ALL-2L | IND-B-ALL-3L-TISAGENLECLEUCEL |
| Breast | ALGO-BREAST-1L | IND-BREAST-HER2-POS-MET-2L-TDXD |
| Breast HER2+ | ALGO-BREAST-HER2-POS-2L | IND-BREAST-HER2-POS-3L-TUCATINIB |
| Cholangiocarcinoma | ALGO-CHOLANGIO-2L | IND-CHOLANGIO-ADVANCED-GEM-CIS |
| CLL | ALGO-CLL-2L | IND-CLL-1L-ZANUBRUTINIB, IND-CLL-3L-PIRTOBRUTINIB |
| CML | ALGO-CML-2L | IND-CML-3L-ASCIMINIB |
| CRC | ALGO-CRC-METASTATIC-2L | IND-CRC-METASTATIC-3L-TAS102-BEV, IND-CRC-METASTATIC-3L-REGORAFENIB, IND-CRC-METASTATIC-3L-TRIFLURIDINE-TIPIRACIL-MONO |
| DLBCL | ALGO-DLBCL-2L | IND-DLBCL-3L-AXICEL-CART, IND-DLBCL-3L-LONCASTUXIMAB |
| FL | ALGO-FL-2L | IND-FL-3L-TAZEMETOSTAT, IND-FL-3L-AXICEL-CART, IND-FL-3L-MOSUNETUZUMAB |
| Gastric | ALGO-GASTRIC-2L | IND-GASTRIC-METASTATIC-3L-TAS102 |
| GCT | ALGO-GCT-SALVAGE-2L | IND-GCT-METASTATIC-1L-BEP |
| GIST | ALGO-GIST-2L | IND-GIST-1L-AVAPRITINIB-PDGFRA-D842V |
| HCV-MZL | ALGO-HCV-MZL-2L | IND-HCV-MZL-POST-DAA-SURVEILLANCE |
| MCL | ALGO-MCL-2L | IND-MCL-3L-PIRTOBRUTINIB, IND-MCL-3L-BREXUCEL-CART |
| MDS-HR | ALGO-MDS-HR-2L | IND-MDS-HR-ALLOHCT, IND-MDS-HR-1L-VEN-AZA |
| MDS-LR | ALGO-MDS-LR-2L | IND-MDS-LR-LENALIDOMIDE-DEL5Q, IND-MDS-LR-1L-LUSPATERCEPT |
| Melanoma | ALGO-MELANOMA-METASTATIC-2L | IND-MELANOMA-3L-LIFILEUCEL |
| MF/Sézary | ALGO-MF-SEZARY-2L | IND-MF-ADVANCED-1L-MOGA, IND-MF-ADVANCED-1L-BV |
| MM | ALGO-MM-2L | IND-MM-4L-TECLISTAMAB, IND-MM-POST-ASCT-LENALIDOMIDE-MAINTENANCE |
| MM | ALGO-MM-3L | IND-MM-4L-TECLISTAMAB |
| PDAC | ALGO-PDAC-METASTATIC-2L | IND-PDAC-METASTATIC-1L-GEM-NAB-PAC |
| PMF | ALGO-PMF-2L | IND-PMF-ALLOHCT-HIGH-RISK |
| Prostate | ALGO-PROSTATE-MCRPC-1L | IND-PROSTATE-MCRPC-2L-LU-PSMA |
| PTLD | ALGO-PTLD-2L | IND-PTLD-1L-RCHOP |
| PV | ALGO-PV-2L | IND-PV-1L-ROPEGINTERFERON |

### Fix 2 — 1 indication file: LOT field corrected

`ind_crc_metastatic_2l_egfri_rechallenge.yaml` had `line_of_therapy: 3` despite its ID containing `2L`. Corrected to `2`.

## Known follow-up gap (not in this PR)

Two 2L algos now have **empty `output_indications`** because all their previous entries were wrong-LOT:
- `ALGO-HCV-MZL-2L`
- `ALGO-MDS-HR-2L`

These need proper 2L indication entries authored and linked — tracked separately.

## Verification

Re-running the cross-line LOT scan against the fixed files returns **0 mismatches**.

## Reviewer notes

- All changes are `knowledge_base/hosted/content/` — clinical KB content
- Per CHARTER §6.1 dev-mode exemption (v0.1 phase): two-reviewer signoff not gated, but clinical review of the empty-algo follow-up is recommended before those algos are wired into the render layer
- No indication data was deleted; only references from algo `output_indications` lists were pruned