### PR TITLE
feat(ctgov): UA facility extraction (rebased onto master) — supersedes #593

### DIFF
--- a/knowledge_base/clients/ctgov_client.py
+++ b/knowledge_base/clients/ctgov_client.py
@@ -37,7 +37,13 @@ _FIELDS = ",".join([
     "Condition", "BriefSummary",
     "EligibilityCriteria", "MinimumAge", "MaximumAge", "Sex",
     "LeadSponsorName",
-    "LocationCountry",
+    # Per-site location fields. The flat v2 API returns these as parallel
+    # arrays — Country[i] / City[i] / Facility[i] / Status[i] correspond to
+    # the same physical site. `_parse_study` zips them into a structured
+    # `locations` list. Without these, only country-level data flows
+    # through and the render layer can only emit a binary UA badge.
+    # See docs/reviews/ctgov-wiring-audit-2026-05-18.md Gap 2.
+    "LocationCountry", "LocationCity", "LocationFacility", "LocationStatus",
     "PrimaryOutcomeMeasure",
 ])
 
@@ -194,12 +200,47 @@ def _parse_study(raw: dict) -> dict:
     sponsor_mod = _get("sponsorCollaboratorsModule.leadSponsor") or {}
     sponsor     = sponsor_mod.get("name", "") if isinstance(sponsor_mod, dict) else raw.get("LeadSponsorName", "")
 
-    # Countries (flat field is a list; protocolSection is nested)
-    countries_raw = raw.get("LocationCountry") or []
-    if not countries_raw:
-        locs = _get("contactsLocationsModule.locations") or []
-        countries_raw = list({loc.get("country", "") for loc in locs if loc.get("country")})
-    countries = countries_raw if isinstance(countries_raw, list) else [countries_raw]
+    # Locations. Two response shapes:
+    #   1. fields= mode (the search path) → parallel flat arrays:
+    #      LocationCountry, LocationCity, LocationFacility, LocationStatus
+    #   2. full-record mode (get_trial) → contactsLocationsModule.locations
+    #      as a list of dicts {country, city, facility, status, …}
+    # The structured `locations` list normalises both into the dict shape
+    # so downstream consumers don't branch.
+    locations: list[dict] = []
+    flat_country = raw.get("LocationCountry") or []
+    flat_city = raw.get("LocationCity") or []
+    flat_facility = raw.get("LocationFacility") or []
+    flat_status = raw.get("LocationStatus") or []
+    if flat_country and isinstance(flat_country, list):
+        # Parallel arrays — zip defensively (lengths can drift if some
+        # sites lack a city tag). Pad shorter arrays with None.
+        n = max(len(flat_country), len(flat_city), len(flat_facility), len(flat_status))
+        def _at(arr: list, i: int):
+            return arr[i] if i < len(arr) else None
+        for i in range(n):
+            locations.append({
+                "country":  _at(flat_country, i),
+                "city":     _at(flat_city, i),
+                "facility": _at(flat_facility, i),
+                "status":   _at(flat_status, i),
+            })
+    else:
+        for loc in (_get("contactsLocationsModule.locations") or []):
+            if not isinstance(loc, dict):
+                continue
+            locations.append({
+                "country":  loc.get("country"),
+                "city":     loc.get("city"),
+                "facility": loc.get("facility"),
+                "status":   loc.get("status"),
+            })
+
+    countries = [loc["country"] for loc in locations if loc.get("country")]
+    # Stable de-dup preserving order of first appearance — downstream
+    # consumers expect a unique-country list (matches pre-change shape).
+    _seen: set[str] = set()
+    countries = [c for c in countries if not (c in _seen or _seen.add(c))]
 
     # Primary outcomes
     outcomes_raw = raw.get("PrimaryOutcomeMeasure") or []
@@ -226,6 +267,12 @@ def _parse_study(raw: dict) -> dict:
         "sponsor":            sponsor,
         "countries":          [c for c in countries if c],
         "site_count":         len(countries),
