### PR TITLE
feat(kb): HEME-1 MM-1L TI-NDMM — D-Rd+Rd two-plan pair (MAIA)

### DIFF
--- a/knowledge_base/hosted/content/algorithms/algo_mm_1l.yaml
+++ b/knowledge_base/hosted/content/algorithms/algo_mm_1l.yaml
@@ -3,14 +3,19 @@ applicable_to_disease: DIS-MM
 applicable_to_line_of_therapy: 1
 purpose: >
   Select default + alternative Indication for first-line multiple myeloma based
-  on cytogenetic risk and fitness. Outputs the two-plan pair per CHARTER §2 —
-  D-VRd (preferred for high-risk; also NCCN Cat 1 for standard-risk post-PERSEUS
-  Sonneveld NEJM 2024 PFS HR 0.42) vs VRd (standard-risk default where D-VRd
-  access/funding is unavailable). High-risk always routes to D-VRd.
+  on transplant eligibility, cytogenetic risk, and fitness. Outputs two-plan pair
+  per CHARTER §2. Transplant-eligible (TE): VRd (standard) vs D-VRd+ASCT
+  (aggressive, PERSEUS HR 0.42). Transplant-ineligible (TI): Rd continuous
+  (standard, MAIA control) vs D-Rd (aggressive, MAIA HR 0.56). Routing between
+  TE and TI cohorts is determined by applicable_to.demographic_constraints.fit_for_transplant
+  on each Indication entity — the decision tree below governs regimen selection
+  within the TE cohort; TI cohort routing support pending engine transplant-gate.
 
 output_indications:
 - IND-MM-1L-VRD
 - IND-MM-1L-DVRD
+- IND-MM-1L-RD
+- IND-MM-1L-DARA-RD
 default_indication: IND-MM-1L-VRD
 alternative_indication: IND-MM-1L-DVRD
 decision_tree:
@@ -51,5 +56,34 @@ sources:
 - SRC-ESMO-MM-2023
 - SRC-PERSEUS-SONNEVELD-2024
 - SRC-GRIFFIN-VOORHEES-2020
+- SRC-MAIA-FACON-2019
 last_reviewed: '2026-05-09'
-notes: "Cytogenetic risk + aggressive biology are the primary regimen determinants; frailty is recorded but doesn't switch regimen (handled at Regimen dose-modification layer). Transplant eligibility is a downstream consideration that affects total cycle count and post- induction pathway (ASCT + consolidation + maintenance vs continuous induction-then-maintenance), but not the induction regimen choice. Both Indications carry CI-LENALIDOMIDE-PREGNANCY and CI-BORTEZOMIB-SEVERE-NEUROPATHY; D-VRd additionally carries CI-HBV-NO-PROPHYLAXIS. RF-MM-RENAL-DYSFUNCTION (investigate) triggers dose adjustment but does not shift regimen choice. RF-MM-INFECTION-SCREENING (hold) operates via parallel SUP-HBV-PROPHYLAXIS, not a decision-tree branch.\nEtiology rails (parallel to indication selection):\n- HBV (HBsAg+ OR anti-HBc+) — entecavir 0.5 mg PO daily before first\n  daratumumab or isatuximab dose, continued through induction +\n  ≥12 months post-last-anti-CD38. Anti-CD38 mAbs have documented HBV\n  reactivation risk (FDA labels; NCCN MM 2.2025). For VRd-only (no\n  anti-CD38), HBV reactivation risk is lower but entecavir still\n  recommended in HBsAg+ on prolonged steroid pulse. CI-HBV-NO-\n  PROPHYLAXIS (extended 2026-04-27 to cover daratumumab) is a hard\n  contraindication on D-VRd, blocking plan finalization until\n  SUP-HBV-PROPHYLAXIS is acknowledged.\n\n- HCV — Less common in MM cohort; treat MM first and coordinate DAA\n  timing with hepatologist. Avoid sofosbuvir + amiodarone interaction.\n\nHIV+ MM is rare (older population, typically post-PCP / post-PJP era); manage per ART-aware MM consensus (continue ART, prefer integrase- inhibitor backbone, no empiric VRd dose-reduction). BIO-HBV-STATUS, BIO-HCV-STATUS, BIO-HIV-STATUS missing — flagged for future round.\n"
+notes: >
+  Cytogenetic risk + aggressive biology are the primary regimen determinants
+  within each transplant-eligibility cohort. Frailty is recorded but doesn't
+  switch regimen (handled at Regimen dose-modification layer).
+
+  Transplant-eligibility gate: IND-MM-1L-VRD and IND-MM-1L-DVRD have
+  fit_for_transplant: true; IND-MM-1L-RD and IND-MM-1L-DARA-RD have
+  fit_for_transplant: false. The engine should apply this demographic gate
+  before running the decision tree. Until the engine supports
+  applicable_to.demographic_constraints routing, the decision tree outputs
+  TE indications by default. TI cohort: D-Rd (MAIA, Facon NEJM 2019, HR
+  0.56) as aggressive plan; Rd continuous as standard plan.
+
+  Both TE Indications carry CI-LENALIDOMIDE-PREGNANCY and CI-BORTEZOMIB-
+  SEVERE-NEUROPATHY; D-VRd and D-Rd additionally carry CI-HBV-NO-PROPHYLAXIS.
+  RF-MM-RENAL-DYSFUNCTION (investigate) triggers dose adjustment but does
+  not shift regimen choice. RF-MM-INFECTION-SCREENING (hold) operates via
+  parallel SUP-HBV-PROPHYLAXIS, not a decision-tree branch.
+
+  Etiology rails (parallel to indication selection):
+  - HBV (HBsAg+ OR anti-HBc+) — entecavir 0.5 mg PO daily before first
+    daratumumab dose, continued through therapy + ≥12 months post-last-anti-CD38.
+    Anti-CD38 mAbs have documented HBV reactivation risk (FDA labels; NCCN
+    MM 2.2025). CI-HBV-NO-PROPHYLAXIS is a hard contraindication on D-VRd
+    and D-Rd, blocking plan finalization until SUP-HBV-PROPHYLAXIS acknowledged.
+  - HCV — Less common in MM cohort; treat MM first and coordinate DAA timing
+    with hepatologist.
+  - HIV+ MM is rare; manage per ART-aware MM consensus (continue ART, prefer
+    integrase-inhibitor backbone). BIO-HIV-STATUS flagged for future wave.

