### PR TITLE
feat(kb): W5c RF wiring for ALGO-BREAST-1L — TNBC, early-stage, metastatic stage RFs

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_breast_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_breast_1l.yaml
@@ -15,6 +15,7 @@ output_indications:
 - IND-BREAST-HR-POS-EARLY-ADJ-RIBOCICLIB
 - IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
 - IND-BREAST-HER2-POS-MET-1L-THP
+- IND-BREAST-HER2-POS-MET-2L-TDXD
 - IND-BREAST-TNBC-EARLY-NEOADJUVANT
 - IND-BREAST-BRCA-POS-MET-PARPI
 - IND-BREAST-TNBC-METASTATIC-1L-PEMBRO-CHEMO
@@ -35,34 +36,88 @@ decision_tree:
 - step: 2
   evaluate:
     any_of:
+    - red_flag: RF-BREAST-EARLY-STAGE
+    # Legacy finding-based evaluations for backward engine compatibility:
+    - {finding: stage_group, value: "I"}
+    - {finding: stage_group, value: "II"}
+    - {finding: stage_group, value: "III"}
+    - {finding: stage_group, value: "IIA"}
+    - {finding: stage_group, value: "IIB"}
+    - {finding: stage_group, value: "IIIA"}
+    - {finding: stage_group, value: "IIIB"}
+    - {finding: stage_group, value: "IIIC"}
+    - {finding: stage_group, value: "early"}
+    - {finding: disease_extent, value: "localized"}
+    - {finding: disease_extent, value: "locally_advanced"}
     - condition: "Stage I-III (early)"
   if_true:
     result: IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
+    notes: >
+      RF-BREAST-EARLY-STAGE fired (stage I-III) — curative-intent
+      neoadjuvant TCHP for HER2+ early breast cancer.
   if_false:
     result: IND-BREAST-HER2-POS-MET-1L-THP
-  notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      No early-stage finding — route to metastatic 1L THP
+      (trastuzumab + pertuzumab + taxane; CLEOPATRA).
+  notes: >
+    W5c RF wiring: RF-BREAST-EARLY-STAGE added as primary gate;
+    legacy finding lookups and free-text condition retained for
+    backward engine compatibility.
   # Step 3 — HER2-negative; check TNBC vs HR+
 - step: 3
   evaluate:
     any_of:
+    - red_flag: RF-BREAST-TNBC
+    # Legacy finding-based evaluations for backward engine compatibility:
+    - {finding: tnbc_status, value: true}
+    - {finding: tnbc_status, value: positive}
+    - {finding: breast_subtype, value: TNBC}
+    - {finding: breast_subtype, value: triple_negative}
     - condition: "ER <1% AND PR <1% (TNBC)"
   if_true:
     next_step: 4
+    notes: >
+      RF-BREAST-TNBC fired (ER<1% AND PR<1% AND HER2-negative) — route
+      to TNBC stage gate (step 4). DO NOT use CDK4/6i or endocrine therapy
+      for TNBC patients.
   if_false:
     next_step: 5
-  notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      No TNBC signal — patient is HR+/HER2-. Route to step 5
+      (CDK4/6i + aromatase inhibitor default for HR+ metastatic disease).
+  notes: >
+    W5c RF wiring: RF-BREAST-TNBC added as primary gate; legacy
+    finding lookups retained. Step 5 is degenerate (both branches
+    → CDKI) and is not RF-wirable without adding HR+ explicit indication.
   # Step 4 — TNBC: early vs metastatic stage gate.
   # Early stage → neoadjuvant (KEYNOTE-522); metastatic → step 6 (BRCA/PD-L1 routing).
 - step: 4
   evaluate:
     any_of:
+    - red_flag: RF-BREAST-STAGE-IV-METASTATIC
+    # Legacy finding-based evaluations for backward engine compatibility:
+    - {finding: stage_group, value: "IV"}
+    - {finding: stage_group, value: "IVA"}
+    - {finding: stage_group, value: "metastatic"}
+    - {finding: disease_extent, value: "metastatic"}
+    - {finding: distant_metastasis, value: true}
+    - {finding: m_stage, value: M1}
     - condition: "Stage IV (locally recurrent unresectable or distant metastatic)"
   if_true:
     next_step: 6
-    notes: "Metastatic TNBC: route to BRCA mutation gate (step 6)."
+    notes: >
+      RF-BREAST-STAGE-IV-METASTATIC fired — metastatic TNBC: route to
+      BRCA mutation gate (step 6). Palliative-intent therapy.
   if_false:
     result: IND-BREAST-TNBC-EARLY-NEOADJUVANT
