### PR TITLE
chore(devex): pre-commit hook — block stale site builds

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# pre-commit hook: prevent stale site builds from being committed.
+#
+# If scripts/build_site.py or scripts/site_styles.py are staged, the
+# generated docs/ must also be staged (or you must skip with --no-verify,
+# which is banned in this repo per CLAUDE.md).
+#
+# Install:
+#   python scripts/install_hooks.py
+#   OR  cp scripts/hooks/pre-commit .git/hooks/pre-commit
+#
+# The check is advisory-to-blocking: it only fires when site source files
+# change.  All other commits pass through immediately.
+set -euo pipefail
+
+# ── 1. Find staged site-source files ─────────────────────────────────────
+STAGED=$(git diff --cached --name-only 2>/dev/null || true)
+
+SITE_SRC_CHANGED=$(echo "$STAGED" | grep -E \
+    "^scripts/(build_site|site_styles)\.py$" || true)
+
+if [ -z "$SITE_SRC_CHANGED" ]; then
+    exit 0  # No site source changes — nothing to check.
+fi
+
+# ── 2. Check that docs/style.css is also staged ──────────────────────────
+STYLE_STAGED=$(echo "$STAGED" | grep -E "^docs/style\.css$" || true)
+
+if [ -n "$STYLE_STAGED" ]; then
+    exit 0  # style.css is staged — assume a full site rebuild was done.
+fi
+
+# ── 3. Fail with helpful message ─────────────────────────────────────────
+echo ""
+echo "  pre-commit: site source changed, but docs/style.css not staged."
+echo ""
+echo "  Changed site source:"
+echo "$SITE_SRC_CHANGED" | sed 's/^/    /'
+echo ""
+echo "  You must rebuild and stage docs/ before committing:"
+echo "    C:/Python312/python.exe scripts/build_site.py"
+echo "    git add docs/"
+echo ""
+echo "  If you intentionally changed site source without rebuilding"
+echo "  (e.g., docs-only commit), stage a rebuild first, then re-commit."
+echo ""
+exit 1

--- a/scripts/install_hooks.py
+++ b/scripts/install_hooks.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Install git hooks from scripts/hooks/ into .git/hooks/.
+
+Usage:
+    python scripts/install_hooks.py
+
+Run this once after cloning or when hooks are updated.
+"""
+
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).parent.parent
+    hooks_src = repo_root / "scripts" / "hooks"
+
+    # Resolve .git — could be a directory (main worktree) or a file
+    # (linked worktree pointing to the real .git).
+    git_entry = repo_root / ".git"
+    if git_entry.is_file():
+        # Worktree: .git is "gitdir: /path/to/real/.git/worktrees/X"
+        # We want the main .git dir which is two levels up from the worktree dir.
+        gitdir_line = git_entry.read_text(encoding="utf-8").strip()
+        if gitdir_line.startswith("gitdir:"):
+            worktree_gitdir = Path(gitdir_line[len("gitdir:"):].strip())
+            # worktrees/X → two parents up = main .git dir
+            real_git = worktree_gitdir.parent.parent
+        else:
+            real_git = git_entry.parent / ".git"
+    else:
+        real_git = git_entry
+
+    hooks_dst = real_git / "hooks"
+
+    if not hooks_src.is_dir():
+        print(f"No hooks directory found at {hooks_src}", file=sys.stderr)
+        sys.exit(1)
+    if not hooks_dst.is_dir():
+        print(f"Not inside a git repo (no .git/hooks at {hooks_dst})", file=sys.stderr)
+        sys.exit(1)
+
+    installed: list[str] = []
+    skipped: list[str] = []
+
+    for src in sorted(hooks_src.iterdir()):
+        if src.name.endswith((".sample", ".md", ".txt", ".py")):
+            skipped.append(src.name)
+            continue
+        dst = hooks_dst / src.name
+        shutil.copy2(src, dst)
+        # Make executable (required on POSIX; Windows ignores this but it's harmless).
+        dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        installed.append(src.name)
+        print(f"  installed  .git/hooks/{src.name}")
+
+    if not installed:
+        print("No hooks to install.")
+    else:
+        print(f"\n{len(installed)} hook(s) installed.")
+    if skipped:
+        print(f"{len(skipped)} file(s) skipped: {', '.join(skipped)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/hooks/pre-commit` — a bash hook that fires when `scripts/build_site.py` or `scripts/site_styles.py` are staged
- If `docs/style.css` is **not** also staged, the commit is blocked with a reminder to run `build_site.py`
- Adds `scripts/install_hooks.py` — copies hooks from `scripts/hooks/` to `.git/hooks/`, handles linked worktrees (resolves `.git` file pointer)

Prevents the class of bug where CSS source changes are committed without regenerating the site — the root cause of PR #536 going stale.

## Install

```bash
python scripts/install_hooks.py
```

## Test plan

- [x] `python scripts/install_hooks.py` succeeds from both main worktree and linked worktrees
- [x] Commit with only non-site files staged → hook passes immediately
- [x] Commit with `scripts/site_styles.py` staged + `docs/style.css` staged → hook passes
- Manual test: stage `scripts/site_styles.py` without `docs/style.css` → hook blocks with message

🤖 Generated with [Claude Code](https://claude.com/claude-code)