--- a/knowledge_base/hosted/content/drugs/lomustine.yaml
+++ b/knowledge_base/hosted/content/drugs/lomustine.yaml
@@ -24,6 +24,19 @@ black_box_warnings:
 
 absolute_contraindications: []
 
+regulatory_status:
+  ukraine_registration:
+    registered: false
+    registration_number: null
+    reimbursed_nszu: false
+    reimbursement_indications: []
+    last_verified: "2026-05-09"
+    notes: >
+      Lomustine (CCNU) not currently registered or reimbursed in Ukraine.
+      PCV chemotherapy is rarely administered in Ukraine; lomustine typically
+      requires compassionate-use import if needed for REG-RT-PCV-LGG.
+      Named-patient import or cross-border procurement required.
+
 last_reviewed: "2026-05-08"
 review_status: stub
 drafted_by: claude_extraction

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_dara_rd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_dara_rd.yaml
@@ -1,0 +1,157 @@
+id: IND-MM-1L-DARA-RD
+plan_track: aggressive
+
+applicable_to:
+  disease_id: DIS-MM
+  line_of_therapy: 1
+  stage_requirements: []
+  biomarker_requirements_required:
+    - biomarker_id: BIO-HBV-STATUS
+      required: true
+      value_constraint: "any value valid (categorical etiology gate; HBsAg+ or anti-HBc+ → entecavir prophylaxis mandatory before first daratumumab dose; anti-CD38 class effect — fulminant reactivation reported)"
+    - biomarker_id: BIO-HCV-STATUS
+      required: true
+      value_constraint: "any value valid (categorical etiology gate; anti-HCV+ → reflex BIO-HCV-RNA; coordinate DAA with hepatology)"
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+    fit_for_transplant: false
+
+recommended_regimen: REG-D-RD-MAIA
+phases: []
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~93% (MAIA D-Rd arm; vs ~76% Rd control, P<0.001)"
+  complete_response: "~48% ≥VGPR post-induction; ~24% sCR/CR (MAIA 30-month update)"
+  progression_free_survival: "30-month PFS ~53% (D-Rd); HR 0.56 (95% CI 0.43–0.73) vs Rd alone (MAIA)"
+  overall_survival_5y: "60-month OS ~66.3% D-Rd vs ~53.1% Rd (MAIA 5-yr update, Facon JCO 2024)"
+
+hard_contraindications:
+  - CI-LENALIDOMIDE-PREGNANCY
+  - CI-HBV-NO-PROPHYLAXIS
+red_flags_triggering_alternative:
+  - RF-MM-CORD-COMPRESSION
+  - RF-MM-HYPERCALCEMIA
+  - RF-MM-HYPERVISCOSITY
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-B2-MICROGLOBULIN
+  - TEST-IMMUNOGLOBULINS
+  - TEST-SPEP-UPEP
+  - TEST-FREE-LIGHT-CHAINS
+  - TEST-FISH-PANEL
+  - TEST-BM-ASPIRATE
+  - TEST-BM-TREPHINE
+  - TEST-WHOLE-BODY-MRI
+  - TEST-HBV-SEROLOGY
+  - TEST-ECHO
+desired_tests: []
+
+rationale: >
+  Aggressive-plan default for newly-diagnosed transplant-ineligible multiple
+  myeloma (ECOG ≤2, fit_for_transplant: false). The MAIA trial (Facon NEJM
+  2019, PMID 30926586) demonstrated that adding daratumumab to Rd (D-Rd)
+  significantly improves ORR (~93% vs ~76%), PFS (HR 0.56), and OS (5-yr
+  ~66% vs ~53%) vs Rd alone in transplant-ineligible NDMM. D-Rd is given
+  until progression — no transplant, no consolidation phase. Anti-CD38
+  class HBV reactivation risk mandates pre-treatment HBV serology +
+  entecavir prophylaxis if HBsAg+ or anti-HBc+. Red-cell phenotyping
+  before first daratumumab dose is mandatory (anti-CD38 crossmatching
+  interference). НСЗУ reimbursement for daratumumab not currently available
+  in Ukraine — funding pathway must be confirmed before plan announcement.
+
+rationale_ua: >
+  агресивний-plan default for newly-diagnosed непридатний до трансплантації
+  множинна мієлома (ECOG ≤2, fit_for_transplant: false). Дослідження MAIA
+  (Facon NEJM 2019, PMID 30926586) продемонструвало, що додавання
+  даратумумабу до Rd (D-Rd) значно покращує ЗВВ (~93% проти ~76%), ВБП
+  (ВР 0.56) та ЗВ (5-річна ~66% проти ~53%) порівняно з Rd у непридатних
+  до трансплантації пацієнтів. D-Rd призначається до прогресування.
+  HBV реактивація на анти-CD38 — обов'язковий скринінг + ентекавір при
+  HBsAg+ або anti-HBc+. Феротипування еритроцитів перед першою дозою
+  даратумумабу є обов'язковим. НСЗУ не відшкодовує даратумумаб — шлях
+  фінансування має бути підтверджений до оголошення плану.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+sources:
+  - source_id: SRC-MAIA-FACON-2019
+    position: supports
+    relevant_quote_paraphrase: "MAIA: D-Rd vs Rd in transplant-ineligible NDMM; PFS HR 0.56 (95% CI 0.43–0.73); ORR 92.9% vs 75.8%; 30-month PFS 52.9% vs 37.9%; 5-yr OS 66.3% vs 53.1% (Facon JCO 2024 update)"
+  - source_id: SRC-NCCN-MM-2025
+    position: supports
+    relevant_quote_paraphrase: "D-Rd is a Category 1 preferred regimen for transplant-ineligible NDMM; MAIA data support daratumumab addition to Rd backbone"
+
+do_not_do:
+  - "Не призначати daratumumab без попереднього red-cell phenotyping (type and screen) — анти-CD38 інтерферує з прямим Coombs та crossmatching."
+  - "Не починати без HBV скринінгу + entecavir prophylaxis при HBsAg+ або anti-HBc+ — ризик HBV реактивації значно підвищений на анти-CD38."
+  - "Не підтверджувати D-Rd план без верифікованого funding pathway — daratumumab НЕ реімбурсується через НСЗУ; пацієнт повинен бути попереджений до оголошення плану."
+  - "Не пропускати VTE профілактику (aspirin/LMWH) — IMiD-induced VTE ризик не зменшується від додавання даратумумабу."
+  - "Не пропускати HSV/VZV профілактику — даратумумаб додає до immunosuppression леналідоміду."
+  - "Не пропускати PJP профілактику — анти-CD38 + IMiD + steroid = підвищений ризик опортуністичних інфекцій."
+  - "Не розпочинати у жінок репродуктивного віку без двох методів контрацепції (леналідомід — тератоген)."
+  - "Не призначати у transplant-eligible пацієнтів — D-VRd (IND-MM-1L-DVRD) є відповідним планом для придатних до трансплантації."
+  - "Не скорочувати дексаметазон без клінічної підстави у перших 6 циклах — зниження дози стероїду у цей момент може знизити ефективність анти-CD38."
+
+do_not_do_en:
+  - "Do not prescribe daratumumab without prior red-cell phenotyping (type and screen) — anti-CD38 interferes with direct Coombs and crossmatching."
+  - "Do not start without HBV screening + entecavir prophylaxis in HBsAg+ or anti-HBc+ — risk of HBV reactivation significantly elevated on anti-CD38."
+  - "Do not confirm D-Rd plan without verified funding pathway — daratumumab is NOT reimbursed via NSZU; patient must be informed before the plan is announced."
+  - "Do not skip VTE prophylaxis (aspirin/LMWH) — IMiD-induced VTE risk is not reduced by adding daratumumab."
+  - "Do not skip HSV/VZV prophylaxis — daratumumab adds to lenalidomide immunosuppression."
+  - "Do not skip PJP prophylaxis — anti-CD38 + IMiD + steroid = elevated risk of opportunistic infections."
+  - "Do not start in women of reproductive age without two methods of contraception (lenalidomide is teratogenic)."
+  - "Do not use in transplant-eligible patients — D-VRd (IND-MM-1L-DVRD) is the appropriate plan for transplant-eligible patients."
+  - "Do not reduce dexamethasone without clinical indication in first 6 cycles — steroid dose reduction at this point may reduce anti-CD38 efficacy."
+known_controversies:
+  - topic: "D-Rd vs attenuated Rd in frail transplant-ineligible NDMM"
+    positions:
+      - position: "D-Rd for frail patients (IMWG frailty ≥2, age >80) — MAIA frail subgroup analysis suggests PFS benefit maintained; daratumumab adds limited additional toxicity beyond Rd"
+        sources: [SRC-MAIA-FACON-2019, SRC-NCCN-MM-2025]
+      - position: "Attenuated Rd-lite upfront (len 10 mg, dex 20 mg weekly) — reduce toxicity in frailest patients; standard D-Rd doses may cause excess cytopenias/infections in IMWG frailty ≥2"
+        sources: [SRC-NCCN-MM-2025]
+    our_default: "D-Rd with standard doses per MAIA; attenuate len/dex per dose_adjustment rules if IMWG frailty ≥2 or age >75"
+  - topic: "D-VRd continuous (no ASCT) vs D-Rd for transplant-ineligible NDMM"
+    positions:
+      - position: "D-Rd (MAIA) — NCCN Cat 1; prospective RCT data; favourable toxicity profile in older/frail patients; no bortezomib neuropathy"
+        sources: [SRC-MAIA-FACON-2019, SRC-NCCN-MM-2025]
+      - position: "D-VRd continuous (GRIFFIN-style 6+ cycles without ASCT) — higher MRD-negativity rate but no RCT vs D-Rd; bortezomib adds neuropathy risk in older TI population"
+        sources: [SRC-NCCN-MM-2025]
+    our_default: "D-Rd (MAIA) as the TI-NDMM aggressive plan; D-VRd-continuous not recommended outside clinical trial for TI patients given neuropathy burden"
+
+time_critical: false  # outpatient cancer planning, not time-critical (FDA non-device CDS criterion 4)
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: 0
+notes: >
+  STUB — requires clinical co-lead signoff before publication. Aggressive
+  counterpart to IND-MM-1L-RD for two-plan output in transplant-ineligible
+  NDMM (CHARTER §2). Major access constraint in Ukraine: daratumumab is
+  not currently НСЗУ-reimbursed — funding pathway (clinical trial /
+  charitable / out-of-pocket) MUST be confirmed BEFORE this Plan is
+  finalized. Red-cell phenotyping (type and screen) BEFORE first
+  daratumumab dose is mandatory due to anti-CD38 interference with
+  crossmatching.
+
+  MAIA trial (Facon NEJM 2019, PMID 30926586): 737 transplant-ineligible
+  NDMM patients randomized D-Rd vs Rd. Primary endpoint PFS: HR 0.56
+  (95% CI 0.43–0.73), p<0.001. 5-year OS update (Facon JCO 2024):
+  66.3% vs 53.1% (HR 0.66, p<0.0001) — first OS benefit for an anti-CD38
+  doublet addition in TI-NDMM.
+
+  Scope gate: fit_for_transplant: false restricts IND-MM-1L-DARA-RD to
+  transplant-ineligible patients. For transplant-eligible aggressive-plan
+  patients, see IND-MM-1L-DVRD (D-VRd + ASCT + dara-len maintenance).
+
+  Treatment is continuous until progression or unacceptable toxicity —
+  no fixed-duration transplant pathway. No phases block needed (single
+  continuous regimen, no ASCT step).