-    notes: "Stage I-III TNBC: KEYNOTE-522 neoadjuvant pembrolizumab+chemo regardless of PD-L1 status."
+    notes: >
+      No metastatic finding — early-stage TNBC (I-III): KEYNOTE-522
+      neoadjuvant pembrolizumab+chemo regardless of PD-L1 status.
+  notes: >
+    W5c RF wiring: RF-BREAST-STAGE-IV-METASTATIC added as primary gate;
+    legacy finding lookups and free-text condition retained for
+    backward engine compatibility.
   # Step 5 — HR+/HER2- branch: early-stage high-risk → adjuvant CDK4/6i; metastatic → CDK4/6i 1L.
   # monarchE (Johnston, Lancet Oncol 2023): abemaciclib 2yr adjuvant; high-risk = ≥4+ nodes
   # OR 1-3 nodes + Ki67 ≥20% or grade 3. NATALEE (ribociclib 3yr) broadens eligibility.
@@ -107,7 +162,9 @@ sources:
 - SRC-ESMO-BREAST-METASTATIC-2024
 - SRC-MONARCHE-JOHNSTON-2023
 - SRC-NATALEE-SLAMON-2024
-last_reviewed: '2026-05-09'
+- SRC-KEYNOTE522-SCHMID-2022
+- SRC-KEYNOTE355-CORTES-2020
+last_reviewed: '2026-05-10'
 notes: >
   Receptor-subtype is the dominant branch point — biomarker_driven
   archetype materialized. T-DXd 2L HER2+ metastatic referenced as
@@ -115,5 +172,8 @@ notes: >
   as 1L choice. Step 5 wired 2026-05-09 (BREAST-1 D1) for early
   HR+/HER2- high-risk adjuvant CDK4/6i; D2 adds NATALEE ribociclib
   as alternative (IND-BREAST-HR-POS-EARLY-ADJ-RIBOCICLIB).
+  W5c RF wiring (2026-05-10): RF-BREAST-EARLY-STAGE, RF-BREAST-TNBC,
+  RF-BREAST-STAGE-IV-METASTATIC added as primary gates for steps 2-4;
+  legacy finding lookups retained for backward engine compatibility.
   OOS: Lu-PSMA analog targeted ADCs; brain-met HER2CLIMB pathways;
   early low-risk HR+/HER2- standard AI adjuvant (no CDK4/6i needed).

