### PR TITLE
ci(daily-refresh): sync ctgov-studies cache before site build

### DIFF
--- a/.github/workflows/daily-site-refresh.yml
+++ b/.github/workflows/daily-site-refresh.yml
@@ -49,6 +49,33 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
+      # Per-NCT ctgov cache for the cited-trials status section (PR #595,
+      # #596). Caches `knowledge_base/hosted/content/cache/ctgov_studies/`
+      # between runs so we don't re-fetch ~149 NCTs every day. Key is
+      # derived from Source + Indication file hashes — when the citing
+      # NCT set changes, the key changes and we refetch on next run.
+      # `restore-keys` falls back to any older snapshot so a small KB
+      # edit doesn't invalidate the whole cache.
+      - name: Restore ctgov-studies cache
+        uses: actions/cache@v4
+        with:
+          path: knowledge_base/hosted/content/cache/ctgov_studies
+          key: ctgov-studies-${{ hashFiles('knowledge_base/hosted/content/sources/*.yaml', 'knowledge_base/hosted/content/indications/*.yaml') }}
+          restore-keys: |
+            ctgov-studies-
+
+      # Populate / refresh the per-NCT cache for cited pivotal trials.
+      # Script enforces a 30-day TTL on cache entries; restored entries
+      # within TTL are skipped, only new or stale NCTs hit upstream.
+      # `continue-on-error: true` — if api.clinicaltrials.gov is
+      # unreachable, the rendered Plans simply omit the cited-trials
+      # section (the render layer suppresses silently when cache is
+      # empty); daily refresh still publishes the rest of the site.
+      - name: Sync ctgov-studies cache for cited pivotal trials
+        continue-on-error: true
+        run: |
+          python scripts/sync_ctgov_studies.py --sleep 0.3
+
       - name: Regenerate docs/ from current KB
         run: |
           python -m scripts.build_site


### PR DESCRIPTION
## Summary

**Stacked on [#595](https://github.com/romeo111/OpenOnco/pull/595)** (NCT-ID enrichment foundation). Closes the production deployment loop for the cited-trials status section in [#596](https://github.com/romeo111/OpenOnco/pull/596).

## Why

Cache directory `knowledge_base/hosted/content/cache/ctgov_studies/` is `.gitignore`'d (same pattern as the existing `cache/ctgov/`). So without a CI step:
- ✅ Locally, after `python scripts/sync_ctgov_studies.py`, the render layer surfaces the cited-trials section
- ❌ On the GH Actions runner that builds openonco.info, the cache stays empty and the section silently suppresses

This PR adds the missing CI step so the section appears in production builds.

## What's in the box

Two new steps inserted between `Install dependencies` and `Regenerate docs/`:

```yaml
- name: Restore ctgov-studies cache
  uses: actions/cache@v4
  with:
    path: knowledge_base/hosted/content/cache/ctgov_studies
    key: ctgov-studies-${{ hashFiles('knowledge_base/hosted/content/sources/*.yaml', 'knowledge_base/hosted/content/indications/*.yaml') }}
    restore-keys: |
      ctgov-studies-

- name: Sync ctgov-studies cache for cited pivotal trials
  continue-on-error: true
  run: |
    python scripts/sync_ctgov_studies.py --sleep 0.3
```

## Steady-state cost

- **Day 1 (first run):** 149 NCT lookups, ~80s, cache saved (~700 KB).
- **Day N+1, no KB change:** `restore-keys: ctgov-studies-` hits previous snapshot. Sync script's 30-day TTL skips all 149 (no API calls).
- **Day N+1, KB edit:** cache key changes (file hash). `restore-keys` still restores the most recent snapshot. Most NCTs still within TTL; sync skips them. Only NCTs newly added to the KB hit upstream.

Cache size ~700 KB — well under the 10 GB per-repo Actions cache limit.

## Failure modes

| Mode | Result |
| --- | --- |
| api.clinicaltrials.gov 5xx for one NCT | Sync script records failure, exits 1, `continue-on-error: true` lets workflow continue. Render layer skips that one NCT, surfaces the others. |
| api.clinicaltrials.gov fully unreachable | Sync fails, `continue-on-error` lets build proceed. Render layer suppresses the cited-trials section entirely (its silent-empty fallback). |
| Cache restore key miss | First-run shape: 149 API calls. ~80s added to the daily refresh — acceptable one-off cost. |
| Cache write fails | `actions/cache@v4` logs but doesn't fail the job. Next day re-fetches. |

## What this PR does NOT do

- **No changes to `Regenerate docs/`, `Commit and push`, or any other existing step.** Only insertion of two new steps.
- **No new schedule.** Still 07:23 UTC daily, same `concurrency` group, same trigger.
- **No new secrets.** Uses the existing default `GITHUB_TOKEN`.

## Test plan

- [x] YAML syntax validates (`yaml.safe_load`)
- [x] Step order verified — Restore → Sync → Regenerate
- [x] Cache key uses `hashFiles` on the right directories (Source + Indication, where NCTs live)
- [x] `continue-on-error: true` on sync step so ctgov outages don't break the daily refresh
- [x] No clinical content edits
- [x] Local run of `scripts/sync_ctgov_studies.py` verified: 149 NCTs fetched, 0 failures (run completed on this machine before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)