### PR TITLE
feat(render): cited-trials status section — Gap 3 finale

### DIFF
--- a/knowledge_base/engine/render.py
+++ b/knowledge_base/engine/render.py
@@ -1865,6 +1865,84 @@ def _outlook_notes_index(outlook) -> dict[str, str]:
     return idx
 
 
+def _render_cited_trials_status(
+    body_html: str,
+    target_lang: str = "uk",
+    cache_root=None,
+) -> str:
+    """Decorate cited pivotal trials with live status from the per-NCT
+    cache. Closes Gap 3 from `docs/reviews/ctgov-wiring-audit-2026-05-18.md`.
+
+    Strategy: extract every NCT that already appears in the rendered
+    Plan body (so we decorate exactly what was cited, no more), look up
+    each in the per-NCT cache, render a status badge block. Skips the
+    section entirely when no cached badge is available — never invents
+    placeholder content.
+
+    Render-time only (CHARTER §8.3): does not influence routing.
+    """
+    from .citation_enrichment import (
+        DEFAULT_CACHE_ROOT,
+        extract_nct_ids,
+        trial_status_badge,
+    )
+
+    if not body_html:
+        return ""
+
+    root = cache_root if cache_root is not None else DEFAULT_CACHE_ROOT
+    cited = extract_nct_ids(body_html)
+    if not cited:
+        return ""
+
+    rows = []
+    for nct in cited:
+        badge = trial_status_badge(nct, cache_root=root)
+        if badge is None:
+            continue
+        status_class = "trial-status--recruiting" if badge.is_recruiting else "trial-status--closed"
+        status_label = badge.status.replace("_", " ").title()
+        synced = badge.last_synced or ""
+        if synced and len(synced) >= 10:
+            synced_short = synced[:10]
+        else:
+            synced_short = synced
+        rows.append(
+            '<li class="cited-trial">'
+            f'<a href="https://clinicaltrials.gov/study/{_h(nct)}" '
+            f'target="_blank" rel="noopener" class="cited-trial-nct">{_h(nct)}</a>'
+            f' <span class="badge {status_class}">{_h(status_label)}</span>'
+            + (f' <span class="cited-trial-synced">({_h(synced_short)})</span>' if synced_short else "")
+            + "</li>"
+        )
+
+    if not rows:
+        # NCTs were cited but none have cached status — suppress the
+        # section rather than emit an empty list. The cache may be
+        # unpopulated (fresh checkout) or the prewarm hasn't run.
+        return ""
+
+    heading = (
+        "Цитовані випробування — поточний статус"
+        if target_lang == "uk"
+        else "Cited trials — current status"
+    )
+    sub = (
+        "Поточний статус набору з ClinicalTrials.gov, оновлено через "
+        "кеш per-NCT (`scripts/sync_ctgov_studies.py`)."
+        if target_lang == "uk"
+        else "Recruiting status from ClinicalTrials.gov, refreshed via "
+             "the per-NCT cache (`scripts/sync_ctgov_studies.py`)."
+    )
+    return (
+        '<section class="cited-trials-status">'
+        f'<h2>{_h(heading)}</h2>'
+        f'<p class="section-sub">{_h(sub)}</p>'
+        f'<ul class="cited-trials-list">{"".join(rows)}</ul>'
+        '</section>'
+    )
+
+
 def _render_experimental_options(option, target_lang: str = "uk") -> str:
     """Render the clinical-trial track surfaced after engine selection.
 
@@ -3072,6 +3150,13 @@ def render_plan_html(
     if fda.data_sources_summary:
         items = "".join(f"<li>{_h(s)}</li>" for s in fda.data_sources_summary)
         body.append(f"<section><h2>Sources cited</h2><ul class='sources'>{items}</ul></section>")
+
+    # Cited trials — live status decoration for cited pivotal NCT IDs.
+    # Scans the in-progress body for `NCT\d{8}` occurrences and looks up
+    # cached ctgov data via `_render_cited_trials_status`. Render-time
+    # only (CHARTER §8.3); empty when the cache has nothing.
+    # See docs/reviews/ctgov-wiring-audit-2026-05-18.md Gap 3.
+    body.append(_render_cited_trials_status("".join(body), target_lang))
 
     # Experimental options (Phase C — clinical-trial track)
     body.append(_render_experimental_options(plan_result.experimental_options, target_lang))

--- a/tests/test_cited_trials_render.py
+++ b/tests/test_cited_trials_render.py
@@ -1,0 +1,132 @@
+"""Cited-trials status render — Gap 3 finale.
+
+Closes the render layer of Gap 3 from
+`docs/reviews/ctgov-wiring-audit-2026-05-18.md`. The foundation
+(extraction + cache + badge) shipped in the parent PR; this layer
+decorates Plan output with a "Cited trials — current status" section.
+
+Coverage:
+
+1. `_render_cited_trials_status` extracts NCTs from input HTML, looks
+   up cached badges, emits a section with status badges (link to
+   ctgov, recruiting / closed colour class, last-synced date).
+2. Section is suppressed when no NCTs cited, or when none have
+   cached status (silent fallback — never invent placeholder content).
+3. Badge colour class differs for recruiting vs closed trials.
+4. Render-time only (CHARTER §8.3): no engine routing side effect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from knowledge_base.engine.citation_enrichment import save_study_to_cache
+from knowledge_base.engine.render import _render_cited_trials_status
+
+
+def test_empty_body_returns_empty_string(tmp_path: Path):
+    assert _render_cited_trials_status("", "uk", cache_root=tmp_path) == ""
+
+
+def test_no_ncts_in_body_returns_empty_string(tmp_path: Path):
+    body = "<section><p>Some clinical text without trial citations.</p></section>"
+    assert _render_cited_trials_status(body, "uk", cache_root=tmp_path) == ""
+
+
+def test_nct_cited_but_no_cache_suppresses_section(tmp_path: Path):
+    """Conservative fallback: when an NCT appears in the rendered body
+    but the per-NCT cache has nothing, suppress the section rather than
+    show a placeholder. Avoids implying the data was looked up when it
+    wasn't."""
+    body = "<p>KEYNOTE-024 (NCT02220894) showed OS benefit.</p>"
+    out = _render_cited_trials_status(body, "uk", cache_root=tmp_path)
+    assert out == ""
+
+
+def test_renders_recruiting_badge(tmp_path: Path):
+    save_study_to_cache(
+        "NCT04001023",
+        {"nct_id": "NCT04001023", "status": "RECRUITING", "phase": "PHASE3"},
+        cache_root=tmp_path,
+    )
+    body = '<p>Trial reference: NCT04001023</p>'
+    out = _render_cited_trials_status(body, "uk", cache_root=tmp_path)
+    assert "cited-trials-status" in out
+    assert "NCT04001023" in out
+    assert "trial-status--recruiting" in out
+    assert "Recruiting" in out
+    assert 'href="https://clinicaltrials.gov/study/NCT04001023"' in out
+
+
+def test_renders_closed_badge_with_different_class(tmp_path: Path):
+    save_study_to_cache(
+        "NCT02220894",
+        {"status": "COMPLETED"},
+        cache_root=tmp_path,
+    )
+    body = "<p>KEYNOTE-024 (NCT02220894).</p>"
+    out = _render_cited_trials_status(body, "uk", cache_root=tmp_path)
+    assert "trial-status--closed" in out
+    assert "trial-status--recruiting" not in out
+    assert "Completed" in out
+
+
+def test_multiple_ncts_each_get_their_own_row(tmp_path: Path):
+    save_study_to_cache(
+        "NCT01", {"status": "RECRUITING"}, cache_root=tmp_path
+    )
+    save_study_to_cache(
+        "NCT02", {"status": "COMPLETED"}, cache_root=tmp_path
+    )
+    save_study_to_cache(
+        "NCT03", {"status": "TERMINATED"}, cache_root=tmp_path
+    )
+    # Use 8-digit NCTs since the extractor requires exactly 8 digits.
+    save_study_to_cache("NCT10000001", {"status": "RECRUITING"}, cache_root=tmp_path)
+    save_study_to_cache("NCT10000002", {"status": "COMPLETED"},  cache_root=tmp_path)
+    save_study_to_cache("NCT10000003", {"status": "TERMINATED"}, cache_root=tmp_path)
+    body = (
+        "Body mentions NCT10000001, then NCT10000002, then NCT10000003."
+    )
+    out = _render_cited_trials_status(body, "uk", cache_root=tmp_path)
+    assert out.count("<li") == 3
+    assert "NCT10000001" in out and "NCT10000002" in out and "NCT10000003" in out
+
+
+def test_partial_cache_only_shows_what_we_have(tmp_path: Path):
+    """Body cites two NCTs but cache only has one. Section appears with
+    the one we know; the uncached one is silently dropped."""
+    save_study_to_cache(
+        "NCT10000001", {"status": "RECRUITING"}, cache_root=tmp_path
+    )
+    body = "Citing NCT10000001 and NCT99999999."
+    out = _render_cited_trials_status(body, "uk", cache_root=tmp_path)
+    assert "NCT10000001" in out
+    assert "NCT99999999" not in out
+
+
+def test_last_synced_date_truncated_to_yyyy_mm_dd(tmp_path: Path):
+    save_study_to_cache(
+        "NCT10000001",
+        {"status": "RECRUITING"},
+        cache_root=tmp_path,
+    )
+    out = _render_cited_trials_status(
+        "NCT10000001", "uk", cache_root=tmp_path
+    )
+    # ISO timestamp written by save_study_to_cache → trimmed to date.
+    import re
+    m = re.search(r'cited-trial-synced">\(([^)]+)\)', out)
+    assert m is not None
+    # Just yyyy-mm-dd
+    assert re.fullmatch(r'\d{4}-\d{2}-\d{2}', m.group(1))
+
+
+def test_localized_heading_uk_vs_en(tmp_path: Path):
+    save_study_to_cache(
+        "NCT10000001", {"status": "RECRUITING"}, cache_root=tmp_path
+    )
+    uk = _render_cited_trials_status("NCT10000001", "uk", cache_root=tmp_path)
+    en = _render_cited_trials_status("NCT10000001", "en", cache_root=tmp_path)
+    assert "Цитовані випробування" in uk
+    assert "Cited trials" in en


