### PR TITLE
feat(ux): /ukr/prevent.html — Ukrainian mirror of prevention questionnaire

### DIFF
--- a/docs/prevent.html
+++ b/docs/prevent.html
@@ -217,7 +217,7 @@
   </nav>
   <div class="top-right">
     <div class="lang-switch" role="group" aria-label="Language">
-      <a class="lang-other" href="/ukr/"><span class="lang-flag flag-ua" aria-hidden="true"></span>UA</a>
+      <a class="lang-other" href="/ukr/prevent.html"><span class="lang-flag flag-ua" aria-hidden="true"></span>UA</a>
       <span class="lang-current"><span class="lang-flag flag-en" aria-hidden="true"></span>EN</span>
     </div>
     <div class="top-cta-group">

--- a/docs/ukr/prevent.html
+++ b/docs/ukr/prevent.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenOnco · Оцінка ризику профілактики</title>
+<meta name="description" content="Структурована форма оцінки ризику профілактики / ранньої діагностики. HCP-mediated. Генерує патієнт-профіль сумісний з OpenOnco PreventionPlan engine.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://openonco.info/ukr/prevent.html">
+<link rel="alternate" hreflang="en" href="https://openonco.info/prevent.html">
+<link rel="alternate" hreflang="uk" href="https://openonco.info/ukr/prevent.html">
+<link rel="alternate" hreflang="x-default" href="https://openonco.info/">
+<meta property="og:site_name" content="OpenOnco">
+<meta property="og:type" content="website">
+<meta property="og:title" content="OpenOnco · Оцінка ризику профілактики">
+<meta property="og:description" content="Структурована форма оцінки ризику профілактики / ранньої діагностики.">
+<meta property="og:url" content="https://openonco.info/ukr/prevent.html">
+<meta property="og:locale" content="uk_UA">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Source+Sans+3:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="/style.css" rel="stylesheet">
+<style>
+  /* Prevention questionnaire specific styles — mirrored from EN /prevent.html */
+  .prevent-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    gap: 2rem;
+    max-width: 1400px;
+    margin: 1rem auto 4rem;
+    padding: 0 1.5rem;
+  }
+  @media (max-width: 1024px) {
+    .prevent-layout { grid-template-columns: 1fr; }
+  }
+  .prevent-form-col h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.8rem;
+    margin: 0 0 0.5rem;
+    color: #0a2e1a;
+  }
+  .prevent-intro {
+    background: #f0f7f3;
+    border-left: 3px solid #0a2e1a;
+    padding: 0.85rem 1.1rem;
+    margin-bottom: 1.25rem;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    color: #1f3f2e;
+  }
+  .prevent-intro strong { color: #0a2e1a; }
+  fieldset.prevent-section {
+    border: 1px solid #d5e0d8;
+    border-radius: 8px;
+    padding: 1rem 1.2rem 1.2rem;
+    margin: 0 0 1.1rem;
+    background: #fff;
+  }
+  fieldset.prevent-section legend {
+    font-weight: 600;
+    padding: 0 0.5rem;
+    color: #0a2e1a;
+    font-size: 1.05rem;
+  }
+  .prevent-section-desc {
+    font-size: 0.85rem;
+    color: #556;
+    margin: 0 0 0.7rem;
+  }
+  .prevent-field {
+    display: block;
+    margin: 0.35rem 0;
+    line-height: 1.45;
+    font-size: 0.93rem;
+  }
+  .prevent-field input[type="checkbox"] {
+    margin-right: 0.5rem;
+    transform: translateY(2px);
+  }
+  .prevent-field input[type="number"],
+  .prevent-field input[type="text"],
+  .prevent-field select {
+    margin-left: 0.3rem;
+    padding: 0.2rem 0.4rem;
+    border: 1px solid #c8d1cb;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.92rem;
+  }
+  .prevent-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1.2rem;
+    flex-wrap: wrap;
+  }
+  .prevent-actions button {
+    cursor: pointer;
+    border: 1px solid #0a2e1a;
+    background: #0a2e1a;
+    color: #fff;
+    font-weight: 600;
+    padding: 0.65rem 1.2rem;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-family: inherit;
+  }
+  .prevent-actions button:hover { background: #144527; }
+  .prevent-actions button.secondary {
+    background: #fff;
+    color: #0a2e1a;
+  }
+  .prevent-actions button.secondary:hover { background: #f0f7f3; }
+  .prevent-output-col {
+    position: sticky;
+    top: 1rem;
+    align-self: flex-start;
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
+  }
+  .prevent-output-col h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.35rem;
+    margin: 0 0 0.7rem;
+    color: #0a2e1a;
+  }
+  .prevent-preview {
+    background: #1a2128;
+    color: #e8e8e8;
+    padding: 1rem;
+    border-radius: 8px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    line-height: 1.4;
+    overflow-x: auto;
+    margin: 0 0 1rem;
+    max-height: 380px;
+    overflow-y: auto;
+  }
+  .prevent-fired-rfs {
+    background: #fff8eb;
+    border: 1px solid #e0c890;
+    border-radius: 6px;
+    padding: 0.7rem 0.95rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+  }
+  .prevent-fired-rfs h3 {
+    margin: 0 0 0.4rem;
+    font-size: 0.95rem;
+    color: #6b4f00;
+  }
+  .prevent-fired-rfs ul { margin: 0; padding-left: 1.2rem; }
+  .prevent-fired-rfs li { margin: 0.15rem 0; }
+  .prevent-fired-rfs li code {
+    background: #f0e3b8;
+    padding: 0 0.3rem;
+    border-radius: 3px;
+    font-size: 0.83rem;
+  }
+  .prevent-charter-note {
+    font-size: 0.78rem;
+    color: #667;
+    background: #fafbfa;
+    padding: 0.7rem 0.95rem;
+    border-radius: 6px;
+    border: 1px solid #e0e5e2;
+    line-height: 1.5;
+  }
+  .prevent-charter-note strong { color: #0a2e1a; }
+  .prevent-quick-scenarios {
+    margin-bottom: 1.2rem;
+  }
+  .prevent-quick-scenarios label {
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: #0a2e1a;
+    display: block;
+    margin-bottom: 0.4rem;
+  }
+  .prevent-quick-scenarios select {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid #c8d1cb;
+    border-radius: 5px;
+    font-family: inherit;
+    font-size: 0.92rem;
+  }
+  .small {
+    font-size: 0.82rem;
+    color: #666;
+  }
+</style>
+</head>
+<body>
+<header class="top-bar">
+  <div class="brand-line">
+    <a href="/ukr/" class="brand-mini">OpenOnco</a>
+  </div>
+  <nav class="top-nav">
+    <a href="/ukr/">Головна</a>
+    <a href="/ukr/capabilities.html">Можливості</a>
+    <a href="/ukr/about.html">Про проєкт</a>
+  </nav>
+  <div class="top-right">
+    <div class="lang-switch" role="group" aria-label="Мова">
+      <span class="lang-current"><span class="lang-flag flag-ua" aria-hidden="true"></span>UA</span>
+      <a class="lang-other" href="/prevent.html"><span class="lang-flag flag-en" aria-hidden="true"></span>EN</a>
+    </div>
+    <div class="top-cta-group">
+      <a href="/ukr/try.html" class="btn-cta-top btn-cta-try">План лікування</a>
+      <a href="/ukr/prevent.html" class="btn-cta-top btn-cta-secondary" aria-current="page">Профілактика</a>
+      <a href="/ukr/kb.html" class="btn-cta-top btn-cta-secondary">Онко-вікі</a>
+      <a href="/ukr/ask.html" class="btn-cta-top btn-cta-secondary">Туморборд</a>
+    </div>
+  </div>
+</header>
+
+<main>
+<div class="prevent-layout">
+
+<!-- ЛІВА: questionnaire form -->
+<section class="prevent-form-col">
+  <h1>Оцінка ризику для профілактики / ранньої діагностики</h1>
+  <p class="prevent-intro">
+    <strong>Інструмент для лікаря (HCP-mediated).</strong> Заповніть профіль пацієнта з ризику нижче. Система ідентифікує prevention-eligible фактори ризику (інфекційні канцерогени IARC Group 1, червоні прапори спадкового родоводу, професійні впливи, хронічні стани, ятрогенні + lifestyle) і генерує структурований Prevention Plan з двома треками (стандартна інтервенція + альтернатива зі спостереженням) за CHARTER §15.2 C4. Це не медичний пристрій; завжди звіряйтесь з лікарем-куратором.
+  </p>
+
+  <div class="prevent-quick-scenarios">
+    <label for="quick-scenario">Швидко завантажити готовий сценарій:</label>
+    <select id="quick-scenario" onchange="loadScenario(this.value)">
+      <option value="">— Порожня форма —</option>
+      <optgroup label="Інфекційні (IARC Group 1)">
+        <option value="hcv">Хронічний HCV (без поточної лімфоми) → DAA шлях профілактики</option>
+        <option value="hbv">Хронічний HBV (без поточного ГЦК) → противірусна терапія + спостереження</option>
+        <option value="hpv">Персистуючий HPV-16+, невакцинований → Gardasil-9 + скринінг</option>
+        <option value="hpylori">H. pylori позитивний (без поточної злоякісності) → PBMT ерадикація</option>
+        <option value="hiv">Новодіагностований ВІЛ → АРТ + cancer-screening cadence</option>
+      </optgroup>
+      <optgroup label="Підозра спадкового синдрому (germline panel candidate)">
+        <option value="lynch">Сім'я відповідає Амстердамським критеріям II → Lynch panel</option>
+        <option value="brca">Сімейний BRCA-родовід + ашкеназі → BRCA1/2 панель</option>
+        <option value="vhl">Сім'я з гемангіобластомою + феохромоцитомою → VHL панель</option>
+        <option value="lfs">Сім'я відповідає Chompret критеріям → TP53 панель</option>
+        <option value="fap">Батько з підтвердженим APC + класичний FAP фенотип</option>
+      </optgroup>
+      <optgroup label="Професійні / екологічні (IARC Group 1)">
+        <option value="asbestos">Кар'єрна експозиція азбестом + куріння → mesothelioma surveillance</option>
+        <option value="benzene">Бензол на нафтопереробці → AML/MDS surveillance</option>
+        <option value="radon">Високий радон у домі + колишній курець → LDCT</option>
+      </optgroup>
+      <optgroup label="Хронічні стани">
+        <option value="barretts">Довго-сегментний стравохід Барретта → EGD спостереження</option>
+        <option value="ibd">UC ×22 роки extensive coлiт → CRC спостереження</option>
+        <option value="psc">PSC + супутній IBD (підгрупа найвищого ризику)</option>
+      </optgroup>
+    </select>
+  </div>
+
+  <form id="prevent-form">
+
+    <fieldset class="prevent-section">
+      <legend>A. Демографія пацієнта</legend>
+      <label class="prevent-field">Вік (років): <input type="number" name="age" min="0" max="120" id="f-age" placeholder="наприклад 45"></label>
+      <label class="prevent-field">Стать:
+        <select name="sex" id="f-sex">
+          <option value="">—</option>
+          <option value="female">Жіноча</option>
+          <option value="male">Чоловіча</option>
+        </select>
+      </label>
+      <label class="prevent-field">ECOG performance status: <input type="number" name="ecog" min="0" max="4" id="f-ecog" placeholder="0-4"></label>
+    </fieldset>
+
+    <fieldset class="prevent-section">
+      <legend>B. Хронічні інфекції (IARC Group 1)</legend>
+      <p class="prevent-section-desc">Кожна підвищує ризик специфічних раків; інтервенція — curative або risk-reducing противірусна / антибіотична / вакцина-терапія.</p>
+      <label class="prevent-field"><input type="checkbox" data-finding="hcv_rna" data-value="detectable" id="f-hcv">Хронічний Hepatitis C (HCV-RNA визначувана) — спрацьовує DAA шлях профілактики</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="hbsag" data-value="positive" id="f-hbv">Хронічний Hepatitis B (HBsAg+ ≥6 міс АБО HBV-DNA визначувана)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="hpv_high_risk_status" data-value="positive" id="f-hpv">Персистуючий HPV високого ризику (HPV-16/18 та ін на co-test)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="hpv_vaccine_status" data-value="unvaccinated" id="f-hpv-unvax">HPV-вакцинація не завершена (вікова межа 9-45)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="h_pylori_status" data-value="positive" id="f-hpylori">Helicobacter pylori позитивний (УДТ / антиген у калі / біопсія)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="hiv_status" data-value="positive" id="f-hiv">ВІЛ-позитивний (будь-яка стадія)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="ebv_dna_pcr" data-value="detectable" id="f-ebv">EBV-DNA визначувана + контекст імунокомпрометації (post-transplant / ТГСК / вроджений імунодефіцит / ВІЛ+)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="post_transplant_immunosuppression" data-value="true" id="f-immunosuppression">Імуносупресія post-transplant (для EBV co-контексту)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="htlv_1_status" data-value="positive" id="f-htlv1">HTLV-1 позитивний (ендемічний регіон або відомий носій)</label>
+    </fieldset>
+
+    <fieldset class="prevent-section">
+      <legend>C. Сімейний родовід (червоні прапори спадкового раку)</legend>
+      <p class="prevent-section-desc">Обчислені прапори. Pedigree-to-criteria evaluator — v0.2-C розширення engine (наразі очікує флаги попередньо обчислені клініцистом).</p>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_amsterdam_ii_criteria_met" data-value="true" id="f-lynch-amsterdam">Сім'я відповідає Амстердамським критеріям II (Lynch підозра: ≥3 Lynch-spectrum рака, ≥2 покоління, ≥1 родич першого ступеня, ≥1 дx &lt;50)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_breast_cancer_under_50" data-value="true" id="f-brca-breast">Родич першого ступеня з раком молочної залози &lt;50 (BRCA підозра)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_ovarian_cancer_any_age" data-value="true" id="f-brca-ovarian">Родич першого ступеня з high-grade serous ovarian (будь-який вік)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_ashkenazi_jewish_ancestry_with_breast_or_ovarian" data-value="true" id="f-brca-ashkenazi">Ашкеназі-єврейське походження + сімейний breast/ovarian (founder мутації)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_hemangioblastoma_cns_or_retinal" data-value="true" id="f-vhl-hemangioblastoma">Сімейна ЦНС/ретинальна гемангіобластома (VHL підозра)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_pheochromocytoma_paraganglioma_with_rcc_or_hemangioblastoma" data-value="true" id="f-vhl-pheo">Сімейний кластер феохромоцитома + RCC/гемангіобластома</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_classic_fap_phenotype" data-value="true" id="f-fap-phenotype">Сімейний класичний FAP фенотип (&gt;100 колоректальних аденом)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_apc_known_pathogenic_variant" data-value="true" id="f-fap-apc">Сімейний підтверджений патогенний варіант APC</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_chompret_criteria_met" data-value="true" id="f-lfs-chompret">Сім'я відповідає Chompret критеріям (LFS / TP53 підозра)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="family_men2_phenotype_cluster" data-value="true" id="f-men2-phenotype">Сімейний кластер MEN2 фенотипу (MTC + феохромоцитома + параthyroid АБО мукозальні невроми)</label>
+    </fieldset>
+
+    <fieldset class="prevent-section">
+      <legend>D. Lifestyle &amp; екологічні фактори ризику</legend>
+      <label class="prevent-field"><input type="checkbox" data-finding="current_tobacco_use_documented" data-value="true" id="f-smoker">Поточне куріння (будь-яка кількість ≥3 місяці)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="heavy_alcohol_use_documented" data-value="true" id="f-alcohol">Heavy alcohol use (≥3 drinks/день чоловіки, ≥2/день жінки)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="bmi_kg_m2" data-value="35" id="f-bmi-obese">BMI ≥ 30 (ожиріння — cancer-cluster ризик)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="residential_radon_exposure_ge_4_pci_per_l" data-value="true" id="f-radon">Радон у домі ≥ 4 pCi/L</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="residential_pm2_5_annual_average_gt_35" data-value="true" id="f-pm25">PM2.5 &gt; 35 μg/m³ річне середнє</label>
+    </fieldset>
+
+    <fieldset class="prevent-section">
+      <legend>E. Професійні експозиції (IARC Group 1)</legend>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_asbestos_exposure_documented" data-value="true" id="f-asbestos">Професійна експозиція азбестом (суднобудівник, ізолятор, демонтаж)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_benzene_exposure_documented" data-value="true" id="f-benzene">Професійний бензол (нафтопереробка, розчинники)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_diesel_exhaust_exposure_documented" data-value="true" id="f-diesel">Дизельний вихлоп (водії вантажівок, шахтарі, важка техніка)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_formaldehyde_exposure_documented" data-value="true" id="f-formaldehyde">Формальдегід (патологоанатомія, бальзамування, ДСП)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_aromatic_amine_exposure_documented" data-value="true" id="f-aromatic">Ароматичні аміни (дойна/гумова/шкіряна промисловість до-регуляційна)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_silica_exposure_documented" data-value="true" id="f-silica">Кристалічний кремній (видобуток, кар'єри, піскоструминна обробка)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="occupational_firefighter_career_documented" data-value="true" id="f-firefighter">Кар'єрний пожежник (≥10 років)</label>
+    </fieldset>
+
+    <fieldset class="prevent-section">
+      <legend>F. Хронічні медичні стани</legend>
+      <label class="prevent-field"><input type="checkbox" data-finding="barretts_esophagus_diagnosis_confirmed" data-value="true" id="f-barretts">Підтверджений стравохід Барретта</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="inflammatory_bowel_disease_uc_diagnosis_ge_8y" data-value="true" id="f-ibd-uc">Виразковий коліт ≥ 8 років</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="primary_sclerosing_cholangitis_diagnosis_confirmed" data-value="true" id="f-psc">Первинний склерозуючий холангіт (PSC)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="primary_sclerosing_cholangitis_with_ibd" data-value="true" id="f-psc-ibd">PSC з супутнім IBD (підгрупа найвищого ризику)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="celiac_disease_refractory_type_2" data-value="true" id="f-celiac">Рефрактерна целіакія типу 2</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="chronic_pancreatitis_hereditary_pancreatitis_prss1_or_spink1" data-value="true" id="f-pancreatitis">Спадковий панкреатит (PRSS1 / SPINK1)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="hashimoto_thyroiditis_diagnosis_confirmed" data-value="true" id="f-hashimoto">Тиреоїдит Хашимото</label>
+    </fieldset>
+
+    <fieldset class="prevent-section">
+      <legend>G. Ятрогенні фактори ризику (попередні лікування)</legend>
+      <label class="prevent-field"><input type="checkbox" data-finding="prior_anthracycline_cumulative_dose_ge_250" data-value="true" id="f-anthracycline">Попередня сумарна доза антрациклінів ≥250 mg/m² (cardio-late-effect)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="prior_cranial_radiotherapy_documented" data-value="true" id="f-cranial-rt">Попередня краніальна радіотерапія (secondary brain tumor / ендокринні late-effects)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="prior_alkylator_chemotherapy_documented" data-value="true" id="f-alkylator">Попередня алкілаторна хіміотерапія (ризик t-AML)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="ppi_continuous_use_ge_10y" data-value="true" id="f-ppi-longterm">PPI постійне використання ≥10 років (gastric NET ризик)</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="combined_hrt_continuous_use_ge_5y" data-value="true" id="f-hrt">Комбінована HRT (естроген + прогестин) ≥5 років</label>
+      <label class="prevent-field"><input type="checkbox" data-finding="tamoxifen_continuous_use_ge_5y" data-value="true" id="f-tamoxifen">Тривалий tamoxifen ≥5 років (endometrial cancer surveillance)</label>
+    </fieldset>
+
+    <div class="prevent-actions">
+      <button type="button" onclick="updatePreview()">Згенерувати Prevention Plan →</button>
+      <button type="button" class="secondary" onclick="copyJSON()">Скопіювати JSON пацієнта</button>
+      <button type="button" class="secondary" onclick="openInTryBuilder()">Відкрити у Plan Builder →</button>
+      <button type="button" class="secondary" onclick="resetForm()">Скинути форму</button>
+    </div>
+  </form>
+</section>
+
+<!-- ПРАВА: Output preview -->
+<aside class="prevent-output-col">
+  <h2>Попередній перегляд профілю пацієнта</h2>
+  <pre class="prevent-preview" id="json-preview">{
+  "patient_id": "PREVENT-WEB-001",
+  "comment": "Заповніть форму ліворуч, потім натисніть «Згенерувати Prevention Plan»",
+  "biomarkers": {},
+  "demographics": {},
+  "findings": {}
+}</pre>
+
+  <div class="prevent-fired-rfs" id="fired-rfs-block" style="display:none;">
+    <h3>Prevention RedFlags, які спрацюють:</h3>
+    <ul id="fired-rfs-list"></ul>
+    <p class="small" style="margin-top: 0.5rem;">Кожен спрацьований RF маршрутизує до 2-track Prevention Plan (інтервенція + спостереження за CHARTER §15.2 C4). Натисніть <strong>Відкрити у Plan Builder</strong>, щоб запустити engine і побачити повний вивід.</p>
+  </div>
+
+  <div class="prevent-charter-note">
+    <strong>CHARTER §15 C1 інваріант:</strong> OpenOnco — HCP-mediated інструмент, не patient-direct медичний пристрій. Ця анкета — для prevention-консультацій під керівництвом лікаря. Весь контент — STUB, очікує two-Clinical-Co-Lead signoff за §6.1 dev-mode exemption.
+    <br><br>
+    <strong>Дані:</strong> нічого тут не передається на сервер. Усе обробляється client-side після натискання <em>Відкрити у Plan Builder</em> (який вбудовує OpenOnco engine через Pyodide).
+    <br><br>
+    <strong>Покриття:</strong> 50+ prevention-пілотів через 7 категорій факторів ризику (інфекційні / спадкові / хронічні стани / професійні / ятрогенні / lifestyle / репродуктивні) за IARC Monographs + USPSTF + NCCN Genetic/Familial High-Risk + AGA + AASLD.
+  </div>
+</aside>
+
+</div>
+</main>
+
+<script>
+// Pre-built scenarios — each is a snapshot of finding-keys that fire specific prevention RFs
+const SCENARIOS = {
+  hcv: { age: 52, sex: 'male', ecog: 1, checks: ['f-hcv'] },
+  hbv: { age: 42, sex: 'female', ecog: 0, checks: ['f-hbv'] },
+  hpv: { age: 29, sex: 'female', ecog: 0, checks: ['f-hpv', 'f-hpv-unvax'] },
+  hpylori: { age: 48, sex: 'male', ecog: 1, checks: ['f-hpylori'] },
+  hiv: { age: 35, sex: 'male', ecog: 0, checks: ['f-hiv'] },
+  lynch: { age: 38, sex: 'female', ecog: 0, checks: ['f-lynch-amsterdam'] },
+  brca: { age: 32, sex: 'female', ecog: 0, checks: ['f-brca-breast', 'f-brca-ovarian', 'f-brca-ashkenazi'] },
+  vhl: { age: 24, sex: 'male', ecog: 0, checks: ['f-vhl-hemangioblastoma', 'f-vhl-pheo'] },
+  lfs: { age: 28, sex: 'female', ecog: 0, checks: ['f-lfs-chompret'] },
+  fap: { age: 16, sex: 'male', ecog: 0, checks: ['f-fap-phenotype', 'f-fap-apc'] },
+  asbestos: { age: 62, sex: 'male', ecog: 1, checks: ['f-asbestos', 'f-smoker'] },
+  benzene: { age: 55, sex: 'male', ecog: 0, checks: ['f-benzene'] },
+  radon: { age: 58, sex: 'female', ecog: 0, checks: ['f-radon'] },
+  barretts: { age: 54, sex: 'male', ecog: 0, checks: ['f-barretts'] },
+  ibd: { age: 44, sex: 'female', ecog: 0, checks: ['f-ibd-uc'] },
+  psc: { age: 39, sex: 'male', ecog: 1, checks: ['f-psc', 'f-psc-ibd'] }
+};
+
+// RF mapping (UA): які finding-key активує який RF (для preview панелі)
+const RF_MAP = {
+  'hcv_rna': 'RF-CHRONIC-HCV-NHL-PREVENTION-OPPORTUNITY → DAA антивірусний шлях',
+  'hbsag': 'RF-CHRONIC-HBV-MALIGNANCY-PREVENTION → entecavir/TAF + HCC спостереження',
+  'hpv_high_risk_status': 'RF-CHRONIC-HPV-MALIGNANCY-PREVENTION → Gardasil-9 + Pap/анальний скринінг',
+  'hpv_vaccine_status': 'RF-CHRONIC-HPV-MALIGNANCY-PREVENTION → вакцинація + скринінг',
+  'h_pylori_status': 'RF-CHRONIC-H-PYLORI-MALIGNANCY-PREVENTION → PBMT ерадикація (Україна — перевага)',
+  'hiv_status': 'RF-CHRONIC-HIV-MALIGNANCY-PREVENTION → АРТ + cancer-screening cadence',
+  'ebv_dna_pcr': 'RF-CHRONIC-EBV-MALIGNANCY-PREVENTION → активне EBV-DNA спостереження + preemptive rituximab при росту титрів',
+  'htlv_1_status': 'RF-CHRONIC-HTLV-1-MALIGNANCY-PREVENTION → гематологічне спостереження + transmission counseling',
+  'family_amsterdam_ii_criteria_met': 'RF-LYNCH-FAMILY-HISTORY-SUSPICION → germline MMR/EPCAM панель',
+  'family_breast_cancer_under_50': 'RF-BRCA-HBOC-FAMILY-HISTORY-SUSPICION → BRCA1/2 + розширена панель',
+  'family_ovarian_cancer_any_age': 'RF-BRCA-HBOC-FAMILY-HISTORY-SUSPICION → BRCA1/2 + розширена панель',
+  'family_ashkenazi_jewish_ancestry_with_breast_or_ovarian': 'RF-BRCA-HBOC-FAMILY-HISTORY-SUSPICION → BRCA1/2 founder mutation testing',
+  'family_hemangioblastoma_cns_or_retinal': 'RF-VHL-FAMILY-HISTORY-SUSPICION → germline VHL панель + VHL Alliance surveillance protocol',
+  'family_pheochromocytoma_paraganglioma_with_rcc_or_hemangioblastoma': 'RF-VHL-FAMILY-HISTORY-SUSPICION → germline VHL панель',
+  'family_classic_fap_phenotype': 'RF-FAP-FAMILY-HISTORY-SUSPICION → germline APC панель + sigmoidoscopy з 10-12 років',
+  'family_apc_known_pathogenic_variant': 'RF-FAP-FAMILY-HISTORY-SUSPICION → germline APC панель',
+  'family_chompret_criteria_met': 'RF-LI-FRAUMENI-FAMILY-HISTORY-SUSPICION → germline TP53 панель + Toronto Protocol',
+  'family_men2_phenotype_cluster': 'RF-MEN2-FAMILY-HISTORY-SUSPICION → germline RET панель + планування prophylactic thyroidectomy',
+  'current_tobacco_use_documented': 'RF-UNIVERSAL-CURRENT-SMOKER-MULTI-CANCER → cessation + LDCT eligibility',
+  'heavy_alcohol_use_documented': 'RF-UNIVERSAL-HEAVY-ALCOHOL-MULTI-CANCER → AUD counseling + cancer-screening adjustment',
+  'bmi_kg_m2': 'RF-UNIVERSAL-ELEVATED-BMI-CANCER-CLUSTER → структурована weight-loss програма (+13 IARC раків)',
+  'residential_radon_exposure_ge_4_pci_per_l': 'RF-ENVIRONMENTAL-AIR-POLLUTION-LUNG-PREVENTION → mitigation + LDCT',
+  'residential_pm2_5_annual_average_gt_35': 'RF-ENVIRONMENTAL-AIR-POLLUTION-LUNG-PREVENTION',
+  'occupational_asbestos_exposure_documented': 'RF-OCC-ASBESTOS-MALIGNANCY-PREVENTION → LDCT + cessation + pleural surveillance',
+  'occupational_benzene_exposure_documented': 'RF-OCC-BENZENE-MALIGNANCY-PREVENTION → CBC q6-12mo + low-threshold BM eval',
+  'occupational_diesel_exhaust_exposure_documented': 'RF-OCC-DIESEL-EXHAUST-PREVENTION → LDCT + cessation',
+  'occupational_formaldehyde_exposure_documented': 'RF-OCC-FORMALDEHYDE-PREVENTION → CBC + ENT symptom awareness',
+  'occupational_aromatic_amine_exposure_documented': 'RF-OCC-AROMATIC-AMINES-MALIGNANCY-PREVENTION → urinalysis + cytology + cystoscopy threshold',
+  'occupational_silica_exposure_documented': 'RF-OCC-SILICA-PREVENTION → HRCT + LDCT + smoking cessation',
+  'occupational_firefighter_career_documented': 'RF-OCC-FIREFIGHTER-PREVENTION → multi-cancer-screening (LDCT, dermatology, GI)',
+  'barretts_esophagus_diagnosis_confirmed': 'RF-BARRETTS-ESOPHAGUS-PREVENTION → EGD q3-5y + high-dose PPI',
+  'inflammatory_bowel_disease_uc_diagnosis_ge_8y': 'RF-IBD-CRC-PREVENTION → colonoscopy q1-2y + chromoendoscopy',
+  'primary_sclerosing_cholangitis_diagnosis_confirmed': 'RF-PSC-CHOLANGIOCARCINOMA-PREVENTION → MRI/MRCP + CA 19-9 щорічно',
+  'primary_sclerosing_cholangitis_with_ibd': 'PSC-IBD підгрупа найвищого ризику → щорічна colonoscopy з PSC дx',
+  'celiac_disease_refractory_type_2': 'RF-CELIAC-EATL-PREVENTION → строгий GFD + small-bowel imaging q1-2y',
+  'chronic_pancreatitis_hereditary_pancreatitis_prss1_or_spink1': 'RF-CHRONIC-PANCREATITIS-PDAC-PREVENTION → MRI/MRCP + EUS surveillance',
+  'hashimoto_thyroiditis_diagnosis_confirmed': 'RF-AUTOIMMUNE-THYROIDITIS-LYMPHOMA-PREVENTION → TSH + thyroid US q6-12mo',
+  'prior_anthracycline_cumulative_dose_ge_250': 'RF-IATROGENIC-ANTHRACYCLINE-LATE-CARDIO-PREVENTION → echo q1-5y',
+  'prior_cranial_radiotherapy_documented': 'RF-IATROGENIC-CRANIAL-RT-LATE-PREVENTION → neuro exam + endocrine panel + brain MRI при симптомах',
+  'prior_alkylator_chemotherapy_documented': 'RF-IATROGENIC-ALKYLATOR-TAML-PREVENTION → CBC q3-6mo перші 10 років',
+  'ppi_continuous_use_ge_10y': 'RF-IATROGENIC-LONG-TERM-PPI-GASTRIC-NET-PREVENTION → de-prescribing + EGD surveillance',
+  'combined_hrt_continuous_use_ge_5y': 'RF-IATROGENIC-COMBINED-HRT-PREVENTION → year-5 shared-decision review',
+  'tamoxifen_continuous_use_ge_5y': 'RF-IATROGENIC-TAMOXIFEN-ENDOMETRIAL-PREVENTION → симптом-prompted evaluation; рутинне TVUS НЕ рекомендується (ACOG)'
+};
+
+function buildPatient() {
+  const ageEl = document.getElementById('f-age');
+  const sexEl = document.getElementById('f-sex');
+  const ecogEl = document.getElementById('f-ecog');
+  const age = ageEl.value ? parseInt(ageEl.value, 10) : null;
+  const sex = sexEl.value || null;
+  const ecog = ecogEl.value !== '' ? parseInt(ecogEl.value, 10) : null;
+
+  const demographics = {};
+  if (age !== null) demographics.age = age;
+  if (sex) demographics.sex = sex;
+  if (ecog !== null) demographics.ecog = ecog;
+
+  const findings = {};
+  const firedRFs = [];
+  document.querySelectorAll('#prevent-form input[type="checkbox"][data-finding]').forEach(cb => {
+    if (cb.checked) {
+      const key = cb.dataset.finding;
+      let value = cb.dataset.value;
+      if (value === 'true') value = true;
+      else if (value === 'false') value = false;
+      else if (!isNaN(value) && value !== '') value = parseFloat(value);
+      findings[key] = value;
+      if (RF_MAP[key]) firedRFs.push(RF_MAP[key]);
+    }
+  });
+
+  const summary = describePatient(demographics, findings);
+  const patient = {
+    patient_id: 'PREVENT-WEB-' + Date.now().toString().slice(-4),
+    comment: summary,
+    biomarkers: {},
+    demographics,
+    findings
+  };
+  return { patient, firedRFs };
+}
+
+function describePatient(demo, findings) {
+  const parts = [];
+  if (demo.age) parts.push(`${demo.age}р`);
+  if (demo.sex) parts.push(demo.sex === 'female' ? 'жін' : 'чол');
+  if (Object.keys(findings).length) parts.push(`з ${Object.keys(findings).length} prevention-eligible прапор(ів)`);
+  return parts.length ? `Prevention assessment: ${parts.join(' ')}` : 'Порожній prevention profile';
+}
+
+function updatePreview() {
+  const { patient, firedRFs } = buildPatient();
+  document.getElementById('json-preview').textContent = JSON.stringify(patient, null, 2);
+  const block = document.getElementById('fired-rfs-block');
+  const list = document.getElementById('fired-rfs-list');
+  list.innerHTML = '';
+  if (firedRFs.length === 0) {
+    block.style.display = 'none';
+  } else {
+    block.style.display = 'block';
+    [...new Set(firedRFs)].forEach(rf => {
+      const li = document.createElement('li');
+      li.textContent = rf;
+      list.appendChild(li);
+    });
+  }
+}
+
+function copyJSON() {
+  const { patient } = buildPatient();
+  navigator.clipboard.writeText(JSON.stringify(patient, null, 2)).then(() => {
+    alert('JSON пацієнта скопійовано у буфер обміну. Вставте у /ukr/try.html textarea, щоб запустити engine.');
+  }).catch(() => {
+    alert('Clipboard API недоступний. Скопіюйте з preview панелі вручну.');
+  });
+}
+
+function openInTryBuilder() {
+  const { patient } = buildPatient();
+  const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(patient))));
+  window.open('/ukr/try.html#prefill=' + encoded, '_blank');
+}
+
+function loadScenario(key) {
+  if (!key) return;
+  const s = SCENARIOS[key];
+  if (!s) return;
+  resetForm();
+  document.getElementById('f-age').value = s.age;
+  document.getElementById('f-sex').value = s.sex;
+  document.getElementById('f-ecog').value = s.ecog;
+  s.checks.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.checked = true;
+  });
+  updatePreview();
+}
+
+function resetForm() {
+  document.getElementById('prevent-form').reset();
+  document.getElementById('json-preview').textContent = JSON.stringify({
+    patient_id: 'PREVENT-WEB-001',
+    comment: 'Заповніть форму ліворуч, потім натисніть «Згенерувати Prevention Plan»',
+    biomarkers: {},
+    demographics: {},
+    findings: {}
+  }, null, 2);
+  document.getElementById('fired-rfs-block').style.display = 'none';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('#prevent-form input, #prevent-form select').forEach(el => {
+    el.addEventListener('change', updatePreview);
+  });
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Pairs EN /prevent.html with a fully-translated UA version. Closes the lang-switch loop (EN UA-flag now points at /ukr/prevent.html instead of /ukr/ homepage fallback). All 50+ field labels, 16 scenarios, action buttons, charter note, and JS RF_MAP descriptions translated. Trigger field-names (data-finding) stay snake_case English — engine contract identifiers tied to RF YAML triggers.