### PR TITLE
feat(clients): NCI PDQ source scaffold — referenced, public domain

### DIFF
--- a/docs/reviews/pdq-license-2026-05-18.md
+++ b/docs/reviews/pdq-license-2026-05-18.md
@@ -1,0 +1,184 @@
+# NCI PDQ license review — 2026-05-18
+
+Per `specs/SOURCE_INGESTION_SPEC.md` §8 (process for adding a new source)
+and §20 (checklist for connecting a hosted source). This review classifies
+the NCI Physician Data Query (PDQ) corpus for OpenOnco reuse.
+
+## TL;DR
+
+- **License class:** US Public Domain (17 U.S.C. §105 — federal-government works).
+- **Hosting mode:** `referenced` (default per `SOURCE_INGESTION_SPEC §1.4`).
+- **All four constraints clear:** commercial use ✓, redistribution ✓, modifications ✓, share-alike NOT required.
+- **Attribution:** not required, but NCI publishes a courtesy attribution string we will use.
+- **One trademark gotcha:** "PDQ®" is a registered trademark of HHS; we may not use it in product naming in a way that implies NCI endorsement.
+- **`legal_review.status: reviewed`** in `src_pdq.yaml`. Re-review triggers documented below.
+
+## What PDQ is
+
+PDQ (Physician Data Query) is the National Cancer Institute's comprehensive,
+peer-reviewed cancer information database. The PDQ Cancer Information
+Summaries Editorial Boards — six expert boards covering adult/pediatric
+treatment, screening, prevention, supportive care, integrative medicine,
+and cancer genetics — author and maintain parallel summaries in two
+registers:
+
+- **Health Professional (HP) version** — full clinical detail, references.
+- **Patient version** — same scope at plain-language reading level.
+
+Summaries are updated continuously as new evidence emerges. Each summary
+carries a `Date Last Modified` field, citable references, and is
+indexed by a CDR (Cancer Data Repository) ID.
+
+PDQ is also available via the NCI Cancer.gov syndication API in JSON
+form for programmatic consumption.
+
+Public-facing URL: <https://www.cancer.gov/publications/pdq>.
+Reuse policy: <https://www.cancer.gov/policies/copyright-reuse>.
+
+## Why we want it
+
+The audit `docs/reviews/openonco-state-audit-2026-05-17.md` flagged
+that the rationale prose on Indication entries (the "why this regimen")
+is thin. PDQ treatment summaries are exactly that prose, NCI-authored,
+fully citable, and license-clean.
+
+The current corpus mass uses primary trial RCTs (KEYNOTE, CheckMate,
+PALOMA, etc.) and tier-1 guidelines (NCCN — restricted reuse, ESMO —
+mixed). PDQ adds a tier-2 confirmatory layer that is:
+
+1. Public-domain (no reuse friction at all).
+2. Comprehensive across cancer types (~80 disease summaries, plus
+   screening / supportive care).
+3. Routinely cross-referenced by NCCN and ESMO.
+
+We will not use PDQ as a *leading* source (it's an editorial-board
+summary of others' work, not primary evidence). `precedence_policy:
+confirmatory` is appropriate.
+
+## License classification
+
+### Primary basis: 17 U.S.C. §105
+
+> "Copyright protection under this title is not available for any work
+> of the United States Government …"
+
+NCI is an agency of the US Department of Health and Human Services — a
+federal-government entity. PDQ content is authored by federal employees
+acting in their official capacity (and contracted editorial board
+members whose contributions are released as government works per the
+PDQ Editorial Board contracts referenced on cancer.gov). It is therefore
+ineligible for US copyright protection and is in the **public domain
+within the United States**.
+
+### NCI's own statement
+
+The cancer.gov reuse policy at
+<https://www.cancer.gov/policies/copyright-reuse> states:
+
+> "Most of the text on this website is freely available for reuse —
+> except for material we have explicitly noted as borrowed from
+> external sources. Cancer information is generally NOT copyrighted
+> and there are usually no restrictions on its use."
+
+> "PDQ® is a registered trademark of the U.S. Department of Health and
+> Human Services. Content of PDQ documents can be used freely as text.
+> The PDQ name itself, as a registered trademark, cannot be used as
+> the name of an NCI publication or service that is not, in fact, PDQ."
+
+### Four-constraint check (per `SOURCE_INGESTION_SPEC §8`)
+
+| Constraint | Answer | Source |
+| --- | --- | --- |
+| Commercial use allowed? | **Yes** | 17 U.S.C. §105; NCI policy |
+| Redistribution allowed? | **Yes** | Same |
+| Modifications allowed? | **Yes** | Same — public-domain text is freely modifiable |
+| ShareAlike required? | **No** | Public-domain works carry no downstream license obligation |
+
+This places PDQ in the most permissive bucket of `SOURCE_INGESTION_SPEC
+§2` — Tier 0 / Tier 4 depending on terminology; either way, no
+restriction friction for OpenOnco's `CHARTER §2` free-public-resource
+posture.
+
+### Known restrictions (recorded on `src_pdq.yaml`)
+
+1. **Trademark.** The PDQ® mark may not be used as the name of a
+   non-PDQ product, or in a way that implies NCI endorsement of a
+   derivative work. We address this by:
+   - Referring to the corpus as "NCI PDQ" only when quoting NCI.
+   - Never naming an OpenOnco product / module "PDQ".
+   - Attributing via the standard NCI-suggested string when content is
+     reproduced.
+2. **Embedded third-party copyrights.** Some PDQ summaries quote
+   figures or tables from non-government sources (e.g. a tumor-stage
+   diagram licensed from a textbook). Where PDQ embeds explicit
+   attribution, we propagate it. Where the summary is plain text
+   without embedded attribution, the federal-government-work analysis
+   applies.
+
+## Hosting mode
+
+`referenced`, per `SOURCE_INGESTION_SPEC §1.4` default. We do not host
+PDQ content in this repo; we cite PDQ summaries by URL and CDR ID and
+optionally fetch the syndication API on demand. The H1–H5 hosting
+justification framework does not apply (referenced mode skips it).
+
+If a future workstream chooses to migrate to `hosted` mode (e.g. for
+offline rendering or for guaranteed snapshots), the change would need a
+fresh review covering:
+
+- Snapshot cadence and versioning (PDQ updates continuously; we would
+  freeze monthly).
+- Re-publication attribution boilerplate (already drafted in
+  `src_pdq.yaml.attribution.text`).
+- Storage scale estimate (PDQ HP corpus ≈ 1200 pages across ~80 summaries).
+
+For now: referenced.
+
+## Engineering scope (this PR)
+
+1. `knowledge_base/clients/pdq_client.py` — `BaseSourceClient` subclass.
+   Caching + rate-limiting come from the base. Live calls gated behind
+   `OPENONCO_PDQ_LIVE=1` so CI cannot accidentally hit upstream.
+2. `knowledge_base/hosted/content/sources/src_pdq.yaml` — Source entity
+   with all `license`, `attribution`, `hosting_mode`, `legal_review`
+   fields populated.
+3. `tests/test_pdq_client.py` — 9 offline-fixture tests covering
+   gate semantics, HTTP-seam stubbing, query parameter assembly, URL
+   encoding, source-entity schema, and source-id drift guard.
+4. `tests/fixtures/pdq_responses/` — 2 stub JSON files derived from
+   the public NCI documentation; no NCI content reproduced.
+
+## NOT in scope (deliberately)
+
+- **No Indication enrichment** in this PR. Populating Indication prose
+  fields from PDQ is a separate workstream gated by clinical co-lead
+  review per `CHARTER §6.1` for each authored field.
+- **No live API calls** by default. `OPENONCO_PDQ_LIVE` must be set
+  explicitly by the operator.
+- **No `hosted` mode migration.** Stays `referenced`.
+- **No CI cron** for scheduled re-fetch (per `SOURCE_INGESTION_SPEC §18`
+  — added when first hosting workstream lands).
+
+## Re-review triggers
+
+Update this doc and flip `legal_review.status` if any of:
+
+1. NCI changes its `cancer.gov/policies/copyright-reuse` page in a way
+   that adds constraints on reuse, attribution, or commercial use.
+2. OpenOnco changes its `CHARTER §2` posture (e.g. introduces any paid
+   commercial tier) — would not affect the license analysis but might
+   trigger NCI courtesy review.
+3. We adopt `hosted` mode for PDQ (snapshotting + redistribution).
+4. We use the PDQ® mark in product naming, marketing, or any
+   user-facing surface implying NCI endorsement.
+5. NCI delegates editorial-board authorship to a non-government entity
+   in a way that creates ambiguity about 17 U.S.C. §105 applicability.
+
+## Sign-off
+
+- **Reviewer:** claude (self-review under `CHARTER §6.1` dev-mode
+  exemption, v0.1 phase, per memory `project_charter_dev_mode_exemptions.md`).
+- **Date:** 2026-05-18.
+- **Notes:** Classification rests on a US public-law analysis plus
+  NCI's own published reuse policy. The trademark consideration is the
+  only operational constraint and is reflected in `src_pdq.yaml.known_restrictions`.

--- a/knowledge_base/clients/pdq_client.py
+++ b/knowledge_base/clients/pdq_client.py
@@ -1,0 +1,167 @@
+"""NCI PDQ (Physician Data Query) source client.
+
+PDQ is the National Cancer Institute's free, government-authored corpus
+of cancer information summaries (treatment, screening, prevention,
+supportive care) maintained in two parallel registers: a Health
+Professional (HP) version and a Patient version. As a US federal-government
+work, PDQ content is **public domain** under 17 U.S.C. §105 and may be
+reused without permission — see `docs/reviews/pdq-license-2026-05-18.md`
+for the full classification.
+
+Why we want it
+--------------
+The audit `docs/reviews/openonco-state-audit-2026-05-17.md` flagged that
+the "why this regimen" prose fields on Indications are thin. PDQ
+treatment summaries are exactly that prose, written by an NCI editorial
+board, fully citable, and license-clean for free public reuse.
+
+Scope of this scaffold
+----------------------
+This is a **scaffold**, not a populated ingest. It delivers:
+
+* The `PdqClient` subclass of `BaseSourceClient` with caching + rate
+  limiting from the base.
+* A `PdqQuery` dataclass with two modes: `get_summary` by CDR ID,
+  and `search` by free-text terms.
+* No live calls happen in tests — fixtures live under
+  `tests/fixtures/pdq_responses/`.
+
+Live calls are gated behind the `OPENONCO_PDQ_LIVE` env var so this code
+cannot accidentally hit the upstream during a CI run.
+
+Upstream endpoint
+-----------------
+NCI Cancer.gov publishes PDQ summaries via two surfaces:
+
+1. **Syndication API** at `https://www.cancer.gov/syndication` — JSON
+   endpoints for content fragments, indexed by CDR (Cancer Data
+   Repository) ID. Documented at
+   https://www.cancer.gov/syndication/api-documentation.
+2. **Cancer.gov pages** at `https://www.cancer.gov/types/<cancer>/hp/<topic>-treatment-pdq`
+   — human-readable HTML, the same content as a rendered fallback.
+
+The scaffold codes against (1). The exact URL templates are kept as
+class attributes so they can be patched at test time or revised when
+NCI updates the API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from knowledge_base.clients.base import (
+    BaseSourceClient,
+    CacheBackend,
+    RateLimit,
+)
+
+
+_PDQ_LIVE_ENV = "OPENONCO_PDQ_LIVE"
+_USER_AGENT = "OpenOnco/0.1 (+https://openonco.info)"
+
+
+@dataclass
+class PdqQuery:
+    """Either a single-summary fetch by CDR ID (mode='get_summary') or a
+    free-text search across the PDQ index (mode='search').
+
+    `audience` selects the HP vs Patient register — they cover the same
+    topics but differ in reading level and degree of clinical detail.
+    """
+
+    mode: Literal["get_summary", "search"] = "get_summary"
+    cdr_id: Optional[str] = None
+    terms: str = ""
+    audience: Literal["hp", "patient"] = "hp"
+    max_results: int = 20
+
+
+class PdqClient(BaseSourceClient[PdqQuery, dict]):
+    """NCI PDQ client. Public-domain corpus, no auth required.
+
+    Conservative rate limit: 1 req/s with burst=3. NCI does not publish a
+    formal rate limit for the syndication API; this stays well under any
+    plausible threshold and avoids hammering cancer.gov.
+    """
+
+    source_id = "SRC-PDQ"
+    rate_limit = RateLimit(tokens_per_second=1.0, burst=3)
+    cache_ttl_seconds = 7 * 24 * 3600  # 7 days — PDQ content updates ~monthly
+    api_version = "syndication-v1"
+
+    # Endpoint templates. Patchable at test time; documented in the module
+    # docstring above.
+    base_url: str = "https://www.cancer.gov/syndication"
+    summary_path: str = "/syndication/json/summary/{cdr_id}"
+    search_path: str = "/syndication/json/summaries"
+
+    def __init__(self, cache: Optional[CacheBackend] = None) -> None:
+        super().__init__(cache=cache)
+
+    # ── Subclass hook ────────────────────────────────────────────────────
+
+    def _fetch_raw(self, query: PdqQuery) -> tuple[dict, Optional[str]]:
+        if not self._is_live():
+            raise RuntimeError(
+                f"PDQ live calls are gated behind env var {_PDQ_LIVE_ENV}=1. "
+                "Set it explicitly to fetch from cancer.gov; tests should "
+                "use a stubbed CacheBackend or monkeypatch _fetch_raw."
+            )
+        if query.mode == "get_summary":
+            return self._fetch_summary(query), self.api_version
+        return self._fetch_search(query), self.api_version
+
+    # ── Public helpers ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_live() -> bool:
+        return os.environ.get(_PDQ_LIVE_ENV) in ("1", "true", "TRUE", "yes")
+
+    def _fetch_summary(self, query: PdqQuery) -> dict:
+        if not query.cdr_id:
+            raise ValueError("PdqQuery.mode='get_summary' requires cdr_id")
+        url = self.base_url + self.summary_path.format(
+            cdr_id=urllib.parse.quote(query.cdr_id, safe="")
+        )
+        return _http_get_json(url)
+
+    def _fetch_search(self, query: PdqQuery) -> dict:
+        params = {
+            "audience": query.audience,
+            "terms": query.terms,
+            "size": str(min(query.max_results, 50)),
+        }
+        url = self.base_url + self.search_path + "?" + urllib.parse.urlencode(params)
+        return _http_get_json(url)
+
+    def health(self) -> dict:
+        """Healthcheck: when live, ping the index; when not live, report
+        that the gate is closed (still 'ok' — the client is functional,
+        it's just not allowed to hit upstream)."""
+        if not self._is_live():
+            return {"ok": True, "latency_ms": None, "last_error": None,
+                    "note": f"{_PDQ_LIVE_ENV} not set; offline scaffold only"}
+        try:
+            self._fetch_search(PdqQuery(mode="search", terms="cancer", max_results=1))
+            return {"ok": True, "latency_ms": None, "last_error": None}
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "latency_ms": None, "last_error": str(exc)}
+
+
+# ── Module-level helpers ───────────────────────────────────────────────────
+
+
+def _http_get_json(url: str, timeout: int = 20) -> dict:
+    """Minimal stdlib GET → JSON. Tests substitute via monkeypatch."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+    return json.loads(body)
+
+
+__all__ = ["PdqClient", "PdqQuery"]

--- a/knowledge_base/hosted/content/sources/src_pdq.yaml
+++ b/knowledge_base/hosted/content/sources/src_pdq.yaml
@@ -1,0 +1,75 @@
+id: SRC-PDQ
+source_type: guideline
+title: "NCI Physician Data Query (PDQ) — cancer information summaries"
+version: "syndication-v1"
+authors:
+  - PDQ Cancer Information Summaries Editorial Boards
+  - National Cancer Institute
+journal: "Cancer.gov"
+url: https://www.cancer.gov/publications/pdq
+access_level: open_access
+currency_status: current
+current_as_of: "2026-05-18"
+evidence_tier: 2
+precedence_policy: confirmatory
+
+# Licensing & hosting (SOURCE_INGESTION_SPEC §3)
+# PDQ is a service of the National Cancer Institute, an agency of the
+# US federal government. As a US federal-government work, PDQ content
+# is in the public domain in the United States per 17 U.S.C. §105 and
+# may be reused without permission, modification restrictions, or
+# share-alike obligations. NCI requests but does not require
+# attribution. Full classification: docs/reviews/pdq-license-2026-05-18.md.
+hosting_mode: referenced
+ingestion:
+  method: live_api
+  client: knowledge_base.clients.pdq_client.PdqClient
+  endpoint: https://www.cancer.gov/syndication
+  rate_limit: "1 req/s, burst 3 (self-imposed; NCI publishes no formal limit)"
+cache_policy:
+  enabled: true
+  ttl_hours: 168
+  scope: query_result
+license:
+  name: "US Public Domain (17 U.S.C. §105)"
+  url: https://www.cancer.gov/policies/copyright-reuse
+attribution:
+  required: false
+  text: "Reproduced from PDQ®, the National Cancer Institute's comprehensive cancer information database (cancer.gov)."
+commercial_use_allowed: true
+redistribution_allowed: true
+modifications_allowed: true
+sharealike_required: false
+known_restrictions:
+  - "PDQ® is a registered trademark of the U.S. Department of Health and Human Services. The PDQ trademark may not be used to imply NCI endorsement of a derivative product."
+  - "Non-US copyright may apply to material PDQ summaries quote from non-government sources (figures, tables); follow the embedded attribution when present."
+legal_review:
+  status: reviewed
+  reviewer: claude
+  date: "2026-05-18"
+  notes: |
+    Self-review under CHARTER §6.1 dev-mode exemption (v0.1 phase).
+    Classification rests on 17 U.S.C. §105 and NCI's published reuse
+    policy at cancer.gov/policies/copyright-reuse. Re-review triggers:
+    (a) any change to that policy, (b) any plan to redistribute
+    PDQ-derived content under a non-public-domain license, (c) any use
+    of the PDQ® trademark in product naming. Full reasoning in
+    docs/reviews/pdq-license-2026-05-18.md.
+
+relates_to_diseases: []
+last_verified: "2026-05-18"
+verifier: claude
+notes: |
+  Scaffold lands the client + Source entity without populating any
+  indication.evidence_sources or regimen prose fields from PDQ yet.
+  Populating Indications with PDQ-derived rationale prose is a
+  separate follow-up workstream gated by clinical co-lead review of
+  each authored field.
+
+  Why PDQ matters: NCI editorial boards write structured, neutral,
+  citable summaries of treatment evidence per cancer type. The "why"
+  prose currently thin in our Indication.notes_for_clinician fields
+  can pull verbatim from PDQ without license friction.
+pages_count: 1200
+references_count: 18000
+corpus_role: primary_guideline

--- a/tests/fixtures/pdq_responses/search_pembrolizumab.json
+++ b/tests/fixtures/pdq_responses/search_pembrolizumab.json
@@ -1,0 +1,17 @@
+{
+  "total": 7,
+  "results": [
+    {
+      "cdr_id": "CDR0000062955",
+      "title": "Breast Cancer Treatment (PDQ®)",
+      "audience": "Health Professionals",
+      "url": "https://www.cancer.gov/types/breast/hp/breast-treatment-pdq"
+    },
+    {
+      "cdr_id": "CDR0000062847",
+      "title": "Non-Small Cell Lung Cancer Treatment (PDQ®)",
+      "audience": "Health Professionals",
+      "url": "https://www.cancer.gov/types/lung/hp/non-small-cell-lung-treatment-pdq"
+    }
+  ]
+}

--- a/tests/fixtures/pdq_responses/summary_breast_treatment_hp.json
+++ b/tests/fixtures/pdq_responses/summary_breast_treatment_hp.json
@@ -1,0 +1,24 @@
+{
+  "cdr_id": "CDR0000062955",
+  "title": "Breast Cancer Treatment (PDQ®)–Health Professional Version",
+  "audience": "Health Professionals",
+  "url": "https://www.cancer.gov/types/breast/hp/breast-treatment-pdq",
+  "date_last_modified": "2026-04-10",
+  "summary": {
+    "general_information": "Breast cancer is the most frequently diagnosed cancer in women in the United States...",
+    "stage_information": "Staging is based on the AJCC TNM system, 8th edition...",
+    "treatment_options_by_stage": [
+      {
+        "stage": "Stage I",
+        "options": ["Breast-conserving surgery + radiation therapy", "Total mastectomy"]
+      },
+      {
+        "stage": "Metastatic",
+        "options": ["Systemic therapy guided by hormone receptor and HER2 status"]
+      }
+    ]
+  },
+  "references": [
+    {"id": 1, "citation": "Siegel RL, et al. CA Cancer J Clin. 2024;74:12-49."}
+  ]
+}

--- a/tests/test_pdq_client.py
+++ b/tests/test_pdq_client.py
@@ -1,0 +1,194 @@
+"""PDQ client — offline scaffold tests.
+
+No live cancer.gov calls. Live calls are gated behind the
+`OPENONCO_PDQ_LIVE` env var; this suite leaves that unset and verifies
+the client refuses to fetch. The HTTP seam is exercised by
+monkeypatching `_http_get_json` to return fixture payloads, and the
+cache + rate-limit infrastructure from BaseSourceClient gets covered
+end-to-end via `fetch()`.
+
+Audit: docs/reviews/pdq-license-2026-05-18.md
+Spec:  specs/SOURCE_INGESTION_SPEC.md §8, §20
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from knowledge_base.clients import pdq_client
+from knowledge_base.clients.base import InMemoryCacheBackend
+from knowledge_base.clients.pdq_client import PdqClient, PdqQuery
+
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "pdq_responses"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+# ── Gate semantics ────────────────────────────────────────────────────────
+
+
+def test_offline_mode_refuses_to_fetch(monkeypatch):
+    """Without OPENONCO_PDQ_LIVE set, _fetch_raw raises so a stray test
+    can't accidentally hit cancer.gov."""
+    monkeypatch.delenv("OPENONCO_PDQ_LIVE", raising=False)
+    client = PdqClient(cache=InMemoryCacheBackend())
+    with pytest.raises(RuntimeError, match="OPENONCO_PDQ_LIVE"):
+        client.fetch(PdqQuery(mode="get_summary", cdr_id="CDR0000062955"))
+
+
+def test_health_reports_offline_gate_when_env_unset(monkeypatch):
+    monkeypatch.delenv("OPENONCO_PDQ_LIVE", raising=False)
+    client = PdqClient(cache=InMemoryCacheBackend())
+    out = client.health()
+    assert out["ok"] is True
+    assert "OPENONCO_PDQ_LIVE" in out["note"]
+
+
+# ── Live-flag path with monkeypatched HTTP ────────────────────────────────
+
+
+def test_get_summary_returns_fixture_via_cache(monkeypatch):
+    """With the live flag set AND the HTTP seam stubbed, fetch() resolves
+    the summary fixture and the result is cached on second call."""
+    monkeypatch.setenv("OPENONCO_PDQ_LIVE", "1")
+    fixture = _load_fixture("summary_breast_treatment_hp.json")
+
+    captured_urls: list[str] = []
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured_urls.append(url)
+        return fixture
+
+    monkeypatch.setattr(pdq_client, "_http_get_json", fake_get)
+
+    client = PdqClient(cache=InMemoryCacheBackend())
+    resp1 = client.fetch(PdqQuery(mode="get_summary", cdr_id="CDR0000062955"))
+    assert resp1.cache_hit is False
+    assert resp1.source_id == "SRC-PDQ"
+    assert resp1.api_version == "syndication-v1"
+    assert resp1.data["cdr_id"] == "CDR0000062955"
+
+    resp2 = client.fetch(PdqQuery(mode="get_summary", cdr_id="CDR0000062955"))
+    assert resp2.cache_hit is True  # served from cache, no second HTTP call
+    assert len(captured_urls) == 1
+    assert "CDR0000062955" in captured_urls[0]
+    assert captured_urls[0].startswith("https://www.cancer.gov/syndication")
+
+
+def test_search_passes_query_params(monkeypatch):
+    monkeypatch.setenv("OPENONCO_PDQ_LIVE", "1")
+    fixture = _load_fixture("search_pembrolizumab.json")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return fixture
+
+    monkeypatch.setattr(pdq_client, "_http_get_json", fake_get)
+    client = PdqClient(cache=InMemoryCacheBackend())
+    resp = client.fetch(
+        PdqQuery(mode="search", terms="pembrolizumab", audience="hp", max_results=5)
+    )
+    assert resp.data["total"] == 7
+    assert "terms=pembrolizumab" in captured["url"]
+    assert "audience=hp" in captured["url"]
+    assert "size=5" in captured["url"]
+
+
+def test_get_summary_requires_cdr_id(monkeypatch):
+    monkeypatch.setenv("OPENONCO_PDQ_LIVE", "1")
+    monkeypatch.setattr(pdq_client, "_http_get_json", lambda url, timeout=20: {})  # noqa: ARG005
+
+    client = PdqClient(cache=InMemoryCacheBackend())
+    with pytest.raises(ValueError, match="cdr_id"):
+        client.fetch(PdqQuery(mode="get_summary", cdr_id=None))
+
+
+def test_search_size_capped_at_50(monkeypatch):
+    """Tighter than NCI's plausible page-size; defensive against accidental
+    over-fetch when a caller passes max_results=10_000."""
+    monkeypatch.setenv("OPENONCO_PDQ_LIVE", "1")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return {"results": []}
+
+    monkeypatch.setattr(pdq_client, "_http_get_json", fake_get)
+
+    client = PdqClient(cache=InMemoryCacheBackend())
+    client.fetch(PdqQuery(mode="search", terms="x", max_results=10_000))
+    assert "size=50" in captured["url"]
+
+
+def test_url_encoding_of_cdr_id(monkeypatch):
+    """Defensive: if a caller passes a CDR ID containing reserved chars,
+    we still produce a valid URL."""
+    monkeypatch.setenv("OPENONCO_PDQ_LIVE", "1")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return {}
+
+    monkeypatch.setattr(pdq_client, "_http_get_json", fake_get)
+    client = PdqClient(cache=InMemoryCacheBackend())
+    client.fetch(PdqQuery(mode="get_summary", cdr_id="CDR/00012?345"))
+    assert "CDR%2F00012%3F345" in captured["url"]
+
+
+# ── Source entity ─────────────────────────────────────────────────────────
+
+
+def test_source_entity_loads_and_carries_license_metadata():
+    """src_pdq.yaml must parse cleanly under the Source schema and carry
+    the public-domain / referenced-hosting / no-attribution-required
+    classification."""
+    import yaml
+    from knowledge_base.schemas import Source
+
+    path = (
+        Path(__file__).parent.parent
+        / "knowledge_base"
+        / "hosted"
+        / "content"
+        / "sources"
+        / "src_pdq.yaml"
+    )
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    src = Source.model_validate(raw)
+    assert src.id == "SRC-PDQ"
+    assert src.hosting_mode.value == "referenced"
+    assert src.commercial_use_allowed is True
+    assert src.redistribution_allowed is True
+    assert src.modifications_allowed is True
+    assert src.sharealike_required is False
+    assert src.license is not None
+    assert "Public Domain" in src.license.name
+    assert src.legal_review is not None
+    assert src.legal_review.status.value == "reviewed"
+
+
+def test_source_id_matches_client_constant():
+    """Drift guard: a rename of either side without the other should
+    surface here, not in production."""
+    from knowledge_base.schemas import Source
+    import yaml
+
+    path = (
+        Path(__file__).parent.parent
+        / "knowledge_base"
+        / "hosted"
+        / "content"
+        / "sources"
+        / "src_pdq.yaml"
+    )
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    src = Source.model_validate(raw)
+    assert PdqClient.source_id == src.id


