### PR TITLE
feat(sources): src_ctgov.yaml — close Gap 1 from ctgov audit

### DIFF
--- a/knowledge_base/hosted/content/sources/src_ctgov.yaml
+++ b/knowledge_base/hosted/content/sources/src_ctgov.yaml
@@ -1,0 +1,85 @@
+id: SRC-CTGOV-REGISTRY
+source_type: clinical_trial_registry
+title: "ClinicalTrials.gov — US National Library of Medicine clinical trial registry"
+version: "v2"
+authors:
+  - "U.S. National Library of Medicine"
+  - "National Institutes of Health"
+url: https://clinicaltrials.gov/
+access_level: open_access
+currency_status: current
+current_as_of: "2026-05-18"
+evidence_tier: 2
+precedence_policy: confirmatory
+
+# Licensing & hosting (SOURCE_INGESTION_SPEC §3)
+# ClinicalTrials.gov is a service of the US National Library of Medicine
+# (NLM), part of the National Institutes of Health (NIH), a US federal
+# agency. The registry's records are works of the US federal government
+# and are in the public domain under 17 U.S.C. §105. NLM's published
+# Terms and Conditions at clinicaltrials.gov/about-site/terms-conditions
+# confirm: "Information available on this Site is in the public domain
+# and freely available for further dissemination."
+hosting_mode: referenced
+ingestion:
+  method: live_api
+  client: knowledge_base.clients.ctgov_client.CtgovClient
+  endpoint: https://clinicaltrials.gov/api/v2
+  rate_limit: "~0.8 req/s, burst 3 (self-imposed; NLM publishes a soft 50 req/min courtesy limit)"
+cache_policy:
+  enabled: true
+  ttl_hours: 168
+  scope: query_result
+license:
+  name: "US Public Domain (17 U.S.C. §105)"
+  url: https://clinicaltrials.gov/about-site/terms-conditions
+attribution:
+  required: false
+  text: "Data from ClinicalTrials.gov, a service of the U.S. National Library of Medicine."
+commercial_use_allowed: true
+redistribution_allowed: true
+modifications_allowed: true
+sharealike_required: false
+known_restrictions:
+  - "Trial-record content submitted by sponsors may include third-party material (institution-authored protocol text, IRB-authored consent language). The federal-government-work analysis covers the NLM's curatorial layer; embedded sponsor content carries the sponsor's own copyright posture. The published Terms note: 'You should review the full content of any individual study record and contact the study sponsor for permission to use any third-party material.'"
+  - "NCT IDs and structured fields (status, phase, enrollment, sites) are operational metadata, not copyrightable."
+legal_review:
+  status: reviewed
+  reviewer: claude
+  date: "2026-05-18"
+  notes: |
+    Self-review under CHARTER §6.1 dev-mode exemption (v0.1 phase).
+    Same license posture as NCI PDQ (SRC-PDQ): US federal-government
+    work, 17 U.S.C. §105, public domain. NLM's own Terms and
+    Conditions explicitly state the data is in the public domain and
+    freely redistributable. The third-party-material caveat is real
+    but applies to the prose / consent text inside individual trial
+    records; OpenOnco's use of ctgov is structured metadata (NCT ID,
+    status, phase, sites, brief summary), not bulk reproduction of
+    protocol prose.
+
+    Re-review triggers: (a) NLM changes its Terms and Conditions
+    posture, (b) OpenOnco starts bulk-reproducing trial-record prose
+    (would need per-record attribution), (c) migration to `hosted`
+    mode (snapshotting). Companion audit:
+    docs/reviews/ctgov-wiring-audit-2026-05-18.md.
+
+relates_to_diseases: []
+last_verified: "2026-05-18"
+verifier: claude
+notes: |
+  Closes Gap 1 from docs/reviews/ctgov-wiring-audit-2026-05-18.md:
+  the code constant "SRC-CTGOV-REGISTRY" (referenced by ctgov_client,
+  experimental_option schema, mdt_orchestrator) now resolves to a
+  real Source entity.
+
+  Existing wiring (177 prewarmed cache files, experimental_options
+  bundle, render-layer track) carries unchanged. This PR is metadata
+  only — no engine or client code touched.
+
+  See companion scaffolds shipping same shape:
+    - src_pdq.yaml  (PR #589)
+    - src_cpic.yaml (PR #590)
+pages_count: 0
+references_count: 480000  # rough order — ctgov.gov currently lists ~500k registered studies
+corpus_role: terminology

--- a/tests/test_src_ctgov_entity.py
+++ b/tests/test_src_ctgov_entity.py
@@ -1,0 +1,67 @@
+"""src_ctgov.yaml drift guard.
+
+Gap 1 from docs/reviews/ctgov-wiring-audit-2026-05-18.md: the code
+constant SRC-CTGOV-REGISTRY (referenced from ctgov_client, the
+experimental_option schema, and mdt_orchestrator) must resolve to a
+real Source entity. Validator only checks YAML-to-YAML refs, not code
+constants — so this test closes the missing invariant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from knowledge_base.clients.ctgov_client import CtgovClient
+from knowledge_base.schemas import Source
+
+
+_SRC_YAML = (
+    Path(__file__).parent.parent
+    / "knowledge_base"
+    / "hosted"
+    / "content"
+    / "sources"
+    / "src_ctgov.yaml"
+)
+
+
+def _load() -> Source:
+    return Source.model_validate(yaml.safe_load(_SRC_YAML.read_text(encoding="utf-8")))
+
+
+def test_src_ctgov_yaml_exists_and_loads():
+    assert _SRC_YAML.is_file(), f"missing Source entity at {_SRC_YAML}"
+    src = _load()
+    assert src.id == "SRC-CTGOV-REGISTRY"
+
+
+def test_source_id_matches_client_constant():
+    """The whole point of this PR — code constant resolves to an entity."""
+    src = _load()
+    assert CtgovClient.source_id == src.id
+
+
+def test_license_metadata_is_us_public_domain():
+    src = _load()
+    assert src.hosting_mode.value == "referenced"
+    assert src.license is not None
+    assert "Public Domain" in src.license.name
+    assert src.commercial_use_allowed is True
+    assert src.redistribution_allowed is True
+    assert src.modifications_allowed is True
+    assert src.sharealike_required is False
+
+
+def test_legal_review_signed_off():
+    src = _load()
+    assert src.legal_review is not None
+    assert src.legal_review.status.value == "reviewed"
+
+
+def test_ingestion_block_points_at_real_client():
+    """Catches a future rename of CtgovClient that forgets to update YAML."""
+    src = _load()
+    assert src.ingestion is not None
+    assert src.ingestion.client == "knowledge_base.clients.ctgov_client.CtgovClient"


### PR DESCRIPTION
## Summary

Adds the missing `Source` entity for `SRC-CTGOV-REGISTRY`. Closes **Gap 1** from the ctgov wiring audit in [#591](https://github.com/romeo111/OpenOnco/pull/591).

The code constant `SRC-CTGOV-REGISTRY` is referenced from `ctgov_client.py:458`, the `ExperimentalOption` schema, and `mdt_orchestrator.py`, but no YAML Source entity existed. The KB validator only checks references between YAML entities, not code constants, so the latent citation-resolution bug went unnoticed.

Sibling scaffolds shipping the same shape for new sources: [#589 (NCI PDQ)](https://github.com/romeo111/OpenOnco/pull/589), [#590 (CPIC)](https://github.com/romeo111/OpenOnco/pull/590).

## License posture

Same as NCI PDQ: ClinicalTrials.gov is operated by the US National Library of Medicine (NIH/NLM), a US federal agency. Records are federal-government works in the US public domain per 17 U.S.C. §105. NLM's published Terms explicitly state the data is "in the public domain and freely available for further dissemination."

| Constraint | Value |
| --- | --- |
| `hosting_mode` | `referenced` |
| License | US Public Domain (17 U.S.C. §105) |
| Commercial use | ✓ |
| Redistribution | ✓ |
| Modifications | ✓ |
| ShareAlike required | ✗ |
| Attribution required | ✗ (NLM publishes courtesy text only) |
| `legal_review.status` | `reviewed` |

**Third-party-material caveat** recorded under `known_restrictions`: trial-record content submitted by sponsors may include institution-authored protocol text. The federal-government-work analysis covers the NLM curatorial layer; embedded sponsor content carries the sponsor's own posture. OpenOnco's use is structured metadata (NCT ID, status, phase, sites, brief summary) — not bulk prose reproduction.

## What's in the box

- **`knowledge_base/hosted/content/sources/src_ctgov.yaml`** — Source entity with full license metadata, ingestion block pointing at `knowledge_base.clients.ctgov_client.CtgovClient`, third-party-material caveat under `known_restrictions`.
- **`tests/test_src_ctgov_entity.py`** — 5 drift-guard tests:
  - Entity exists + parses under Source schema
  - `CtgovClient.source_id` matches `src.id` (catches future renames)
  - License posture is US Public Domain, 4 constraints clear
  - `legal_review.status == reviewed`
  - `ingestion.client` points at the real `CtgovClient` FQN (catches future moves)

## What this PR does NOT do

- **No code changes** — pure metadata.
- **No engine wiring changes** — existing 177 prewarmed cache files, `experimental_options` bundle, render-layer experimental track all unchanged.
- **No Gap 2** (UA-site facility extraction) — separate workstream per the audit.
- **No Gap 3** (NCT-ID enrichment of cited pivotal trials) — separate workstream per the audit.

## Test plan

- [x] `pytest tests/test_src_ctgov_entity.py` — 5/5 pass
- [x] `pytest tests/test_experimental_options.py tests/test_trial_outlook.py` — 39/39 pass (no regressions)
- [x] KB validator strict — 388 → 389 sources, all references resolve
- [x] No clinical content edits
- [x] Explicit pathspecs, no `git add -A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)