--- a/knowledge_base/hosted/content/redflags/rf_breast_early_stage.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_breast_early_stage.yaml
@@ -1,0 +1,104 @@
+id: RF-BREAST-EARLY-STAGE
+definition: >
+  Early-stage (non-metastatic) breast cancer: clinical or pathological stage
+  I, II, or III. Defined by absence of distant metastasis (M0 per TNM 8th
+  edition). Early-stage breast cancer is potentially curable with locoregional
+  and systemic therapy; the treatment intent is curative, not palliative.
+
+  Early stage is the gating criterion for neoadjuvant (pre-operative) or
+  adjuvant (post-operative) systemic therapy rather than palliative 1L
+  metastatic regimens. Neoadjuvant therapy (TCHP for HER2+; pembro+chemo
+  for TNBC KEYNOTE-522; endocrine ± CDK4/6i for HR+) is preferred for
+  stage II-III tumors. Stage I HR+ tumors may receive adjuvant endocrine
+  therapy without neoadjuvant chemotherapy.
+
+  Fires to route ALGO-BREAST-1L step 2 (HER2+ branch) to neoadjuvant therapy
+  (IND-BREAST-HER2-POS-EARLY-NEOADJUVANT) rather than metastatic 1L
+  (IND-BREAST-HER2-POS-MET-1L-THP).
+
+definition_ua: >
+  Ранній (нементастатичний) рак молочної залози: клінічна або патологічна
+  стадія I, II або III. Відсутність дистантних метастазів (M0). Куративна
+  мета лікування. Маршрутизує до неоад'ювантної або ад'ювантної терапії.
+
+trigger:
+  type: stage_classification
+  all_of:
+    - any_of:
+        - finding: stage_group
+          value: "I"
+        - finding: stage_group
+          value: "IA"
+        - finding: stage_group
+          value: "IB"
+        - finding: stage_group
+          value: "II"
+        - finding: stage_group
+          value: "IIA"
+        - finding: stage_group
+          value: "IIB"
+        - finding: stage_group
+          value: "III"
+        - finding: stage_group
+          value: "IIIA"
+        - finding: stage_group
+          value: "IIIB"
+        - finding: stage_group
+          value: "IIIC"
+        - finding: stage_group
+          value: "early"
+        - finding: disease_extent
+          value: "localized"
+        - finding: disease_extent
+          value: "locally_advanced"
+    - any_of:
+        - finding: stage_group
+          value_not: "IV"
+        - finding: distant_metastasis
+          value: false
+        - finding: m_stage
+          value: M0
+
+clinical_direction: intensify
+severity: major
+priority: 50
+category: other
+
+branch_targets:
+  ALGO-BREAST-1L: "2"
+
+relevant_diseases:
+  - DIS-BREAST
+
+shifts_algorithm:
+  - ALGO-BREAST-1L
+
+sources:
+  - SRC-NCCN-BREAST-2025
+
+last_reviewed: "2026-05-08"
+reviewer_signoffs: []
+draft: true
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+notes: >
+  W5c RF authoring. Converts free-text `{condition: "Stage I-III (early)"}` in
+  ALGO-BREAST-1L step 2 (HER2+ branch) into a formal RF entity.
+
+  The trigger uses a positive stage group match (I/II/III with substages)
+  combined with a negative M0 check. The `any_of: [stage_group: "I"...]`
+  covers TNM 8th-edition staging codes; the `any_of: [stage_group ≠ "IV",
+  distant_metastasis: false]` adds belt-and-suspenders exclusion of M1.
+
+  Note: The `value_not` field is non-standard — the engine team should
+  confirm whether this negation syntax is supported. If not, use the positive
+  stage_group values as the sole trigger (stages I, II, III) without the
+  M0 negation check. The M0 confirmation is belt-and-suspenders.
+
+  ALGO-BREAST-1L step 2 routes:
+    if_true (RF fires = early stage): IND-BREAST-HER2-POS-EARLY-NEOADJUVANT
+    if_false (RF doesn't fire = metastatic/unknown): IND-BREAST-HER2-POS-MET-1L-THP
+
+  CHARTER §6.1: Two-reviewer clinical co-lead signoff required before
+  removing draft: true.

--- a/knowledge_base/hosted/content/redflags/rf_breast_stage_iv_metastatic.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_breast_stage_iv_metastatic.yaml
@@ -1,0 +1,83 @@
+id: RF-BREAST-STAGE-IV-METASTATIC
+definition: >
+  Metastatic (stage IV) breast cancer: presence of distant metastasis (M1
+  per TNM 8th edition) involving any organ system (bone, liver, lung, brain,
+  peritoneum, other). Stage IV breast cancer is currently incurable with
+  available systemic therapy; treatment intent is disease control, quality
+  of life, and life prolongation.
+
+  Stage IV status is the gating criterion for palliative systemic therapy
+  (CDK4/6i+AI for HR+/HER2-; THP for HER2+; pembro+chemo or PARPi for TNBC)
+  rather than curative-intent neoadjuvant/adjuvant approaches.
+
+  Fires to route ALGO-BREAST-1L step 4 (TNBC branch) from early-stage
+  neoadjuvant (IND-BREAST-TNBC-EARLY-NEOADJUVANT) toward metastatic
+  evaluation (step 6: BRCA mutation gate → PARPi vs pembro+chemo).
+
+definition_ua: >
+  Метастатичний (стадія IV) рак молочної залози: наявність дистантних
+  метастазів (M1). Паліативний намір лікування — контроль захворювання,
+  якість життя, продовження виживання.
+
+trigger:
+  type: stage_classification
+  any_of:
+    - finding: stage_group
+      value: "IV"
+    - finding: stage_group
+      value: "IVA"
+    - finding: stage_group
+      value: "IVB"
+    - finding: stage_group
+      value: "metastatic"
+    - finding: disease_extent
+      value: "metastatic"
+    - finding: distant_metastasis
+      value: true
+    - finding: m_stage
+      value: M1
+
+clinical_direction: intensify
+severity: major
+priority: 50
+category: other
+
+branch_targets:
+  ALGO-BREAST-1L: "4"
+
+relevant_diseases:
+  - DIS-BREAST
+
+shifts_algorithm:
+  - ALGO-BREAST-1L
+
+sources:
+  - SRC-NCCN-BREAST-2025
+  - SRC-ESMO-BREAST-METASTATIC-2024
+
+last_reviewed: "2026-05-08"
+reviewer_signoffs: []
+draft: true
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+notes: >
+  W5c RF authoring. Converts free-text `{condition: "Stage IV (locally
+  recurrent unresectable or distant metastatic)"}` in ALGO-BREAST-1L step 4
+  (TNBC metastatic gate) into a formal RF entity.
+
+  The trigger fires on any M1 / Stage IV finding. ALGO-BREAST-1L step 4
+  routes:
+    if_true (RF fires = metastatic): next_step: 6 (BRCA mutation gate)
+    if_false (RF doesn't fire = early stage): IND-BREAST-TNBC-EARLY-NEOADJUVANT
+
+  Locally recurrent unresectable disease is treated with metastatic-intent
+  therapy and is included in the stage IV / distant metastasis definition
+  for this routing purpose.
+
+  Note: Recheck `disease_extent` finding key naming convention against KB
+  engine vocabulary when available. ESMO-BREAST-METASTATIC-2024 source
+  (`SRC-ESMO-BREAST-METASTATIC-2024`) may need ID verification.
+
+  CHARTER §6.1: Two-reviewer clinical co-lead signoff required before
+  removing draft: true.

--- a/knowledge_base/hosted/content/redflags/rf_breast_tnbc.yaml
+++ b/knowledge_base/hosted/content/redflags/rf_breast_tnbc.yaml
@@ -1,0 +1,125 @@
+id: RF-BREAST-TNBC
+definition: >
+  Triple-negative breast cancer (TNBC): estrogen receptor (ER) <1% nuclear
+  staining on IHC AND progesterone receptor (PR) <1% nuclear staining on IHC
+  AND HER2-negative (IHC 0 or 1+, OR IHC 2+ with ISH non-amplified).
+  TNBC represents ~15-20% of all invasive breast cancers and is defined by
+  the absence of all three hormone/growth-factor receptor targets.
+
+  Clinical significance: TNBC lacks ER, PR, and HER2 targets, precluding
+  endocrine therapy (tamoxifen, aromatase inhibitors) and HER2-directed
+  therapy. Treatment is chemotherapy-based:
+  - Early TNBC: pembrolizumab + neoadjuvant chemotherapy (KEYNOTE-522;
+    Schmid NEJM 2022) — pCR rate 64.8% vs 51.2% with chemo alone, regardless
+    of PD-L1 status. KEYNOTE-522 is the standard-of-care regimen.
+  - Metastatic TNBC (BRCA-WT): pembrolizumab + chemotherapy (KEYNOTE-355)
+    for CPS ≥10; chemotherapy alone (nab-paclitaxel, paclitaxel, or
+    gemcitabine+carboplatin) for CPS <10.
+  - Metastatic TNBC + germline BRCA1/2 mutation: olaparib or talazoparib
+    preferred 1L over chemotherapy (OlympiAD; exploits HRD).
+
+  Fires to route ALGO-BREAST-1L step 3 toward the TNBC track (step 4 stage
+  gate → PARPi or pembro+chemo routing) instead of the HR+/HER2- track
+  (CDK4/6i+AI, step 5).
+
+  The engine sequential check (step 1: HER2+ gate via RF-BREAST-HER2-AMP-
+  ACTIONABLE; step 3: TNBC gate via this RF) means HER2-positive patients
+  are already routed away before step 3 fires. The HER2-negative component
+  of the TNBC definition is therefore confirmed by the prior sequential
+  filtering, but is included in the trigger for completeness and for use
+  in non-sequential contexts.
+
+definition_ua: >
+  Тричі негативний рак молочної залози (ТНРМЗ): ЕР <1% AND ПР <1%
+  (ядерне забарвлення за ІГХ) AND HER2-негативний (ІГХ 0/1+ або ІГХ 2+ з
+  ненмпліфікованим ISH). ~15-20% інвазивного РМЗ. Лікування хіміотерапевтичне:
+  ранній ТНРМЗ — пембролізумаб + неоад'ювантна хіміотерапія (KEYNOTE-522,
+  pCR 64.8%); метастатичний ТНРМЗ + BRCA1/2 — олапариб/талазопариб;
+  CPS ≥10 — пембролізумаб+хіміо (KEYNOTE-355).
+
+trigger:
+  type: receptor_status_composite
+  all_of:
+    - any_of:
+        - finding: er_status
+          value: negative
+        - finding: er_ihc
+          value: negative
+        - finding: er_ihc
+          value: "0%"
+        - finding: er_ihc
+          value: absent
+        - finding: BIO-ESTROGEN-RECEPTOR
+          value: negative
+    - any_of:
+        - finding: pr_status
+          value: negative
+        - finding: pr_ihc
+          value: negative
+        - finding: pr_ihc
+          value: "0%"
+        - finding: pr_ihc
+          value: absent
+        - finding: BIO-PROGESTERONE-RECEPTOR
+          value: negative
+    - any_of:
+        # HER2-negative confirmation (belt-and-suspenders; sequential algo screens HER2+ first)
+        - finding: her2_status
+          value: negative
+        - finding: her2_ihc
+          value: "0"
+        - finding: her2_ihc
+          value: "1+"
+        - finding: her2_ish
+          value: non_amplified
+
+clinical_direction: intensify
+severity: major
+priority: 60
+category: high-risk-biology
+
+branch_targets:
+  ALGO-BREAST-1L: "3"
+
+relevant_diseases:
+  - DIS-BREAST
+
+shifts_algorithm:
+  - ALGO-BREAST-1L
+
+sources:
+  - SRC-NCCN-BREAST-2025
+  - SRC-KEYNOTE522-SCHMID-2022
+  - SRC-KEYNOTE355-CORTES-2020
+
+last_reviewed: "2026-05-08"
+reviewer_signoffs: []
+draft: true
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+
+notes: >
+  W5c RF authoring. Converts free-text `{condition: "ER <1% AND PR <1%
+  (TNBC)"}` in ALGO-BREAST-1L step 3 into a formal RF entity.
+
+  The trigger uses an `all_of` composite with ER-negative, PR-negative,
+  and HER2-negative conditions. Each receptor check uses an `any_of`
+  to accommodate multiple finding key naming conventions (er_status,
+  er_ihc, BIO-ESTROGEN-RECEPTOR).
+
+  In ALGO-BREAST-1L sequential logic, step 1 first gates HER2+ via
+  RF-BREAST-HER2-AMP-ACTIONABLE. Patients reaching step 3 are HER2-negative
+  by definition. The HER2-negative component of this RF is included for
+  standalone use but is not strictly required within the sequential algo.
+
+  KEYNOTE-522 (Schmid NEJM 2022, PMID 35294803): early TNBC pembro+chemo —
+  pCR 64.8% vs 51.2%, regardless of PD-L1; EFS benefit maintained at 5yr.
+  KEYNOTE-355 (Cortes NEJM 2020, PMID 31789049): metastatic TNBC CPS ≥10 —
+  pembro+chemo mPFS 9.7 vs 5.6 mo.
+
+  ER/PR thresholds: ASCO/CAP 2020 guideline: ER or PR positive ≥1%
+  nuclear staining. Values <1% are ER-negative or PR-negative respectively.
+  This RF fires when BOTH ER and PR are below the 1% threshold.
+
+  CHARTER §6.1: Two-reviewer clinical co-lead signoff required before
+  removing draft: true.


### PR DESCRIPTION
## Summary

Rebase of PR #544 (`feat/w5c-rf-breast-tnbc-stage-2026-05-08-1702`) onto current `origin/master`. The original PR had unrelated-histories conflict (no common ancestor with master) so content was cherry-picked onto a fresh master-based branch.

- Add **RF-BREAST-TNBC**: triple-negative status gate (ER<1% AND PR<1% AND HER2-negative)
- Add **RF-BREAST-EARLY-STAGE**: stage I–III gate (non-metastatic, curative intent)
- Add **RF-BREAST-STAGE-IV-METASTATIC**: stage IV gate (distant metastasis present)
- Wire all three RFs into `algo_breast_1l.yaml` steps 2, 3, 4 as primary gates
- Retain legacy finding-based lookups for backward engine compatibility
- Add `IND-BREAST-HER2-POS-MET-2L-TDXD` to `output_indications`
- Add sources: `SRC-KEYNOTE522-SCHMID-2022`, `SRC-KEYNOTE355-CORTES-2020`
- Preserve master's step-5 monarchE/NATALEE adjuvant CDK4/6i wiring (2026-05-09)

Supersedes PR #544.

## Test plan
- [ ] KB validator passes on all 4 changed files
- [ ] `pytest tests/` green
- [ ] `algo_breast_1l.yaml` routes TNBC patients correctly via RF-BREAST-TNBC
- [ ] Stage I–III HER2+ routes to neoadjuvant TCHP via RF-BREAST-EARLY-STAGE
- [ ] Stage IV TNBC routes to BRCA gate (step 6) via RF-BREAST-STAGE-IV-METASTATIC

🤖 Generated with [Claude Code](https://claude.com/claude-code)