### PR DESCRIPTION
## Summary

Adds the NCI Physician Data Query (PDQ) corpus as a new source — referenced-mode, public-domain. Scaffold only: client + Source entity + license review + offline tests. No Indication prose populated yet (that's a follow-up workstream gated by clinical co-lead review per CHARTER §6.1).

## Why

The state audit shipped in [#588](https://github.com/romeo111/OpenOnco/pull/588) flagged that `Indication.notes_for_clinician` rationale prose is thin. PDQ treatment summaries are NCI-authored, fully citable, license-clean prose for exactly that gap. As a US federal-government work, PDQ is in the public domain under 17 U.S.C. §105 — most permissive bucket of `SOURCE_INGESTION_SPEC §2`.

## What's in the box

- **`knowledge_base/clients/pdq_client.py`** — `BaseSourceClient[PdqQuery, dict]` subclass. Caching + rate-limiting from the base. Live calls gated behind `OPENONCO_PDQ_LIVE=1` so CI can't accidentally hit cancer.gov. `PdqQuery` supports `get_summary` by CDR ID and `search` by free-text terms. Search size capped at 50 defensively, URL-encoded CDR IDs.
- **`knowledge_base/hosted/content/sources/src_pdq.yaml`** — Source entity with full license metadata: `hosting_mode: referenced`, `license: US Public Domain (17 U.S.C. §105)`, `commercial_use_allowed: true`, `redistribution_allowed: true`, `sharealike_required: false`, `precedence_policy: confirmatory`, `legal_review.status: reviewed`. Trademark caveat (PDQ® mark) recorded under `known_restrictions`.
- **`docs/reviews/pdq-license-2026-05-18.md`** — full license classification with four-constraint check, hosting-mode rationale, re-review triggers, and what's intentionally out of scope.
- **`tests/test_pdq_client.py`** — 9 offline tests covering gate semantics, HTTP-seam stubbing, query params, URL encoding, source-entity schema, source-id drift guard.
- **`tests/fixtures/pdq_responses/`** — 2 stub JSON files derived from NCI public docs (no NCI content copied).

## Per `SOURCE_INGESTION_SPEC §20` checklist

- [x] License reviewed — `docs/reviews/pdq-license-2026-05-18.md`
- [x] Hosting mode selected — `referenced` (default per §1.4; no H1-H5 needed)
- [x] Schema validator — Source entity validates clean
- [x] Source entity with all license/attribution/legal_review fields
- [x] Client written
- [ ] First fetch + diff vs null baseline + clinical review — deferred until first ingest workstream
- [ ] CI job for scheduled re-fetch — deferred until first hosted-mode workstream
- [x] No `hosted` justification needed (referenced mode)

## What this PR does NOT do (deliberately)

- **No Indication enrichment.** Populating `Indication.notes_for_clinician` from PDQ content is a separate workstream needing two Clinical Co-Lead signoffs per CHARTER §6.1 for each authored field.
- **No live API calls by default.** `OPENONCO_PDQ_LIVE=1` must be set explicitly.
- **No `hosted` mode migration.** Stays `referenced`; re-review required to flip.

## Test plan

- [x] `pytest tests/test_pdq_client.py` — 9/9 pass
- [x] `pytest tests/test_base_source_client.py tests/test_engine.py tests/test_actionability_invariants.py` — 44 pass / 3 skip, no regressions
- [x] KB validator strict — 3119 entities (388 → 389 sources), all references resolve
- [x] Trademark caveat recorded; PDQ® mark not used in any product-naming surface
- [x] No clinical content edits (no `knowledge_base/hosted/content/{indications,regimens,...}` touched)
- [x] No `git add -A` / `--no-verify` — explicit pathspecs only

## Re-review triggers (recorded in license doc)

1. NCI changes its reuse policy
2. OpenOnco CHARTER §2 posture shift (any paid tier)
3. Migration to `hosted` mode
4. Use of the PDQ® trademark in product naming
5. NCI delegates editorial authorship outside the federal-government-work scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)