### PR TITLE
chore: add root LICENSE (MIT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenOnco contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds a root `LICENSE` file (standard MIT text) so GitHub detects and displays the project's license.

**Why:** the project already declares **code MIT** (`pyproject.toml`) + **content/specs CC BY 4.0** (`README`), but no root `LICENSE` file existed — so GitHub showed *no license*, which undercuts the "full open source" story and discourages reuse. This makes the already-declared license detectable.

**Notes:**
- This is **not a license change** — it materializes the MIT declaration that already exists in `pyproject.toml`.
- The `LICENSE` file covers the **code** (standard convention); the **CC BY 4.0** content/specs split remains documented in `README.md`.
- Copyright holder line is **"OpenOnco contributors"** — change it here if you prefer different attribution before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)