### PR TITLE
feat(ncit): NCI Thesaurus source scaffold + term-normalization hooks

### DIFF
--- a/docs/reviews/ncit-license-2026-05-18.md
+++ b/docs/reviews/ncit-license-2026-05-18.md
@@ -1,0 +1,190 @@
+# NCI Thesaurus license review — 2026-05-18
+
+Per `specs/SOURCE_INGESTION_SPEC.md` §8 and §20. Classifies the NCI
+Thesaurus (NCIt) for OpenOnco reuse as the term-normalization layer
+behind `BIO-*` / `DIS-*` entity IDs.
+
+## TL;DR
+
+- **License class:** US Public Domain (17 U.S.C. §105 — federal-government works).
+- **Hosting mode:** `referenced` (default per `SOURCE_INGESTION_SPEC §1.4`).
+- **Four constraints clear:** commercial ✓, redistribution ✓, modifications ✓, share-alike NOT required.
+- **Attribution:** not required; courtesy text published in `src_ncit.yaml.attribution.text`.
+- **One scope boundary:** NCIt cross-references concepts to other vocabularies (SNOMED CT, MedDRA, ICD-O-3, MeSH). Cross-reference *codes* are NOT NCI-authored content — those code systems retain their own licenses. OpenOnco only consumes the NCIt concept layer.
+- **`legal_review.status: reviewed`** in `src_ncit.yaml`. Re-review triggers documented below.
+
+## What NCIt is
+
+The NCI Thesaurus is the National Cancer Institute's reference vocabulary
+for cancer concepts. Maintained by the NCI Enterprise Vocabulary Services
+(EVS), it covers:
+
+- Diseases (e.g. C2926 = Non-Small Cell Lung Carcinoma)
+- Biomarkers / genes / variants (e.g. C17068 = EGFR Gene, C20188 = EGFR Mutation)
+- Drugs and active agents
+- Anatomic sites
+- Procedures and interventions
+- Pathologic findings
+
+Each concept carries a stable NCIt code, a preferred term, alternate
+synonyms, NCI-authored definitions, and machine-readable cross-references
+to other vocabularies (SNOMED CT, MedDRA, ICD-O-3, MeSH, etc.).
+
+Public-facing surfaces:
+- Browser: <https://ncithesaurus.nci.nih.gov/ncitbrowser/>
+- EVS REST API: <https://api-evsrest.nci.nih.gov/api/v1/>
+- Documentation: <https://api-evsrest.nci.nih.gov/swagger-ui.html>
+
+## Why we want it
+
+The OpenOnco patient-input flow accepts free-text disease and biomarker
+mentions ("lung cancer", "EGFR positive"). These need to resolve to KB
+IDs (`DIS-NSCLC`, `BIO-EGFR-MUTATION`) so the engine can route.
+
+Today's normalization is ad-hoc: each `Disease` / `Biomarker` entity
+carries its own `names: {en, ua}` block, plus a small `alternate_names`
+list, and the matching layer compares free text against those. That
+scales poorly:
+
+- Multi-language matching is brittle (Ukrainian + English only)
+- Synonyms drift between entities
+- New free-text input that wasn't anticipated by the entity author silently misses
+
+NCIt gives us a canonical mapping layer:
+
+1. Patient enters "lung cancer" → NCIt search returns C2926 (NSCLC) +
+   neighbours (C3262 Lung Carcinoma, C3905 Small Cell Lung Carcinoma, …)
+2. Each KB Disease has `codes.ncit` populated (`DIS-NSCLC.codes.ncit = "C2926"`)
+3. The matching layer resolves free text → NCIt code → KB ID
+
+Same pattern for biomarkers. NCIt's synonym tables (NCI maintains them
+centrally) eliminate the per-entity-author-rolls-their-own problem.
+
+## License classification
+
+### Primary basis: 17 U.S.C. §105
+
+> "Copyright protection under this title is not available for any work
+> of the United States Government …"
+
+NCI EVS is a unit of the National Institutes of Health, a US federal
+agency. NCIt content is authored by federal employees acting in their
+official capacity. It is therefore ineligible for US copyright
+protection and is in the **public domain within the United States**.
+
+### NCI's own statement
+
+The cancer.gov reuse policy at <https://www.cancer.gov/policies/copyright-reuse>
+states:
+
+> "Most of the text on this website is freely available for reuse —
+> except for material we have explicitly noted as borrowed from
+> external sources. Cancer information is generally NOT copyrighted
+> and there are usually no restrictions on its use."
+
+Same posture used for SRC-PDQ (PR #589) and SRC-CTGOV-REGISTRY (PR #592).
+
+### Four-constraint check (per `SOURCE_INGESTION_SPEC §8`)
+
+| Constraint | Answer | Source |
+| --- | --- | --- |
+| Commercial use allowed? | **Yes** | 17 U.S.C. §105; NCI policy |
+| Redistribution allowed? | **Yes** | Same |
+| Modifications allowed? | **Yes** | Same — public-domain text is freely modifiable |
+| ShareAlike required? | **No** | Public-domain works carry no downstream license obligation |
+
+### Cross-reference scope boundary
+
+NCIt records carry cross-references to other vocabularies. For example,
+the NCIt record for "Non-Small Cell Lung Carcinoma" includes the
+matching SNOMED CT code (254637007) and ICD-10 code (C34.9).
+
+**The cross-reference *codes themselves* are NOT NCI-authored content.**
+The license posture of each external vocabulary applies:
+
+- **SNOMED CT codes** — IHTSDO license, country affiliate fees apply.
+  Excluded from MVP per `CLAUDE.md` ("No SNOMED CT, no MedDRA in MVP — license gates").
+- **MedDRA codes** — paid commercial license required. Excluded similarly.
+- **ICD-10 / ICD-O-3 codes** — WHO maintains; permissive for most uses.
+- **MeSH codes** — NLM, public domain.
+
+OpenOnco's use of NCIt is **only the NCIt concept code layer**:
+`{code: "C2926", name: "Non-Small Cell Lung Carcinoma", synonyms: [...]}`.
+We do NOT consume the cross-referenced SNOMED CT / MedDRA codes. The
+EVS API can be queried with `include=summary` to get exactly this
+narrow projection — synonyms + definition, no cross-refs. This is the
+default in `ncit_client.NcitQuery.include`.
+
+If a future workstream needs richer cross-references, that workstream
+must re-evaluate license posture for each external code system before
+consuming.
+
+## Hosting mode
+
+`referenced`, per `SOURCE_INGESTION_SPEC §1.4` default. We do not host
+NCIt content in the repo; we store NCIt codes (e.g. "C2926") on
+`Disease.codes.ncit` and `BiomarkerExternalIDs.ncit`, and resolve them
+to display text via live API calls (with 30-day cache).
+
+If a future workstream needs offline normalization (e.g. for a
+fully-offline Pyodide bundle), migrating to `hosted` mode requires
+fresh review covering snapshot cadence (NCIt updates monthly),
+attribution boilerplate (already drafted), and storage scale.
+
+For now: referenced.
+
+## Engineering scope (this PR)
+
+1. `knowledge_base/clients/ncit_client.py` — `BaseSourceClient` subclass.
+   Two query modes: `get_concept` (by NCIt code) and `search` (by
+   free-text term). Live calls gated behind `OPENONCO_NCIT_LIVE=1`.
+   `include=summary` default keeps responses narrow (no cross-ref codes).
+2. `knowledge_base/hosted/content/sources/src_ncit.yaml` — Source entity
+   with full license metadata, hosting=referenced, attribution-required=false,
+   `legal_review.status: reviewed`. Cross-reference scope boundary
+   recorded under `known_restrictions`.
+3. `knowledge_base/schemas/disease.py` — `DiseaseCodes.ncit: Optional[str]`.
+4. `knowledge_base/schemas/biomarker.py` — `BiomarkerExternalIDs.ncit: Optional[str]`.
+5. `tests/test_ncit_client.py` — 14 offline tests covering gate semantics,
+   HTTP-seam stubbing, query parameters, URL encoding, schema field
+   round-trips, source-id drift guard.
+6. `tests/fixtures/ncit_responses/` — 2 stub JSON files derived from
+   the EVS public schema (no NCIt content reproduced beyond canonical
+   codes already in our memory like C2926, C17068, C20188).
+
+## NOT in scope (deliberately)
+
+- **No per-Disease / per-Biomarker code population.** Populating `ncit`
+  on each `Disease` / `Biomarker` YAML is a separate clinical-content
+  workstream gated by `CHARTER §6.1` (two Clinical Co-Lead signoffs
+  per authored mapping).
+- **No live API calls by default.** `OPENONCO_NCIT_LIVE` must be set
+  explicitly.
+- **No SNOMED CT / MedDRA cross-references** consumed.
+- **No `hosted` mode migration.**
+- **No CI cron** for scheduled re-fetch.
+- **No actual term-normalization layer** in the engine yet — that's a
+  follow-up that consumes `Disease.codes.ncit` and the EVS search
+  endpoint.
+
+## Re-review triggers
+
+Update this doc and flip `legal_review.status` if any of:
+
+1. NCI changes its `cancer.gov/policies/copyright-reuse` page.
+2. OpenOnco changes its `CHARTER §2` posture (any paid tier).
+3. We start consuming cross-referenced **SNOMED CT** or **MedDRA**
+   codes from NCIt records — would inherit those vocabularies' license
+   constraints; both are explicitly excluded from MVP per `CLAUDE.md`.
+4. We adopt `hosted` mode (snapshotting NCIt content into the repo).
+5. EVS API changes its terms of service.
+
+## Sign-off
+
+- **Reviewer:** claude (self-review under `CHARTER §6.1` dev-mode
+  exemption, v0.1 phase, per memory `project_charter_dev_mode_exemptions.md`).
+- **Date:** 2026-05-18.
+- **Notes:** Third "US Public Domain" source after PDQ and CTGOV.
+  The novel constraint here is the cross-reference scope boundary —
+  documented under `src_ncit.yaml.known_restrictions` and enforced
+  by `NcitQuery.include` defaulting to `summary` rather than `full`.

--- a/knowledge_base/clients/ncit_client.py
+++ b/knowledge_base/clients/ncit_client.py
@@ -1,0 +1,169 @@
+"""NCI Thesaurus (NCIt) source client.
+
+NCIt is the National Cancer Institute's reference vocabulary for cancer
+concepts — diseases, biomarkers, drugs, anatomic sites, procedures, with
+preferred terms, synonyms, definitions, and cross-references to other
+vocabularies (ICD-10, MeSH, SNOMED-CT). Each concept carries a stable
+NCIt code (e.g. C4878 = Non-Small Cell Lung Carcinoma).
+
+Why we want it
+--------------
+The state audit (`docs/reviews/openonco-state-audit-2026-05-17.md`) and
+the patient-input flow both rely on free-text disease/biomarker terms
+resolving cleanly to KB entities. NCIt is the canonical vocabulary
+backing that normalization:
+
+- "lung cancer" / "non-small cell lung cancer" / "NSCLC" → NCIt C2926 →
+  our `DIS-NSCLC`
+- "EGFR positive" / "EGFR mutation" → NCIt C20188 (EGFR Mutation) →
+  our `BIO-EGFR-MUTATION`
+
+This scaffold lands the client + Source entity + optional `ncit_code`
+fields on `Disease.codes` and `BiomarkerExternalIDs`. Populating the
+codes per-entity is a separate clinical-content workstream gated by
+CHARTER §6.1.
+
+Licensing
+---------
+NCIt content is a work of the US federal government (NCI Enterprise
+Vocabulary Services, NIH). Public domain under 17 U.S.C. §105. Full
+classification: `docs/reviews/ncit-license-2026-05-18.md`.
+
+Upstream endpoint
+-----------------
+NCI Enterprise Vocabulary Services (EVS) REST API at
+`https://api-evsrest.nci.nih.gov/api/v1/`. Endpoints used:
+
+- `GET /concept/ncit/{code}` — concept by stable NCIt code
+- `GET /concept/ncit/search?term=…` — free-text concept search
+
+Documentation: https://api-evsrest.nci.nih.gov/swagger-ui.html. Field
+shapes and search parameters are stable; the URL templates are class
+attributes so a future EVS revision can be patched without touching
+the integration code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from knowledge_base.clients.base import (
+    BaseSourceClient,
+    CacheBackend,
+    RateLimit,
+)
+
+
+_NCIT_LIVE_ENV = "OPENONCO_NCIT_LIVE"
+_USER_AGENT = "OpenOnco/0.1 (+https://openonco.info)"
+
+
+@dataclass
+class NcitQuery:
+    """Either a single-concept fetch by NCIt code (mode='get_concept')
+    or a free-text search (mode='search').
+
+    `include` controls EVS field expansion. Default "summary" keeps the
+    response small (code, name, definition, synonyms). "full" pulls
+    parent/child relationships and external cross-refs.
+    """
+
+    mode: Literal["get_concept", "search"] = "get_concept"
+    code: Optional[str] = None
+    term: str = ""
+    include: Literal["minimal", "summary", "full"] = "summary"
+    max_results: int = 20
+
+
+class NcitClient(BaseSourceClient[NcitQuery, dict]):
+    """NCIt EVS client. Public-domain corpus, no auth required.
+
+    Conservative rate limit: 1 req/s with burst=3. EVS does not publish
+    a formal rate limit; this stays well under any plausible threshold.
+    Cache TTL is long (30 days) because NCIt content updates monthly
+    and individual concept records change infrequently.
+    """
+
+    source_id = "SRC-NCIT"
+    rate_limit = RateLimit(tokens_per_second=1.0, burst=3)
+    cache_ttl_seconds = 30 * 24 * 3600
+    api_version = "v1"
+
+    base_url: str = "https://api-evsrest.nci.nih.gov/api/v1"
+    concept_path: str = "/concept/ncit/{code}"
+    search_path: str = "/concept/ncit/search"
+
+    def __init__(self, cache: Optional[CacheBackend] = None) -> None:
+        super().__init__(cache=cache)
+
+    # ── Subclass hook ────────────────────────────────────────────────────
+
+    def _fetch_raw(self, query: NcitQuery) -> tuple[dict, Optional[str]]:
+        if not self._is_live():
+            raise RuntimeError(
+                f"NCIt live calls are gated behind env var {_NCIT_LIVE_ENV}=1. "
+                "Set it explicitly to fetch from api-evsrest.nci.nih.gov; "
+                "tests should use a stubbed CacheBackend or monkeypatch "
+                "_fetch_raw."
+            )
+        if query.mode == "get_concept":
+            return self._fetch_concept(query), self.api_version
+        return self._fetch_search(query), self.api_version
+
+    # ── Public helpers ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_live() -> bool:
+        return os.environ.get(_NCIT_LIVE_ENV) in ("1", "true", "TRUE", "yes")
+
+    def _fetch_concept(self, query: NcitQuery) -> dict:
+        if not query.code:
+            raise ValueError("NcitQuery.mode='get_concept' requires code")
+        path = self.concept_path.format(code=urllib.parse.quote(query.code, safe=""))
+        params = {"include": query.include}
+        url = self.base_url + path + "?" + urllib.parse.urlencode(params)
+        return _http_get_json(url)
+
+    def _fetch_search(self, query: NcitQuery) -> dict:
+        params = {
+            "term": query.term,
+            "include": query.include,
+            "pageSize": str(min(query.max_results, 100)),
+        }
+        url = self.base_url + self.search_path + "?" + urllib.parse.urlencode(params)
+        return _http_get_json(url)
+
+    def health(self) -> dict:
+        if not self._is_live():
+            return {"ok": True, "latency_ms": None, "last_error": None,
+                    "note": f"{_NCIT_LIVE_ENV} not set; offline scaffold only"}
+        try:
+            # C2926 = Non-Small Cell Lung Carcinoma — stable canary code,
+            # has existed since NCIt's earliest published versions.
+            self._fetch_concept(NcitQuery(mode="get_concept", code="C2926"))
+            return {"ok": True, "latency_ms": None, "last_error": None}
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "latency_ms": None, "last_error": str(exc)}
+
+
+# ── Module-level helpers ───────────────────────────────────────────────────
+
+
+def _http_get_json(url: str, timeout: int = 20) -> dict:
+    """Minimal stdlib GET → JSON. Tests substitute via monkeypatch."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+    parsed = json.loads(body)
+    # EVS search endpoint returns {concepts: [...], total: N} — already a
+    # dict. Concept endpoint returns the concept dict directly. No
+    # wrapping needed (unlike PostgREST in cpic_client).
+    return parsed
+
+
+__all__ = ["NcitClient", "NcitQuery"]

--- a/knowledge_base/hosted/content/sources/src_ncit.yaml
+++ b/knowledge_base/hosted/content/sources/src_ncit.yaml
@@ -1,0 +1,85 @@
+id: SRC-NCIT
+source_type: terminology
+title: "NCI Thesaurus — controlled cancer vocabulary"
+version: "evs-v1"
+authors:
+  - National Cancer Institute Enterprise Vocabulary Services
+  - National Institutes of Health
+journal: "ncithesaurus.nci.nih.gov"
+url: https://ncithesaurus.nci.nih.gov/ncitbrowser/
+access_level: open_access
+currency_status: current
+current_as_of: "2026-05-18"
+evidence_tier: 6
+precedence_policy: secondary_evidence_base
+
+# Licensing & hosting (SOURCE_INGESTION_SPEC §3)
+# NCI Thesaurus is published by the NCI Enterprise Vocabulary Services
+# (EVS), a unit of the National Institutes of Health. As a work of the
+# US federal government, NCIt content is in the public domain in the
+# United States under 17 U.S.C. §105. NCI's terms at
+# https://www.cancer.gov/policies/copyright-reuse state that cancer
+# information is generally not copyrighted and may be freely reused.
+# Full classification: docs/reviews/ncit-license-2026-05-18.md.
+hosting_mode: referenced
+ingestion:
+  method: live_api
+  client: knowledge_base.clients.ncit_client.NcitClient
+  endpoint: https://api-evsrest.nci.nih.gov/api/v1
+  rate_limit: "1 req/s, burst 3 (self-imposed; EVS publishes no formal limit)"
+cache_policy:
+  enabled: true
+  ttl_hours: 720
+  scope: query_result
+license:
+  name: "US Public Domain (17 U.S.C. §105)"
+  url: https://www.cancer.gov/policies/copyright-reuse
+attribution:
+  required: false
+  text: "Concept normalization via NCI Thesaurus (ncithesaurus.nci.nih.gov)."
+commercial_use_allowed: true
+redistribution_allowed: true
+modifications_allowed: true
+sharealike_required: false
+known_restrictions:
+  - "NCIt cross-references concepts to other vocabularies (SNOMED CT, MedDRA, ICD-O-3, MeSH). Cross-reference *codes* (e.g. a SNOMED CT concept ID) are NOT NCI-authored content — those code systems retain their original licenses. OpenOnco only consumes the NCIt concept code itself, not the cross-referenced codes from license-restricted vocabularies."
+  - "NCIt content updates monthly. Cached concept records past 30 days are refreshed by the client's TTL."
+legal_review:
+  status: reviewed
+  reviewer: claude
+  date: "2026-05-18"
+  notes: |
+    Self-review under CHARTER §6.1 dev-mode exemption (v0.1 phase).
+    Same posture as SRC-PDQ and SRC-CTGOV-REGISTRY: US federal-government
+    work under 17 U.S.C. §105. Concept codes, preferred terms,
+    synonyms, and NCI-authored definitions are public domain.
+    Cross-references to license-restricted vocabularies (SNOMED CT,
+    MedDRA) are NOT consumed by OpenOnco — we use only the NCIt code
+    layer.
+
+    Re-review triggers: (a) NCI changes its reuse policy, (b) any
+    plan to consume cross-referenced SNOMED CT / MedDRA codes from
+    NCIt records (would inherit those vocabularies' licenses), (c)
+    migration to `hosted` mode. Full reasoning in
+    docs/reviews/ncit-license-2026-05-18.md.
+
+relates_to_diseases: []
+last_verified: "2026-05-18"
+verifier: claude
+notes: |
+  Scaffold lands the client + Source entity + optional `ncit` fields
+  on `Disease.codes` and `BiomarkerExternalIDs`. Populating per-entity
+  codes is a separate clinical-content workstream gated by CHARTER §6.1.
+
+  Why NCIt matters: the patient-input flow normalizes free-text terms
+  ("lung cancer", "EGFR positive") to KB IDs (`DIS-NSCLC`, `BIO-EGFR-MUTATION`).
+  NCIt is the canonical NIH-maintained vocabulary backing that mapping;
+  every cancer concept has a stable code, preferred term, synonym list,
+  and machine-readable cross-references.
+
+  Sibling source scaffolds shipping same license shape:
+    - src_pdq.yaml  (PR #589)
+    - src_ctgov.yaml (PR #592)
+pages_count: 0
+references_count: 0
+corpus_role: terminology

--- a/knowledge_base/schemas/biomarker.py
+++ b/knowledge_base/schemas/biomarker.py
@@ -85,6 +85,11 @@ class BiomarkerExternalIDs(Base):
     clingen_id: Optional[str] = None
     hgvs_protein: Optional[str] = None
     hgvs_coding: Optional[str] = None
+    # NCI Thesaurus stable concept code (e.g. "C20188" = EGFR Mutation,
+    # "C17068" = EGFR Gene). Backs term normalization from free-text
+    # biomarker mentions to KB biomarker IDs. Optional in MVP; see
+    # `knowledge_base/clients/ncit_client.py`.
+    ncit: Optional[str] = None
 
 
 class Biomarker(Base):

--- a/knowledge_base/schemas/disease.py
+++ b/knowledge_base/schemas/disease.py
@@ -13,6 +13,12 @@ class DiseaseCodes(Base):
     icd_10: Optional[str] = None
     snomed_ct: Optional[str] = None  # only populated if country license acquired
     who_classification: Optional[str] = None
+    # NCI Thesaurus stable concept code (e.g. "C2926" = Non-Small Cell
+    # Lung Carcinoma). Backs term normalization from free-text patient
+    # input to KB disease IDs. See `knowledge_base/clients/ncit_client.py`
+    # and `docs/reviews/ncit-license-2026-05-18.md`. Optional in MVP;
+    # populating per-disease is a separate clinical-content workstream.
+    ncit: Optional[str] = None
 
 
 class Disease(Base):

--- a/tests/fixtures/ncit_responses/concept_c2926_nsclc.json
+++ b/tests/fixtures/ncit_responses/concept_c2926_nsclc.json
@@ -1,0 +1,20 @@
+{
+  "code": "C2926",
+  "name": "Non-Small Cell Lung Carcinoma",
+  "terminology": "ncit",
+  "version": "26.05d",
+  "definitions": [
+    {
+      "definition": "A heterogeneous aggregate of at least three distinct histological types of lung cancer, including squamous cell carcinoma, adenocarcinoma, and large cell carcinoma.",
+      "source": "NCI"
+    }
+  ],
+  "synonyms": [
+    {"name": "NSCLC", "termType": "AB"},
+    {"name": "Non-Small Cell Lung Cancer", "termType": "SY"},
+    {"name": "Non-small Cell Lung Carcinoma", "termType": "SY"}
+  ],
+  "parents": [
+    {"code": "C3262", "name": "Lung Carcinoma"}
+  ]
+}

--- a/tests/fixtures/ncit_responses/search_egfr.json
+++ b/tests/fixtures/ncit_responses/search_egfr.json
@@ -1,0 +1,20 @@
+{
+  "total": 23,
+  "concepts": [
+    {
+      "code": "C17068",
+      "name": "EGFR Gene",
+      "terminology": "ncit"
+    },
+    {
+      "code": "C20188",
+      "name": "EGFR Mutation",
+      "terminology": "ncit"
+    },
+    {
+      "code": "C20188",
+      "name": "EGFR Protein Overexpression",
+      "terminology": "ncit"
+    }
+  ]
+}

--- a/tests/test_ncit_client.py
+++ b/tests/test_ncit_client.py
@@ -1,0 +1,236 @@
+"""NCIt client — offline scaffold tests.
+
+No live api-evsrest.nci.nih.gov calls. Live calls are gated behind
+`OPENONCO_NCIT_LIVE`; this suite leaves it unset and verifies refusal.
+The HTTP seam is monkeypatched to return fixture payloads; cache and
+rate-limit infrastructure from BaseSourceClient is exercised end-to-end
+via `fetch()`.
+
+Audit: docs/reviews/ncit-license-2026-05-18.md
+Spec:  specs/SOURCE_INGESTION_SPEC.md §8, §20
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from knowledge_base.clients import ncit_client
+from knowledge_base.clients.base import InMemoryCacheBackend
+from knowledge_base.clients.ncit_client import NcitClient, NcitQuery
+
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "ncit_responses"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+# ── Gate semantics ────────────────────────────────────────────────────────
+
+
+def test_offline_mode_refuses_to_fetch(monkeypatch):
+    monkeypatch.delenv("OPENONCO_NCIT_LIVE", raising=False)
+    client = NcitClient(cache=InMemoryCacheBackend())
+    with pytest.raises(RuntimeError, match="OPENONCO_NCIT_LIVE"):
+        client.fetch(NcitQuery(mode="get_concept", code="C2926"))
+
+
+def test_health_reports_offline_gate_when_env_unset(monkeypatch):
+    monkeypatch.delenv("OPENONCO_NCIT_LIVE", raising=False)
+    client = NcitClient(cache=InMemoryCacheBackend())
+    out = client.health()
+    assert out["ok"] is True
+    assert "OPENONCO_NCIT_LIVE" in out["note"]
+
+
+# ── Live-flag path with monkeypatched HTTP ────────────────────────────────
+
+
+def test_get_concept_by_code_returns_fixture_via_cache(monkeypatch):
+    monkeypatch.setenv("OPENONCO_NCIT_LIVE", "1")
+    fixture = _load_fixture("concept_c2926_nsclc.json")
+
+    captured_urls: list[str] = []
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured_urls.append(url)
+        return fixture
+
+    monkeypatch.setattr(ncit_client, "_http_get_json", fake_get)
+
+    client = NcitClient(cache=InMemoryCacheBackend())
+    resp1 = client.fetch(NcitQuery(mode="get_concept", code="C2926"))
+    assert resp1.cache_hit is False
+    assert resp1.source_id == "SRC-NCIT"
+    assert resp1.data["code"] == "C2926"
+    assert resp1.data["name"] == "Non-Small Cell Lung Carcinoma"
+
+    resp2 = client.fetch(NcitQuery(mode="get_concept", code="C2926"))
+    assert resp2.cache_hit is True
+    assert len(captured_urls) == 1
+    assert "C2926" in captured_urls[0]
+    assert "include=summary" in captured_urls[0]
+
+
+def test_search_passes_query_params(monkeypatch):
+    monkeypatch.setenv("OPENONCO_NCIT_LIVE", "1")
+    fixture = _load_fixture("search_egfr.json")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return fixture
+
+    monkeypatch.setattr(ncit_client, "_http_get_json", fake_get)
+    client = NcitClient(cache=InMemoryCacheBackend())
+    resp = client.fetch(NcitQuery(mode="search", term="EGFR", max_results=10))
+    assert resp.data["total"] == 23
+    assert "term=EGFR" in captured["url"]
+    assert "pageSize=10" in captured["url"]
+
+
+def test_get_concept_requires_code(monkeypatch):
+    monkeypatch.setenv("OPENONCO_NCIT_LIVE", "1")
+    monkeypatch.setattr(ncit_client, "_http_get_json", lambda url, timeout=20: {})  # noqa: ARG005
+
+    client = NcitClient(cache=InMemoryCacheBackend())
+    with pytest.raises(ValueError, match="code"):
+        client.fetch(NcitQuery(mode="get_concept", code=None))
+
+
+def test_search_size_capped_at_100(monkeypatch):
+    monkeypatch.setenv("OPENONCO_NCIT_LIVE", "1")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return {"concepts": []}
+
+    monkeypatch.setattr(ncit_client, "_http_get_json", fake_get)
+
+    client = NcitClient(cache=InMemoryCacheBackend())
+    client.fetch(NcitQuery(mode="search", term="x", max_results=10_000))
+    assert "pageSize=100" in captured["url"]
+
+
+def test_url_encoding_of_code(monkeypatch):
+    monkeypatch.setenv("OPENONCO_NCIT_LIVE", "1")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return {}
+
+    monkeypatch.setattr(ncit_client, "_http_get_json", fake_get)
+    client = NcitClient(cache=InMemoryCacheBackend())
+    # NCIt codes are always C<digits> in practice, but be defensive about
+    # reserved chars getting in via a malformed call.
+    client.fetch(NcitQuery(mode="get_concept", code="C/12?34"))
+    assert "C%2F12%3F34" in captured["url"]
+
+
+def test_include_parameter_round_trips(monkeypatch):
+    """`include=full` requests parents + children; default is `summary`."""
+    monkeypatch.setenv("OPENONCO_NCIT_LIVE", "1")
+    captured = {}
+
+    def fake_get(url: str, timeout: int = 20) -> dict:  # noqa: ARG001
+        captured["url"] = url
+        return {}
+
+    monkeypatch.setattr(ncit_client, "_http_get_json", fake_get)
+    client = NcitClient(cache=InMemoryCacheBackend())
+    client.fetch(NcitQuery(mode="get_concept", code="C2926", include="full"))
+    assert "include=full" in captured["url"]
+
+
+# ── Source entity ─────────────────────────────────────────────────────────
+
+
+def test_source_entity_loads_and_carries_license_metadata():
+    """src_ncit.yaml must parse cleanly under the Source schema and
+    carry the public-domain / referenced-hosting classification."""
+    import yaml
+    from knowledge_base.schemas import Source
+
+    path = (
+        Path(__file__).parent.parent
+        / "knowledge_base"
+        / "hosted"
+        / "content"
+        / "sources"
+        / "src_ncit.yaml"
+    )
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    src = Source.model_validate(raw)
+    assert src.id == "SRC-NCIT"
+    assert src.hosting_mode.value == "referenced"
+    assert src.commercial_use_allowed is True
+    assert src.redistribution_allowed is True
+    assert src.modifications_allowed is True
+    assert src.sharealike_required is False
+    assert src.license is not None
+    assert "Public Domain" in src.license.name
+    assert src.legal_review is not None
+    assert src.legal_review.status.value == "reviewed"
+
+
+def test_source_id_matches_client_constant():
+    """Drift guard: a rename of either side without the other should
+    surface here, not in production."""
+    from knowledge_base.schemas import Source
+    import yaml
+
+    path = (
+        Path(__file__).parent.parent
+        / "knowledge_base"
+        / "hosted"
+        / "content"
+        / "sources"
+        / "src_ncit.yaml"
+    )
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    src = Source.model_validate(raw)
+    assert NcitClient.source_id == src.id
+
+
+# ── Schema additions ──────────────────────────────────────────────────────
+
+
+def test_disease_codes_accepts_ncit_field():
+    """`DiseaseCodes.ncit` should round-trip — backs the normalization
+    layer that maps free-text disease terms to KB IDs."""
+    from knowledge_base.schemas.disease import DiseaseCodes
+
+    codes = DiseaseCodes.model_validate({"icd_10": "C34.9", "ncit": "C2926"})
+    assert codes.ncit == "C2926"
+    assert codes.icd_10 == "C34.9"
+
+
+def test_disease_codes_ncit_optional():
+    """Existing Disease YAMLs predate this field. They must still load."""
+    from knowledge_base.schemas.disease import DiseaseCodes
+
+    codes = DiseaseCodes.model_validate({"icd_10": "C34.9"})
+    assert codes.ncit is None
+
+
+def test_biomarker_external_ids_accepts_ncit_field():
+    from knowledge_base.schemas.biomarker import BiomarkerExternalIDs
+
+    ids = BiomarkerExternalIDs.model_validate(
+        {"hgnc_symbol": "EGFR", "ncit": "C20188"}
+    )
+    assert ids.ncit == "C20188"
+    assert ids.hgnc_symbol == "EGFR"
+
+
+def test_biomarker_external_ids_ncit_optional():
+    from knowledge_base.schemas.biomarker import BiomarkerExternalIDs
+
+    ids = BiomarkerExternalIDs.model_validate({"hgnc_symbol": "EGFR"})
+    assert ids.ncit is None


### PR DESCRIPTION
## Summary

Adds NCI Thesaurus (NCIt) as a new source — referenced-mode, US Public Domain. Same license posture as PDQ ([#589](https://github.com/romeo111/OpenOnco/pull/589)) and ctgov ([#592](https://github.com/romeo111/OpenOnco/pull/592)).

Closes the **terminology gap** flagged by the state audit ([#588](https://github.com/romeo111/OpenOnco/pull/588)): today's term normalization is ad-hoc per-entity. NCIt gives us a canonical NIH-maintained layer to back free-text → KB-ID resolution.

## Why

Patient enters "lung cancer" / "EGFR positive"; engine needs `DIS-NSCLC` / `BIO-EGFR-MUTATION`. NCIt is the canonical bridge:

```
Patient input  →  NCIt code  →  KB ID
"lung cancer"  →  C2926      →  DIS-NSCLC
"EGFR positive" → C20188     →  BIO-EGFR-MUTATION
```

## What ships

1. **`knowledge_base/clients/ncit_client.py`** — `BaseSourceClient[NcitQuery, dict]` subclass. Two modes: `get_concept` (by NCIt code) and `search` (by free-text term). Live calls gated behind `OPENONCO_NCIT_LIVE=1`. `include=summary` default keeps responses narrow — no cross-ref codes from SNOMED CT / MedDRA (both excluded per CLAUDE.md MVP guidance).

2. **`knowledge_base/hosted/content/sources/src_ncit.yaml`** — Source entity with US Public Domain license, hosting=referenced, attribution required=false, `legal_review.status: reviewed`. **Cross-reference scope boundary** recorded under `known_restrictions`: we consume only the NCIt code layer.

3. **Schema additions** — both Optional, both backward compatible:
   - `DiseaseCodes.ncit: Optional[str]` (sibling to existing `icd_10`, `snomed_ct`, etc.)
   - `BiomarkerExternalIDs.ncit: Optional[str]` (sibling to `hgnc_symbol`, `civic_id`, etc.)

4. **`tests/test_ncit_client.py`** — 14 offline tests: gate semantics, HTTP-seam stubbing, query params (including `include=full`), URL encoding, schema round-trip on both Disease + Biomarker (additions are optional with `None` defaults), source-id drift guard.

5. **`tests/fixtures/ncit_responses/`** — 2 stub JSON files (concept C2926, search "EGFR").

6. **`docs/reviews/ncit-license-2026-05-18.md`** — full 4-constraint classification with the cross-reference scope boundary documented as the novel constraint.

## Cross-reference scope boundary (novel)

NCIt records cross-reference to other vocabularies (SNOMED CT, MedDRA, ICD-O-3, MeSH). Those external codes retain their own licenses. **OpenOnco consumes only the NCIt concept code layer** — `{code, name, synonyms, definition}`. `NcitQuery.include` defaults to `summary` (no cross-refs); requesting `full` is supported but opting in requires consciousness of the inherited license posture.

`CLAUDE.md` explicitly excludes SNOMED CT and MedDRA from MVP. The `include=summary` default enforces that boundary.

## Per `SOURCE_INGESTION_SPEC §20` checklist

- [x] License reviewed — `docs/reviews/ncit-license-2026-05-18.md`
- [x] Hosting mode selected — `referenced`
- [x] Schema validator — Source entity validates; new Optional fields validate
- [x] Source entity with all license/attribution/legal_review fields
- [x] Client written
- [ ] First fetch + clinical review — deferred until per-entity NCIt code population workstream
- [ ] CI cron — deferred

## What this PR does NOT do

- **No per-Disease / per-Biomarker NCIt code population.** Each authored mapping needs `CHARTER §6.1` two-reviewer signoff.
- **No engine-side term-normalization layer.** Follow-up that consumes `Disease.codes.ncit` and EVS search to resolve patient input.
- **No live API calls by default.**
- **No SNOMED CT / MedDRA cross-references consumed.**

## Test plan

- [x] `pytest tests/test_ncit_client.py` — 14/14 pass
- [x] `pytest tests/test_biomarker_schema.py tests/test_engine.py tests/test_actionability_invariants.py tests/test_base_source_client.py` — 76 pass / 3 pre-existing skips, no regressions
- [x] KB validator strict — 388 → 389 sources, all references resolve
- [x] Existing Disease / Biomarker YAMLs still load (covered by `test_disease_codes_ncit_optional` + `test_biomarker_external_ids_ncit_optional`)
- [x] No clinical content edits
- [x] Explicit pathspecs

## Re-review triggers (in the license doc)

1. NCI changes its reuse policy
2. OpenOnco adopts a commercial tier under CHARTER §2
3. Migration to `hosted` mode
4. **Consumption of cross-referenced SNOMED CT / MedDRA codes** — both are MVP-excluded per CLAUDE.md; opting in would inherit those vocabularies' license posture
5. EVS API changes its terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)