### PR TITLE
fix(algos): remove misplaced RF from HNSCC step 1; clarify degenerate steps

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_eatl_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_eatl_1l.yaml
@@ -19,10 +19,14 @@ decision_tree:
       result: IND-EATL-1L-CHOEP-AUTOSCT
     if_false:
       result: IND-EATL-1L-CHOEP-AUTOSCT
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      Degenerate step — single-track algorithm: both branches route to the
+      same default. No RF can change outcome until a second Indication is
+      modeled (e.g. IND-EATL-1L-BV-CHP for CD30+ subtype). Remove step and
+      replace with direct default routing when still single-track.
 
 sources: [SRC-NCCN-BCELL-2025]
-last_reviewed: "2026-04-25"
+last_reviewed: "2026-05-08"
 notes: >
   Single track для 1L EATL. Future: окрема Indication для CD30+ subtype
   (BV-CHP замість CHOEP). Refractory → salvage (ICE + allo-SCT consideration).

--- a/knowledge_base/hosted/content/algorithms/algo_fl_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_fl_2l.yaml
@@ -103,8 +103,12 @@ decision_tree:
   if_false:
     result: IND-FL-3L-MOSUNETUZUMAB
   notes: >
-    Free-text condition without matching disease-scoped RF; engine routes to
-    default. Flag for RF authoring.
+    Degenerate step — both branches route to mosunetuzumab (3L default).
+    Conditions are informational only: patients who failed EZH2-tazemetostat
+    route or are CAR-T-ineligible are correctly captured here. No RF can
+    change outcome at this step; the step functions as a pass-through to the
+    default Indication. Remove when a fourth track (e.g. loncastuximab,
+    glofitamab) creates a meaningful bifurcation.
 
 sources:
 - SRC-GADOLIN-SEHN-2016

--- a/knowledge_base/hosted/content/algorithms/algo_hnscc_rm_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_hnscc_rm_1l.yaml
@@ -42,11 +42,17 @@ decision_tree:
     evaluate:
       any_of:
         - condition: "PD-L1 CPS ≥20 AND no rapid progression / visceral crisis AND ECOG 0-2"
-        - red_flag: RF-HNSCC-TRANSFORMATION-PROGRESSION
     if_true:
       result: IND-HNSCC-RM-1L-PEMBRO-MONO-CPS-HIGH
     if_false:
       next_step: 2
+    notes: >
+      RF-HNSCC-TRANSFORMATION-PROGRESSION removed (2026-05-08): it is a
+      hold/critical flag (rapid progression / airway compromise) that
+      CONTRA-indicates pembro-mono, not selects it. Patients with that RF
+      firing should fall through to step 2 (pembro-chemo default) or
+      palliative hold per MDT. Biomarker gate (CPS ≥20 numeric finding
+      lookup via RF-HNSCC-CPS-HIGH) deferred to future RF authoring round.
   - step: 2
     evaluate:
       any_of:
@@ -55,20 +61,24 @@ decision_tree:
       result: IND-HNSCC-RM-1L-PEMBRO-CHEMO
     if_false:
       result: IND-HNSCC-RM-1L-PEMBRO-CHEMO
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      Degenerate step — both branches route to pembro-chemo. CPS <1 is
+      already handled in step 0 (→ EXTREME), so any patient reaching this
+      step has CPS ≥1 and pembro-chemo is the correct default. Remove step
+      when CPS 1-19 vs ≥20 gets a further bifurcating Indication.
 
 sources:
   - SRC-NCCN-HNSCC-2025
   - SRC-EXTREME-VERMORKEN-2008
-last_reviewed: '2026-04-30'
+last_reviewed: '2026-05-08'
 notes: >
-  W5b drift fix (2026-04-30): added step 0 only — CPS<1 → EXTREME via
-  IND-HNSCC-RM-1L-EXTREME. Step 1 + step 2 preserved verbatim per
-  brief's "additive only" gate. The pre-existing notes about the
-  free-text "CPS ≥20" branch and the RF-HNSCC-TRANSFORMATION-PROGRESSION
-  drift documented in `patient_hnscc_cps_high_pembro_mono.json` remain
-  unchanged — that is a separate KB drift to be addressed in a
-  follow-up RF-authoring session, NOT in W5b.
+  W5b drift fix (2026-04-30): added step 0 only — CPS<1 → EXTREME.
+  W5c structural fix (2026-05-08): removed RF-HNSCC-TRANSFORMATION-
+  PROGRESSION from step 1 any_of — it is a hold/critical flag that
+  contra-indicates pembro-mono (rapid progression / airway compromise),
+  not a positive selector for it. CPS-stratum biomarker gate
+  (RF-HNSCC-CPS-HIGH with numeric pdl1_cps ≥20 finding lookup) deferred
+  to future RF authoring round.
   Genotype-driven 1L (HRAS-mutant tipifarnib, NTRK-fusion
   larotrectinib/entrectinib, BRAF V600E dabra+trame) are
   investigational / accelerated and not authored as 1L Indications