+        # Per-site detail (one entry per location). Each dict carries
+        # {country, city, facility, status}; values may be None when the
+        # upstream record didn't fill them. Consumed by
+        # `engine.experimental_options._to_trial` to populate
+        # `ExperimentalTrial.ua_sites_detail`.
+        "locations":          locations,
         "url":                f"https://clinicaltrials.gov/study/{nct_id}" if nct_id else "",
     }
 

--- a/knowledge_base/engine/experimental_options.py
+++ b/knowledge_base/engine/experimental_options.py
@@ -31,6 +31,7 @@ from typing import Callable, Optional
 from knowledge_base.schemas.experimental_option import (
     ExperimentalOption,
     ExperimentalTrial,
+    UaSiteDetail,
 )
 from knowledge_base.engine.trial_outlook import score_trial
 
@@ -74,16 +75,51 @@ class TrialQuery:
 SearchFn = Callable[..., list[dict]]
 
 
-def _ua_sites_from_countries(countries: list[str]) -> list[str]:
-    """Surface UA presence as a string list. ctgov returns ISO-2 country
-    codes via LocationCountry; we don't have city granularity from the
-    summary fields, so a single `"UA"` marker suffices for now. The full
-    site list lives behind a separate `get_trial(nct_id)` call."""
+_UA_COUNTRY_TOKENS = {"UA", "UKRAINE"}
 
+
+def _is_ua_country(value: object) -> bool:
+    """ctgov is inconsistent: search-mode flat fields return full names
+    ("Ukraine"), full-record mode returns ISO-2 codes ("UA"). Match
+    either, case-insensitively."""
+    if not isinstance(value, str):
+        return False
+    return value.strip().upper() in _UA_COUNTRY_TOKENS
+
+
+def _ua_sites_from_countries(countries: list[str]) -> list[str]:
+    """Binary UA marker, kept for cache-shape backward compat. The
+    structured per-site detail lives in `ua_sites_detail` (populated by
+    `_ua_sites_detail_from_locations`); this list is now redundant in
+    new data but preserved so legacy cached `ExperimentalOption` JSONs
+    keep loading.
+    """
     if not countries:
         return []