--- a/knowledge_base/hosted/content/indications/ind_mm_1l_rd.yaml
+++ b/knowledge_base/hosted/content/indications/ind_mm_1l_rd.yaml
@@ -1,0 +1,124 @@
+id: IND-MM-1L-RD
+plan_track: standard
+
+applicable_to:
+  disease_id: DIS-MM
+  line_of_therapy: 1
+  stage_requirements: []
+  biomarker_requirements_required: []
+  biomarker_requirements_excluded: []
+  demographic_constraints:
+    ecog_max: 2
+    fit_for_transplant: false
+
+recommended_regimen: REG-RD-CONTINUOUS
+phases: []
+concurrent_therapy: []
+followed_by: []
+
+evidence_level: high
+strength_of_recommendation: strong
+nccn_category: "1"
+
+expected_outcomes:
+  overall_response_rate: "~76% (MAIA Rd control arm; Facon NEJM 2019)"
+  complete_response: "~34% ≥VGPR; ~9% sCR/CR (MAIA Rd arm 30-month update)"
+  progression_free_survival: "30-month PFS ~38% (Rd alone, MAIA control); median PFS ~31.9 months"
+  overall_survival_5y: "~53% (MAIA Rd 5-yr update, Facon JCO 2024)"
+
+hard_contraindications:
+  - CI-LENALIDOMIDE-PREGNANCY
+red_flags_triggering_alternative:
+  - RF-MM-CORD-COMPRESSION
+  - RF-MM-HYPERCALCEMIA
+  - RF-MM-HYPERVISCOSITY
+
+required_tests:
+  - TEST-CBC
+  - TEST-CMP
+  - TEST-LFT
+  - TEST-LDH
+  - TEST-B2-MICROGLOBULIN
+  - TEST-IMMUNOGLOBULINS
+  - TEST-SPEP-UPEP
+  - TEST-FREE-LIGHT-CHAINS
+  - TEST-FISH-PANEL
+  - TEST-BM-ASPIRATE
+  - TEST-BM-TREPHINE
+  - TEST-WHOLE-BODY-MRI
+  - TEST-HBV-SEROLOGY
+desired_tests: []
+
+rationale: >
+  Standard-plan default for newly-diagnosed transplant-ineligible multiple
+  myeloma (ECOG ≤2, fit_for_transplant: false) when daratumumab funding
+  is unavailable or patient is not a candidate for anti-CD38 therapy.
+  Rd continuous (lenalidomide 25 mg d1-21 + dexamethasone 40 mg weekly,
+  28-day cycles until progression) was established by the MAIA control
+  arm (Facon NEJM 2019) and the FIRST trial (Benboubker NEJM 2014) as
+  the standard-access backbone for TI-NDMM. ORR ~76%, 30-month PFS ~38%.
+  No HBV prophylaxis required for Rd (no anti-CD38), but HBV serology
+  still recommended per NCCN given immunosuppression from IMiD+steroid.
+  No red-cell phenotyping required (no daratumumab).
+
+rationale_ua: >
+  стандарт-plan default for newly-diagnosed непридатний до трансплантації
+  множинна мієлома (ECOG ≤2, fit_for_transplant: false) коли фінансування
+  даратумумабу недоступне або пацієнт не є кандидатом на анти-CD38 терапію.
+  Rd безперервно (леналідомід 25 мг д1-21 + дексаметазон 40 мг щотижня,
+  28-денні цикли до прогресування) встановлений дослідженнями MAIA (Facon
+  NEJM 2019) та FIRST (Benboubker NEJM 2014) як стандартний доступний
+  режим для непридатних до трансплантації НДММ. ЗВВ ~76%, 30-місячна ВБП
+  ~38%. Схема повністю фінансується через НСЗУ — є стандартом доступу в
+  Україні при недоступності даратумумабу.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction
+sources:
+  - source_id: SRC-MAIA-FACON-2019
+    position: supports
+    relevant_quote_paraphrase: "MAIA Rd control arm: ORR 75.8%, 30-month PFS 37.9%, 5-yr OS 53.1%; establishes Rd continuous as TI-NDMM standard backbone"
+  - source_id: SRC-NCCN-MM-2025
+    position: supports
+    relevant_quote_paraphrase: "Rd continuous is a Category 1 preferred regimen for transplant-ineligible NDMM; standard-access option where anti-CD38 funding is unavailable"
+
+do_not_do:
+  - "Не пропускати VTE профілактику (aspirin 81-100 mg або LMWH) — ризик тромбозу на леналідоміді 10-20% без профілактики."
+  - "Не пропускати HSV/VZV профілактику (acyclovir 400 mg BID) — IMiD + steroid підвищують ризик оперізуючого герпесу."
+  - "Не починати у жінок репродуктивного віку без підтверджених двох методів контрацепції + негативного тесту на вагітність (леналідомід — тератоген)."
+  - "Не пропускати редукцію дози леналідоміду при CrCl 30-60 mL/min (10 mg) — повна доза значно токсична при нирковій недостатності."
+  - "Не призначати zoledronate без попередньої стоматологічної оцінки — ризик osteonecrosis of the jaw."
+  - "Не використовувати IND-MM-1L-RD якщо daratumumab фінансується — агресивний план (IND-MM-1L-DARA-RD) має кращі результати виживаності."
+
+do_not_do_en:
+  - "Do not skip VTE prophylaxis (aspirin 81-100 mg or LMWH) — IMiD-induced VTE risk 10-20% without prophylaxis."
+  - "Do not skip HSV/VZV prophylaxis (acyclovir 400 mg BID) — IMiD + steroid elevates herpes zoster reactivation risk."
+  - "Do not start in women of reproductive age without two methods of contraception + negative pregnancy test (lenalidomide is teratogenic)."
+  - "Do not skip lenalidomide dose reduction at CrCl 30-60 mL/min (use 10 mg) — full dose significantly toxic in renal impairment."
+  - "Do not prescribe zoledronate without prior dental evaluation — osteonecrosis of the jaw risk."
+  - "Do not use IND-MM-1L-RD if daratumumab is funded — aggressive plan (IND-MM-1L-DARA-RD) has superior survival outcomes."
+known_controversies: []
+
+time_critical: false  # outpatient cancer planning, not time-critical (FDA non-device CDS criterion 4)
+last_reviewed: "2026-05-09"
+reviewers: []
+reviewer_signoffs: 0
+notes: >
+  STUB — requires clinical co-lead signoff before publication. Standard
+  counterpart to IND-MM-1L-DARA-RD for two-plan output in transplant-
+  ineligible NDMM (CHARTER §2). Rd continuous is the standard-access
+  option when daratumumab funding is unavailable (common in Ukraine
+  where НСЗУ does not currently reimburse daratumumab).
+
+  MAIA trial context (Facon NEJM 2019, PMID 30926586): this indication
+  represents the control arm — Rd alone. D-Rd improved PFS HR 0.56 and
+  5-yr OS HR 0.66 vs Rd. In a well-resourced setting, D-Rd is preferred;
+  Rd is the fallback when daratumumab is inaccessible.
+
+  FIRST trial (Benboubker NEJM 2014, PMID 25184863): Rd continuous vs
+  Rd18 (18 cycles fixed) vs MPT — Rd continuous showed superior PFS
+  (26 months) vs MPT (21.9 months). Established the "until progression"
+  strategy.
+
+  Scope gate: fit_for_transplant: false restricts IND-MM-1L-RD to
+  transplant-ineligible patients. For transplant-eligible standard-plan
+  patients, see IND-MM-1L-VRD (VRd backbone + ASCT pathway).