--- a/knowledge_base/hosted/content/algorithms/algo_rcc_metastatic_2l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_rcc_metastatic_2l.yaml
@@ -12,7 +12,12 @@ decision_tree:
         - {condition: "Prior PD-(L)1 + VEGF-TKI failure"}
     if_true: {result: IND-RCC-METASTATIC-2L-BELZUTIFAN}
     if_false: {result: IND-RCC-METASTATIC-2L-BELZUTIFAN}  # default — algorithm only fires post-1L
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      Degenerate step — single-track algorithm: both branches route to
+      belzutifan. Condition is informational only (prior PD-(L)1 + VEGF-TKI
+      failure is the entry criterion for this algo, not a bifurcating gate).
+      No RF can change outcome until ≥2 Indications are wired (cabozantinib,
+      lenvatinib + everolimus, tivozanib). Remove step when second track added.
 sources: [SRC-NCCN-KIDNEY-2025, SRC-ESMO-RCC-2024]
 last_reviewed: "2026-04-26"
 notes: >

--- a/knowledge_base/hosted/content/algorithms/algo_t_all_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_t_all_1l.yaml
@@ -20,10 +20,14 @@ decision_tree:
       result: IND-T-ALL-1L-HYPER-CVAD
     if_false:
       result: IND-T-ALL-1L-HYPER-CVAD
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      Degenerate step — single-track algorithm: both branches route to the
+      same default. No RF can change outcome until IND-T-ALL-1L-PEDIATRIC-
+      INSPIRED (AYA) or IND-T-ALL-1L-ETP-ALLOSCT (ETP-ALL variant) is
+      modeled as a second Indication.
 
 sources: [SRC-NCCN-BCELL-2025]
-last_reviewed: "2026-04-25"
+last_reviewed: "2026-05-08"
 notes: >
   Single-track для T-ALL 1L поки що — варіант choice (pediatric-inspired
   vs Hyper-CVAD) ще не модельований як окрема Indication. Future:

--- a/knowledge_base/hosted/content/algorithms/algo_t_pll_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_t_pll_1l.yaml
@@ -20,10 +20,14 @@ decision_tree:
       result: IND-T-PLL-1L-ALEMTUZUMAB
     if_false:
       result: IND-T-PLL-1L-ALEMTUZUMAB
-    notes: "Free-text condition without matching disease-scoped RF; engine routes to default. Flag for RF authoring."
+    notes: >
+      Degenerate step — single-track algorithm: both branches route to the
+      same default (alemtuzumab). No RF can change outcome until a second
+      Indication is modeled (e.g. venetoclax-based salvage, or
+      pentostatin-based alternative for alemtuzumab-intolerant).
 
 sources: [SRC-NCCN-BCELL-2025]
-last_reviewed: "2026-04-25"
+last_reviewed: "2026-05-08"
 notes: >
   Single track — T-PLL refractory до conventional chemo; alemtuzumab —
   disease-defining. Refer до tertiary center.


### PR DESCRIPTION
## Summary

Rebase of PR #548 (`feat/algo-degenerate-cleanup-2026-05-08-1900`) onto current `origin/master`. The original PR had unrelated-histories conflict (no common ancestor with master) so content was cherry-picked onto a fresh master-based branch.

- **`algo_hnscc_rm_1l.yaml`**: Remove `RF-HNSCC-TRANSFORMATION-PROGRESSION` from step 1 `any_of` — this is a hold/critical flag that **contra-indicates** pembro-mono (rapid progression / airway compromise), not selects it. Patients with that RF should fall to pembro-chemo or MDT palliative hold.
- **5 single-track algos** (`algo_eatl_1l`, `algo_fl_2l` step 3, `algo_rcc_metastatic_2l`, `algo_t_all_1l`, `algo_t_pll_1l`): Replace generic "Free-text condition … Flag for RF authoring" notes with explicit degenerate-step explanations (why both branches route to the same default, and what would need to change to create a bifurcation).

Supersedes PR #548.

## Test plan
- [ ] KB validator passes on all 6 changed files
- [ ] `pytest tests/` green
- [ ] HNSCC step 1: patients with RF-HNSCC-TRANSFORMATION-PROGRESSION no longer route to pembro-mono (they fall to step 2 / pembro-chemo default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)