-    norm = {c.strip().upper() for c in countries if c and isinstance(c, str)}
-    return ["UA"] if "UA" in norm or "UKRAINE" in norm else []
+    return ["UA"] if any(_is_ua_country(c) for c in countries) else []
+
+
+def _ua_sites_detail_from_locations(locations: list) -> list[UaSiteDetail]:
+    """Filter a parsed ctgov `locations` list to UA records and convert
+    them to `UaSiteDetail`. Empty when the upstream record carried no
+    UA site OR when only country-level info was available."""
+    if not locations:
+        return []
+    out: list[UaSiteDetail] = []
+    for loc in locations:
+        if not isinstance(loc, dict):
+            continue
+        if not _is_ua_country(loc.get("country")):
+            continue
+        out.append(
+            UaSiteDetail(
+                facility=loc.get("facility") or None,
+                city=loc.get("city") or None,
+                state=loc.get("state") or None,
+                status=loc.get("status") or None,
+            )
+        )
+    return out
 
 
 def _to_trial(
@@ -120,6 +156,7 @@ def _to_trial(
         last_scored=sync_ts,
     )
 
+    raw_locations = study.get("locations") or []
     return ExperimentalTrial(
         nct_id=nct,
         title=study.get("title") or study.get("BriefTitle") or "",
@@ -133,6 +170,7 @@ def _to_trial(
         sites_ua=_ua_sites_from_countries(
             list(countries) if isinstance(countries, list) else []
         ),
+        ua_sites_detail=_ua_sites_detail_from_locations(raw_locations),
         sites_global_count=study.get("location_count"),
         last_synced=sync_ts,
         outlook=outlook,

--- a/knowledge_base/engine/render.py
+++ b/knowledge_base/engine/render.py
@@ -1865,6 +1865,46 @@ def _outlook_notes_index(outlook) -> dict[str, str]:
     return idx
 
 
+def _render_ua_sites(trial, target_lang: str) -> str:
+    """Render the UA-sites cell for one trial row.
+
+    Three states, in priority order:
+
+    1. `ua_sites_detail` non-empty → list each UA facility with city +
+       per-site status. This is the high-information path; surfaces the
+       cities a Ukrainian patient can actually ask about. Closes Gap 2
+       from `docs/reviews/ctgov-wiring-audit-2026-05-18.md`.
+    2. `sites_ua` non-empty (legacy path) → binary UA badge. Old cached
+       records carry this; new records also carry it for backward compat.
+    3. Neither → em-dash placeholder.
+    """
+    detail = getattr(trial, "ua_sites_detail", None) or []
+    if detail:
+        # One line per UA site: "City — Facility (status)". Empty fields
+        # collapse cleanly (e.g. "Kyiv (RECRUITING)" when facility absent).
+        lines: list[str] = []
+        for site in detail:
+            parts: list[str] = []
+            if site.city:
+                parts.append(_h(site.city))
+            if site.facility:
+                parts.append(_h(site.facility))
+            line = " — ".join(parts) if parts else _h("Ukraine")
+            if site.status:
+                line += f' <span class="trial-site-status">({_h(site.status)})</span>'
+            lines.append(f'<li>{line}</li>')
+        title_attr = "Recruiting sites in Ukraine"
+        return (
+            f'<div class="trial-ua-detail" title="{_h(title_attr)}">'
+            '<span class="badge badge--ua">UA</span>'
+            f'<ul class="trial-ua-sites">{"".join(lines)}</ul>'
+            '</div>'
+        )
+    if getattr(trial, "sites_ua", None):
+        return '<span class="badge badge--ua" title="Site present in Ukraine">UA</span>'
+    return "—"
+
+
 def _render_cited_trials_status(
     body_html: str,
     target_lang: str = "uk",
@@ -1987,9 +2027,12 @@ def _render_experimental_options(option, target_lang: str = "uk") -> str:
 
     rows = []
     for t in trials:
-        ua_badge = ""
-        if t.sites_ua:
-            ua_badge = '<span class="badge badge--ua" title="Site present in Ukraine">UA</span>'
+        # Structured UA detail (city + facility + per-site status) when
+        # the upstream ctgov record carried site-level fields. Closes
+        # Gap 2 from docs/reviews/ctgov-wiring-audit-2026-05-18.md.
+        # Falls back to the binary UA badge for old cached records that
+        # only know country-level info.
+        ua_cell = _render_ua_sites(t, target_lang)
         elig = t.inclusion_summary or ""
         elig_short = (elig[:140] + "…") if len(elig) > 140 else elig
         outlook_cell = _render_trial_outlook(
@@ -2003,7 +2046,7 @@ def _render_experimental_options(option, target_lang: str = "uk") -> str:
             f'<td class="trial-phase">{_h(t.phase or "—")}</td>'
             f'<td class="trial-status">{_h(t.status)}</td>'
             f'<td class="trial-sponsor">{_h(t.sponsor or "—")}</td>'
-            f'<td class="trial-ua">{ua_badge or "—"}</td>'
+            f'<td class="trial-ua">{ua_cell}</td>'
             f'<td class="trial-outlook">{outlook_cell}</td>'
             f'<td class="trial-elig">{_h(elig_short)}</td>'
             "</tr>"

--- a/knowledge_base/schemas/__init__.py
+++ b/knowledge_base/schemas/__init__.py
@@ -19,7 +19,7 @@ from .diagnostic import (
 )
 from .disease import Disease
 from .drug import Drug
-from .experimental_option import ExperimentalOption, ExperimentalTrial
+from .experimental_option import ExperimentalOption, ExperimentalTrial, UaSiteDetail
 from .indication import (
     Indication,
     IndicationPhase,

--- a/knowledge_base/schemas/experimental_option.py
+++ b/knowledge_base/schemas/experimental_option.py
@@ -62,6 +62,28 @@ class TrialOutlook(Base):
     last_scored: Optional[str] = None  # ISO date
 
 
+class UaSiteDetail(Base):
+    """One Ukrainian recruiting site for an `ExperimentalTrial`.
+
+    Closes Gap 2 from `docs/reviews/ctgov-wiring-audit-2026-05-18.md` — the
+    previous render shape exposed a single "UA" badge per trial, discarding
+    facility, city, and per-site status. Per `CHARTER §1` the UA-local
+    angle is one of OpenOnco's structural differentiators, so the patient
+    looking at their Plan should see *where* in Ukraine to ask about
+    screening, not just that a UA site exists somewhere.
+
+    All fields optional because ctgov v2's flat-fields response sometimes
+    returns parallel arrays of different lengths (e.g. facility list
+    longer than city list when one site lacks a city tag). The mapper
+    zips defensively and fills `None` where data is missing.
+    """
+
+    facility: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    status: Optional[str] = None  # RECRUITING | ACTIVE_NOT_RECRUITING | …
+
+
 class ExperimentalTrial(Base):
     """One ClinicalTrials.gov study entry, parsed from the v2 API."""
 
@@ -75,6 +97,12 @@ class ExperimentalTrial(Base):
     exclusion_summary: Optional[str] = None
     countries: list[str] = Field(default_factory=list)  # ISO-2 codes from ctgov
     sites_ua: list[str] = Field(default_factory=list)   # UA city names if any
+    # Structured per-UA-site detail (facility, city, state, status).
+    # Populated when ctgov returns location-level fields; empty list when
+    # the search-mode response only carried country names. Render falls
+    # back to the binary `sites_ua` badge when this list is empty.
+    # Default-empty for cache-shape backward compatibility.
+    ua_sites_detail: list[UaSiteDetail] = Field(default_factory=list)
     sites_global_count: Optional[int] = None
     last_synced: Optional[str] = None  # ISO date
 

--- a/tests/test_ctgov_ua_facilities.py
+++ b/tests/test_ctgov_ua_facilities.py
@@ -1,0 +1,288 @@
+"""UA facility extraction — Gap 2 from `docs/reviews/ctgov-wiring-audit-2026-05-18.md`.
+
+Closes the gap where `_ua_sites_from_countries` returned a binary
+`["UA"]` marker and discarded city / facility / per-site status. New
+shape: structured `UaSiteDetail` list on `ExperimentalTrial`, surfaced
+in render.
+
+Coverage across all 4 layers touched:
+
+1. Schema  — `UaSiteDetail` model + `ua_sites_detail` field default
+2. Client  — `_parse_study` builds structured `locations` list from
+   flat parallel arrays AND from the `contactsLocationsModule` shape;
+   `LocationCity` / `LocationFacility` / `LocationStatus` added to
+   `_FIELDS`.
+3. Engine  — `_ua_sites_detail_from_locations` filters to UA records;
+   `_to_trial` wires it through; legacy `sites_ua` binary marker still
+   populated for cache-shape backward compat.
+4. Render  — `_render_ua_sites` shows city / facility / status when
+   `ua_sites_detail` present; falls back to binary badge for old cached
+   records.
+"""
+
+from __future__ import annotations
+
+from knowledge_base.schemas.experimental_option import (
+    ExperimentalTrial,
+    UaSiteDetail,
+)
+from knowledge_base.clients.ctgov_client import _FIELDS, _parse_study
+from knowledge_base.engine.experimental_options import (
+    _is_ua_country,
+    _to_trial,
+    _ua_sites_detail_from_locations,
+    _ua_sites_from_countries,
+)
+from knowledge_base.engine.render import _render_ua_sites
+
+
+# ── Schema ───────────────────────────────────────────────────────────────
+
+
+def test_ua_sites_detail_defaults_to_empty_list():
+    t = ExperimentalTrial(nct_id="NCT01234567", title="t", status="RECRUITING")
+    assert t.ua_sites_detail == []
+
+
+def test_ua_sites_detail_round_trip():
+    sites = [
+        UaSiteDetail(facility="Kyiv City Cancer Hospital", city="Kyiv",
+                     status="RECRUITING"),
+        UaSiteDetail(facility="LDS", city="Lviv", status="ACTIVE_NOT_RECRUITING"),
+    ]
+    t = ExperimentalTrial(
+        nct_id="NCT01234567",
+        title="t",
+        status="RECRUITING",
+        ua_sites_detail=sites,
+    )
+    dumped = t.model_dump()
+    reloaded = ExperimentalTrial.model_validate(dumped)
+    assert len(reloaded.ua_sites_detail) == 2
+    assert reloaded.ua_sites_detail[0].city == "Kyiv"
+    assert reloaded.ua_sites_detail[1].status == "ACTIVE_NOT_RECRUITING"
+
+
+def test_legacy_cached_trial_loads_without_ua_sites_detail():
+    """Old cache JSONs predate this field. They must still load —
+    `ua_sites_detail` is optional with empty-list default."""
+    legacy_payload = {
+        "nct_id": "NCT01234567",
+        "title": "Legacy",
+        "status": "RECRUITING",
+        "countries": ["Ukraine"],
+        "sites_ua": ["UA"],
+    }
+    t = ExperimentalTrial.model_validate(legacy_payload)
+    assert t.ua_sites_detail == []
+    assert t.sites_ua == ["UA"]
+
+
+# ── Client _parse_study ──────────────────────────────────────────────────
+
+
+def test_fields_request_includes_location_detail():
+    """Without LocationCity / LocationFacility / LocationStatus in the
+    field list, ctgov returns only country names and the new fields stay
+    empty. This guards against a future drop of those fields."""
+    for f in ("LocationCity", "LocationFacility", "LocationStatus"):
+        assert f in _FIELDS, f"`{f}` must be requested via fields= "
+
+
+def test_parse_study_flat_arrays_zipped_into_locations():
+    """Search-mode response shape: parallel flat arrays."""
+    raw = {
+        "NCTId": "NCT99999991",
+        "BriefTitle": "Test",
+        "OverallStatus": "RECRUITING",
+        "LocationCountry": ["Ukraine", "Poland"],
+        "LocationCity":    ["Kyiv",    "Warsaw"],
+        "LocationFacility": ["Kyiv Cancer Center", "Warsaw Clinic"],
+        "LocationStatus":   ["RECRUITING", "RECRUITING"],
+    }
+    parsed = _parse_study(raw)
+    assert parsed["locations"] == [
+        {"country": "Ukraine", "city": "Kyiv", "facility": "Kyiv Cancer Center",
+         "status": "RECRUITING"},
+        {"country": "Poland", "city": "Warsaw", "facility": "Warsaw Clinic",
+         "status": "RECRUITING"},
+    ]
+    # Countries de-duped while preserving order:
+    assert parsed["countries"] == ["Ukraine", "Poland"]
+
+
+def test_parse_study_uneven_flat_arrays_pad_with_none():
+    """Real ctgov responses sometimes drop city tags on a subset of
+    sites. Zip must pad shorter arrays with None, not truncate."""
+    raw = {
+        "NCTId": "NCT99999992",
+        "BriefTitle": "t",
+        "OverallStatus": "RECRUITING",
+        "LocationCountry": ["Ukraine", "Ukraine", "Poland"],
+        "LocationCity":    ["Kyiv"],  # only one city tag
+        "LocationFacility": ["A"],     # only one facility
+        "LocationStatus":   [],
+    }
+    parsed = _parse_study(raw)
+    assert len(parsed["locations"]) == 3
+    assert parsed["locations"][0]["city"] == "Kyiv"
+    assert parsed["locations"][1]["city"] is None
+    assert parsed["locations"][2]["country"] == "Poland"
+
+
+def test_parse_study_full_record_shape_via_locations_module():
+    """Full-record-mode response (get_trial): nested structured locations."""
+    raw = {
+        "protocolSection": {
+            "identificationModule": {"nctId": "NCT99999993", "briefTitle": "t"},
+            "statusModule":         {"overallStatus": "RECRUITING"},
+            "contactsLocationsModule": {
+                "locations": [
+                    {"country": "Ukraine", "city": "Lviv",
+                     "facility": "Lviv State Oncology", "status": "RECRUITING"},
+                    {"country": "Germany", "city": "Berlin",
+                     "facility": "Charité", "status": "ACTIVE_NOT_RECRUITING"},
+                ]
+            },
+        }
+    }
+    parsed = _parse_study(raw)
+    assert parsed["locations"][0]["city"] == "Lviv"
+    assert parsed["locations"][0]["status"] == "RECRUITING"
+    assert parsed["countries"] == ["Ukraine", "Germany"]
+
+
+# ── Engine helpers ───────────────────────────────────────────────────────
+
+
+def test_is_ua_country_matches_iso2_and_full_name_case_insensitive():
+    assert _is_ua_country("UA")
+    assert _is_ua_country("ua")
+    assert _is_ua_country("Ukraine")
+    assert _is_ua_country("UKRAINE")
+    assert not _is_ua_country("US")
+    assert not _is_ua_country("United States")
+    assert not _is_ua_country(None)
+    assert not _is_ua_country("")
+
+
+def test_ua_sites_from_countries_legacy_binary_marker_preserved():
+    """Old-shape helper still returns ["UA"] / [] — used for cache-shape
+    backward compat."""
+    assert _ua_sites_from_countries(["US", "Ukraine"]) == ["UA"]
+    assert _ua_sites_from_countries(["US"]) == []
+    assert _ua_sites_from_countries([]) == []
+
+
+def test_ua_sites_detail_filters_non_ua_locations():
+    locations = [
+        {"country": "Ukraine", "city": "Kyiv", "facility": "Kyiv X", "status": "RECRUITING"},
+        {"country": "Poland",  "city": "Warsaw", "facility": "Warsaw Y", "status": "RECRUITING"},
+        {"country": "UA",      "city": "Lviv", "facility": "Lviv Z", "status": "ACTIVE_NOT_RECRUITING"},
+    ]
+    out = _ua_sites_detail_from_locations(locations)
+    assert len(out) == 2
+    assert out[0].city == "Kyiv"
+    assert out[1].city == "Lviv"
+    assert out[1].status == "ACTIVE_NOT_RECRUITING"
+
+
+def test_ua_sites_detail_empty_when_no_ua_sites():
+    assert _ua_sites_detail_from_locations([]) == []
+    assert _ua_sites_detail_from_locations(
+        [{"country": "US", "city": "Boston"}]
+    ) == []
+
+
+def test_ua_sites_detail_tolerates_missing_subfields():
+    """ctgov sometimes returns a location with only country populated."""
+    out = _ua_sites_detail_from_locations(
+        [{"country": "Ukraine"}]
+    )
+    assert len(out) == 1
+    assert out[0].city is None
+    assert out[0].facility is None
+    assert out[0].status is None
+
+
+# ── _to_trial integration ────────────────────────────────────────────────
+
+
+def test_to_trial_populates_both_legacy_marker_and_detail():
+    """One trial-record round-trip: structured locations in, both
+    `sites_ua` (legacy) and `ua_sites_detail` (new) out."""
+    study = {
+        "nct_id": "NCT99999994",
+        "title": "t",
+        "status": "RECRUITING",
+        "phase": "PHASE2",
+        "sponsor": "S",
+        "summary": "",
+        "eligibility_criteria": "Inclusion Criteria: foo",
+        "countries": ["Ukraine", "Poland"],
+        "locations": [
+            {"country": "Ukraine", "city": "Kyiv", "facility": "F1",
+             "status": "RECRUITING"},
+            {"country": "Poland", "city": "Warsaw"},
+        ],
+    }
+    t = _to_trial(study, sync_ts="2026-05-18")
+    assert t is not None
+    assert t.sites_ua == ["UA"]   # legacy marker preserved
+    assert len(t.ua_sites_detail) == 1
+    assert t.ua_sites_detail[0].facility == "F1"
+    assert t.ua_sites_detail[0].city == "Kyiv"
+
+
+# ── Render ───────────────────────────────────────────────────────────────
+
+
+def test_render_ua_sites_shows_city_and_facility_when_detail_present():
+    t = ExperimentalTrial(
+        nct_id="NCT01234567", title="t", status="RECRUITING",
+        sites_ua=["UA"],
+        ua_sites_detail=[
+            UaSiteDetail(facility="Kyiv Cancer Center", city="Kyiv",
+                         status="RECRUITING"),
+        ],
+    )
+    out = _render_ua_sites(t, target_lang="uk")
+    assert "Kyiv" in out
+    assert "Kyiv Cancer Center" in out
+    assert "RECRUITING" in out
+    assert "badge--ua" in out  # badge still emitted as the visual anchor
+
+
+def test_render_ua_sites_falls_back_to_binary_badge_when_no_detail():
+    """Legacy cached trial: only sites_ua = ['UA'], no detail. Render
+    must keep the old badge behavior so existing cache renders unchanged."""
+    t = ExperimentalTrial(
+        nct_id="NCT01234567", title="t", status="RECRUITING",
+        sites_ua=["UA"],
+        ua_sites_detail=[],
+    )
+    out = _render_ua_sites(t, target_lang="uk")
+    assert "badge--ua" in out
+    assert "<ul" not in out  # no detail list
+
+
+def test_render_ua_sites_emits_dash_for_non_ua_trial():
+    t = ExperimentalTrial(
+        nct_id="NCT01234567", title="t", status="RECRUITING",
+        sites_ua=[],
+        ua_sites_detail=[],
+    )
+    assert _render_ua_sites(t, target_lang="uk") == "—"
+
+
+def test_render_ua_sites_collapses_empty_fields():
+    """When only country was known for a UA site (no city, no facility),
+    render still shows something usable."""
+    t = ExperimentalTrial(
+        nct_id="NCT01234567", title="t", status="RECRUITING",
+        sites_ua=["UA"],
+        ua_sites_detail=[UaSiteDetail()],  # all fields None
+    )
+    out = _render_ua_sites(t, target_lang="uk")
+    assert "Ukraine" in out
+    assert "<ul" in out


### PR DESCRIPTION
Rebased version of [#593](https://github.com/romeo111/OpenOnco/pull/593) onto current master. Single render.py conflict resolved by keeping both helper functions side-by-side (`_render_ua_sites` from this PR + `_render_cited_trials_status` from already-merged #596). Original #593 closed in favor of this clean-history version.

## Summary

Closes Gap 2 from ctgov wiring audit. Schema + client + engine + render layers updated so the per-trial UA cell shows structured detail (city, facility, per-site recruitment status) instead of a binary `[UA]` badge.

See [#593](https://github.com/romeo111/OpenOnco/pull/593) for the original detailed PR body. This rebased PR is functionally identical except for the merge conflict resolution.

## Conflict resolution

`knowledge_base/engine/render.py` — both this PR and #596 (already merged) inserted a new helper function before `_render_experimental_options`. Resolved by keeping both functions side-by-side in the order: `_render_ua_sites` → `_render_cited_trials_status` → `_render_experimental_options`. The functions don't interact; they decorate different parts of the rendered Plan.

## Verification

- [x] `pytest tests/test_ctgov_ua_facilities.py tests/test_cited_trials_render.py tests/test_experimental_options.py tests/test_trial_outlook.py` — 65/65 pass on rebased state
- [x] KB validator strict — all entities valid, all references resolve
- [x] Render layer integration verified: `_render_ua_sites` called from trial-row in `_render_experimental_options`; `_render_cited_trials_status` called from `render_plan_html` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)