--- a/knowledge_base/hosted/content/regimens/reg_rd_continuous.yaml
+++ b/knowledge_base/hosted/content/regimens/reg_rd_continuous.yaml
@@ -1,0 +1,128 @@
+id: REG-RD-CONTINUOUS
+name: "Lenalidomide + Dexamethasone continuous (Rd, MAIA control arm — MM 1L transplant-ineligible)"
+name_ua: "Леналідомід + Дексаметазон безперервно (Rd, контрольна група MAIA — MM 1Л непридатні до трансплантації)"
+alternate_names:
+  - "Rd continuous"
+  - "Len-Dex"
+  - "Lenalidomide-Dex until progression"
+  - "MAIA control arm"
+  - "CALGB 100104 backbone"
+
+# MAIA control arm (Facon NEJM 2019, PMID 30926586):
+# Lenalidomide 25 mg PO days 1-21 + dexamethasone 40 mg PO weekly, 28-day cycles
+# until progression. Standard-of-care triplet-ineligible or access-limited option.
+components:
+  - drug_id: DRUG-LENALIDOMIDE
+    dose: "25 mg PO daily (10 mg if CrCl 30-60 mL/min)"
+    schedule: "Days 1-21 of each 28-day cycle; continuous until progression"
+    route: PO
+  - drug_id: DRUG-DEXAMETHASONE
+    dose: "40 mg PO weekly (20 mg if age >75 or frail)"
+    schedule: "Days 1, 8, 15, 22 of each 28-day cycle"
+    route: PO
+
+cycle_length_days: 28
+total_cycles: "Continuous until progression or unacceptable toxicity"
+toxicity_profile: low-moderate
+
+premedication:
+  - "Acyclovir 400 mg PO BID (HSV/VZV prophylaxis per NCCN MM)"
+  - "Aspirin 81-100 mg PO daily for VTE prophylaxis (IMiD class); LMWH if prior VTE or high-risk profile"
+  - "Confirm two reliable contraceptive methods (women of reproductive potential) — REMS/iPLEDGE-equivalent required for lenalidomide"
+
+mandatory_supportive_care:
+  - SUP-MM-VTE-PROPHYLAXIS
+  - SUP-MM-BONE-PROTECTION
+
+monitoring_schedule_id: MON-VRD-REGIMEN
+
+dose_adjustments:
+  - condition: "CrCl 30-60 mL/min"
+    modification: "Lenalidomide 10 mg daily; dexamethasone unchanged"
+    rationale: "Lenalidomide ~80% renally cleared; dose-interval extension recommended"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "CrCl <30 mL/min (no dialysis)"
+    modification: "Lenalidomide 5 mg daily or 10 mg every other day; reassess if <15 mL/min"
+    rationale: "Major lenalidomide exposure increase"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "Age >75 OR frail (IMWG frailty ≥2)"
+    modification: "Dexamethasone 20 mg weekly; consider lenalidomide 15 mg starting dose"
+    rationale: "Frail patients have increased steroid toxicity (infections, delirium, hyperglycemia)"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "ANC <1000 OR platelets <50K"
+    modification: "Hold lenalidomide; resume at 20 mg → 15 mg → 10 mg → 5 mg on recovery"
+    rationale: "Cumulative lenalidomide myelosuppression; dose ladder per NCCN"
+    source_refs: [SRC-NCCN-MM-2025]
+  - condition: "Grade ≥3 rash"
+    modification: "Withhold lenalidomide; systemic corticosteroids; resume at next-lower dose if resolves ≤Grade 1"
+    rationale: "Lenalidomide dermatological toxicity (Stevens-Johnson rarely)"
+    source_refs: [SRC-NCCN-MM-2025]
+
+ukraine_availability:
+  all_components_registered: true
+  all_components_reimbursed: true
+  notes: >
+    Lenalidomide reimbursed via НСЗУ for myeloma. Dexamethasone widely
+    available. Rd is the standard-access backbone for transplant-ineligible
+    NDMM in Ukraine when daratumumab funding is unavailable.
+
+between_visit_watchpoints:
+  - trigger_ua: "Втома або слабкість під час леналідоміду"
+    action_ua: "Часто зустрічається — занотовуйте; не зупиняйте без консультації"
+    urgency: log_at_next_visit
+    sources:
+      - SRC-NCCN-MM-2025
+  - trigger_ua: "Біль або набряк в одній нозі"
+    action_ua: "Подзвоніть у клініку того ж дня — леналідомід підвищує ризик тромбозу; антикоагулянти призначаються профілактично"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-NCCN-MM-2025
+      - SRC-CTCAE-V5
+  - trigger_ua: "Лихоманка вище 38°C"
+    action_ua: "Подзвоніть у клініку того ж дня — можлива нейтропенія або інфекція"
+    urgency: call_clinic_same_day
+    sources:
+      - SRC-CTCAE-V5
+  - trigger_ua: "Раптова задишка, біль у грудях або кровохаркання"
+    action_ua: "Звертайтесь у лікарню негайно — можлива легенева тромбоемболія"
+    urgency: er_now
+    sources:
+      - SRC-NCCN-MM-2025
+
+sources:
+  - SRC-MAIA-FACON-2019
+  - SRC-NCCN-MM-2025
+
+last_reviewed: "2026-05-09"
+notes: >
+  Rd continuous (lenalidomide + low-dose dexamethasone until progression)
+  was the MAIA control arm (Facon NEJM 2019, PMID 30926586) and represents
+  the standard-access first-line regimen for transplant-ineligible NDMM.
+  MAIA control arm outcomes: ORR 75.8%, PFS HR (D-Rd vs Rd) 0.56 (95% CI
+  0.43–0.73), 30-month PFS ~53.3% for D-Rd vs ~37.8% for Rd.
+
+  Rd continuous showed superiority over MPT and melphalan-prednisone in the
+  FIRST trial (Benboubker NEJM 2014, PMID 25184863): PFS 26 months vs 21.9
+  months for MPT.
+
+  Dose of dexamethasone: low-dose (40 mg weekly = "Ld schedule") is
+  preferred over high-dose (480 mg/cycle); ECOG E4A03 showed equivalent
+  efficacy and better tolerability with low-dose dex in NDMM (Rajkumar
+  LANCET ONCOL 2010).
+
+  Renal adjustment is critical: lenalidomide is ~80% renally cleared.
+  CrCl 30-60 → 10 mg daily; CrCl <30 → 5 mg daily or 10 mg qod.
+  Myeloma renal impairment often improves with therapy — recheck CrCl
+  monthly and escalate dose when GFR recovers.
+
+  Second primary malignancy (SPM) risk: CALGB 100104 and IFM 2005-02
+  documented elevated SPM (MDS/AML) with lenalidomide maintenance
+  post-ASCT; risk applies to continuous Rd as well at smaller magnitude.
+  Must be included in informed consent discussion.
+notes_ua: >
+  Rd безперервно (леналідомід + низькодозовий дексаметазон до прогресування)
+  була контрольною групою у дослідженні MAIA (Facon NEJM 2019, PMID 30926586)
+  і є стандартною схемою першої лінії для непридатних до трансплантації пацієнтів
+  з НДММ. Схема фінансується через НСЗУ — є стандартом доступу в Україні.
+ukrainian_review_status: pending_clinical_signoff
+ukrainian_drafted_by: claude_extraction