### PR DESCRIPTION
## Summary

**Stacked on [#595](https://github.com/romeo111/OpenOnco/pull/595)** (NCT-ID enrichment foundation). Closes the render layer of Gap 3 from the ctgov wiring audit ([#591](https://github.com/romeo111/OpenOnco/pull/591)).

The foundation provides extraction + cache + badge. This PR wires it into `render_plan_html`: a new "Cited trials — current status" section appears below "Sources cited" and lists every cited pivotal NCT with its current ClinicalTrials.gov status.

> **Note on stacking:** The diff against `master` shows both PRs; the actual change in this PR is `knowledge_base/engine/render.py` (helper + hook) + `tests/test_cited_trials_render.py`. Set base = #595 to see the isolated diff.

## What renders

For each cited NCT that has cached status:

```
[NCT02220894]  [Completed]  (2026-05-18)
[NCT04001023]  [Recruiting] (2026-05-18)
```

Status badges use different CSS classes (`trial-status--recruiting` / `trial-status--closed`) so they can be styled distinctly. Each NCT links to `clinicaltrials.gov/study/<NCT>`.

## Conservative defaults (no surprises)

The render hook **silently suppresses** the section when:
- No NCTs appear in the body
- NCTs appear but none have cached status (e.g. fresh checkout where prewarm hasn't run)

This avoids implying we looked up data that we didn't, and keeps the Plan looking clean before the first sync run.

## Hook location

`knowledge_base/engine/render.py:3077` — right after "Sources cited", before "Experimental options". The helper takes the joined body HTML and regex-extracts NCTs from it, so we decorate exactly what was cited anywhere upstream (Indication notes, Source citations, RedFlag rationale prose, etc.) — no manual list to maintain.

## Tests — 9 new

- Empty body → empty string
- Body with no NCTs → empty string
- NCT cited but no cache → suppressed
- Recruiting badge → `trial-status--recruiting` class
- Completed badge → `trial-status--closed` class
- Three NCTs → three `<li>` rows in order
- Partial cache → cached shown, uncached silently dropped
- `last_synced` truncated to YYYY-MM-DD
- Localized heading: "Цитовані випробування…" (uk) / "Cited trials…" (en)

## Test plan

- [x] `pytest tests/test_cited_trials_render.py` — 9/9 pass
- [x] `pytest tests/test_citation_enrichment.py tests/test_experimental_options.py tests/test_trial_outlook.py tests/test_engine.py tests/test_reference_case_e2e.py tests/test_burkitt_engine.py` — 107/107 pass
- [x] KB validator strict — all entities valid, all refs resolve
- [x] Render-time only (CHARTER §8.3): zero engine routing side effect
- [x] No live API calls (cache-only, as specced)
- [x] No clinical content edits
- [x] Explicit pathspecs

## What this PR does NOT do

- **No live ctgov calls** in render path — cache-only. Operator runs `python scripts/sync_ctgov_studies.py` once to populate.
- **No patient-mode wiring** — clinician mode only. Patient mode has separate rendering and would need explicit opt-in (technical IDs minimization).
- **No clinical content edits.**

## End-to-end loop now possible

1. Run `python scripts/sync_ctgov_studies.py` once (network access)
2. ~149 JSON files appear under `knowledge_base/hosted/content/cache/ctgov_studies/`
3. Commit those
4. `render_plan_html` automatically decorates every cited pivotal trial with live status

🤖 Generated with [Claude Code](https://claude.com/claude-code)