### PR TITLE
fix(heme): FL-2L AUGMENT ORR/CR confirmed + GADOLIN paywall note

### DIFF
--- a/knowledge_base/hosted/content/indications/ind_fl_2l_obg_benda.yaml
+++ b/knowledge_base/hosted/content/indications/ind_fl_2l_obg_benda.yaml
@@ -92,9 +92,16 @@ reviewers: []
 reviewer_signoffs: []
 notes: >
   STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1). Standard-track 2L
-  for rituximab-refractory FL. GADOLIN (Sehn 2016 Lancet Oncol, PMID 27345636).
-  OBG+B induction × 6 → OBG maintenance 1000 mg IV q2mo × 2yr. Primary PFS
-  and OS data per citations (PFS HR 0.55 abstract-verified). ORR/CR values
-  (~77%/~14%) removed pending full-text extraction — not present in
-  PubMed abstract. OBG+B is specifically validated in rituximab-refractory
-  disease; in rituximab-sensitive relapse, BR re-challenge or R² may be preferred.
+  for rituximab-refractory FL. GADOLIN (Sehn 2016 Lancet Oncol, PMID 27345636,
+  DOI 10.1016/S1470-2045(16)30097-3). No PMC ID confirmed — Lancet Oncol full
+  text is paywalled; ORR/CR not present in PubMed abstract.
+
+  OBG+B induction × 6 → OBG maintenance 1000 mg IV q2mo × 2yr.
+  PFS HR 0.55 (95% CI 0.40-0.74; p=0.0001) abstract-verified.
+  OS HR 0.67 per Cheson 2018 update. ORR/CR fields omitted from
+  expected_outcomes pending access to full text or an open-access
+  secondary source (ESMO/NCCN guidelines citing GADOLIN ORR data
+  would qualify). Clinical co-lead should verify before publishing.
+
+  OBG+B is specifically validated in rituximab-refractory disease;
+  in rituximab-sensitive relapse, BR re-challenge or R² may be preferred.

--- a/knowledge_base/hosted/content/indications/ind_fl_2l_r2.yaml
+++ b/knowledge_base/hosted/content/indications/ind_fl_2l_r2.yaml
@@ -24,6 +24,12 @@ expected_outcomes:
   progression_free_survival:
     value: "Median 39.4 mo vs 14.1 mo; HR 0.46 (95% CI 0.34-0.62; p<0.001)"
     source: SRC-AUGMENT-LEONARD-2019
+  overall_response_rate:
+    value: "78% (95% CI 71-83%) R² vs 53% (95% CI 46-61%) R+placebo"
+    source: SRC-AUGMENT-LEONARD-2019
+  complete_response:
+    value: "34% (95% CI 27-41%) R² vs 18% (95% CI 13-25%) R+placebo"
+    source: SRC-AUGMENT-LEONARD-2019
 
 hard_contraindications: []
 
@@ -64,7 +70,9 @@ sources:
     position: supports
     relevant_quote_paraphrase: >
       R² (rituximab+lenalidomide) vs R+placebo in r/r iNHL: PFS HR 0.46
-      (95% CI 0.34-0.62; p<0.001); median PFS 39.4 vs 14.1 mo.
+      (95% CI 0.34-0.62; p<0.001); median PFS 39.4 vs 14.1 mo. ORR 78%
+      (95% CI 71-83%) vs 53% (95% CI 46-61%); CR 34% (95% CI 27-41%) vs
+      18% (95% CI 13-25%). [Full text: Leonard JP et al, JCO 2019, PMC7035866]
   - source_id: SRC-NCCN-BCELL-2025
     position: supports
     relevant_quote_paraphrase: >
@@ -89,10 +97,14 @@ reviewers: []
 reviewer_signoffs: []
 notes: >
   STUB — pending Clinical Co-Lead sign-off (CHARTER §6.1). Aggressive-track
-  chemo-free 2L for r/r FL. AUGMENT (Leonard 2019 JCO, PMID 30897038).
-  R² × 12 cycles q28d. PFS abstract-confirmed (HR 0.46; median 39.4 vs 14.1 mo).
-  ORR/CR values (~78%/~34%) removed pending full-text extraction — JCO
-  full-text returned 403; not present in PubMed abstract. Lenalidomide
-  mandatory REMS pregnancy-prevention program. VTE prophylaxis mandatory.
-  Teratogenicity covered in do_not_do_en — no CI-PREGNANCY-TERATOGEN entity
-  currently modeled.
+  chemo-free 2L for r/r FL. AUGMENT (Leonard 2019 JCO, PMID 30897038,
+  PMC7035866). R² × 12 cycles q28d.
+
+  Outcome data confirmed from AUGMENT full text (PMC7035866):
+  PFS HR 0.46 (95% CI 0.34-0.62; p<0.001); median PFS 39.4 vs 14.1 mo.
+  ORR 78% (95% CI 71-83%) R² vs 53% (95% CI 46-61%) R+placebo (IRC assessment).
+  CR 34% (95% CI 27-41%) R² vs 18% (95% CI 13-25%) R+placebo.
+
+  Lenalidomide mandatory REMS pregnancy-prevention program. VTE prophylaxis
+  mandatory. Teratogenicity covered in do_not_do_en — no CI-PREGNANCY-TERATOGEN
+  entity currently modeled.


### PR DESCRIPTION
## Summary

- `IND-FL-2L-R2`: add AUGMENT full-text-confirmed ORR/CR outcome data (ORR 78% vs 53%, CR 34% vs 18%; PMC7035866; IRC-assessed)
- `IND-FL-2L-OBG-BENDA`: update notes with GADOLIN DOI + paywall note (Lancet Oncol 2016 full text paywalled; ORR/CR not in abstract)

## Context

Supersedes #539. Original branch `chunk/fl2l-gadolin-augment-2026-05-09` had an unrelated-histories conflict with master. Content cherry-picked onto `origin/master` (89ff394dc). Sources, regimens, and algo files were already in master; only the 2 indication updates (from the final 2 commits of #539) are applied here.

## Test plan

- [ ] Validate Knowledge Base CI passes
- [ ] `ind_fl_2l_r2.yaml`: confirm `expected_outcomes` has `overall_response_rate` and `complete_response` fields with PMC7035866 source
- [ ] `ind_fl_2l_obg_benda.yaml`: confirm notes include DOI 10.1016/S1470-2045(16)30097-3 and paywall note

🤖 Generated with [Claude Code](https://claude.com/claude-code)