### PR DESCRIPTION
## Summary

- Add `IND-MM-1L-DARA-RD`: D-Rd aggressive-track 1L transplant-ineligible NDMM (MAIA trial, Facon NEJM 2019, PFS HR 0.56)
- Add `IND-MM-1L-RD`: Rd continuous standard-track 1L TI-NDMM
- Add `REG-RD-CONTINUOUS`: Rd continuous regimen schedule
- Update `ALGO-MM-1L`: add TI indications to output_indications, update purpose + notes + sources (SRC-MAIA-FACON-2019)
- Update `lomustine.yaml`: add ukraine_registration block (not registered/reimbursed in UA)

## Context

Supersedes #537. Original branch `feat/mm-1l-ti-ndmm` had an unrelated-histories conflict with master. Content cherry-picked onto `origin/master` (89ff394dc). Schema fixes from commit `898a9cb67` (known_controversies structure in ind_mm_1l_dara_rd + lomustine ukraine_registration) are incorporated in the new files.

## Test plan

- [ ] Validate Knowledge Base CI passes
- [ ] `ind_mm_1l_dara_rd.yaml`: confirm schema validates (known_controversies as list of dicts)
- [ ] `algo_mm_1l.yaml`: confirm `output_indications` has all 4 entries (VRD, DVRD, RD, DARA-RD)
- [ ] `lomustine.yaml`: confirm `regulatory_status.ukraine_registration` block present

🤖 Generated with [Claude Code](https://claude.com/claude-code)