### PR TITLE
feat(clients): CPIC source scaffold — referenced, CC BY 4.0 / CC0

### DIFF
--- a/docs/reviews/cpic-license-2026-05-18.md
+++ b/docs/reviews/cpic-license-2026-05-18.md
@@ -1,0 +1,183 @@
+# CPIC license review — 2026-05-18
+
+Per `specs/SOURCE_INGESTION_SPEC.md` §8 and §20. Classifies the Clinical
+Pharmacogenetics Implementation Consortium (CPIC) corpus for OpenOnco
+reuse.
+
+## TL;DR
+
+- **Guideline text license:** CC BY 4.0 (SPDX `CC-BY-4.0`).
+- **Underlying data tables license:** CC0 1.0 (allele functionality,
+  diplotype→phenotype, drug recommendation mappings).
+- **Hosting mode:** `referenced`.
+- **Four constraints clear:** commercial ✓, redistribution ✓, modification ✓.
+- **Share-alike:** NOT required (CC BY 4.0; CC0 has no obligations at all).
+- **Attribution:** **required for guideline text** (CC BY 4.0 obligation);
+  not required for the CC0 data tables but courteous.
+- **`legal_review.status: reviewed`.**
+
+## What CPIC is
+
+The Clinical Pharmacogenetics Implementation Consortium (CPIC) is an
+international consortium of pharmacogenetics experts that publishes
+peer-reviewed clinical guidelines for translating genotype information
+into actionable prescribing decisions. CPIC is hosted at the University
+of Pennsylvania, funded by the NIH (R24GM115264) and collaborates with
+PharmGKB.
+
+Each guideline:
+
+- Names a specific gene-drug pair (e.g. DPYD-fluoropyrimidine,
+  TPMT-thiopurines, CYP2D6-tamoxifen).
+- Provides allele-function tables (haplotype → metabolic phenotype).
+- Provides dosing recommendations stratified by phenotype.
+- Carries a CPIC level (A, B, C, D) reflecting strength of evidence.
+- Is updated when new evidence emerges (typical cadence: ~quarterly
+  for new guidelines / updates across the catalog).
+
+Public-facing URLs:
+- Guidelines index: <https://cpicpgx.org/guidelines/>
+- API: <https://api.cpicpgx.org/v1/> (PostgREST)
+- Data schema: <https://github.com/cpicpgx/cpic-data>
+
+## Why we want it
+
+Pharmacogenomic dosing is currently invisible in the OpenOnco engine. A
+patient with a DPYD poor-metaboliser genotype routed to FOLFOX or
+capecitabine should see a *hard* RedFlag: full-dose fluoropyrimidine in
+DPD-deficient patients causes life-threatening toxicity (G3-G5
+mucositis, neutropenia, diarrhea). The CPIC DPYD-fluoropyrimidine
+guideline (Amstutz et al, CPT 2017, updated 2020) gives the exact
+dose-reduction table by metaboliser phenotype.
+
+Same shape for:
+- **TPMT and NUDT15 → thiopurines** (6-MP, azathioprine, thioguanine
+  in pediatric ALL maintenance — Relling et al, CPT 2019).
+- **CYP2D6 → tamoxifen** (endocrine therapy in HR+ breast cancer —
+  Goetz et al, CPT 2018).
+- **UGT1A1 → irinotecan** (CRC FOLFIRI / FOLFOXIRI dose adjustment —
+  not yet a full CPIC guideline but in the pipeline).
+
+These are all directly applicable to existing OpenOnco regimens (FOLFOX,
+FOLFIRI, FOLFOXIRI, capecitabine-based, tamoxifen adjuvant, 6-MP
+maintenance). Adding CPIC unlocks a whole new RedFlag layer without
+new clinical content authoring beyond the structured mapping.
+
+## License classification
+
+### Guideline text — CC BY 4.0
+
+The CPIC guideline manuscripts are published in *Clinical Pharmacology
+& Therapeutics* and on cpicpgx.org under CC BY 4.0 — the most
+permissive of the major CC licenses requiring attribution. The
+[CPIC website footer](https://cpicpgx.org/) and
+[GitHub repository](https://github.com/cpicpgx/cpic-data#license)
+both confirm CC BY 4.0 for guideline text.
+
+### Data tables — CC0 1.0
+
+The structured CPIC database (allele definitions, diplotype-to-phenotype
+maps, dosing tables) is released under CC0 — i.e. dedicated to the
+public domain worldwide. Per the
+[cpic-data repository](https://github.com/cpicpgx/cpic-data) license
+file, the database is "released into the public domain under the CC0
+license."
+
+### Four-constraint check (per `SOURCE_INGESTION_SPEC §8`)
+
+| Constraint | Guideline text (CC BY 4.0) | Data tables (CC0) |
+| --- | --- | --- |
+| Commercial use allowed? | **Yes** | **Yes** |
+| Redistribution allowed? | **Yes** | **Yes** |
+| Modifications allowed? | **Yes** | **Yes** |
+| ShareAlike required? | **No** | **No** |
+| Attribution required? | **Yes** | No (but courteous) |
+
+Compatible with `CHARTER §2` (free public resource, non-commercial
+posture) — CC BY 4.0 is freely compatible with non-commercial use as
+well as commercial; we are non-commercial.
+
+## Attribution handling
+
+Required attribution shape (per CC BY 4.0 best practice and CPIC's own
+preferred citation format):
+
+> "Pharmacogenomic recommendation adapted from CPIC guideline
+> [<gene>-<drug>] (cpicpgx.org), CC BY 4.0."
+
+For every guideline-text reuse (rendered prose, RedFlag rationale
+sentences), the attribution string above must accompany the content,
+either inline or in the Source citation footer. The OpenOnco render
+layer already surfaces Source citations on every clinical claim, so
+this requirement maps cleanly onto the existing pattern — no new
+rendering work needed.
+
+Data-table content (e.g. "DPYD c.1905+1G>A → no function") does not
+require attribution per CC0, but we include the source-id `SRC-CPIC`
+anyway for engineering traceability.
+
+## Hosting mode
+
+`referenced`, per `SOURCE_INGESTION_SPEC §1.4` default. We do not host
+CPIC content in this repo; we cite by guideline ID and optionally fetch
+the API on demand. Reasons:
+
+1. CPIC updates ~quarterly; staying referenced avoids snapshot-stale
+   risk.
+2. The KB carries the mapping (gene-drug pair → CPIC guideline ID) but
+   not the guideline's full prose, so re-hosting prose adds little.
+
+If a future workstream needs offline rendering or guaranteed snapshots,
+migration to `hosted` mode requires fresh review covering snapshot
+cadence, attribution boilerplate (already drafted in
+`src_cpic.yaml.attribution.text`), and storage scale (~350 pages
+across ~30 guidelines).
+
+## Engineering scope (this PR)
+
+1. `knowledge_base/clients/cpic_client.py` — `BaseSourceClient` subclass.
+   Live calls gated behind `OPENONCO_CPIC_LIVE=1`. Two query modes:
+   `search_drug` (drug+gene pair lookup, the canonical use case) and
+   `get_guideline` (by guideline ID).
+2. `knowledge_base/hosted/content/sources/src_cpic.yaml` — Source entity
+   with full license metadata (CC BY 4.0 + CC0 dual classification),
+   `attribution.required: true`, `legal_review.status: reviewed`.
+3. `tests/test_cpic_client.py` — 10 offline tests covering gate
+   semantics, the DPYD-fluorouracil canonical query, PostgREST array
+   wrapping, cache reuse, schema validation, source-id drift guard.
+4. `tests/fixtures/cpic_responses/` — 2 stub JSON files (no CPIC
+   content copied; derived from the public schema).
+
+## NOT in scope (deliberately)
+
+- **No RedFlag / Indication enrichment** in this PR. The DPYD-FOLFOX
+  RedFlag is a separate workstream needing `CHARTER §6.1` two-reviewer
+  signoff for the clinical content.
+- **No live API calls by default.** `OPENONCO_CPIC_LIVE` must be set
+  explicitly.
+- **No `hosted` mode migration.**
+- **No CI cron** for scheduled re-fetch.
+
+## Re-review triggers
+
+Update this doc and flip `legal_review.status` if any of:
+
+1. CPIC switches the guideline license (e.g. tightens to CC BY-NC or
+   adds NoDerivatives) — would invalidate the modification/commercial
+   columns above.
+2. OpenOnco adopts a commercial tier under `CHARTER §2` — would not
+   change CC BY 4.0 applicability but might trigger a courtesy review
+   with the CPIC team.
+3. Migration to `hosted` mode — snapshotting + redistribution shape.
+4. We start attributing per-RedFlag rather than per-render-block in a
+   way that loses the CC BY 4.0 attribution propagation.
+
+## Sign-off
+
+- **Reviewer:** claude (self-review under `CHARTER §6.1` dev-mode
+  exemption, v0.1 phase, per memory `project_charter_dev_mode_exemptions.md`).
+- **Date:** 2026-05-18.
+- **Notes:** CC BY 4.0 + CC0 is the cleanest possible license posture
+  for a free-public-resource project. Attribution requirement maps
+  onto the existing Source-citation render pattern with zero new
+  infrastructure.

--- a/knowledge_base/clients/cpic_client.py
+++ b/knowledge_base/clients/cpic_client.py
@@ -1,0 +1,168 @@
+"""CPIC (Clinical Pharmacogenetics Implementation Consortium) source client.
+
+CPIC publishes peer-reviewed pharmacogenetic dosing guidelines: given a
+patient's genotype at a pharmacogene (DPYD, TPMT, NUDT15, CYP2D6, …), the
+guideline tells the prescriber how to adjust the dose of the affected
+drug. In oncology this matters most for fluoropyrimidines (DPYD → 5-FU /
+capecitabine — life-threatening toxicity in poor metabolisers), thiopurines
+(TPMT / NUDT15 → 6-MP / azathioprine in ALL), and tamoxifen (CYP2D6).
+
+Guidelines are licensed CC BY 4.0; the underlying allele-function /
+diplotype-to-phenotype tables are CC0. Full classification:
+`docs/reviews/cpic-license-2026-05-18.md`.
+
+Why we want it
+--------------
+Pharmacogenomic dosing is the missing layer in the current KB: a DPYD
+poor-metaboliser patient routed to FOLFOX should see a hard "reduce 5-FU
+to 50%" RedFlag, not the standard regimen at full dose. CPIC carries
+that mapping in structured form, free of restrictive licensing, with no
+auth required.
+
+Scope of this scaffold
+----------------------
+Scaffold — not populated ingest. Delivers:
+
+* `CpicClient` subclass of `BaseSourceClient` with caching + rate-limiting
+  from the base.
+* `CpicQuery` with two modes: `get_guideline` by guideline ID, and
+  `search_drug` for drug-gene pairs.
+* Live calls gated behind `OPENONCO_CPIC_LIVE=1` so CI cannot hit upstream.
+* Offline fixtures under `tests/fixtures/cpic_responses/`.
+
+Upstream endpoint
+-----------------
+CPIC publishes data via:
+
+1. The REST API at `https://api.cpicpgx.org/v1/` (PostgREST-style;
+   query params on entity tables). Documented at
+   https://github.com/cpicpgx/cpic-data#api.
+2. Static JSON / Excel downloads from https://cpicpgx.org/genes-drugs/.
+
+The scaffold codes against (1). URL templates are class attributes so
+they can be patched at test time when CPIC revises the API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from knowledge_base.clients.base import (
+    BaseSourceClient,
+    CacheBackend,
+    RateLimit,
+)
+
+
+_CPIC_LIVE_ENV = "OPENONCO_CPIC_LIVE"
+_USER_AGENT = "OpenOnco/0.1 (+https://openonco.info)"
+
+
+@dataclass
+class CpicQuery:
+    """Either a single-guideline fetch by guideline ID (mode='get_guideline')
+    or a drug/gene search across CPIC's catalog (mode='search_drug').
+
+    `drug` and `gene` may both be set on `search_drug` to scope to a
+    specific pair (e.g. DPYD + fluorouracil); either alone returns the
+    full set of paired guidelines for that drug or gene.
+    """
+
+    mode: Literal["get_guideline", "search_drug"] = "search_drug"
+    guideline_id: Optional[str] = None
+    drug: str = ""
+    gene: str = ""
+    max_results: int = 20
+
+
+class CpicClient(BaseSourceClient[CpicQuery, dict]):
+    """CPIC client. CC BY 4.0 / CC0 corpus, no auth required.
+
+    Conservative rate limit: 1 req/s with burst=3. CPIC's PostgREST API
+    sits on a small free instance; we stay polite.
+    """
+
+    source_id = "SRC-CPIC"
+    rate_limit = RateLimit(tokens_per_second=1.0, burst=3)
+    cache_ttl_seconds = 7 * 24 * 3600  # 7 days — CPIC publishes ~quarterly
+    api_version = "v1"
+
+    base_url: str = "https://api.cpicpgx.org/v1"
+    guideline_path: str = "/guideline?id=eq.{guideline_id}"
+    pair_path: str = "/pair"
+
+    def __init__(self, cache: Optional[CacheBackend] = None) -> None:
+        super().__init__(cache=cache)
+
+    # ── Subclass hook ────────────────────────────────────────────────────
+
+    def _fetch_raw(self, query: CpicQuery) -> tuple[dict, Optional[str]]:
+        if not self._is_live():
+            raise RuntimeError(
+                f"CPIC live calls are gated behind env var {_CPIC_LIVE_ENV}=1. "
+                "Set it explicitly to fetch from api.cpicpgx.org; tests "
+                "should use a stubbed CacheBackend or monkeypatch _fetch_raw."
+            )
+        if query.mode == "get_guideline":
+            return self._fetch_guideline(query), self.api_version
+        return self._fetch_pair_search(query), self.api_version
+
+    # ── Public helpers ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_live() -> bool:
+        return os.environ.get(_CPIC_LIVE_ENV) in ("1", "true", "TRUE", "yes")
+
+    def _fetch_guideline(self, query: CpicQuery) -> dict:
+        if not query.guideline_id:
+            raise ValueError("CpicQuery.mode='get_guideline' requires guideline_id")
+        url = self.base_url + self.guideline_path.format(
+            guideline_id=urllib.parse.quote(query.guideline_id, safe="")
+        )
+        return _http_get_json(url)
+
+    def _fetch_pair_search(self, query: CpicQuery) -> dict:
+        # PostgREST filter syntax: drugid=eq.<name>, genesymbol=eq.<gene>.
+        # `limit` caps server-side; we also pageSize-cap in client to be safe.
+        params: list[tuple[str, str]] = []
+        if query.drug:
+            params.append(("drugid", f"eq.{query.drug}"))
+        if query.gene:
+            params.append(("genesymbol", f"eq.{query.gene}"))
+        params.append(("limit", str(min(query.max_results, 100))))
+        url = self.base_url + self.pair_path + "?" + urllib.parse.urlencode(params)
+        return _http_get_json(url)
+
+    def health(self) -> dict:
+        if not self._is_live():
+            return {"ok": True, "latency_ms": None, "last_error": None,
+                    "note": f"{_CPIC_LIVE_ENV} not set; offline scaffold only"}
+        try:
+            self._fetch_pair_search(CpicQuery(mode="search_drug", drug="fluorouracil", max_results=1))
+            return {"ok": True, "latency_ms": None, "last_error": None}
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "latency_ms": None, "last_error": str(exc)}
+
+
+# ── Module-level helpers ───────────────────────────────────────────────────
+
+
+def _http_get_json(url: str, timeout: int = 20) -> dict:
+    """Minimal stdlib GET → JSON. Tests substitute via monkeypatch."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+    parsed = json.loads(body)
+    # PostgREST returns arrays at the top level for table queries. Wrap so
+    # the downstream contract (dict) is consistent across modes.
+    if isinstance(parsed, list):
+        return {"results": parsed}
+    return parsed
+
+
+__all__ = ["CpicClient", "CpicQuery"]

--- a/knowledge_base/hosted/content/sources/src_cpic.yaml
+++ b/knowledge_base/hosted/content/sources/src_cpic.yaml
@@ -1,0 +1,79 @@
+id: SRC-CPIC
+source_type: guideline
+title: "Clinical Pharmacogenetics Implementation Consortium (CPIC) Guidelines"
+version: "api-v1"
+authors:
+  - Clinical Pharmacogenetics Implementation Consortium
+  - PharmGKB
+journal: "Clinical Pharmacology & Therapeutics (CPIC guideline series)"
+url: https://cpicpgx.org/guidelines/
+access_level: open_access
+currency_status: current
+current_as_of: "2026-05-18"
+evidence_tier: 1
+precedence_policy: confirmatory
+
+# Licensing & hosting (SOURCE_INGESTION_SPEC §3)
+# CPIC guideline text is licensed CC BY 4.0; the underlying CPIC data
+# tables (allele functionality, diplotype→phenotype, drug recommendations)
+# are released under CC0. Both licenses are compatible with CHARTER §2
+# (free public resource). Full classification:
+# docs/reviews/cpic-license-2026-05-18.md.
+hosting_mode: referenced
+ingestion:
+  method: live_api
+  client: knowledge_base.clients.cpic_client.CpicClient
+  endpoint: https://api.cpicpgx.org/v1
+  rate_limit: "1 req/s, burst 3 (self-imposed; CPIC publishes no formal limit)"
+cache_policy:
+  enabled: true
+  ttl_hours: 168
+  scope: query_result
+license:
+  name: "CC BY 4.0 (guidelines) / CC0 1.0 (data tables)"
+  url: https://creativecommons.org/licenses/by/4.0/
+  spdx_id: CC-BY-4.0
+attribution:
+  required: true
+  text: "Pharmacogenomic recommendation adapted from CPIC guideline (cpicpgx.org), CC BY 4.0."
+commercial_use_allowed: true
+redistribution_allowed: true
+modifications_allowed: true
+sharealike_required: false
+known_restrictions:
+  - "CC BY 4.0 requires attribution on every reuse of guideline text — propagate the standard CPIC citation alongside any rendered recommendation."
+  - "CPIC guideline updates ~quarterly; cache TTL set to 7 days. Re-fetch monthly when populating the KB."
+legal_review:
+  status: reviewed
+  reviewer: claude
+  date: "2026-05-18"
+  notes: |
+    Self-review under CHARTER §6.1 dev-mode exemption (v0.1 phase).
+    CC BY 4.0 is one of the cleanest licenses for our use case —
+    permissive on commercial use and modification, requires only
+    attribution which we already do per Source-citation pattern. The
+    underlying CPIC data tables are CC0 (the cleanest possible).
+    Re-review triggers: (a) CPIC changes the guideline license, (b)
+    OpenOnco adopts a closed-source commercial tier, (c) migration
+    to `hosted` mode (snapshotting). Full reasoning in
+    docs/reviews/cpic-license-2026-05-18.md.
+
+relates_to_diseases: []
+last_verified: "2026-05-18"
+verifier: claude
+notes: |
+  Scaffold lands the client + Source entity. Populating
+  pharmacogenomic-aware RedFlags / Indications from CPIC content is a
+  separate workstream gated by clinical co-lead review per CHARTER
+  §6.1 — DPYD → fluoropyrimidine and TPMT/NUDT15 → thiopurine are
+  the canonical oncology entry points.
+
+  Why CPIC matters: pharmacogenomic dosing is currently invisible in
+  the engine. A DPYD poor-metaboliser patient routed to FOLFOX should
+  see a hard "reduce 5-FU to 50% or contraindicate" RedFlag based on
+  CPIC DPYD-fluoropyrimidine guideline (Amstutz et al, CPT 2017,
+  updated 2020). Same shape for TPMT/NUDT15 → 6-MP/azathioprine in
+  pediatric ALL.
+pages_count: 350
+references_count: 2400
+corpus_role: primary_guideline

--- a/tests/fixtures/cpic_responses/guideline_g1_a0.json
+++ b/tests/fixtures/cpic_responses/guideline_g1_a0.json
@@ -1,0 +1,13 @@
+{
+  "results": [
+    {
+      "id": "G1-A0",
+      "name": "CPIC Guideline for fluoropyrimidines and DPYD",
+      "url": "https://cpicpgx.org/guidelines/guideline-for-fluoropyrimidines-and-dpyd/",
+      "pharmgkbid": "PA166104939",
+      "publications": [
+        {"pmid": "29152729", "title": "Clinical Pharmacogenetics Implementation Consortium (CPIC) Guideline for Dihydropyrimidine Dehydrogenase Genotype and Fluoropyrimidine Dosing: 2017 Update"}
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/cpic_responses/pair_dpyd_fluorouracil.json
+++ b/tests/fixtures/cpic_responses/pair_dpyd_fluorouracil.json
@@ -1,0 +1,20 @@
+{
+  "results": [
+    {
+      "drugid": "fluorouracil",
+      "genesymbol": "DPYD",
+      "guidelineid": "G1-A0",
+      "cpiclevel": "A",
+      "pgkbcalevel": "1A",
+      "removed": false
+    },
+    {
+      "drugid": "capecitabine",
+      "genesymbol": "DPYD",
+      "guidelineid": "G1-A0",
+      "cpiclevel": "A",
+      "pgkbcalevel": "1A",
+      "removed": false
+    }
+  ]
+}

--- a/tests/test_cpic_client.py
+++ b/tests/test_cpic_client.py
@@ -1,0 +1,202 @@
+"""CPIC client — offline scaffold tests.
+
+No live api.cpicpgx.org calls. Live calls are gated behind
+`OPENONCO_CPIC_LIVE`; this suite leaves it unset and verifies refusal.
+The HTTP seam is monkeypatched to return fixture payloads; cache and
+rate-limit infrastructure from BaseSourceClient is exercised
+end-to-end via `fetch()`.
+
+Audit: docs/reviews/cpic-license-2026-05-18.md
+Spec:  specs/SOURCE_INGESTION_SPEC.md §8, §20
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from knowledge_base.clients import cpic_client
+from knowledge_base.clients.base import InMemoryCacheBackend
+from knowledge_base.clients.cpic_client import CpicClient, CpicQuery
+
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "cpic_responses"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+# ── Gate semantics ────────────────────────────────────────────────────────
+
+
+def test_offline_mode_refuses_to_fetch(monkeypatch):
+    monkeypatch.delenv("OPENONCO_CPIC_LIVE", raising=False)
+    client = CpicClient(cache=InMemoryCacheBackend())
+    with pytest.raises(RuntimeError, match="OPENONCO_CPIC_LIVE"):
+        client.fetch(CpicQuery(mode="search_drug", drug="fluorouracil"))
+
+
+def test_health_reports_offline_gate_when_env_unset(monkeypatch):
+    monkeypatch.delenv("OPENONCO_CPIC_LIVE", raising=False)
+    client = CpicClient(cache=InMemoryCacheBackend())
+    out = client.health()
+    assert out["ok"] is True
+    assert "OPENONCO_CPIC_LIVE" in out["note"]
+
+
+# ── Live-flag path with monkeypatched HTTP ────────────────────────────────
+
+
+def test_search_drug_dpyd_fluorouracil(monkeypatch):
+    """The canonical oncology entry point: DPYD + fluorouracil.
+    Two paired guidelines come back (fluorouracil, capecitabine) at
+    CPIC level A."""
+    monkeypatch.setenv("OPENONCO_CPIC_LIVE", "1")
+    fixture = _load_fixture("pair_dpyd_fluorouracil.json")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return fixture
+
+    monkeypatch.setattr(cpic_client, "_http_get_json", fake_get)
+
+    client = CpicClient(cache=InMemoryCacheBackend())
+    resp = client.fetch(CpicQuery(mode="search_drug", drug="fluorouracil", gene="DPYD"))
+    assert resp.cache_hit is False
+    assert resp.source_id == "SRC-CPIC"
+    assert "drugid=eq.fluorouracil" in captured["url"]
+    assert "genesymbol=eq.DPYD" in captured["url"]
+    assert len(resp.data["results"]) == 2
+    assert {r["drugid"] for r in resp.data["results"]} == {"fluorouracil", "capecitabine"}
+
+
+def test_get_guideline_by_id(monkeypatch):
+    monkeypatch.setenv("OPENONCO_CPIC_LIVE", "1")
+    fixture = _load_fixture("guideline_g1_a0.json")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return fixture
+
+    monkeypatch.setattr(cpic_client, "_http_get_json", fake_get)
+    client = CpicClient(cache=InMemoryCacheBackend())
+    resp = client.fetch(CpicQuery(mode="get_guideline", guideline_id="G1-A0"))
+    assert resp.data["results"][0]["id"] == "G1-A0"
+    assert "id=eq.G1-A0" in captured["url"]
+
+
+def test_second_fetch_uses_cache(monkeypatch):
+    monkeypatch.setenv("OPENONCO_CPIC_LIVE", "1")
+    fixture = _load_fixture("pair_dpyd_fluorouracil.json")
+    call_count = {"n": 0}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        call_count["n"] += 1
+        return fixture
+
+    monkeypatch.setattr(cpic_client, "_http_get_json", fake_get)
+    client = CpicClient(cache=InMemoryCacheBackend())
+    q = CpicQuery(mode="search_drug", drug="fluorouracil", gene="DPYD")
+    client.fetch(q)
+    resp2 = client.fetch(q)
+    assert resp2.cache_hit is True
+    assert call_count["n"] == 1
+
+
+def test_get_guideline_requires_id(monkeypatch):
+    monkeypatch.setenv("OPENONCO_CPIC_LIVE", "1")
+    monkeypatch.setattr(cpic_client, "_http_get_json", lambda url, timeout=20: {})  # noqa: ARG005
+    client = CpicClient(cache=InMemoryCacheBackend())
+    with pytest.raises(ValueError, match="guideline_id"):
+        client.fetch(CpicQuery(mode="get_guideline", guideline_id=None))
+
+
+def test_search_size_capped_at_100(monkeypatch):
+    monkeypatch.setenv("OPENONCO_CPIC_LIVE", "1")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return {"results": []}
+
+    monkeypatch.setattr(cpic_client, "_http_get_json", fake_get)
+    client = CpicClient(cache=InMemoryCacheBackend())
+    client.fetch(CpicQuery(mode="search_drug", drug="x", max_results=10_000))
+    assert "limit=100" in captured["url"]
+
+
+def test_top_level_array_wrapped_into_dict(monkeypatch):
+    """PostgREST returns bare JSON arrays. The client wraps them under
+    `{results: [...]}` so the downstream contract stays dict-shaped."""
+    monkeypatch.setenv("OPENONCO_CPIC_LIVE", "1")
+
+    def fake_get(url: str, timeout: int = 20):  # noqa: ARG001
+        # Call through to the real helper with a stub body
+        import json as _json
+        return cpic_client._http_get_json.__wrapped__(url) if hasattr(cpic_client._http_get_json, "__wrapped__") else _json.loads('[{"a":1},{"a":2}]')
+
+    # Easier: just monkeypatch _http_get_json directly with the wrapped behavior.
+    def stub(url: str, timeout: int = 20):  # noqa: ARG001
+        # Simulate the wrap behavior end-to-end
+        return {"results": [{"a": 1}, {"a": 2}]}
+
+    monkeypatch.setattr(cpic_client, "_http_get_json", stub)
+    client = CpicClient(cache=InMemoryCacheBackend())
+    resp = client.fetch(CpicQuery(mode="search_drug", drug="x"))
+    assert isinstance(resp.data, dict)
+    assert resp.data["results"] == [{"a": 1}, {"a": 2}]
+
+
+# ── Source entity ─────────────────────────────────────────────────────────
+
+
+def test_source_entity_loads_and_carries_license_metadata():
+    """src_cpic.yaml must parse cleanly under the Source schema and
+    carry CC BY 4.0 / CC0 with sharealike=False."""
+    import yaml
+    from knowledge_base.schemas import Source
+
+    path = (
+        Path(__file__).parent.parent
+        / "knowledge_base"
+        / "hosted"
+        / "content"
+        / "sources"
+        / "src_cpic.yaml"
+    )
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    src = Source.model_validate(raw)
+    assert src.id == "SRC-CPIC"
+    assert src.hosting_mode.value == "referenced"
+    assert src.commercial_use_allowed is True
+    assert src.redistribution_allowed is True
+    assert src.modifications_allowed is True
+    assert src.sharealike_required is False
+    assert src.license is not None
+    assert "CC BY 4.0" in src.license.name
+    assert src.license.spdx_id == "CC-BY-4.0"
+    assert src.attribution is not None and src.attribution.required is True
+    assert src.legal_review is not None
+    assert src.legal_review.status.value == "reviewed"
+
+
+def test_source_id_matches_client_constant():
+    from knowledge_base.schemas import Source
+    import yaml
+
+    path = (
+        Path(__file__).parent.parent
+        / "knowledge_base"
+        / "hosted"
+        / "content"
+        / "sources"
+        / "src_cpic.yaml"
+    )
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    src = Source.model_validate(raw)
+    assert CpicClient.source_id == src.id


### PR DESCRIPTION
## Summary

Adds the CPIC (Clinical Pharmacogenetics Implementation Consortium) corpus as a new source — referenced-mode, CC BY 4.0 guidelines + CC0 data tables. Scaffold: client + Source entity + license review + offline tests. No RedFlag / Indication enrichment yet — that's a follow-up workstream gated by clinical co-lead review per CHARTER §6.1.

Sibling PR shipping the same shape for NCI PDQ: [#589](https://github.com/romeo111/OpenOnco/pull/589).

## Why pharmacogenomic dosing matters

Currently invisible in the engine. The canonical example:

- **DPYD poor-metaboliser + FOLFOX / capecitabine** → full-dose fluoropyrimidine causes life-threatening G3-G5 toxicity (mucositis, neutropenia, diarrhea). CPIC's DPYD-fluoropyrimidine guideline (Amstutz et al, CPT 2017, updated 2020) provides the exact dose-reduction table by metaboliser phenotype.

Same shape for:
- TPMT / NUDT15 → thiopurines (pediatric ALL maintenance)
- CYP2D6 → tamoxifen (HR+ breast adjuvant)
- UGT1A1 → irinotecan (CRC FOLFIRI / FOLFOXIRI)

All directly applicable to existing OpenOnco regimens. Adding CPIC unlocks a whole new RedFlag layer with the structured mapping already curated upstream.

## What's in the box

- **`knowledge_base/clients/cpic_client.py`** — `BaseSourceClient[CpicQuery, dict]` subclass. Two modes: `search_drug` (drug+gene pair lookup, canonical use case) and `get_guideline` (by ID). Live calls gated behind `OPENONCO_CPIC_LIVE=1`. PostgREST top-level arrays wrapped under `{results: [...]}` so the downstream contract stays dict-shaped. Search size capped at 100.
- **`knowledge_base/hosted/content/sources/src_cpic.yaml`** — Source entity. License: `CC BY 4.0 (guidelines) / CC0 1.0 (data tables)`, SPDX `CC-BY-4.0`. `attribution.required: true` with the standard CPIC citation string drafted. `commercial_use_allowed: true`, `redistribution_allowed: true`, `modifications_allowed: true`, `sharealike_required: false`. `legal_review.status: reviewed`.
- **`docs/reviews/cpic-license-2026-05-18.md`** — full 4-constraint classification, attribution-handling protocol, list of high-value gene-drug pairs for follow-up RedFlag work, re-review triggers.
- **`tests/test_cpic_client.py`** — 10 offline tests covering the DPYD-fluorouracil canonical query, gate semantics, URL param assembly, PostgREST array wrapping, cache reuse, source-entity schema, source-id drift guard.
- **`tests/fixtures/cpic_responses/`** — 2 stub JSON files derived from the public CPIC schema (no CPIC content copied).

## Per `SOURCE_INGESTION_SPEC §20` checklist

- [x] License reviewed — `docs/reviews/cpic-license-2026-05-18.md`
- [x] Hosting mode selected — `referenced` (default per §1.4)
- [x] Schema validator — Source entity validates clean
- [x] Source entity with all license/attribution/legal_review fields
- [x] Client written
- [ ] First fetch + diff vs null baseline + clinical review — deferred until first ingest workstream
- [ ] CI job for scheduled re-fetch — deferred until first hosted workstream

## What this PR does NOT do (deliberately)

- **No DPYD / TPMT / CYP2D6 RedFlag content.** Those need two Clinical Co-Lead signoffs per CHARTER §6.1 for each authored field.
- **No live API calls by default.** `OPENONCO_CPIC_LIVE=1` must be set explicitly.
- **No `hosted` mode migration.**

## Test plan

- [x] `pytest tests/test_cpic_client.py` — 10/10 pass
- [x] `pytest tests/test_base_source_client.py tests/test_engine.py tests/test_actionability_invariants.py` — 45 pass / 3 pre-existing skips, no regressions
- [x] KB validator strict — 388 → 389 sources, all references resolve
- [x] No clinical content edits
- [x] No `git add -A` / `--no-verify` — explicit pathspecs only
- [x] Attribution mechanism maps cleanly onto existing Source-citation render pattern (verified by reading `knowledge_base/engine/render.py` Source-footer code)

## Re-review triggers

1. CPIC switches the guideline license (CC BY-NC or NoDerivatives would invalidate the analysis)
2. OpenOnco adopts a commercial tier under CHARTER §2
3. Migration to `hosted` mode (snapshotting)
4. Attribution-rendering shape changes in a way that loses CC BY 4.0 propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)