### PR TITLE
docs(mcp): fix "peer-reviewed" overclaim in MCP server README

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -11,9 +11,10 @@ engine over a versioned knowledge base, then relays its output with citations
 and a disclaimer.
 
 No LLM picks the regimen. The recommendation comes from a declarative rule
-engine over peer-reviewed clinical content; the clinical decision stays with the
-engine and the treating oncologist ([CHARTER §8.3](../specs/CHARTER.md)). That
-is the whole point — **safer results, by construction.**
+engine over human-reviewed, source-cited clinical content (most entities are
+still STUB — not yet dual-reviewer signed off); the clinical decision stays with
+the engine and the treating oncologist ([CHARTER §8.3](../specs/CHARTER.md)).
+That is the whole point — **safer results, by construction.**
 
 > Informational decision support, **not** a medical device. Every output must be
 > verified by a qualified oncologist. See [CHARTER §11 + §15](../specs/CHARTER.md).


### PR DESCRIPTION
## What

Reword line 14 of [`mcp_server/README.md`](../blob/master/mcp_server/README.md) which described the knowledge base as **"peer-reviewed clinical content"**.

**Before:**
> The recommendation comes from a declarative rule engine over **peer-reviewed clinical content**; the clinical decision stays with the engine and the treating oncologist (CHARTER §8.3).

**After:**
> The recommendation comes from a declarative rule engine over **human-reviewed, source-cited clinical content (most entities are still STUB — not yet dual-reviewer signed off)**; the clinical decision stays with the engine and the treating oncologist (CHARTER §8.3).

## Why

"Peer-reviewed clinical content" is an overclaim under the project's public-claims policy:

- **"peer-reviewed-validated" is a forbidden public claim.**
- Source guidelines (NCCN/ESMO/etc.) are **referenced, not redistributed** — the KB doesn't host them.
- Most clinical entities are **STUB**: only 15 of 806 carry dual Clinical-Co-Lead sign-off, and no formal clinical validation study has been done.

This file is a public-facing asset (linked from the planned launch), so accuracy matters.

## Scope

- Single-line reword only.
- **Not-a-medical-device disclaimer block left intact.**
- **No KB numbers or other claims changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)