### PR TITLE
fix(style): re-apply mobile/WebView overflow fixes (PR #536 re-land)

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1281,6 +1281,7 @@ body.home-page .home-carousel {
   letter-spacing: 0.4px;
 }
 .qt-label select, .qt-label input, .qt-label textarea {
+  width: 100%; max-width: 100%; min-width: 0;
   font-family: var(--font-sans); font-size: 13px;
   padding: 8px 10px; border: 1px solid var(--gray-200);
   border-radius: 6px; background: white;
@@ -1351,9 +1352,11 @@ body.home-page .home-carousel {
   display: grid; grid-template-columns: 1fr 380px; gap: 18px;
   margin-bottom: 24px; align-items: start;
 }
+.quest-grid > * { min-width: 0; }
 .quest-form-pane {
   background: white; border: 1px solid var(--gray-200);
-  border-radius: 10px; padding: 20px 22px;
+  border-radius: 10px; width: 100%; max-width: 100%; min-width: 0;
+  padding: 20px 22px;
 }
 #jsonPane textarea { width: 100%; font-family: var(--font-mono); }
 .quest-empty {
@@ -1483,7 +1486,7 @@ body.home-page .home-carousel {
   padding: 12px 16px; border-radius: 6px; margin-bottom: 18px;
 }
 .example-lock-banner .elb-text {
-  font-size: 13px; line-height: 1.5; color: var(--gray-700); flex: 1;
+  font-size: 13px; line-height: 1.5; color: var(--gray-700); flex: 1; min-width: 0;
 }
 .example-lock-banner .elb-btn {
   white-space: nowrap; flex-shrink: 0;
@@ -1491,11 +1494,11 @@ body.home-page .home-carousel {
 
 .quest-side {
   position: sticky; top: 20px;
-  display: flex; flex-direction: column; gap: 12px;
+  display: flex; flex-direction: column; gap: 12px; min-width: 0;
 }
 .quest-build-card {
   background: white; border: 1px solid var(--gray-200);
-  border-radius: 8px; padding: 14px 16px;
+  border-radius: 8px; min-width: 0; padding: 14px 16px;
 }
 .build-card-head {
   display: flex; align-items: center; justify-content: space-between;
@@ -1594,6 +1597,81 @@ body.home-page .home-carousel {
 @media (max-width: 760px) {
   .quest-actions-top.quest-cta {
     grid-template-columns: 1fr; padding: 10px;
+  }
+  /* Prevent horizontal overflow in narrow viewports / WebView */
+  .try-page {
+    padding: 20px 0;
+    overflow-x: hidden;
+  }
+  .quest-toolbar {
+    padding: 14px;
+    gap: 10px;
+    margin: 16px 0 14px;
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 0;
+  }
+  .quest-toolbar > .qt-label:nth-of-type(-n+2) {
+    flex: 1 1 100%;
+    min-width: 0;
+    width: 100%;
+  }
+  .qt-label {
+    min-width: 0;
+    width: 100%;
+  }
+  .qt-label select, .qt-label input, .qt-label textarea {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+  }
+  .quest-toolbar > .qt-label:nth-of-type(-n+2) select {
+    font-size: 15px;
+    padding: 10px 12px;
+  }
+  .qt-modes {
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .qt-modes .mode-btn {
+    flex: 1;
+    padding: 8px;
+    font-size: 12px;
+  }
+  .qt-reset {
+    width: 100%;
+    text-align: center;
+    box-sizing: border-box;
+  }
+  .qt-spacer {
+    display: none;
+  }
+  .quest-grid {
+    grid-template-columns: 1fr;
+  }
+  .quest-form-pane {
+    padding: 14px;
+    box-sizing: border-box;
+  }
+  .example-lock-banner {
+    flex-direction: column;
+    gap: 10px;
+  }
+  .example-lock-banner .elb-btn {
+    width: 100%;
+    text-align: center;
+  }
+  .quest-build-card {
+    box-sizing: border-box;
+    padding: 12px;
+  }
+  .plan-modal {
+    padding: 8px;
+  }
+  .plan-modal-card {
+    border-radius: 8px;
+    width: 100%;
+    height: min(96vh, 100%);
   }
 }
 

--- a/scripts/site_styles.py
+++ b/scripts/site_styles.py
@@ -1289,6 +1289,7 @@ body.home-page .home-carousel {
   letter-spacing: 0.4px;
 }
 .qt-label select, .qt-label input, .qt-label textarea {
+  width: 100%; max-width: 100%; min-width: 0;
   font-family: var(--font-sans); font-size: 13px;
   padding: 8px 10px; border: 1px solid var(--gray-200);
   border-radius: 6px; background: white;
@@ -1359,9 +1360,11 @@ body.home-page .home-carousel {
   display: grid; grid-template-columns: 1fr 380px; gap: 18px;
   margin-bottom: 24px; align-items: start;
 }
+.quest-grid > * { min-width: 0; }
 .quest-form-pane {
   background: white; border: 1px solid var(--gray-200);
-  border-radius: 10px; padding: 20px 22px;
+  border-radius: 10px; width: 100%; max-width: 100%; min-width: 0;
+  padding: 20px 22px;
 }
 #jsonPane textarea { width: 100%; font-family: var(--font-mono); }
 .quest-empty {
@@ -1491,7 +1494,7 @@ body.home-page .home-carousel {
   padding: 12px 16px; border-radius: 6px; margin-bottom: 18px;
 }
 .example-lock-banner .elb-text {
-  font-size: 13px; line-height: 1.5; color: var(--gray-700); flex: 1;
+  font-size: 13px; line-height: 1.5; color: var(--gray-700); flex: 1; min-width: 0;
 }
 .example-lock-banner .elb-btn {
   white-space: nowrap; flex-shrink: 0;
@@ -1499,11 +1502,11 @@ body.home-page .home-carousel {
 
 .quest-side {
   position: sticky; top: 20px;
-  display: flex; flex-direction: column; gap: 12px;
+  display: flex; flex-direction: column; gap: 12px; min-width: 0;
 }
 .quest-build-card {
   background: white; border: 1px solid var(--gray-200);
-  border-radius: 8px; padding: 14px 16px;
+  border-radius: 8px; min-width: 0; padding: 14px 16px;
 }
 .build-card-head {
   display: flex; align-items: center; justify-content: space-between;
@@ -1602,6 +1605,81 @@ body.home-page .home-carousel {
 @media (max-width: 760px) {
   .quest-actions-top.quest-cta {
     grid-template-columns: 1fr; padding: 10px;
+  }
+  /* Prevent horizontal overflow in narrow viewports / WebView */
+  .try-page {
+    padding: 20px 0;
+    overflow-x: hidden;
+  }
+  .quest-toolbar {
+    padding: 14px;
+    gap: 10px;
+    margin: 16px 0 14px;
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 0;
+  }
+  .quest-toolbar > .qt-label:nth-of-type(-n+2) {
+    flex: 1 1 100%;
+    min-width: 0;
+    width: 100%;
+  }
+  .qt-label {
+    min-width: 0;
+    width: 100%;
+  }
+  .qt-label select, .qt-label input, .qt-label textarea {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+  }
+  .quest-toolbar > .qt-label:nth-of-type(-n+2) select {
+    font-size: 15px;
+    padding: 10px 12px;
+  }
+  .qt-modes {
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .qt-modes .mode-btn {
+    flex: 1;
+    padding: 8px;
+    font-size: 12px;
+  }
+  .qt-reset {
+    width: 100%;
+    text-align: center;
+    box-sizing: border-box;
+  }
+  .qt-spacer {
+    display: none;
+  }
+  .quest-grid {
+    grid-template-columns: 1fr;
+  }
+  .quest-form-pane {
+    padding: 14px;
+    box-sizing: border-box;
+  }
+  .example-lock-banner {
+    flex-direction: column;
+    gap: 10px;
+  }
+  .example-lock-banner .elb-btn {
+    width: 100%;
+    text-align: center;
+  }
+  .quest-build-card {
+    box-sizing: border-box;
+    padding: 12px;
+  }
+  .plan-modal {
+    padding: 8px;
+  }
+  .plan-modal-card {
+    border-radius: 8px;
+    width: 100%;
+    height: min(96vh, 100%);
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `min-width: 0` to all flex/grid children that can overflow narrow viewports: `.quest-grid > *`, `.quest-form-pane`, `.quest-side`, `.quest-build-card`, `.elb-text`
- Adds `width: 100%; max-width: 100%; min-width: 0` on `.qt-label select/input/textarea` and `.quest-form-pane`
- Expands `@media (max-width: 760px)` with full mobile overrides for `.try-page`, `.quest-toolbar`, `.qt-label`, `.qt-modes`, `.qt-reset`, `.example-lock-banner`, and `.plan-modal`
- Rebuilds `docs/style.css` from `scripts/site_styles.py`

PR #536 (codex/mobile-webview-layout) was closed due to no common git ancestor with master. This re-lands the same mobile overflow fixes cleanly from master.

## Test plan

- [ ] Open `docs/try.html` in a mobile browser / WebView at 360px width — no horizontal scrollbar
- [ ] Toolbar selects and inputs stay within viewport
- [ ] Mode buttons and reset button fill available width on mobile
- [ ] Plan modal uses full screen on narrow viewport
- [ ] Desktop layout (> 760px) unchanged — grid/pane sizes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)