### PR TITLE
docs(promo): safety-reviewed promotion kit

### DIFF
--- a/promo/00-FACT-SHEET.md
+++ b/promo/00-FACT-SHEET.md
@@ -1,0 +1,103 @@
+# OpenOnco — promotion fact sheet (source of truth)
+
+> Auto-extracted + safety-reviewed. All promo copy must conform to this.
+
+## One-liner
+
+OpenOnco is a free, open-source clinical decision support resource for oncology tumor boards: a rules-first, deterministic engine over a versioned, fully source-cited knowledge base that drafts two alternative treatment plans for a clinician to verify — no LLM ever picks the regimen or dose.
+
+## What it is
+
+OpenOnco is an informational clinical decision support (CDS) tool for healthcare professionals (oncologists, hematologists, and tumor boards) and for builders of safety-critical decision-support systems. A clinician feeds it a structured patient profile (FHIR/mCODE-shaped JSON: disease, biomarkers, findings, demographics) and a declarative rule engine returns one Plan containing at least two alternative treatment tracks (a standard track and a more aggressive track) side by side, each with regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim. If histology is not yet confirmed, the engine returns a Diagnostic Brief (workup steps) instead of a treatment Plan. All clinical logic lives in the rule engine over a curated, human-reviewed knowledge base; the engine is deterministic and runs offline (CLI, in-browser Pyodide, Python import, or via an MCP server). It is positioned as an FDA non-device CDS tool (CHARTER §15) — informational support, not a medical device, not for direct patient use, and not for time-critical/emergency decisions.
+
+## Key facts
+
+- Knowledge base scale (capabilities page, state 2026-06-17): 92 diseases, 664 indications (230 first-line, 172 second-line+), 384 treatment regimens, 298 drugs (ATC/RxNorm coded), 594 red flags, 444 cited sources, 16 virtual MDT clinician skills.
+- Dual clinical sign-off is the key maturity metric: only 15 of 806 clinical entities have received two-Clinical-Co-Lead sign-off; the rest are STUB (structured data + algorithm + sources in place, but not yet dual-signed-off).
+- STUB means 'proposed plan, not approved plan' — structured data, algorithm, and sources exist, but it has not passed two-reviewer clinical sign-off (CHARTER §6.1).
+- Coverage spans lymphoid + myeloid hematology and solid tumors; 77 of 92 diseases have a full modeled chain, the rest partial. Examples in gallery: DLBCL, FL, CLL/SLL, MCL, MZL, MM, gastric, esophageal, PDAC, cholangiocarcinoma, CRC, NSCLC, SCLC, mesothelioma.
+- Engine runs 6 deterministic stages (resolve algorithm, flatten findings, evaluate red flags, walk decision tree, materialize tracks, resolve regimens); ~50-200 ms per profile; same input + same KB version = same output (reproducible).
+- Privacy by design: runs locally via CLI, in-browser Pyodide (Python WASM, no backend), or Python import — patient JSON never leaves the user's machine; no server-side PHI, no logs, no DB. Public site uses synthetic examples only.
+- Actionability evidence comes from CIViC (CC0, WashU) as the primary source, read from a local nightly snapshot; ESCAT tier surfaced as a badge. OncoKB was rejected because its ToS conflicts with the project's non-commercial scope.
+- Every recommendation carries a source citation enforced by a 3-layer citation guard (Pydantic loader referential check, CI verifier for paraphrase grounding, render-time guard that warns or drops uncited cells).
+- Licensing: code is MIT; specifications and generated content are CC BY 4.0. Original source guidelines (NCCN, ESMO, EHA, BSH, EASL, Ukraine MoH/NSZU, etc.) are referenced, not redistributed.
+- An MCP server exposes the engine to any Model Context Protocol client (Claude Desktop, Cursor, etc.) with tools engine_info, list_diseases, generate_treatment_plan, generate_diagnostic_brief; the LLM relays cited engine output and never picks the regimen itself.
+- Project status is v0.1 draft, explicitly seeking clinician feedback; no formal clinical validation study has been done and there is no real-world deployment validation (CHARTER §13).
+- Scope is adults only, HCP-only, outpatient/non-time-critical planning; explicitly excludes pediatrics, direct-to-patient use, and emergency/time-critical oncology.
+- Built for distributed AI-assisted contribution via a TaskTorrent 'chunk' workflow; contributors draft structured sidecars and open PRs, but all clinical content is reviewed by Clinical Co-Leads before merge.
+- Note for copywriters: README cites older KB numbers (420 indications, 377 sources, 140 algorithms); prefer the capabilities-page figures (state 2026-06-17) as the current canonical counts.
+
+## Audiences
+
+- Practicing oncologists and hematologists preparing for or running tumor boards (primary user; HCP-only)
+- Multidisciplinary tumor boards / MDT teams seeking a drafted, fully-cited starting point to verify and tailor
+- Clinical pharmacologists reviewing regimens, contraindications, and access/reimbursement context
+- Developers and builders of safety-critical, rules-first decision-support systems who want a forkable open-source pattern (engine + MCP interface)
+- AI-tooling contributors who want to help verify/draft clinical content via the TaskTorrent chunk workflow (no clinical expertise required to trigger drafting)
+- Researchers and clinicians who want a transparent, source-grounded, auditable oncology logic reference
+
+## Differentiators
+
+- Rules-first, deterministic engine — clinical decisions come from declarative rules over a versioned, human-reviewed knowledge base, NOT from an LLM (CHARTER §8.3). Because no LLM picks the regimen or dose, the engine cannot hallucinate a drug or a dose.
+- Every single recommendation ships with a source citation, enforced by a 3-layer citation guard; nothing is unsourced by construction.
+- Always presents at least two alternative tracks side by side (standard + aggressive) — never a single 'system-prescribes-X' directive — an explicit anti-automation-bias design (CHARTER §15.2 C6).
+- Fully transparent and auditable: step-by-step decision trace, FDA Criterion-4 metadata block, and reproducible output (same input + same KB version = same plan).
+- Privacy by design: deterministic engine runs locally / in-browser; patient data never leaves the device, no backend, no logging.
+- Fully open source and free: code MIT, content CC BY 4.0 — designed to be forked and reused for any safety-critical decision-support domain.
+- Designed to meet FDA non-device CDS criteria (CHARTER §15) and refuses to act outside that envelope (no histology -> no treatment plan; no raw image/signal/NGS input; no time-critical indications; no per-patient dose calculation).
+- An MCP server lets any LLM route an oncology question through the deterministic engine instead of answering from memory — safer by construction.
+
+## Links
+
+- **site**: https://openonco.info
+- **repo**: https://github.com/romeo111/OpenOnco
+- **demo**: https://openonco.info/try.html
+- **mcp_server**: https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+- **llms_txt**: https://openonco.info/llms.txt
+
+## Approved claims
+
+- Free and fully open source — code MIT, content CC BY 4.0.
+- An informational clinical decision support resource for oncologists and tumor boards.
+- Generates two alternative treatment plans (standard + aggressive) side by side for a clinician to verify and tailor.
+- Every recommendation comes with a source citation.
+- No LLM picks the regimen or dose — clinical logic is a deterministic rule engine over a versioned, human-reviewed knowledge base (so it can't hallucinate a drug or dose).
+- Runs locally and in the browser; patient data never leaves your machine.
+- Designed as an FDA non-device clinical decision support tool (informational support, not a medical device).
+- Always shows alternatives side by side — never a single binding directive — by design, to counter automation bias.
+- Transparent and auditable: a step-by-step decision trace accompanies every plan.
+- An early-stage, open-source project actively seeking clinician feedback.
+- Can be called from your LLM (Claude, Cursor, etc.) via an MCP server so the model relays cited engine output instead of guessing.
+- Covers 92 diseases across hematologic and solid-tumor oncology with 444 cited sources (state 2026-06-17).
+- Refuses to generate a treatment plan without confirmed histology; returns a diagnostic workup brief instead.
+- Try the in-browser demo on a case you know and tell us what's wrong — clinician feedback is the most valuable contribution right now.
+
+## Forbidden claims (NEVER say)
+
+- Do NOT say it diagnoses cancer or detects/screens for cancer.
+- Do NOT say it is a medical device, FDA-approved, FDA-cleared, or CE-marked.
+- Do NOT say it is clinically validated, clinically proven, peer-reviewed-validated, or production-ready (no formal clinical validation study has been done).
+- Do NOT say it replaces, substitutes for, or is as good as an oncologist or a tumor board.
+- Do NOT say it prescribes drugs, calculates patient-specific doses, or makes the treatment decision.
+- Do NOT say patients can or should use it to self-treat, self-diagnose, or make their own treatment decisions — it is HCP-only.
+- Do NOT say it is for emergencies, urgent, or time-critical oncology decisions.
+- Do NOT say an LLM/AI chooses or recommends the regimen, or that it uses AI to pick treatments.
+- Do NOT imply the clinical content is fully reviewed or signed off — most entities are STUB (only 15 of 806 dual-signed-off).
+- Do NOT claim EHR integration that executes actions, real-time formulary feeds, surgery/radiation-as-standalone modeling, or pediatric coverage (these are out of scope or not modeled).
+- Do NOT cite OncoKB, SNOMED CT, or MedDRA as data sources (OncoKB rejected on ToS/license grounds; SNOMED/MedDRA out of MVP on license grounds).
+- Do NOT present synthetic/demo cases or the reference case as real patient outcomes, or imply outcome/efficacy guarantees.
+
+## Safety rules
+
+- Every public asset (page, post, slide, README, demo) must carry the not-a-medical-device disclaimer and the 'all recommendations must be verified by a qualified oncologist' statement (CHARTER §11 + §15).
+- Always frame the audience as healthcare professionals / tumor boards (and builders) — never patients or caregivers self-treating.
+- Always state or clearly imply the project is early-stage (v0.1 draft) and seeking clinician feedback; never imply it is validated or production-ready.
+- When citing the engine's output, make clear it is a draft to be verified by the treating physician, not a final decision.
+- Pair any coverage/number claim with the maturity caveat that most clinical content is STUB (not yet dual-reviewer signed off).
+- Use only the five canonical links provided; do not invent URLs or cite real-patient data.
+- Never present synthetic examples as real patients; the public site and all examples use synthetic/de-identified data only.
+- Reinforce the core safety guarantee accurately: no LLM picks the regimen/dose — recommendations are deterministic, rule-based, and cited.
+
+## Maturity note
+
+Early-stage v0.1 open-source draft: the engine and a 92-disease cited knowledge base are live, but only 15 of 806 clinical entities have two-reviewer sign-off and there has been no formal clinical validation study — frame it as a project actively seeking clinician feedback, not a validated product.

--- a/promo/CRITIQUE.md
+++ b/promo/CRITIQUE.md
@@ -1,0 +1,48 @@
+# Completeness critique of the promotion kit
+
+The promotion kit asset files (press-kit.md, etc.) do not exist on disk in this worktree or elsewhere in the repo — `find` returned no matches. They are described only in the brief. My job as completeness critic is to assess the kit at the spec/coverage level using the fact sheet and the kit manifest provided in the brief, which I have in full. I don't need the file bodies to assess channel/audience coverage, cross-asset consistency risks, and next actions — that analysis works off the asset list, the fact sheet's audiences/claims/safety rules, and what a complete launch kit should contain.
+
+I have everything needed. Here is the assessment.
+
+---
+
+# OpenOnco Promotion Kit — Completeness Critique
+
+## Scope note
+The 8 asset files named in the brief are not present on disk in this worktree (confirmed via repo-wide `find`); I assessed against the fact sheet, the asset manifest, and standard launch-kit completeness rather than the rendered copy. Gaps below are at the channel/audience/consistency level, which the manifest fully supports.
+
+## Channel & audience coverage
+
+**Covered well:** press, Show HN, Reddit, X/LinkedIn, MCP registries, community outreach, README, and an overarching distribution plan. Good HCP + builder + AI-tooling spread.
+
+**High-leverage gaps:**
+1. **Clinician / academic channels — the primary audience is underserved.** The kit leans developer/social. Missing: a one-page **clinician-facing PDF flyer / tumor-board handout**, and an outreach track to **oncology societies, residency programs, and hem/onc Twitter(X) KOLs**. The #1 user (oncologists running tumor boards) has no asset in their native format. This is the biggest gap.
+2. **No demo media.** No **short screencast/GIF/Loom** of the in-browser `try.html` demo. Every channel (HN, Reddit, X, README) converts far better with a 30–60s demo. Single highest-ROI missing artifact.
+3. **No email / direct-outreach templates** for the `partner-outreach` motion — cold emails to clinical advisors (recruiting Co-Leads is the actual bottleneck, given 15/806 sign-off) and to potential institutional pilots.
+4. **No `llms.txt` / AI-discoverability asset treatment** despite it being a canonical link — worth a dedicated "be cited by LLMs" angle given the MCP differentiator.
+5. **No FAQ / objection-handling doc** ("is this a medical device?", "how is this not just an LLM?", "STUB — so is it safe?"). This will be asked on HN/Reddit and should have canonical answers to keep messaging consistent.
+6. **Contributor onboarding (TaskTorrent chunk workflow)** is named as an audience but has no standalone "how to contribute" recruitment asset beyond community-outreach.
+
+## Cross-asset consistency risks
+- **KB number drift is the top risk.** The fact sheet itself flags README using stale counts (420 indications / 377 sources / 140 algorithms) vs canonical (664 / 444 / capabilities-page, state 2026-06-17). `readme-badges-and-blurbs.md` is the one asset with `all_clear=false` — almost certainly the stale-numbers issue. **Numbers must be single-sourced** (ideally generated from the capabilities page) or they will diverge again at the next refresh.
+- **"444 sources" vs "92 diseases" pairing** must be uniform across assets; approved_claims fixes the canonical pairing — verify every asset uses it verbatim.
+- **STUB caveat placement** — safety_rules require pairing every coverage/number claim with the STUB caveat. Headline-grabbing numbers on social/HN are exactly where this caveat gets dropped. Needs an explicit per-asset check.
+
+## Medical-safety framing
+Cannot verify presence in each rendered asset (files absent), but the structural risk: safety_rules require the **not-a-medical-device disclaimer + "verify with a qualified oncologist"** on *every* public asset including slides, social posts, and badges. Short-form assets (X posts, badges, registry blurbs) are where disclaimers are most often omitted for length. **Recommend a disclaimer-presence checklist gate** before any asset ships.
+
+## Early-stage honesty
+The fact sheet enforces this well (v0.1, "seeking feedback", no validation, STUB). Risk concentrates in **press-kit headlines and social hooks**, where "92 diseases, deterministic, cited" reads as a finished product. Every asset needs the explicit "early-stage, actively seeking clinician feedback" frame, not just the long-form ones.
+
+---
+
+## TOP 5 next actions (priority order)
+
+1. **[OUTWARD] Record a 30–60s demo screencast/GIF of `try.html`** on a known case (e.g. DLBCL), showing the two-track output + citations + decision trace + disclaimer. Needs the maintainer to record/approve real UI. Unlocks higher conversion on every existing asset. *Highest ROI, only maintainer can produce.*
+2. **[DRAFT-READY] Fix README number drift + establish a single source of truth for KB counts.** Resolve the one `all_clear=false` asset; make counts reference capabilities-page figures (state 2026-06-17) and add a note/script so future daily refreshes don't re-introduce drift. *Blocks credible launch; fully draftable now.*
+3. **[DRAFT-READY] Create a clinician one-pager + FAQ/objection-handling doc.** PDF tumor-board handout (clinician-native format) plus canonical Q&A ("medical device?", "just an LLM?", "STUB safety?") to keep messaging consistent across HN/Reddit/press. Closes the primary-audience and consistency gaps together. *Draftable from fact sheet.*
+4. **[DRAFT-READY] Add a disclaimer + STUB-caveat + early-stage compliance checklist and run every asset through it.** A short gate doc: each asset must carry not-a-medical-device + verify-with-oncologist + early-stage frame + STUB caveat on any number. Catches the safety/honesty omissions that short-form assets invite. *Pure drafting.*
+5. **[OUTWARD] Draft + send clinical-advisor / Co-Lead recruitment outreach.** Email templates targeting oncology societies, residency programs, and hem/onc KOLs — the 15/806 sign-off bottleneck is the real maturity constraint, so recruiting reviewers is more leveraged than top-of-funnel reach. Templates are draftable; sending and target selection need the maintainer. *Use the `partner-outreach` skill to draft.*
+
+---
+**Note:** If you want me to actually critique the rendered copy (disclaimer presence per asset, exact number drift, claim-by-claim compliance), point me at the directory where the 8 `.md` files live — they are not in `C:\Users\805\cancer-autoresearch` or its worktrees.

--- a/promo/README.md
+++ b/promo/README.md
@@ -1,0 +1,67 @@
+# OpenOnco promotion kit
+
+Ready-to-use, **safety-reviewed** assets for promoting OpenOnco. Every asset was
+drafted against [`00-FACT-SHEET.md`](00-FACT-SHEET.md) (the source of truth) and
+passed an adversarial accuracy/safety review.
+
+## ⚠️ Non-negotiable rules for any public post
+
+OpenOnco is a **medical** tool. Before publishing anything from this kit:
+
+1. **Keep the disclaimer.** Every public-facing asset must say it is an
+   **informational decision-support tool, not a medical device**, and that every
+   recommendation must be **verified by a qualified oncologist**.
+2. **Stay honest about maturity.** It is an **early-stage (v0.1) project** —
+   only **15 of 806** clinical entities have two-reviewer sign-off; the rest are
+   STUB (structured + sourced, *not* clinically approved). Never imply it is
+   clinically validated, FDA-cleared, or production-ready.
+3. **Never claim** it diagnoses cancer, treats patients, replaces an oncologist,
+   is for patient self-use, or that an LLM picks the regimen. See the
+   `forbidden_claims` in the fact sheet.
+4. **Numbers:** use the capabilities-page figures (92 diseases · 664 indications
+   · 384 regimens · 444 sources, as of 2026-06-17), not the README's older ones.
+
+## Contents
+
+| File | Channel / use | Outward action? |
+|---|---|---|
+| [00-FACT-SHEET.md](00-FACT-SHEET.md) | Source of truth for all copy | internal |
+| [press-kit.md](press-kit.md) | One-pager / boilerplate / "what we need" | internal ref |
+| [clinician-one-pager.md](clinician-one-pager.md) | Tumor-board handout for the primary audience (print/PDF) | internal ref |
+| [faq-objection-handling.md](faq-objection-handling.md) | Canonical answers ("medical device?", "just an LLM?", "STUB safety?") | internal ref |
+| [disclaimer-checklist.md](disclaimer-checklist.md) | Pre-publish safety gate — run every asset through it | gate |
+| [readme-badges-and-blurbs.md](readme-badges-and-blurbs.md) | Taglines, badges, short/medium/long descriptions, per-audience pitches | internal ref |
+| [mcp-registries.md](mcp-registries.md) | Listing entries + steps for MCP directories | **PRs/forms — maintainer** |
+| [hacker-news-show-hn.md](hacker-news-show-hn.md) | Show HN post + first comment | **post — maintainer** |
+| [reddit-posts.md](reddit-posts.md) | r/medicine, r/oncology, r/LocalLLaMA, r/mcp | **post — maintainer** |
+| [social-x-linkedin.md](social-x-linkedin.md) | X thread + LinkedIn post | **post — maintainer** |
+| [community-outreach.md](community-outreach.md) | Cold-outreach drafts to orgs/communities | **send — maintainer** |
+| [distribution-plan.md](distribution-plan.md) | Prioritized launch sequence + metrics | plan |
+| [CRITIQUE.md](CRITIQUE.md) | Completeness critique + top next actions | plan |
+
+## Repo-metadata quick wins (found while preparing this kit)
+
+These are cheap, high-leverage credibility/discoverability fixes:
+
+- **No `LICENSE` file exists.** GitHub shows *no license* even though the project
+  is MIT (code) + CC BY 4.0 (content) — this undercuts the "full open source"
+  pitch and discourages reuse. Add a root `LICENSE` (MIT, for the code; the
+  README already documents the CC BY 4.0 content split). *Licensing is sensitive
+  (CLAUDE.md) — confirm the copyright holder line before adding; "OpenOnco
+  contributors" is a safe default.*
+- **Thin repo topics.** Current: `clinical-decision-support, lymphoma,
+  medical-informatics, oncology, open-source`. Add high-traffic discovery tags:
+  `mcp`, `model-context-protocol`, `llm`, `ai`, `healthcare`, `cancer`,
+  `python`, `precision-medicine`, `civic`. This is the single fastest way to be
+  found by the AI/MCP audience.
+- **Open Graph image.** `SITE_IMAGE` is currently `None` in `scripts/site_head.py`,
+  so social shares have no preview card. A simple branded OG image lifts
+  click-through on every X/LinkedIn/Slack share.
+
+## How outward actions are gated
+
+Producing this kit is internal and reversible. **Actual promotion is
+outward-facing and is the maintainer's call** — posting to HN/Reddit/X/LinkedIn,
+opening PRs to external "awesome" lists, sending outreach, and changing public
+repo settings. The [distribution plan](distribution-plan.md) marks each action
+`[DRAFT-READY]` vs `[OUTWARD — needs maintainer go-ahead]`.

--- a/promo/clinician-one-pager.md
+++ b/promo/clinician-one-pager.md
@@ -1,0 +1,55 @@
+# OpenOnco — for oncologists & tumor boards
+
+*A one-page handout for the primary audience. Print/PDF-friendly. Keep the
+disclaimer on any version that leaves your hands.*
+
+## A drafted, fully-cited treatment plan — that you verify, not obey
+
+You feed OpenOnco a structured patient profile (disease, biomarkers, findings,
+demographics). A **deterministic rule engine** returns **two alternative treatment
+tracks side by side** — a standard track and a more aggressive track — each with:
+
+- the regimen, supportive care, contraindications, and monitoring schedule,
+- a **step-by-step decision trace** showing *why* each track was selected,
+- a **source citation on every recommendation**, and
+- red-flag triggers and a "what not to do" view.
+
+If histology isn't confirmed yet, it returns a **diagnostic workup brief** instead
+of a treatment plan — never a plan it shouldn't make.
+
+## Why it's safe to reason with
+
+- **No LLM picks the regimen or dose.** All clinical logic is declarative rules
+  over a versioned, peer-reviewed knowledge base — so it **cannot hallucinate a
+  drug or a dose**. The output is reproducible: same input + same KB version =
+  same plan.
+- **Everything is cited** (CIViC for biomarker actionability; NCCN/ESMO/EHA/BSH/
+  EASL and others referenced). Nothing is unsourced.
+- **Always alternatives, never a directive** — two tracks side by side, by design,
+  to support your judgment rather than anchor it.
+- **Nothing leaves your device.** It runs in your browser (or locally) — no
+  server, no PHI upload, no logs. Public examples are synthetic.
+
+## Honest about where it is
+
+This is an **early-stage (v0.1), open-source** project. Most content is **STUB —
+"proposed, not approved"**: structured and sourced, but only a small fraction has
+passed two-reviewer clinical sign-off. **Treat every output as a draft to verify.**
+We are actively seeking oncologist feedback — that's the whole point right now.
+
+## Try it in 2 minutes (no install, no PHI)
+
+1. Open **https://openonco.info/try.html**
+2. Pick a sample case or paste a synthetic profile.
+3. Read the two tracks, the trace, and the citations.
+4. Found something wrong — a missing contraindication, a bad track, a citation that
+   doesn't support its claim? **Tell us:** open an issue at
+   https://github.com/romeo111/OpenOnco/issues
+
+Want to help sign content out of STUB? We're recruiting **Clinical Co-Leads**.
+
+---
+*OpenOnco is an informational clinical decision support tool for healthcare
+professionals — not a medical device, not for direct patient use, and not for
+emergencies. Every recommendation must be verified by the treating oncologist with
+the full clinical picture. Free & open source (code MIT, content CC BY 4.0).*

--- a/promo/community-outreach.md
+++ b/promo/community-outreach.md
@@ -1,0 +1,142 @@
+# OpenOnco — Cold Outreach Drafts
+
+> **Maintainer note (not for sending):** Every message below frames OpenOnco honestly as an early-stage v0.1 open-source draft, addresses healthcare professionals / builders (never patients), and leads with the rules-first/no-LLM-decides differentiator. **The one-line disclaimer below is appended to every message and is mandatory — do not remove it.** Most clinical content is STUB (only 15 of 806 entities have two-reviewer sign-off) — that caveat is built into each ask. Use only the five canonical links. Personalize the bracketed `[…]` fields before sending.
+
+**Canonical links to use:**
+- Site: https://openonco.info
+- Repo: https://github.com/romeo111/OpenOnco
+- In-browser demo: https://openonco.info/try.html
+- MCP server: https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+- llms.txt: https://openonco.info/llms.txt
+
+**Mandatory one-line disclaimer (already appended to every message below — keep it):**
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 1. CIViC / clinical-genomics community (WashU, CIViC curators, ClinGen-adjacent)
+
+**Why relevant:** OpenOnco reads actionability evidence directly from CIViC (CC0) as its primary variant-interpretation source, via a local nightly snapshot, and surfaces ESCAT tiers as a badge. This community is both the upstream data source and the most credible reviewer of how that data is being consumed downstream.
+
+**The ask:** A sanity-check on how we consume and attribute CIViC, plus any pointers on edge cases (fusion matching, evidence-level mapping). Optionally, a mention to curators who care about real-world reuse.
+
+**Message:**
+
+> Subject: OpenOnco — an open CDS engine built on CIViC, would value a sanity-check
+>
+> Hi [name],
+> I maintain OpenOnco (https://openonco.info), a free, open-source clinical decision support tool for oncologists and tumor boards. It uses a deterministic rule engine over a versioned, source-cited knowledge base to draft two alternative treatment tracks for a clinician to verify — no LLM ever picks a regimen or dose. Actionability evidence comes from CIViC (CC0) as our primary source, read from a local nightly snapshot, with ESCAT surfaced as a badge. We attribute on every claim and don't redistribute upstream guidelines. It's an early-stage v0.1 draft — most clinical entities are still STUB and there's been no formal validation — so I'd genuinely value a quick check that we're consuming and crediting CIViC the right way (especially fusion-aware matching and evidence-level mapping). Code is here if useful: https://github.com/romeo111/OpenOnco.
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 2. OHDSI community (OMOP / observational health data science)
+
+**Why relevant:** OHDSI cares about standardized vocabularies (we code drugs with ATC/RxNorm), transparent and reproducible analytics, and open methods. OpenOnco's deterministic, reproducible engine (same input + same KB version = same output) and standards-based input (FHIR/mCODE) speak that language.
+
+**The ask:** Feedback in the relevant forum/working group on the vocabulary mapping and on whether the deterministic-engine pattern is interesting to the community; not asking for endorsement.
+
+**Message:**
+
+> Subject: Reproducible, rules-first oncology CDS over a cited KB — feedback welcome
+>
+> Hi OHDSI community,
+> I wanted to share OpenOnco (https://openonco.info), an open-source oncology clinical decision support project that may resonate with this group's values. A clinician feeds it a FHIR/mCODE-shaped patient profile and a deterministic rule engine returns two alternative treatment tracks side by side, each with a step-by-step decision trace and a source citation on every claim — clinical logic lives in declarative rules over a versioned, human-reviewed knowledge base, not in an LLM. Output is reproducible (same input + same KB version = same plan), drugs are coded with ATC/RxNorm, and it runs locally so patient JSON never leaves the machine. It's explicitly early-stage (v0.1, most content still STUB, no formal validation yet), so I'm sharing it for critique rather than adoption — I'd especially welcome feedback on the vocabulary mapping and the reproducibility model. Code (MIT) and content (CC BY 4.0): https://github.com/romeo111/OpenOnco.
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 3. Open-source-in-medicine groups (e.g. Open Source in Healthcare / medicine mailing lists, relevant subreddits, "awesome-*" maintainers)
+
+**Why relevant:** Fully open (code MIT, content CC BY 4.0), privacy-by-design, forkable as a general pattern for safety-critical rules-first decision support. This is exactly the kind of project these communities catalog and discuss.
+
+**The ask:** A look / possible inclusion in a list or discussion thread, and design feedback on the rules-first + citation-guard pattern.
+
+**Message:**
+
+> Subject: OpenOnco — open-source, rules-first oncology decision support (MIT / CC BY)
+>
+> Hi [name / group],
+> Sharing a project that fits this community: OpenOnco (https://openonco.info), a free and fully open-source clinical decision support tool for oncologists and tumor boards. The design choice I'd most like feedback on: all clinical logic is a deterministic rule engine over a versioned, human-reviewed knowledge base — no LLM picks the regimen or dose, so it can't hallucinate a drug — and every recommendation carries a source citation enforced by a 3-layer citation guard. It always shows two alternative tracks side by side (never one binding directive) to counter automation bias, runs locally/in-browser so patient data never leaves the device, and is built to be forked for any safety-critical decision-support domain. Honest status: it's an early-stage v0.1 draft, most entities are STUB pending two-reviewer clinical sign-off, and there's no formal validation study yet. Repo: https://github.com/romeo111/OpenOnco — happy to be cataloged or torn apart in a thread.
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 4. AI-in-oncology newsletters / writers
+
+**Why relevant:** OpenOnco is a counter-example to "let the LLM recommend treatment": it deliberately keeps the LLM out of the clinical decision and routes questions through a deterministic engine — a concrete, opinionated take on safe AI in oncology that's newsletter-worthy.
+
+**The ask:** Consideration for a mention/write-up, with full honesty about maturity; offer to answer questions or give a walkthrough.
+
+**Message:**
+
+> Subject: A deliberately "AI-doesn't-decide" oncology CDS tool — possible story
+>
+> Hi [name],
+> Given your coverage of AI in oncology, OpenOnco (https://openonco.info) might interest you precisely because of what it refuses to do. It's a free, open-source clinical decision support tool for oncologists and tumor boards where no LLM ever picks the regimen or dose — clinical logic is a deterministic rule engine over a versioned, source-cited knowledge base, and it always drafts two alternative tracks side by side for a clinician to verify, never a single directive. There's an MCP server so an LLM (Claude, Cursor, etc.) can route an oncology question through the engine and relay cited output instead of answering from memory. I want to be upfront: it's an early-stage v0.1 project with a 92-disease cited KB but only 15 of 806 entities dual-reviewer signed off and no formal clinical validation — so the honest framing is "a safety-first design pattern actively seeking clinician feedback," not a finished product. Happy to give you a walkthrough or answer anything: try it at https://openonco.info/try.html (synthetic cases only).
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 5. MCP / Claude developer communities (MCP servers directory, Claude/Cursor dev forums, Discord)
+
+**Why relevant:** OpenOnco ships an MCP server exposing `engine_info`, `list_diseases`, `generate_treatment_plan`, `generate_diagnostic_brief` — a clean real-world example of MCP used to make an LLM *safer by construction* (the model relays deterministic, cited engine output instead of guessing).
+
+**The ask:** Try the MCP server, feedback on the tool design, optional listing in MCP directories.
+
+**Message:**
+
+> Subject: MCP server that makes an LLM route oncology questions through a deterministic engine
+>
+> Hi [name / community],
+> Sharing an MCP server you might find interesting as a pattern: OpenOnco (https://github.com/romeo111/OpenOnco/tree/main/mcp_server) exposes a deterministic oncology decision-support engine to any MCP client (Claude Desktop, Cursor, etc.) via four tools — engine_info, list_diseases, generate_treatment_plan, generate_diagnostic_brief. The point is safety-by-construction: the LLM never picks a regimen or dose itself; it relays cited output from a deterministic rule engine over a versioned, human-reviewed knowledge base, so it can't hallucinate a drug. The engine runs locally/offline (~50-200 ms per profile) and is reproducible. Fair warning — it's an early-stage v0.1 project (informational CDS for clinicians, not a medical device, not for patient use) with most clinical content still pending review, so treat it as a reference implementation rather than something production-ready. Would love feedback on the tool surface and whether it's worth listing in MCP directories.
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 6. Ukrainian medical / health-tech community (UA med-tech groups, UA oncology/hematology societies, UA open-source/dev meetups)
+
+**Why relevant:** The project has Ukrainian roots, references Ukraine MoH/NSZU guidelines among its sources, and keeps Ukrainian-language originals in the repo. This community can give clinically grounded feedback and reflects the project's origin.
+
+**The ask:** Clinician feedback (try a known case in the demo), and contributors for drafting/verification via the chunk workflow.
+
+**Message (English — translate to Ukrainian before sending; translate the disclaimer too):**
+
+> Subject: OpenOnco — open-source oncology decision support with Ukrainian roots, seeking clinician feedback
+>
+> Hello [name / group],
+> I'm reaching out because OpenOnco (https://openonco.info) has Ukrainian roots and I'd value this community's eyes on it. It's a free, open-source clinical decision support tool for oncologists and tumor boards: a clinician enters a structured patient profile and a deterministic rule engine drafts two alternative treatment tracks side by side, each with a source citation on every claim — no LLM ever picks the regimen or dose. It references guideline sources including Ukraine MoH/NSZU alongside NCCN, ESMO, EHA and others, runs locally so patient data never leaves the machine, and is honest about being early-stage (v0.1, most content still STUB pending two-reviewer sign-off, no formal validation yet). The single most useful thing right now: try the in-browser demo on a case you know well and tell me what's wrong — https://openonco.info/try.html (synthetic cases only). If you'd like to help draft or verify clinical content, there's an AI-assisted "chunk" contribution workflow in the repo, and all clinical content is reviewed by clinical leads before merge: https://github.com/romeo111/OpenOnco.
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+## 7. Researchers / clinicians wanting a transparent, auditable oncology logic reference (academic CDS / clinical informatics lists)
+
+**Why relevant:** OpenOnco offers a fully transparent, source-grounded, auditable oncology logic layer: step-by-step decision trace, FDA Criterion-4 metadata block, reproducible output, citation on every claim — useful as a reference even before it's a validated product.
+
+**The ask:** Use it as a transparent reference / teaching artifact, and critique the auditability model (decision trace, citation guard, two-track design).
+
+**Message:**
+
+> Subject: A transparent, fully-cited oncology decision-logic reference (open source)
+>
+> Hi [name],
+> If you work on clinical decision support or clinical informatics, OpenOnco (https://openonco.info) may be a useful reference even in its current early form. It's an open-source oncology CDS engine where every recommendation is traceable: a step-by-step decision trace accompanies each plan, every claim carries a source citation (enforced by a 3-layer citation guard), output is reproducible, and the clinical logic is declarative rules over a versioned, human-reviewed knowledge base rather than an LLM — by design it presents two alternative tracks side by side to counter automation bias, and it returns a diagnostic workup brief instead of a treatment plan when histology isn't confirmed. I want to be transparent about maturity: it's a v0.1 draft, only 15 of 806 clinical entities have two-reviewer sign-off, and there's been no formal clinical validation study — so I'm sharing it as an auditable design reference and would welcome critique of the trace/citation/two-track model. Code and specs (MIT / CC BY 4.0): https://github.com/romeo111/OpenOnco.
+>
+> OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, not for emergency or time-critical decisions, and every plan it drafts must be verified by a qualified oncologist.
+
+---
+
+### Sending checklist (maintainer reference, do not send)
+- [ ] Personalized the `[name / group]` fields and picked the right channel per target.
+- [ ] Confirmed only the five canonical links appear; no invented URLs.
+- [ ] **Full disclaimer present in the message body** (both halves: not-a-medical-device AND verify-with-a-qualified-oncologist); audience framed as HCP/builders, never patients.
+- [ ] Maturity stated (v0.1, STUB majority, no formal validation) in every message.
+- [ ] No forbidden claims (no "validated," "FDA-cleared," "diagnoses," "prescribes," "AI picks treatment," OncoKB/SNOMED/MedDRA as sources).
+- [ ] Ukrainian message AND its disclaimer translated before sending.

--- a/promo/disclaimer-checklist.md
+++ b/promo/disclaimer-checklist.md
@@ -1,0 +1,43 @@
+# Pre-publish safety checklist (gate)
+
+Run **every** public-facing OpenOnco asset through this before it ships — including
+short-form ones (tweets, badges, registry blurbs) where caveats are most often
+dropped for length.
+
+## Must be TRUE for every asset
+
+- [ ] **Not-a-medical-device disclaimer present** ("informational decision support,
+      not a medical device").
+- [ ] **"Verify with a qualified oncologist"** (or equivalent) present.
+- [ ] **Early-stage frame present** ("v0.1 / early-stage / seeking clinician
+      feedback") — not implied as finished.
+- [ ] **STUB caveat sits next to any coverage number.** If the asset cites "92
+      diseases / 664 indications / 444 sources", it must also note that most
+      content is STUB ("proposed, not approved"; 15/806 dual-signed-off).
+- [ ] **Numbers are the canonical ones** (capabilities page, state 2026-06-17):
+      92 diseases · 664 indications · 384 regimens · 298 drugs · 594 red flags ·
+      444 sources · 16 MDT skills. **Not** the README's stale figures.
+- [ ] **Links are the canonical five**: site `openonco.info`, repo
+      `github.com/romeo111/OpenOnco`, demo `openonco.info/try.html`, MCP
+      `…/tree/main/mcp_server`, `openonco.info/llms.txt`.
+
+## Must be ABSENT (forbidden claims)
+
+- [ ] No "diagnoses / screens for / detects cancer".
+- [ ] No "FDA-approved / FDA-cleared / clinically validated".
+- [ ] No "replaces your oncologist / the tumor board".
+- [ ] No patient-facing "use this to choose your treatment".
+- [ ] No "calculates your dose" / per-patient dosing.
+- [ ] No "for emergencies / time-critical decisions".
+- [ ] No "the AI/LLM chooses the treatment" (it never does).
+
+## Channel-specific
+
+- [ ] **Short-form (X/badges/registry blurb):** if the disclaimer truly won't fit,
+      link to a page that carries it; never publish a standalone clinical claim
+      without it.
+- [ ] **Medical subreddits (r/medicine etc.):** check self-promotion rules; frame
+      as a tool seeking clinician critique, not an ad.
+- [ ] **Demo media:** show the on-screen disclaimer; use synthetic cases only.
+
+> If any box can't be checked, fix the asset before publishing.

--- a/promo/distribution-plan.md
+++ b/promo/distribution-plan.md
@@ -1,0 +1,291 @@
+# OpenOnco Launch & Distribution Plan
+
+**Asset type:** Prioritized, sequenced launch/distribution plan
+**Project status:** v0.1 draft, early-stage open-source, actively seeking clinician feedback
+**Canonical date for all numbers:** state 2026-06-17 (capabilities page)
+
+> **Read before posting anything.** OpenOnco is an informational clinical
+> decision-support resource for healthcare professionals and tumor boards — **not
+> a medical device, not FDA-cleared/approved, not clinically validated, not for
+> patients, not for emergencies.** Every public post, page, and slide must carry
+> the not-a-medical-device disclaimer and the "all recommendations must be
+> verified by a qualified oncologist" line. No LLM picks the regimen or dose —
+> say so, accurately, in every channel. Most clinical content is **STUB** (only
+> 15 of 806 entities are dual-signed-off); pair every coverage/number claim with
+> that maturity caveat. Use only the five canonical links below.
+
+---
+
+## Canonical links (use these only — do not invent URLs)
+
+| Purpose | URL |
+|---|---|
+| Site | https://openonco.info |
+| In-browser demo | https://openonco.info/try.html |
+| Repo | https://github.com/romeo111/OpenOnco |
+| MCP server | https://github.com/romeo111/OpenOnco/tree/main/mcp_server |
+| llms.txt | https://openonco.info/llms.txt |
+
+---
+
+## The one message every channel carries
+
+Rules-first, deterministic oncology decision support: a declarative rule engine
+over a versioned, fully source-cited, human-reviewed knowledge base (most content
+still **STUB** — not yet dual-reviewer signed off) drafts **two alternative
+treatment plans (standard + aggressive) side by side** for a clinician to verify.
+**No LLM ever picks the regimen or dose — so it can't hallucinate a drug or a
+dose.** Runs locally / in-browser; patient data never leaves the machine. Free
+and open source (code MIT, content CC BY 4.0). Early stage — we want clinician
+feedback.
+
+---
+
+## How actions are tagged
+
+- **[DRAFT-READY]** — copy/config we can write and stage now; no external posting,
+  no outreach. Includes our own repo, our own site, our own social drafts held for
+  review.
+- **[OUTWARD — needs maintainer go-ahead]** — anything that posts publicly to a
+  third-party venue (HN, Reddit, X, LinkedIn), opens a PR to an external
+  repo/list, or contacts a person/org. Draft now, **hold until a maintainer
+  approves the exact text and timing.**
+
+---
+
+## Priority ranking (leverage vs. effort)
+
+Ordered best-leverage-per-unit-effort first. Effort is rough author-time; leverage
+is reach × fit-to-audience × durability.
+
+| # | Action | Leverage | Effort | Tag |
+|---|---|---|---|---|
+| 1 | Repo readiness pass (README counts, disclaimer, screenshots, demo link, contributing) | High | Low | [DRAFT-READY] |
+| 2 | `llms.txt` / machine-readable discoverability check | Med-High | Low | [DRAFT-READY] |
+| 3 | MCP server listing in MCP registries / awesome-mcp lists | High | Low-Med | [OUTWARD] |
+| 4 | Screenshot + short screencast capture (demo + MCP-in-Claude-Desktop) | High (unblocks everything below) | Med | [DRAFT-READY] |
+| 5 | "Awesome" / open-source CDS list submissions | Med-High | Low-Med | [OUTWARD] |
+| 6 | MCP community post (Discord/forum) | High (warm, on-topic audience) | Low | [OUTWARD] |
+| 7 | Show HN post | High (spiky, durable) | Med | [OUTWARD] |
+| 8 | Reddit (dev + selected clinical-informatics subs) | Med | Med | [OUTWARD] |
+| 9 | LinkedIn (founder + project) | Med | Low | [OUTWARD] |
+| 10 | X/Bluesky thread | Med | Low | [OUTWARD] |
+| 11 | Direct clinician / tumor-board outreach for feedback | **Highest strategic value**, slow burn | Med-High | [OUTWARD] |
+
+Rationale for ordering: registries and our own repo/site compound passively and
+have no downside, so they go first. The MCP angle is our single most
+differentiated, least-crowded distribution surface (an oncology engine an LLM can
+*call* instead of guessing) — cheap and high-fit, so it leads the outward push.
+HN/social are spikier and riskier on medical framing, so they come after the
+assets and disclaimers are locked. Clinician outreach is the **most valuable
+outcome** (clinician feedback is the stated #1 contribution we want) but is
+slowest and most relationship-dependent, so it runs as a parallel slow track, not
+a one-shot launch-day blast.
+
+---
+
+## Phase 0 — Foundation (no external posting)  *[all DRAFT-READY]*
+**Timing: Days 1–4. Dependency for every outward action.**
+
+1. **Repo readiness pass.**
+   - Reconcile README to canonical counts. README cites older numbers (420
+     indications, 377 sources, 140 algorithms — confirmed at `README.md` line 11);
+     the capabilities-page figures are canonical: **92 diseases, 664 indications
+     (230 first-line, 172 second-line+), 384 regimens, 298 drugs, 594 red flags,
+     444 cited sources, 16 virtual MDT skills.** Either update README or make it
+     defer to the capabilities page so no asset quotes stale numbers.
+   - Confirm top-of-README carries: one-liner, no-LLM-decides guarantee,
+     not-a-medical-device + verify-with-oncologist disclaimer, "v0.1 draft,
+     seeking clinician feedback," STUB maturity note (15/806 dual-signed-off),
+     and the demo link.
+   - **Fix overclaim in `mcp_server/README.md`.** It currently describes the
+     knowledge base as "peer-reviewed clinical content." That overstates maturity
+     ("peer-reviewed-validated" is a forbidden claim) and most entities are STUB.
+     Reword to "human-reviewed, source-cited clinical content (most entities still
+     STUB — not yet dual-reviewer signed off); source guidelines are referenced,
+     not redistributed." Keep the existing not-a-medical-device disclaimer there.
+   - Confirm license statement: code MIT, specs + generated content CC BY 4.0;
+     source guidelines (NCCN, ESMO, EHA, BSH, EASL, Ukraine MoH/NSZU) referenced,
+     not redistributed.
+   - Confirm `CONTRIBUTING` points AI-tooling contributors at the TaskTorrent
+     chunk workflow and states all clinical content is Clinical-Co-Lead reviewed
+     before merge.
+
+2. **Discoverability / `llms.txt`.** Verify `https://openonco.info/llms.txt`
+   resolves and reflects current scope (synthetic-only examples, HCP framing). It
+   already lists canonical URLs and the "synthetic examples only / does not
+   replace clinician judgment" framing — good. No new URLs.
+
+3. **Screenshot + screencast capture (HARD DEPENDENCY for #4–#10).** Capture from
+   `try.html` using a **synthetic** case only:
+   - Two-track plan view (standard vs. aggressive side by side).
+   - A visible source citation on a recommendation.
+   - The step-by-step decision trace.
+   - The "no confirmed histology → Diagnostic Brief" behavior.
+   - The MCP server answering inside Claude Desktop/Cursor (engine output relayed
+     with citations).
+   - Each image/clip must show or be captioned with the disclaimer; never label a
+     synthetic case as a real patient.
+
+**Exit criteria for Phase 0:** README counts correct; `mcp_server/README.md`
+"peer-reviewed" wording fixed; disclaimers present on repo + site + demo; STUB
+caveat visible; screenshots/screencast captured. **Do not start Phase 1 until
+these pass.**
+
+---
+
+## Phase 1 — Registries & passive discovery  *[OUTWARD — needs go-ahead]*
+**Timing: Days 5–7. Depends on Phase 0.**
+
+1. **MCP registries / `awesome-mcp-servers`.** Submit the MCP server with the
+   "route oncology questions through a deterministic, cited engine instead of
+   answering from memory" framing and the four tools (`engine_info`,
+   `list_diseases`, `generate_treatment_plan`, `generate_diagnostic_brief`).
+   Include disclaimer + "no LLM picks the regimen." **Opens external PRs → needs
+   maintainer go-ahead on exact text.**
+
+2. **Open-source / clinical-informatics "awesome" lists.** Identify
+   awesome-lists for healthcare-OSS, CDS, or rules engines; prepare one-line
+   entries. **External PRs → needs go-ahead.**
+
+These are low-risk, compounding, and seed inbound traffic before any spiky post.
+
+---
+
+## Phase 2 — MCP community (warm, on-topic)  *[OUTWARD — needs go-ahead]*
+**Timing: Days 7–9. Depends on Phases 0–1.**
+
+- One post in the MCP community (official Discord/forum, Cursor community).
+- Angle: a concrete, safety-first MCP use case — "let your LLM *call* an
+  auditable oncology engine instead of guessing; no LLM picks the regimen." Lead
+  with the MCP screencast. HCP framing + disclaimer in the post.
+- Goal here is qualified developer attention and MCP installs, not volume.
+
+---
+
+## Phase 3 — Show HN  *[OUTWARD — needs go-ahead]*
+**Timing: Day 10–12. Depends on Phases 0–2 (especially screenshots + locked disclaimers).**
+
+- **Title (draft):** "Show HN: OpenOnco – open-source, rules-first oncology
+  decision support (no LLM picks the treatment)."
+- **Body must include, honestly:** what it is (HCP-only CDS, two cited tracks),
+  the deterministic/no-LLM-decides differentiator, 3-layer citation guard,
+  local/in-browser privacy model, MIT + CC BY 4.0, the demo link, **and** the
+  honest maturity statement: v0.1 draft, only 15/806 dual-signed-off (most
+  content STUB), no formal clinical validation study, seeking clinician feedback.
+- **Forbidden in the post:** "validated," "FDA-cleared/approved," "diagnoses,"
+  "replaces an oncologist," "for patients," "prescribes/calculates doses,"
+  "AI picks the treatment."
+- Pick a low-traffic morning (US), be present to answer comments, never overclaim
+  in replies.
+
+---
+
+## Phase 4 — Broader social  *[OUTWARD — needs go-ahead]*
+**Timing: Days 12–16. Depends on Phase 0 assets; sequence after HN so you can reuse the best framing.**
+
+1. **Reddit.** Dev subs (e.g., open-source / self-hosted / MCP-adjacent) and,
+   carefully and rules-compliant, clinical-informatics communities. **Read each
+   sub's rules first; many ban medical self-promotion.** HCP framing only; never
+   post to patient/medical-advice subs.
+2. **LinkedIn.** Founder + project post. Best fit for reaching practicing
+   oncologists, hematologists, clinical pharmacologists, and MDT leads. Lead with
+   the "drafted, fully-cited starting point for tumor boards to verify"
+   framing + disclaimer + "seeking clinician feedback."
+3. **X / Bluesky.** Short thread reusing the screencast; one differentiator per
+   post (no-LLM-decides → two cited tracks → local/privacy → open source →
+   feedback ask).
+
+Every post: disclaimer line, HCP-only framing, early-stage honesty, synthetic-data
+note on any visual.
+
+---
+
+## Phase 5 — Clinician & contributor outreach (slow track)  *[OUTWARD — needs go-ahead]*
+**Timing: starts Day 7, runs continuously for weeks. Parallel to Phases 1–4.**
+
+- **Primary ask:** "Try the in-browser demo on a case you know and tell us
+  what's wrong — clinician feedback is the most valuable contribution right now."
+  Point to `try.html` and the GitHub issue tracker.
+- **Targets:** practicing oncologists/hematologists, tumor-board/MDT leads,
+  clinical pharmacologists, oncology-informatics researchers. (Use the
+  partner-outreach approach for tailored messages; keep it HCP-to-HCP, never
+  patient-facing.)
+- **Framing guardrails:** it is a *draft to verify*, not a recommendation; not a
+  replacement for an oncologist or a tumor board; STUB content is "proposed, not
+  approved."
+- **AI-tooling contributors:** invite them to the TaskTorrent chunk workflow
+  (draft structured sidecars → PR; no clinical expertise needed to *trigger*
+  drafting; all clinical content reviewed by Clinical Co-Leads before merge).
+
+---
+
+## Suggested launch sequence (one line)
+
+**Phase 0 foundation (repo + disclaimers + screenshots)** → **registries + awesome-lists** → **MCP community** → **Show HN** → **Reddit / LinkedIn / X** → **clinician outreach (parallel, ongoing)**.
+
+---
+
+## Dependencies (explicit)
+
+- **Screenshots/screencast (Phase 0 #3) gate every social/community post (Phases 2–4).** Do not post visuals you haven't captured from synthetic cases.
+- **README count reconciliation + `mcp_server/README.md` wording fix (Phase 0 #1) gate all numeric and maturity claims everywhere.** Quote 2026-06-17 capabilities figures, not README's older numbers; do not let any linked asset say "peer-reviewed."
+- **Disclaimers + STUB caveat locked (Phase 0) gate all outward posting.** No public post before the medical-safety framing is verified on repo, site, and demo.
+- **HN (Phase 3) before broad social (Phase 4)** so the best-tested framing/Q&A can be reused; but HN is *not* a prerequisite for registries or MCP-community.
+- **Registries/awesome-lists and MCP community first** so inbound has somewhere credible to land before any spike.
+- **All [OUTWARD] items require maintainer sign-off on exact wording + timing** before they go live.
+
+---
+
+## Success metrics
+
+Track against the project's actual goal — clinician feedback first, reach second.
+
+**Primary (what we actually want):**
+- **Clinician feedback issues / emails:** count of substantive feedback items
+  from self-identified HCPs (target: first 5 within 2 weeks of clinician
+  outreach; 15 within 6 weeks). This is the headline success signal.
+- **Qualified clinician demo sessions:** outreach replies that confirm they ran a
+  case on `try.html`.
+
+**Secondary (reach / adoption):**
+- **GitHub stars & forks:** baseline at Phase 0; watch the Show HN / MCP-community
+  spike. Forks matter more than stars given the "forkable pattern" positioning.
+- **MCP installs / config adoption:** registry listing clicks, repo traffic to
+  `mcp_server/`, mentions in MCP community.
+- **Site traffic:** unique visitors and `try.html` sessions; track per-channel
+  referrers (registry vs. HN vs. Reddit vs. LinkedIn) to see which channel sends
+  *qualified* HCP traffic, not just volume.
+- **Contributor signal:** TaskTorrent chunk PRs opened by new contributors.
+
+**Guardrail metric (must stay clean):**
+- **Zero medical-overclaim incidents** — no post, reply, or list entry that says
+  validated / FDA-cleared / diagnoses / replaces an oncologist / for patients /
+  prescribes doses / AI-picks-treatment / peer-reviewed-validated. Audit each
+  outward post against the forbidden-claims list before publishing. A single
+  overclaim is a bigger failure than a slow week of stars.
+
+---
+
+## Pre-publish checklist (run on every outward asset)
+
+- [ ] Not-a-medical-device disclaimer present.
+- [ ] "Verified by a qualified oncologist" line present.
+- [ ] HCP / tumor-board framing — not patients, not caregivers.
+- [ ] "v0.1 draft, seeking clinician feedback" stated or clearly implied.
+- [ ] Any coverage/number paired with the STUB caveat (15/806 dual-signed-off).
+- [ ] Numbers match the 2026-06-17 capabilities figures.
+- [ ] "No LLM picks the regimen/dose; deterministic + cited" stated accurately.
+- [ ] Any visual uses synthetic data and is not labeled as a real patient.
+- [ ] Only the five canonical links used.
+- [ ] No forbidden claim (validated / FDA / diagnoses / replaces oncologist /
+      patient-use / prescribes-doses / AI-picks-treatment / peer-reviewed-validated /
+      OncoKB-SNOMED-MedDRA as sources).
+- [ ] Maintainer signed off on exact wording + timing (for [OUTWARD] items).
+
+---
+
+*OpenOnco is an informational clinical decision-support resource for healthcare
+professionals — **not a medical device**, not FDA-cleared/approved, and not
+clinically validated. All recommendations must be verified by a qualified
+oncologist. v0.1 early-stage open-source draft; examples are synthetic.*

--- a/promo/faq-objection-handling.md
+++ b/promo/faq-objection-handling.md
@@ -1,0 +1,80 @@
+# OpenOnco — FAQ / objection handling
+
+Canonical answers so messaging stays consistent across HN, Reddit, press, and
+outreach. Keep answers honest; never soften the maturity caveats.
+
+### Is this a medical device?
+No. OpenOnco is an **informational clinical decision support** resource for
+healthcare professionals, designed to meet **FDA non-device CDS** criteria
+(CHARTER §15) — it supports a clinician's reasoning and every recommendation must
+be independently verified by a qualified oncologist. It is not a medical device,
+not for direct patient use, and not for time-critical/emergency decisions.
+
+### How is this different from just asking ChatGPT "what's the regimen?"
+A general LLM answers from memory and can confidently fabricate a drug or a dose.
+OpenOnco **never lets an LLM pick the regimen or the dose** (CHARTER §8.3). All
+clinical logic is a **deterministic rule engine** over a versioned, human-reviewed
+knowledge base, and **every recommendation carries a source citation**. The worst
+failure mode is a wrong or incomplete *rule* — auditable and fixable — not a
+plausible fabrication. (Via the MCP server, an LLM can even *route through* the
+engine instead of guessing.)
+
+### Most of the knowledge base is "STUB" — is it safe to use?
+Be clear-eyed: only **15 of 806** clinical entities have two-Clinical-Co-Lead
+sign-off. The rest are **STUB** — structured data, algorithm, and sources are in
+place, but they are **"proposed, not approved."** Treat every output as a *draft to
+verify*, never as an approved plan. This is exactly why the project is asking for
+clinician feedback. Do not use STUB content as a clinical recommendation without
+independent verification.
+
+### Is it FDA-approved or clinically validated?
+No. There has been **no formal clinical validation study** and no real-world
+deployment validation (CHARTER §13). "Designed to meet FDA non-device CDS criteria"
+is a **design goal**, not a clearance or certification.
+
+### Does patient data leave my machine?
+No. The engine is deterministic and runs **locally** — CLI, in-browser via Pyodide
+(Python WASM, no backend), Python import, or the MCP server. Patient JSON never
+leaves the device; no server-side PHI, no logs, no database. The public site uses
+**synthetic examples only**.
+
+### Can patients use it to decide their own treatment?
+No. It is **HCP-only**, adults only, for outpatient/non-time-critical planning. It
+does not diagnose, screen for, or detect cancer. Patients should always work with
+their treating oncologist.
+
+### Does it replace the tumor board or the oncologist?
+No. It produces a **drafted, fully-cited starting point** — always at least two
+alternative tracks side by side — for the clinician and tumor board to verify and
+tailor. It is the "second pair of eyes that read every guideline at once," not the
+decision-maker.
+
+### What does it actually output?
+For a confirmed diagnosis: one Plan with ≥2 treatment tracks (standard + aggressive),
+each with regimen, supportive care, contraindications, monitoring, a step-by-step
+decision trace, and citations. If histology isn't confirmed, it refuses to emit a
+treatment plan and returns a **Diagnostic Brief** (workup steps) instead.
+
+### Is it really free / open source? Can I fork it?
+Yes. **Code MIT, content & specs CC BY 4.0.** Upstream guidelines (NCCN, ESMO, EHA,
+BSH, EASL, Ukraine MoH/NSZU, etc.) are referenced, not redistributed. It's
+explicitly designed to be forked and reused for other safety-critical
+decision-support domains.
+
+### How can I help?
+- **Oncologists/hematologists:** run a case you know cold in the
+  [demo](https://openonco.info/try.html) and open an issue with what's wrong — a
+  missing contraindication, a bad track split, a citation that doesn't support its
+  claim. This is the most valuable contribution.
+- **Become a Clinical Co-Lead** to dual-sign content out of STUB (the real
+  bottleneck).
+- **Developers:** the engine + MCP server are open; PRs welcome.
+
+### Why these diseases / why the Ukrainian roots?
+The project began from a real treatment-planning need and has Ukrainian clinical
+roots (specs and content carry UA originals); coverage spans lymphoid + myeloid
+hematology and major solid tumors and is growing.
+
+---
+*OpenOnco is an informational decision-support tool, not a medical device. All
+recommendations must be verified by a qualified oncologist.*

--- a/promo/hacker-news-show-hn.md
+++ b/promo/hacker-news-show-hn.md
@@ -1,0 +1,129 @@
+# Show HN: OpenOnco
+
+## Title
+
+```
+Show HN: OpenOnco – Rules-first, source-cited oncology decision support (no LLM picks)
+```
+
+## Body
+
+```
+OpenOnco is a free, open-source clinical decision support resource for oncology
+tumor boards. A clinician feeds it a structured patient profile (FHIR/mCODE-shaped
+JSON: disease, biomarkers, findings, demographics), and a declarative rule engine
+returns one Plan with at least two alternative treatment tracks side by side — a
+standard track and a more aggressive track — each with regimen, supportive care,
+contraindications, monitoring, a step-by-step decision trace, and a source citation
+on every claim.
+
+The thing I most want feedback on is the architecture, because it's a deliberate
+bet on what *not* to let an LLM do.
+
+No LLM ever picks the regimen or the dose. All clinical logic lives in a
+deterministic rule engine reading a versioned, human-reviewed knowledge base
+(CHARTER §8.3). Because no model is choosing the treatment, the engine cannot
+hallucinate a drug or a dose — the worst failure mode is a wrong or incomplete
+rule, which is auditable and fixable, not a confident fabrication. Same input +
+same KB version = same output.
+
+How the engine works — six deterministic stages per profile (~50-200 ms):
+resolve algorithm → flatten findings → evaluate red flags → walk decision tree →
+materialize tracks → resolve regimens. If histology isn't confirmed, it refuses to
+emit a treatment Plan and returns a Diagnostic Brief (workup steps) instead.
+
+Design choices that fall out of "rules-first":
+- Every recommendation carries a source citation, enforced by a 3-layer citation
+  guard (Pydantic referential check on load, a CI verifier for paraphrase
+  grounding, and a render-time guard that warns or drops uncited cells). Nothing
+  is unsourced by construction.
+- It always shows at least two tracks side by side, never a single "system
+  prescribes X" directive — an explicit anti-automation-bias choice (CHARTER §15.2 C6).
+- Runs locally: CLI, in-browser via Pyodide (Python WASM, no backend), Python
+  import, or an MCP server. Patient JSON never leaves your machine — no server-side
+  PHI, no logs, no DB. The public site uses synthetic examples only.
+- Actionability evidence comes from CIViC (CC0, WashU), read from a local nightly
+  snapshot; ESCAT tier shows as a badge. (OncoKB was rejected — its ToS conflicts
+  with the project's non-commercial scope.)
+
+There's also an MCP server (tools: engine_info, list_diseases,
+generate_treatment_plan, generate_diagnostic_brief) so any MCP client — Claude
+Desktop, Cursor — can route an oncology question through the deterministic engine
+and relay cited output, instead of answering from memory. The model never picks the
+regimen; it's a transport for the engine's result.
+
+Current scope (capabilities page, state 2026-06-17): 92 diseases across lymphoid
+and myeloid hematology plus solid tumors, 664 indications, 384 regimens, 298 drugs
+(ATC/RxNorm coded), 594 red flags, 444 cited sources, 16 virtual MDT clinician
+skills. 77 of 92 diseases have a full modeled chain.
+
+Honest about maturity: this is a v0.1 draft. The big caveat is clinical sign-off —
+only 15 of 806 clinical entities have passed two-Clinical-Co-Lead review. The rest
+are STUB: structured data, algorithm, and sources are in place, but they are
+"proposed plan, not approved plan." There has been no formal clinical validation
+study and no real-world deployment validation.
+
+Licensing: code is MIT, specs and generated content CC BY 4.0. Original guidelines
+(NCCN, ESMO, EHA, BSH, EASL, Ukraine MoH/NSZU, etc.) are referenced, not
+redistributed.
+
+Scope limits: it's positioned as an FDA non-device CDS tool (CHARTER §15) —
+informational support for healthcare professionals, not a medical device, not for
+direct patient use, adults only, outpatient/non-time-critical planning. Not for
+emergencies. It does not diagnose, screen for, or detect cancer, and it does not
+calculate patient-specific doses. Every plan is a draft to be verified by the
+treating oncologist.
+
+Not a medical device. All recommendations must be verified by a qualified
+oncologist.
+
+Site: https://openonco.info
+Repo: https://github.com/romeo111/OpenOnco
+Try it (synthetic cases): https://openonco.info/try.html
+MCP server: https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+
+I'd love critique from oncologists and from anyone who's built rules-first
+decision-support systems.
+```
+
+## First comment (author)
+
+```
+Author here. Some backstory on why this is shaped the way it is.
+
+It started from a real situation — helping put together treatment-planning material
+for a patient — and the obvious temptation was to just ask an LLM "what's the
+regimen?" That's exactly the thing I decided the system must never do. In a domain
+where a hallucinated drug or a plausible-but-wrong dose can hurt someone, "the model
+sounded confident" is not an acceptable failure mode. So the hard rule became: an
+LLM can write prose, draft code, and help extract structured data from documents
+(with human review), but it never chooses a regimen, a dose, or how to interpret a
+biomarker for treatment selection. Those decisions come only from declarative rules
+over a versioned, human-reviewed knowledge base.
+
+That single constraint drives almost every other design choice: deterministic
+six-stage engine, reproducible output, a citation required on every claim (enforced
+by the loader, CI, and the renderer), two tracks always shown side by side so it
+reads as "here are alternatives to weigh," not "here is the answer," and a hard
+refusal to emit a plan when histology isn't confirmed.
+
+I want to be very plain about what this is NOT, because HN will (rightly) push on it:
+it is not validated, not a medical device, not FDA-cleared, and not a replacement
+for an oncologist or a tumor board. It does not diagnose or screen. Most of the
+knowledge base is still STUB — only 15 of 806 clinical entities have two-reviewer
+sign-off, so please read everything else as "proposed, not approved." There has been
+no formal clinical validation study.
+
+What I'm actually asking for: if you're an oncologist or hematologist, please open
+the in-browser demo (https://openonco.info/try.html — synthetic cases only, no PHI,
+nothing leaves your browser), run a case you know cold, and tell me where it's wrong
+— a missing contraindication, a bad track split, a citation that doesn't support the
+claim, a red flag it should have raised. Tearing the clinical logic apart is the
+single most valuable contribution right now.
+
+And if you build rules-first / safety-critical decision systems: I'd genuinely like
+critique of the engine and the citation-guard approach. The whole thing is meant to
+be forkable for other domains (code MIT, content CC BY 4.0).
+
+Not a medical device. All recommendations must be verified by a qualified oncologist.
+```

--- a/promo/mcp-registries.md
+++ b/promo/mcp-registries.md
@@ -49,8 +49,8 @@ These are pre-cleared against the fact sheet's `approved_claims`, `forbidden_cla
 
 | Registry | Mechanism | Outward action required? | Who acts |
 |---|---|---|---|
-| `modelcontextprotocol/servers` (community list) | PR to README | **Yes — PR** | Maintainer |
-| `punkpeye/awesome-mcp-servers` | PR to README | **Yes — PR** | Maintainer |
+| Official MCP Registry (`registry.modelcontextprotocol.io`) | `server.json` + `mcp-publisher` CLI (GitHub auth) | **Yes — auth-gated publish** | Maintainer |
+| `punkpeye/awesome-mcp-servers` | PR to README | **DONE — PR [#8276](https://github.com/punkpeye/awesome-mcp-servers/pull/8276) open** | — |
 | PulseMCP | Web form / submit page (auto-enriches from GitHub) | **Yes — web form** | Maintainer |
 | Glama | Auto-indexes public GitHub repos; can claim/submit | Mostly automatic; **optional submit/claim** | Maintainer (optional) |
 | mcp.so | Web "Submit" form | **Yes — web form** | Maintainer |
@@ -60,22 +60,30 @@ These are pre-cleared against the fact sheet's `approved_claims`, `forbidden_cla
 
 ---
 
-## 1. `modelcontextprotocol/servers` — community servers list
+## 1. Official MCP Registry (`registry.modelcontextprotocol.io`)
 
-- **Repo:** `https://github.com/modelcontextprotocol/servers`
-- **Mechanism:** Pull request adding a one-line entry under the community/third-party servers section of the README.
-- **Auto-index?** No. **Outward action: open a PR.**
+> **Updated 2026-06-18:** `modelcontextprotocol/servers` is now **reference-servers-only**
+> (its README explicitly houses just the steering-group's reference servers).
+> **Do NOT open a README PR there for a community server — it will be declined.**
+> Community servers now live in the **official MCP Registry**.
+
+- **Registry:** `https://registry.modelcontextprotocol.io`
+- **Mechanism:** add a `server.json` manifest to the repo (registry schema; namespace
+  like `io.github.romeo111/openonco`) and publish with the GitHub-authenticated
+  `mcp-publisher` CLI (or a GitHub Action). **Auth-gated → maintainer action.**
+- **Auto-index?** No — requires the maintainer to authenticate and publish.
 
 **Steps (maintainer):**
-1. Fork `modelcontextprotocol/servers`.
-2. Read its `README.md` and `CONTRIBUTING` for the current section name and alphabetical/format conventions (the community section and its formatting move around — match what's there now).
-3. Add the entry in the correct (usually alphabetical) position.
-4. Open a PR; in the PR description note it's an oncology CDS server, informational/not-a-medical-device, and that the LLM never picks treatment.
-
-**Exact entry line (Markdown):**
-```markdown
-- [OpenOnco](https://github.com/romeo111/OpenOnco/tree/main/mcp_server) — Rules-first, source-cited oncology clinical decision support for clinicians. A deterministic rule engine drafts two alternative treatment plans for a clinician to verify; no LLM picks the regimen or dose. Informational support, not a medical device; early-stage (v0.1).
-```
+1. Add a `server.json` to the repo (server root or `mcp_server/`) per the current
+   registry schema, declaring the four tools and the start command
+   (`python -m mcp_server.server`). Open it as a normal feature-branch PR into
+   OpenOnco (never commit to `master`).
+2. Install the `mcp-publisher` CLI, authenticate with GitHub (proves ownership of
+   the `io.github.romeo111` namespace), and `mcp-publisher publish`.
+3. Verify the listing surfaces the disclaimer-bearing description and the canonical
+   links; use the **short blurb** for the description.
+4. Confirm the schema/CLI names against the current registry docs at submission
+   time — the registry is young and its tooling changes.
 
 ---
 

--- a/promo/mcp-registries.md
+++ b/promo/mcp-registries.md
@@ -1,0 +1,180 @@
+# OpenOnco — MCP Registry & Directory Listings
+
+**Asset:** `mcp-registries`
+**Purpose:** Get the OpenOnco MCP server listed in the major public Model Context Protocol directories.
+**Server path:** `https://github.com/romeo111/OpenOnco/tree/main/mcp_server`
+**State:** 2026-06-17 KB figures · v0.1 draft
+
+> **Read before submitting.** OpenOnco is informational clinical decision support for healthcare professionals and tumor boards — **not a medical device, not FDA-cleared/approved, not clinically validated, not for patients, not for emergencies.** No LLM ever picks the regimen or dose. Every listing below already bakes the not-a-medical-device framing into its blurb. Do not edit a blurb in a way that drops the disclaimer, implies validation/approval, or implies an LLM chooses treatment. When a directory has a hard character limit that won't fit the disclaimer, use the short form (below) and make sure the linked README/site carries the full disclaimer — which it does.
+
+---
+
+## Canonical copy blocks (reuse verbatim)
+
+These are pre-cleared against the fact sheet's `approved_claims`, `forbidden_claims`, and `safety_rules`. Pick the one that fits each registry's length limit.
+
+**Name:** `OpenOnco`
+
+**One-line (≈ 100 chars):**
+> Rules-first, source-cited oncology CDS for clinicians — drafts two treatment plans; no LLM picks the regimen.
+
+**Short blurb (≈ 250 chars):**
+> Free, open-source clinical decision support for oncology tumor boards. A deterministic rule engine over a versioned, fully source-cited knowledge base drafts two alternative treatment plans (standard + aggressive) for the treating oncologist to verify. No LLM picks the regimen or dose. Informational support, not a medical device. Early-stage (v0.1).
+
+**Long blurb (no hard limit):**
+> OpenOnco is a free, open-source, informational clinical decision support resource for oncologists, hematologists, and tumor boards. Feed it a structured FHIR/mCODE-shaped patient profile and a deterministic rule engine returns two alternative treatment tracks side by side (a standard track and a more aggressive track), each with regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim. If histology isn't confirmed, it returns a diagnostic workup brief instead of a treatment plan.
+>
+> The MCP server exposes this engine to any Model Context Protocol client (Claude Desktop, Cursor, etc.) via `engine_info`, `list_diseases`, `generate_treatment_plan`, and `generate_diagnostic_brief`. The LLM relays cited engine output — **it never picks the regimen or dose itself**, so it can't hallucinate a drug or dose. The engine is deterministic (same input + same KB version = same output) and runs offline; patient JSON never leaves the user's machine.
+>
+> Covers 92 diseases across hematologic and solid-tumor oncology with 444 cited sources (state 2026-06-17). Code is MIT; specs and generated content are CC BY 4.0.
+>
+> **This is an early-stage v0.1 draft, actively seeking clinician feedback. It is informational support for healthcare professionals — not a medical device, not FDA-cleared/approved, not clinically validated, and not for direct patient use or time-critical decisions. Most clinical content is STUB (only 15 of 806 entities have two-reviewer sign-off). Every output must be verified by a qualified oncologist.**
+
+**Categories / tags (reuse across registries that accept them):**
+`healthcare` · `clinical-decision-support` · `oncology` · `medical` · `knowledge-base` · `deterministic` · `rules-engine` · `research`
+
+**Links (use ONLY these five — do not invent URLs):**
+- Site: `https://openonco.info`
+- Repo: `https://github.com/romeo111/OpenOnco`
+- MCP server: `https://github.com/romeo111/OpenOnco/tree/main/mcp_server`
+- In-browser demo: `https://openonco.info/try.html`
+- `llms.txt`: `https://openonco.info/llms.txt`
+
+**Tools to declare (exact names, verified in `mcp_server/server.py`):**
+`engine_info`, `list_diseases`, `generate_treatment_plan`, `generate_diagnostic_brief`
+
+---
+
+## At-a-glance: what each registry needs
+
+| Registry | Mechanism | Outward action required? | Who acts |
+|---|---|---|---|
+| `modelcontextprotocol/servers` (community list) | PR to README | **Yes — PR** | Maintainer |
+| `punkpeye/awesome-mcp-servers` | PR to README | **Yes — PR** | Maintainer |
+| PulseMCP | Web form / submit page (auto-enriches from GitHub) | **Yes — web form** | Maintainer |
+| Glama | Auto-indexes public GitHub repos; can claim/submit | Mostly automatic; **optional submit/claim** | Maintainer (optional) |
+| mcp.so | Web "Submit" form | **Yes — web form** | Maintainer |
+| Smithery | Connect GitHub + add `smithery.yaml`; deploys/indexes | **Yes — repo config + connect** | Maintainer |
+
+> **All six require an outward action by the maintainer** (account, PR, or form submission) — Claude cannot submit these. Glama is the only one that may list the repo automatically without any submission, but claiming/curating it is still a maintainer action. Verify each registry's current `CONTRIBUTING`/submission rules at submission time, since formats change.
+
+---
+
+## 1. `modelcontextprotocol/servers` — community servers list
+
+- **Repo:** `https://github.com/modelcontextprotocol/servers`
+- **Mechanism:** Pull request adding a one-line entry under the community/third-party servers section of the README.
+- **Auto-index?** No. **Outward action: open a PR.**
+
+**Steps (maintainer):**
+1. Fork `modelcontextprotocol/servers`.
+2. Read its `README.md` and `CONTRIBUTING` for the current section name and alphabetical/format conventions (the community section and its formatting move around — match what's there now).
+3. Add the entry in the correct (usually alphabetical) position.
+4. Open a PR; in the PR description note it's an oncology CDS server, informational/not-a-medical-device, and that the LLM never picks treatment.
+
+**Exact entry line (Markdown):**
+```markdown
+- [OpenOnco](https://github.com/romeo111/OpenOnco/tree/main/mcp_server) — Rules-first, source-cited oncology clinical decision support for clinicians. A deterministic rule engine drafts two alternative treatment plans for a clinician to verify; no LLM picks the regimen or dose. Informational support, not a medical device; early-stage (v0.1).
+```
+
+---
+
+## 2. `punkpeye/awesome-mcp-servers`
+
+- **Repo:** `https://github.com/punkpeye/awesome-mcp-servers`
+- **Mechanism:** Pull request adding a one-line entry under the appropriate category heading.
+- **Auto-index?** No. **Outward action: open a PR.**
+
+**Steps (maintainer):**
+1. Fork the repo and read `CONTRIBUTING.md` — it specifies the line format (emoji legend for language/scope, alphabetical ordering within category).
+2. Choose the closest existing category. Likely **Healthcare** / **Knowledge & Memory** / **Research & Data** — use whatever exists in the current README; do not invent a category.
+3. Apply the repo's emoji legend honestly: Python (`🐍`), and the platform/scope markers per their legend. Do **not** add a "cloud service" marker — it runs locally.
+4. Open a PR.
+
+**Exact entry line (Markdown — adjust emoji to match the repo's current legend):**
+```markdown
+- [OpenOnco](https://github.com/romeo111/OpenOnco/tree/main/mcp_server) 🐍 - Free, open-source oncology clinical decision support. A deterministic, fully source-cited rule engine drafts two alternative treatment plans (standard + aggressive) for a clinician to verify — no LLM picks the regimen or dose. Informational support, not a medical device; v0.1, seeking clinician feedback.
+```
+
+---
+
+## 3. PulseMCP
+
+- **Site:** `https://www.pulsemcp.com`
+- **Mechanism:** Public "Submit" / add-a-server page; PulseMCP then enriches from the GitHub repo.
+- **Auto-index?** Partial — submission triggers indexing; it pulls README/metadata from GitHub. **Outward action: submit via the form.**
+
+**Steps (maintainer):**
+1. Go to PulseMCP's submit/add-server page.
+2. Provide the **MCP server URL:** `https://github.com/romeo111/OpenOnco/tree/main/mcp_server` (and repo root `https://github.com/romeo111/OpenOnco` if asked separately).
+3. Name: `OpenOnco`. Use the **short blurb** for the description field.
+4. Set category to **Healthcare / Medical** (or nearest available); tags from the canonical list.
+5. Confirm the listing renders the disclaimer-bearing description and links to the demo (`https://openonco.info/try.html`) and site.
+
+**Description to paste:** use the **short blurb** above.
+
+---
+
+## 4. Glama
+
+- **Site:** `https://glama.ai/mcp/servers`
+- **Mechanism:** Glama crawls public GitHub repos and auto-generates listings; maintainers can **claim** a listing and improve metadata.
+- **Auto-index?** **Yes** — may already appear or appear without submission. **Outward action: optional — claim/curate the listing** (recommended).
+
+**Steps (maintainer):**
+1. Search Glama for "OpenOnco" to see if it's auto-listed.
+2. If present, **claim** the repo (Glama verifies GitHub ownership) and edit the description to the **short blurb** so the disclaimer and "no LLM picks the regimen" line are surfaced — auto-generated text may omit safety framing, which must be corrected.
+3. Set category **Healthcare / Medical**; add tags from the canonical list.
+4. If not present, use Glama's "add server" path with the MCP server URL.
+
+> **Safety note:** auto-generated registry text can overstate maturity or drop the disclaimer. Where the listing is editable, replace it with the cleared short blurb. Where it isn't, ensure the linked README (which carries the full disclaimer) is the canonical landing point.
+
+---
+
+## 5. mcp.so
+
+- **Site:** `https://mcp.so`
+- **Mechanism:** Public "Submit" form.
+- **Auto-index?** No. **Outward action: submit via the form.**
+
+**Steps (maintainer):**
+1. Open mcp.so's **Submit** page.
+2. **Name:** `OpenOnco`. **GitHub/URL:** `https://github.com/romeo111/OpenOnco/tree/main/mcp_server`.
+3. **Description:** paste the **short blurb**.
+4. **Category:** Healthcare / Medical (or nearest). **Tags:** from canonical list.
+5. Submit and verify the rendered card keeps the not-a-medical-device line.
+
+---
+
+## 6. Smithery
+
+- **Site:** `https://smithery.ai`
+- **Mechanism:** Connect the GitHub repo to Smithery and add a `smithery.yaml` (deployment/registry config) in the server directory; Smithery then indexes/hosts it.
+- **Auto-index?** No — requires connecting the repo and config. **Outward action: connect repo + add config file (a code change to the repo).**
+
+**Steps (maintainer):**
+1. Sign in to Smithery with GitHub.
+2. Add the OpenOnco repo and point Smithery at the `mcp_server/` directory.
+3. Add a `smithery.yaml` per Smithery's current schema declaring the four tools (`engine_info`, `list_diseases`, `generate_treatment_plan`, `generate_diagnostic_brief`) and the start command — open this as a normal feature-branch PR into OpenOnco (per repo branch rules; never commit to `master`).
+4. Set the listing description to the **short blurb**; category **Healthcare / Medical**; tags from the canonical list.
+5. **Caution:** if Smithery offers hosted/remote execution, confirm it does not run patient data server-side. OpenOnco's privacy-by-design guarantee ("patient data never leaves your machine") only holds for local/in-browser use. If you enable a hosted runtime, the listing must **not** repeat the "data never leaves your machine" claim for that deployment, and the public demo/examples must stay synthetic-only. Prefer listing it as a self-hosted/local server.
+
+---
+
+## Post-submission checklist (every registry)
+
+- [ ] Description carries the **not-a-medical-device** framing and "verified by a qualified oncologist" intent (full or short form).
+- [ ] No claim of FDA approval/clearance, CE mark, clinical validation, or production-readiness.
+- [ ] No implication that an LLM/AI chooses or recommends the regimen.
+- [ ] Maturity is honest: v0.1, seeking clinician feedback; most content STUB.
+- [ ] Audience framed as HCP/tumor boards/builders — never patients self-treating.
+- [ ] Only the five canonical links used; demo and examples are synthetic-only.
+- [ ] Tool names match exactly: `engine_info`, `list_diseases`, `generate_treatment_plan`, `generate_diagnostic_brief`.
+
+---
+
+*OpenOnco is an informational clinical decision support resource for healthcare professionals — not a medical device, not FDA-cleared/approved, and not clinically validated. It is an early-stage v0.1 open-source project actively seeking clinician feedback. No LLM picks the regimen or dose; recommendations are deterministic, rule-based, and source-cited. All recommendations must be verified by a qualified oncologist (CHARTER §11 + §15).*
+
+---
+
+*Submission note (do not publish in listings):* The MCP server source backing every listing above is at `C:\Users\805\cancer-autoresearch\.claude\worktrees\gallant-yonath-456e1c\mcp_server\` (`server.py`, `engine_bridge.py`, `README.md`). The four tool names in the asset were verified against `mcp_server\server.py`. There is no top-level `LICENSE` file in this worktree — confirm MIT/CC BY 4.0 license files are present in the published repo before submitting, since several registries surface a license badge.

--- a/promo/press-kit.md
+++ b/promo/press-kit.md
@@ -1,0 +1,125 @@
+# OpenOnco — Press Kit / One-Pager
+
+> *Informational clinical decision support for oncology professionals. Not a medical device. All recommendations must be verified by a qualified oncologist.*
+
+---
+
+## Headline
+
+**OpenOnco: a free, open-source, rules-first decision-support engine for oncology tumor boards — every recommendation cited, no LLM ever picks the regimen or dose.**
+
+## Summary (2 sentences)
+
+OpenOnco is a free, open-source clinical decision support (CDS) resource for oncologists, hematologists, and tumor boards: a clinician feeds in a structured patient profile and a deterministic rule engine — running over a versioned, fully source-cited, human-reviewed knowledge base — drafts two alternative treatment tracks (standard and aggressive) side by side for the clinician to verify and tailor. No large language model ever chooses the regimen or the dose; every claim ships with a source citation, the engine runs locally so patient data never leaves the machine, and it is positioned as an FDA non-device CDS tool — informational support, not a medical device.
+
+---
+
+## The problem
+
+Tumor-board planning is information-dense and time-pressured: clinicians must reconcile guidelines (NCCN, ESMO, EHA, BSH, EASL, national protocols), biomarker actionability, contraindications, and supportive care for each patient, then defend every choice. General-purpose AI tools are tempting shortcuts, but they can hallucinate a drug or a dose, hide their reasoning, and offer a single confident answer that invites automation bias — none of which is acceptable in a safety-critical clinical setting. What is missing is a transparent, auditable, source-grounded starting point that a clinician can trust enough to *check* — one where the software never pretends to make the decision.
+
+---
+
+## How it works (rules-first, cited)
+
+- **Structured input.** A clinician supplies a patient profile shaped as FHIR/mCODE-style JSON (disease, biomarkers, findings, demographics). Synthetic examples only on the public site.
+- **Deterministic rule engine.** All clinical logic lives in a declarative rule engine over a curated, human-reviewed knowledge base (CHARTER §8.3). It runs **6 stages** — resolve algorithm → flatten findings → evaluate red flags → walk decision tree → materialize tracks → resolve regimens — in roughly **50–200 ms per profile**. Same input + same KB version = same output (reproducible).
+- **No LLM in the decision.** No language model selects the regimen or dose, so the engine cannot hallucinate a drug or a dose. LLMs only relay already-cited engine output.
+- **Two tracks, side by side.** Every Plan returns at least two alternative treatment tracks — a standard track and a more aggressive track — each with regimen, supportive care, contraindications, monitoring, and a step-by-step decision trace. Never a single binding directive (an explicit anti-automation-bias design, CHARTER §15.2 C6).
+- **Histology gate.** If histology is not yet confirmed, the engine refuses to draft a treatment plan and returns a **Diagnostic Brief** (workup steps) instead.
+- **Citations by construction.** Every recommendation carries a source citation, enforced by a **3-layer citation guard**: a Pydantic loader referential check, a CI verifier for paraphrase grounding, and a render-time guard that warns on or drops uncited cells.
+- **Actionability evidence.** Biomarker actionability comes from **CIViC (CC0, WashU)** as the primary source, read from a local nightly snapshot, with the ESCAT tier surfaced as a badge. (OncoKB was rejected because its ToS conflicts with the project's non-commercial scope.)
+- **Runs anywhere, privately.** CLI, in-browser Pyodide (Python WASM, no backend), Python import, or an **MCP server** for any Model Context Protocol client (Claude Desktop, Cursor, etc.). Patient JSON never leaves the user's machine — no server-side PHI, no logs, no database.
+
+---
+
+## Key facts & numbers *(state 2026-06-17)*
+
+| Metric | Value |
+|---|---|
+| Diseases covered | **92** (77 with a full modeled chain, rest partial) |
+| Indications | **664** (230 first-line, 172 second-line+) |
+| Treatment regimens | **384** |
+| Drugs (ATC/RxNorm coded) | **298** |
+| Red flags | **594** |
+| Cited sources | **444** |
+| Virtual MDT clinician skills | **16** |
+| Engine runtime | ~50–200 ms per profile, deterministic |
+
+**Coverage** spans lymphoid + myeloid hematology and solid tumors — e.g. DLBCL, FL, CLL/SLL, MCL, MZL, MM, gastric, esophageal, PDAC, cholangiocarcinoma, CRC, NSCLC, SCLC, mesothelioma.
+
+**Maturity — read this honestly:** the clinical content is mostly **STUB** — meaning the structured data, algorithm, and sources are in place, but the entity has *not* yet passed two-Clinical-Co-Lead sign-off (CHARTER §6.1). Only **15 of 806** clinical entities are dual-signed-off; the rest are "proposed plan, not approved plan." There has been **no formal clinical validation study and no real-world deployment validation** (CHARTER §13). This is a **v0.1 draft** actively seeking clinician feedback — not a validated or production-ready product.
+
+**Licensing:** code is **MIT**; specifications and generated content are **CC BY 4.0**. Original source guidelines (NCCN, ESMO, EHA, BSH, EASL, Ukraine MoH/NSZU, etc.) are *referenced, not redistributed*.
+
+---
+
+## Who it is for
+
+- **Practicing oncologists and hematologists** preparing for or running tumor boards (primary user; HCP-only).
+- **Multidisciplinary tumor boards / MDT teams** wanting a drafted, fully-cited starting point to verify and tailor.
+- **Clinical pharmacologists** reviewing regimens, contraindications, and access/reimbursement context.
+- **Developers / builders of safety-critical, rules-first decision-support systems** who want a forkable open-source pattern (engine + MCP interface).
+- **AI-tooling contributors** who want to help verify or draft clinical content via the TaskTorrent "chunk" workflow (no clinical expertise required to trigger drafting; all clinical content is reviewed by Clinical Co-Leads before merge).
+- **Researchers and clinicians** who want a transparent, source-grounded, auditable oncology logic reference.
+
+**Scope guardrails:** adults only, HCP-only, outpatient / non-time-critical planning. It explicitly **excludes** pediatrics, direct-to-patient use, and emergency / time-critical oncology. It does not diagnose, screen for, or detect cancer; it does not prescribe drugs or calculate patient-specific doses.
+
+---
+
+## What makes it different
+
+1. **Rules-first, deterministic — not an LLM.** Clinical decisions come from declarative rules over a versioned, human-reviewed KB (CHARTER §8.3); because no LLM picks the regimen or dose, the engine *cannot hallucinate a drug or a dose*.
+2. **Cited by construction.** Every single recommendation ships with a source citation, enforced by a 3-layer citation guard — nothing is unsourced.
+3. **Always two tracks, never one directive.** Standard + aggressive side by side, an explicit counter to automation bias.
+4. **Transparent and auditable.** Step-by-step decision trace, FDA Criterion-4 metadata block, reproducible output.
+5. **Private by design.** Runs locally / in-browser; patient data never leaves the device; no backend, no logging.
+6. **Open and forkable.** MIT code + CC BY 4.0 content, reusable for any safety-critical decision-support domain.
+7. **Built to stay inside the FDA non-device CDS envelope.** No histology → no treatment plan; no raw image/signal/NGS input; no time-critical indications; no per-patient dose math.
+8. **MCP-native safety.** An MCP server lets any LLM route an oncology question through the deterministic engine instead of answering from memory — safer by construction.
+
+---
+
+## Links
+
+- **Site:** https://openonco.info
+- **Try the in-browser demo:** https://openonco.info/try.html
+- **Code (GitHub):** https://github.com/romeo111/OpenOnco
+- **MCP server:** https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+- **llms.txt:** https://openonco.info/llms.txt
+
+---
+
+## Boilerplate (reusable)
+
+> OpenOnco is a free, open-source clinical decision support resource for oncology professionals. A clinician feeds it a structured patient profile and a deterministic, rules-first engine — running over a versioned, fully source-cited, human-reviewed knowledge base — drafts two alternative treatment tracks (standard and aggressive) side by side, each with a regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim. No large language model ever chooses the regimen or the dose, so the engine cannot hallucinate a drug or a dose; it runs locally and in the browser, so patient data never leaves the user's machine. OpenOnco is positioned as an FDA non-device clinical decision support tool — informational support for healthcare professionals, not a medical device, and every recommendation must be verified by a qualified oncologist. It is an early-stage (v0.1) project actively seeking clinician feedback. Code is MIT-licensed; content is CC BY 4.0. Learn more at https://openonco.info.
+
+---
+
+## What we need
+
+OpenOnco is early-stage and open — the most valuable contribution right now is honest clinical feedback.
+
+- **Clinician feedback (most valuable).** Try the in-browser demo on a case you know and tell us what's wrong: https://openonco.info/try.html
+- **Clinical Co-Leads / reviewers.** Help move entities from STUB to dual-signed-off (CHARTER §6.1) — only 15 of 806 are signed off today. Oncologists, hematologists, and clinical pharmacologists especially welcome.
+- **Contributors (no clinical expertise required to start).** Draft structured sidecars and open PRs via the TaskTorrent "chunk" workflow; all clinical content is reviewed by Clinical Co-Leads before merge.
+- **Builders of safety-critical CDS.** Fork the engine + MCP pattern, kick the tires, and tell us where the rules-first design breaks.
+
+---
+
+## Screenshots / assets to capture
+
+- **In-browser demo** (`try.html`) — landing state plus a worked synthetic case being entered.
+- **Sample two-track Plan** — standard vs. aggressive tracks side by side, showing regimen, contraindications, monitoring, and a visible source citation on a claim.
+- **Decision-trace view** — the step-by-step trace + FDA Criterion-4 metadata block (the auditability story).
+- **Virtual MDT view** — the 16 MDT clinician skills / multidisciplinary perspective.
+- **Diagnostic Brief** — the "no confirmed histology → workup steps instead of a plan" safety behavior.
+- **Citation guard in action** — a recommendation cell with its source citation (and, if showable, an uncited cell being dropped/flagged).
+- **MCP integration** — the engine called from an MCP client (e.g. Claude Desktop / Cursor) relaying cited engine output.
+- **Capabilities page** — the coverage numbers (state 2026-06-17) with the STUB-vs-signed-off maturity caveat visible.
+
+---
+
+### Disclaimer footer
+
+*OpenOnco is an informational clinical decision support resource for healthcare professionals — it is **not a medical device**, is not FDA-approved, FDA-cleared, or CE-marked, and is **not clinically validated**. It does not diagnose, screen for, or detect cancer; it does not prescribe drugs or calculate patient-specific doses; and it does not replace or substitute for an oncologist or a tumor board. It is intended for adult, outpatient, non-time-critical planning by qualified healthcare professionals only — not for direct patient use and not for emergency or time-critical decisions. All outputs are drafts that **must be verified by a qualified oncologist** (CHARTER §11, §15). This is an early-stage v0.1 open-source project; most clinical content is STUB (only 15 of 806 entities dual-reviewer signed off) and no formal clinical validation study has been performed. All examples use synthetic data; nothing shown represents a real patient or guarantees any clinical outcome.*

--- a/promo/readme-badges-and-blurbs.md
+++ b/promo/readme-badges-and-blurbs.md
@@ -1,0 +1,83 @@
+# OpenOnco — README Blurbs & Promo Copy
+
+Reusable copy for READMEs, landing pages, posts, and decks. All claims are grounded in the OpenOnco fact sheet (state 2026-06-17).
+
+> **Disclaimer (include on every public asset):** OpenOnco is an informational clinical decision support tool for healthcare professionals — **not a medical device**, not FDA-cleared, not for direct patient use, and not for emergency or time-critical decisions. It is an early-stage **v0.1 draft** and is **not clinically validated**. All recommendations are drafts that must be verified by a qualified oncologist.
+
+> **Reuse note for copywriters:** these blurbs are meant to be copied piecemeal. Whenever you excerpt a tagline, description, pitch, or the footer into a standalone public asset, carry the disclaimer above (not-a-medical-device + must-be-verified-by-an-oncologist) with it, and keep the v0.1-draft / STUB maturity framing intact.
+
+---
+
+## Taglines (pick one)
+
+1. **Two cited treatment plans for your tumor board — drafted by rules, not by an LLM.**
+2. **Rules-first, fully cited oncology decision support. No LLM ever picks the regimen or dose.**
+3. **Open-source CDS for oncologists: deterministic, source-cited, and built to be verified — not trusted blindly.**
+
+*(Each tagline is a draft-to-verify framing for HCPs; pair with the disclaimer when used standalone.)*
+
+---
+
+## Descriptions
+
+### Short (1 sentence)
+
+OpenOnco is a free, open-source clinical decision support resource for oncology tumor boards that drafts two alternative, fully source-cited treatment plans from a deterministic rule engine — no LLM ever picks the regimen or dose, and every plan is an early-stage draft for a clinician to verify.
+
+### Medium (1 paragraph)
+
+OpenOnco is an informational clinical decision support (CDS) tool for oncologists, hematologists, and tumor boards. A clinician feeds it a structured patient profile (FHIR/mCODE-shaped JSON: disease, biomarkers, findings, demographics), and a declarative rule engine returns one Plan with at least two alternative treatment tracks side by side — a standard track and a more aggressive track — each carrying regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim. If histology isn't confirmed, it returns a diagnostic workup brief instead of a treatment plan. All clinical logic lives in a deterministic rule engine over a versioned, human-reviewed knowledge base — no LLM chooses the regimen or dose, so it can't hallucinate a drug or a dose. It runs locally (CLI, in-browser Pyodide, Python import, or an MCP server), so patient data never leaves your machine. OpenOnco is an early-stage v0.1 draft actively seeking clinician feedback: the knowledge base spans 92 diseases, but clinical content is still maturing — only 15 of 806 clinical entities have two-reviewer sign-off and the rest are STUB ("proposed plan, not approved plan"). It is not a medical device, is not clinically validated, and every plan must be verified by a qualified oncologist.
+
+### Long (3 paragraphs)
+
+**What it is.** OpenOnco is a free, open-source clinical decision support resource for oncology — designed for healthcare professionals (oncologists, hematologists, tumor boards) and for builders of safety-critical decision-support systems. A clinician submits a structured patient profile (FHIR/mCODE-shaped JSON), and a declarative rule engine returns one Plan containing at least two alternative treatment tracks side by side: a standard track and a more aggressive track. Each track ships with its regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim. When histology is not yet confirmed, the engine declines to produce a treatment plan and instead returns a Diagnostic Brief of workup steps. The knowledge base currently spans 92 diseases across lymphoid and myeloid hematology and solid tumors (with 664 indications, 384 regimens, 298 ATC/RxNorm-coded drugs, 594 red flags, and 444 cited sources) — but coverage is not the same as clinical sign-off: most of this content is still STUB (see "Where it stands").
+
+**How it's different.** Clinical decisions come from declarative rules over a versioned, human-reviewed knowledge base — never from an LLM (CHARTER §8.3). Because no LLM picks the regimen or dose, the engine cannot hallucinate a drug or a dose. The engine is deterministic and reproducible: the same input plus the same KB version always yields the same plan, produced through six fixed stages in roughly 50–200 ms. Every recommendation is source-cited by construction, enforced by a three-layer citation guard (Pydantic referential check, CI paraphrase-grounding verifier, and a render-time guard that warns or drops uncited cells). Actionability evidence is drawn from CIViC (CC0, WashU) read from a local nightly snapshot, with ESCAT tier surfaced as a badge. It is privacy-by-design: the engine runs locally via CLI, in-browser Pyodide (Python WASM, no backend), or Python import — patient JSON never leaves the device, with no server-side PHI, no logs, and no database. It always presents alternatives side by side rather than a single binding directive, an explicit anti-automation-bias design choice (CHARTER §15.2 C6), and it is designed to meet FDA non-device CDS criteria (CHARTER §15) — a design goal, not a certification. Code is MIT; specs and generated content are CC BY 4.0; source guidelines (NCCN, ESMO, EHA, BSH, EASL, Ukraine MoH/NSZU, and others) are referenced, not redistributed. An MCP server exposes the engine to any Model Context Protocol client (Claude Desktop, Cursor, etc.), so an LLM can relay cited engine output instead of answering from memory.
+
+**Where it stands.** OpenOnco is an early-stage **v0.1 draft**. The engine and the cited knowledge base are live, but clinical maturity is deliberately measured by dual sign-off: only **15 of 806** clinical entities have received two-Clinical-Co-Lead approval — the rest are **STUB** (structured data, algorithm, and sources are in place, but not yet dual-reviewer signed off). STUB means "proposed plan, not approved plan." No formal clinical validation study has been done, and there is no real-world deployment validation. OpenOnco is **not** a medical device, is **not** clinically validated, and does **not** replace an oncologist or a tumor board — it produces drafts to be verified by the treating physician. The most valuable contribution right now is clinician feedback: try the in-browser demo (synthetic examples only) on a case you know, and tell us what's wrong.
+
+---
+
+## Suggested README badges
+
+```markdown
+[![Code License: MIT](https://img.shields.io/badge/code%20license-MIT-blue.svg)](https://github.com/romeo111/OpenOnco)
+[![Content License: CC BY 4.0](https://img.shields.io/badge/content%20license-CC%20BY%204.0-lightgrey.svg)](https://github.com/romeo111/OpenOnco)
+[![Site: openonco.info](https://img.shields.io/badge/site-openonco.info-brightgreen.svg)](https://openonco.info)
+[![Try the demo](https://img.shields.io/badge/demo-try%20in%20browser-orange.svg)](https://openonco.info/try.html)
+[![MCP server](https://img.shields.io/badge/MCP-server-purple.svg)](https://github.com/romeo111/OpenOnco/tree/main/mcp_server)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-success.svg)](https://github.com/romeo111/OpenOnco)
+[![Status: v0.1 draft](https://img.shields.io/badge/status-v0.1%20draft-yellow.svg)](https://openonco.info)
+```
+
+Rendered:
+
+[![Code License: MIT](https://img.shields.io/badge/code%20license-MIT-blue.svg)](https://github.com/romeo111/OpenOnco)
+[![Content License: CC BY 4.0](https://img.shields.io/badge/content%20license-CC%20BY%204.0-lightgrey.svg)](https://github.com/romeo111/OpenOnco)
+[![Site: openonco.info](https://img.shields.io/badge/site-openonco.info-brightgreen.svg)](https://openonco.info)
+[![Try the demo](https://img.shields.io/badge/demo-try%20in%20browser-orange.svg)](https://openonco.info/try.html)
+[![MCP server](https://img.shields.io/badge/MCP-server-purple.svg)](https://github.com/romeo111/OpenOnco/tree/main/mcp_server)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-success.svg)](https://github.com/romeo111/OpenOnco)
+[![Status: v0.1 draft](https://img.shields.io/badge/status-v0.1%20draft-yellow.svg)](https://openonco.info)
+
+---
+
+## Elevator pitches by audience
+
+*(Each pitch is HCP/builder-facing; carry the not-a-medical-device + verify-with-an-oncologist disclaimer whenever a pitch is used on its own.)*
+
+**For the oncologist / tumor board:**
+Feed OpenOnco a structured patient profile and get two alternative, fully source-cited treatment tracks (standard + aggressive) side by side, each with a step-by-step decision trace to verify and tailor — drafted by a deterministic rule engine, never by an LLM, so it can't hallucinate a drug or dose. It's an early-stage v0.1 draft: the KB spans 92 diseases but most clinical content is STUB (only 15 of 806 entities are dual-reviewer signed off), so treat every plan as a starting point you verify, not a replacement for your judgment. Try it on a case you know and tell us what's wrong.
+
+**For the AI developer:**
+OpenOnco is a forkable, open-source pattern for safety-critical CDS: a deterministic, reproducible rule engine (six stages, ~50–200 ms, same input + same KB version = same output) over a versioned knowledge base with citations enforced by a three-layer guard — and an MCP server that lets any LLM route an oncology question through the engine instead of answering from memory. Code is MIT; the LLM relays cited engine output and never picks the regimen itself.
+
+**For the open-source contributor:**
+OpenOnco runs on a distributed, AI-assisted "chunk" workflow (TaskTorrent): you can draft structured sidecars and open PRs without clinical expertise, and Clinical Co-Leads review all clinical content before merge. Today only 15 of 806 entities are dual-signed-off and the project is openly seeking clinician feedback — there's a lot of high-leverage, well-scoped work to pick up. Code is MIT, content is CC BY 4.0.
+
+**For the potential funder:**
+OpenOnco is a free public-good oncology CDS resource built rules-first for safety: deterministic logic over a 92-disease, 444-source cited knowledge base, no LLM choosing regimens, privacy-by-design (runs locally, no PHI leaves the device), and designed to meet FDA non-device CDS criteria. It's an early-stage v0.1 draft and is not clinically validated — most clinical content is still STUB (only 15 of 806 entities have two-reviewer sign-off) and no formal validation study has been done. Funding would accelerate dual-reviewer clinical sign-off and the path toward validation.
+
+---
+
+*OpenOnco is an early-stage, open-source project actively seeking clinician feedback. It is an informational tool for healthcare professionals — not a medical device, not clinically validated; all recommendations must be verified by a qualified oncologist. Site: https://openonco.info · Repo: https://github.com/romeo111/OpenOnco · Demo: https://openonco.info/try.html*

--- a/promo/reddit-posts.md
+++ b/promo/reddit-posts.md
@@ -1,0 +1,153 @@
+# OpenOnco — Reddit Promotion Asset
+
+> **Usage note for the poster:** Reddit self-promotion rules are strict and culture varies sharply by subreddit. Post to **one subreddit at a time**, space posts out by several days, and **read each subreddit's rules + recent mod posts before submitting**. Reply to comments in good faith — these are framed as feedback requests, not launches, and should stay that way. Every post below carries the not-a-medical-device disclaimer and the "verify with a qualified oncologist" statement, per project safety rules. Do not edit those out.
+
+---
+
+## 1. r/medicine
+
+**Caution (read first):** r/medicine is heavily moderated and restricts self-promotion. Many "I built a tool" posts are removed on sight. **Message the moderators first** to ask whether a feedback-seeking post about a free, open-source, non-commercial clinician tool is permitted, and disclose that you are the developer. Verification flair may be required to post or comment substantively. Do **not** post a link as the submission — use a self/text post, lead with the critique request, and put links at the bottom. If mods say no, respect it. This is a place to be critiqued by clinicians, not to market.
+
+**Title:**
+Built a free, open-source oncology CDS tool where the rule engine — not an LLM — drafts the treatment plan. Looking for clinicians to tear it apart.
+
+**Body:**
+
+Disclosure: I'm the developer. This is a free, non-commercial, open-source project (no product, no signup, nothing to sell). Mods — happy to remove if this isn't allowed; I've tried to follow the self-promo rules and I'm here for critique, not promotion.
+
+I've been building **OpenOnco**, an informational clinical decision support tool for oncologists, hematologists, and tumor boards. I'd genuinely like clinicians here to look at it and tell me where it's wrong.
+
+What it does: you give it a structured patient profile (FHIR/mCODE-shaped JSON — disease, biomarkers, findings, demographics) and a deterministic rule engine returns one Plan with **at least two alternative treatment tracks side by side** (a standard track and a more aggressive track). Each track carries regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and **a source citation on every claim**. If histology isn't confirmed, it refuses to produce a treatment plan and returns a diagnostic workup brief instead.
+
+The design decision I most want feedback on: **no LLM ever picks the regimen or the dose.** All clinical logic is a declarative rule engine over a versioned, human-reviewed knowledge base. Same input + same KB version = same output. It deliberately shows alternatives side by side rather than a single "system says X" directive, as an anti-automation-bias measure. There's no per-patient dose calculation and no raw image/NGS input.
+
+Honest about maturity — this is the important part:
+- It's **v0.1 draft.** No formal clinical validation study has been done. No real-world deployment.
+- Knowledge base today: 92 diseases, 384 regimens, 664 indications, 298 drugs, 594 red flags, 444 cited sources (state 2026-06-17).
+- **But most of that content is STUB:** structured data + algorithm + sources are in place, but only **15 of 806 clinical entities** have passed the required two-Clinical-Co-Lead sign-off. STUB = "proposed plan, not approved plan." I am not claiming this content is reviewed or safe to use as-is.
+- Actionability evidence is from CIViC (CC0). Source guidelines (NCCN, ESMO, EHA, BSH, EASL, Ukraine MoH/NSZU, etc.) are referenced, not redistributed.
+
+It is positioned explicitly as an FDA **non-device** CDS tool: informational support, **not a medical device**, HCP-only, adults only, outpatient/non-time-critical planning. Not for emergencies. Not for direct patient use. **Every output is a draft that must be verified by the treating oncologist.**
+
+What would actually help me: pick a disease you know cold, run a synthetic case in the browser demo (no install, no backend, the patient JSON never leaves your machine), and tell me where the logic, the citations, or the framing is wrong or unsafe.
+
+- Demo (synthetic cases only): https://openonco.info/try.html
+- Site: https://openonco.info
+- Code: https://github.com/romeo111/OpenOnco
+
+**Disclaimer:** OpenOnco is a research/support tool, not a medical device. It is not FDA-cleared, CE-marked, or clinically validated. All recommendations are drafts and must be verified by a qualified oncologist. It does not diagnose cancer, is HCP-only, and is not for time-critical decisions.
+
+---
+
+## 2. r/oncology
+
+**Caution:** Smaller and less restrictive than r/medicine, but still disclose you're the developer and keep it feedback-first. Lead with the clinical framing (two-track plans, citations) rather than the tech. Expect — and welcome — skepticism about STUB coverage and lack of validation; answer it plainly.
+
+**Title:**
+Free open-source tool that drafts two cited treatment tracks (standard + aggressive) for a case — rule engine, not an LLM. Oncologists: where does it break?
+
+**Body:**
+
+Developer disclosure up front. **OpenOnco** is a free, open-source, non-commercial informational CDS resource aimed at oncologists, hematologists, and tumor boards. I'm looking for clinical critique, not signups.
+
+The idea: feed it a structured patient profile (disease, biomarkers, findings, demographics) and get back **two alternative treatment tracks side by side** — a standard track and a more aggressive one — each with regimen, supportive care, contraindications, monitoring, a decision trace, and **a citation on every claim.** No confirmed histology → it returns a diagnostic workup brief instead of a treatment plan.
+
+Why it might be worth your five minutes:
+- **The engine is deterministic and rules-first. No LLM selects the regimen or dose** — so it can't hallucinate a drug or a dose. The clinical logic is a versioned, human-reviewed knowledge base, not a model's guess.
+- It always presents **alternatives, never one binding directive** — a deliberate hedge against automation bias.
+- Every recommendation is **sourced**, enforced by a citation guard, so you can chase the evidence behind each cell.
+
+Coverage spans lymphoid + myeloid heme and solid tumors — examples in the gallery include DLBCL, FL, CLL/SLL, MCL, MZL, MM, gastric, esophageal, PDAC, cholangiocarcinoma, CRC, NSCLC, SCLC, mesothelioma. 92 diseases total (77 with a full modeled chain), 444 cited sources, actionability from CIViC (CC0); ESCAT tier shown as a badge.
+
+The honest caveats, because they matter clinically:
+- **v0.1 draft. No formal clinical validation study. No real-world deployment.**
+- **Most content is STUB** — data + algorithm + sources exist, but only **15 of 806 entities** have two-reviewer clinical sign-off. Treat everything as a proposed draft, not an approved plan.
+- HCP-only, adults only, outpatient/non-time-critical. Not for emergencies. Not for patient self-use.
+
+What I'd love: run a synthetic case you know well in the demo and tell me where the regimen logic, the citations, or the red flags are wrong, dated, or missing.
+
+- Demo (synthetic only, runs in-browser, data stays local): https://openonco.info/try.html
+- Site: https://openonco.info
+- Code: https://github.com/romeo111/OpenOnco
+
+**Disclaimer:** Research/support tool, not a medical device; not FDA-cleared, CE-marked, or clinically validated. Outputs are drafts to be verified by a qualified oncologist. Does not diagnose cancer. HCP-only. Not for time-critical use.
+
+---
+
+## 3. r/LocalLLaMA
+
+**Caution:** This crowd is technical and allergic to hype/marketing and to medical overclaiming. Lead with the engineering angle (deterministic engine, MCP, "stop your LLM hallucinating regimens"), be blunt about maturity, and don't oversell. Avoid words like "revolutionary." Expect hard questions about determinism, the KB, and the licensing — answer them. Keep the medical disclaimer but make it short and matter-of-fact.
+
+**Title:**
+A deterministic oncology engine + MCP server so your LLM relays cited, rule-based output instead of hallucinating a chemo regimen
+
+**Body:**
+
+If you've ever watched an LLM confidently invent a cancer drug or a dose, this is an attempt at the opposite pattern: keep the LLM out of the decision entirely and make it a relay over a deterministic engine.
+
+**OpenOnco** is a free, open-source (code MIT, content CC BY 4.0) clinical decision support project for oncology. The relevant bit for this sub:
+
+- **The clinical logic is a deterministic rule engine over a versioned, human-reviewed knowledge base. No LLM picks the regimen or dose.** Because the model isn't choosing, it can't hallucinate a drug or a dose. Same input + same KB version = same output.
+- The engine runs **6 deterministic stages** (resolve algorithm → flatten findings → evaluate red flags → walk decision tree → materialize tracks → resolve regimens), ~**50–200 ms** per profile, fully reproducible.
+- It runs **locally / offline**: CLI, **in-browser via Pyodide (Python WASM, no backend)**, or Python import. Patient JSON never leaves the machine — no server-side data, no logs, no DB.
+- **MCP server** exposes the engine to any Model Context Protocol client (Claude Desktop, Cursor, etc.) with tools `engine_info`, `list_diseases`, `generate_treatment_plan`, `generate_diagnostic_brief`. The LLM **relays the cited engine output and never selects the regimen itself.** That's the whole point: the model routes the question through deterministic, sourced logic instead of answering from memory.
+- Every recommendation carries a source citation, enforced by a 3-layer citation guard (Pydantic referential check → CI paraphrase-grounding verifier → render-time guard that drops/flags uncited cells).
+
+Input is structured FHIR/mCODE-shaped JSON; output is one Plan with two alternative tracks (standard + aggressive) side by side, each with a step-by-step decision trace. No confirmed histology → it returns a diagnostic brief instead of a plan.
+
+Maturity, straight: it's **v0.1**. KB is 92 diseases / 384 regimens / 444 cited sources, but **most entities are STUB** — only 15 of 806 have full two-reviewer clinical sign-off — and there's been **no formal clinical validation.** It's a working pattern and a forkable architecture, not a finished product. Honestly the "engine, not the LLM, owns the decision + MCP-as-relay" pattern is reusable for any safety-critical rules-first domain, which is partly why it's open source.
+
+- MCP server: https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+- Repo: https://github.com/romeo111/OpenOnco
+- In-browser demo: https://openonco.info/try.html
+- `llms.txt`: https://openonco.info/llms.txt
+
+Medical note (this part isn't optional): informational HCP-only CDS tool, **not a medical device**, not validated, outputs are drafts to be verified by a qualified oncologist. Not for patient self-use or time-critical decisions.
+
+---
+
+## 4. r/mcp (primary) / r/ClaudeAI (alternate)
+
+**Caution:** Post the MCP-server angle to **r/mcp** if it fits; r/ClaudeAI is the fallback if you want a Claude-Desktop framing. Both like concrete "here's a real MCP server doing a real job" posts over abstract pitches. Show the tool list and the "model relays, never decides" guarantee. Keep medical claims tight and honest; this audience will notice overclaiming. Don't cross-post the same body to both on the same day.
+
+**Title:**
+A real-world MCP server: route oncology questions through a deterministic, fully-cited engine so the model relays answers instead of guessing
+
+**Body:**
+
+Sharing an MCP server that's built around a specific safety idea: **the LLM should never make the call — it should relay output from a deterministic engine, with a citation on every claim.**
+
+**OpenOnco** is a free, open-source oncology clinical decision support project. It ships an **MCP server** that exposes a deterministic rule engine to any MCP client (Claude Desktop, Cursor, etc.). Tools:
+
+- `engine_info`
+- `list_diseases`
+- `generate_treatment_plan`
+- `generate_diagnostic_brief`
+
+How it behaves through MCP: the model passes a structured patient profile to the engine and **relays the engine's cited output verbatim — it does not pick the regimen or the dose.** The clinical logic is a versioned, human-reviewed knowledge base evaluated by deterministic rules, so the same input + same KB version always yields the same plan, and the model can't hallucinate a drug or dose because it isn't the one choosing. `generate_treatment_plan` returns two alternative tracks (standard + aggressive) side by side, each with regimen, contraindications, monitoring, a step-by-step decision trace, and source citations. If histology isn't confirmed, `generate_diagnostic_brief` returns a workup brief instead of a treatment plan.
+
+Why it's a decent MCP case study:
+- It's a clean example of **MCP-as-guardrail**: the server constrains the model to relaying sourced, deterministic output rather than free-generating in a high-stakes domain.
+- Runs locally — engine is offline-capable, patient data never leaves the machine, no backend.
+- Open source: code MIT, content CC BY 4.0. Forkable as a pattern for other rules-first, safety-critical domains.
+
+Honest status: **v0.1 draft.** The KB covers 92 diseases with 444 cited sources, but **most clinical entities are STUB** (only 15 of 806 have two-reviewer sign-off) and there's been **no formal clinical validation.** Use the synthetic demo cases to kick the tires; don't point it at a real patient and trust the output.
+
+- MCP server: https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+- Repo: https://github.com/romeo111/OpenOnco
+- Try it in-browser (synthetic cases): https://openonco.info/try.html
+
+Disclaimer: informational, HCP-only clinical decision support — **not a medical device**, not FDA-cleared/CE-marked, not clinically validated. All output is a draft to be verified by a qualified oncologist. Not for patient self-use or time-critical decisions.
+
+---
+
+### Cross-posting summary (for the poster)
+
+| Subreddit | Angle | Top risk | Mitigation |
+|---|---|---|---|
+| r/medicine | Clinician critique of a free CDS tool | Removal for self-promo | Message mods first; self-post; critique-led; verified flair |
+| r/oncology | Two cited tracks, rules-first | STUB/validation skepticism | Lead clinical, answer caveats plainly |
+| r/LocalLLaMA | Deterministic engine + MCP vs. hallucinated regimens | Hype/medical overclaim allergy | Engineering-led, blunt maturity, short disclaimer |
+| r/mcp ↔ r/ClaudeAI | Real-world MCP-as-guardrail server | Abstract-pitch fatigue | Concrete tool list + "relays, never decides" |
+
+All four bodies use only fact-sheet figures (state 2026-06-17), the five canonical links, the rules-first/no-LLM-decides differentiator, the STUB maturity caveat, and the required not-a-medical-device + verify-with-oncologist disclaimers.

--- a/promo/social-x-linkedin.md
+++ b/promo/social-x-linkedin.md
@@ -1,0 +1,129 @@
+# OpenOnco — Social Promotion Asset
+
+> **Posting note (read before publishing):** Every post below must keep its disclaimer line. OpenOnco is informational clinical decision support for healthcare professionals — not a medical device, not for patients, not for emergencies. All engine output is a draft to be verified by a qualified oncologist. Use only the five canonical links. Numbers reflect the capabilities page, state 2026-06-17.
+
+---
+
+## X / Twitter Thread
+
+### Hook (primary)
+
+**1/**
+Most "AI for oncology" tools let a language model pick the treatment.
+
+OpenOnco does the opposite: a deterministic rule engine picks from a versioned, source-cited knowledge base. No LLM ever chooses the regimen or dose — so it can't hallucinate a drug.
+
+Built for oncologists & tumor boards. Free + open source. 🧵
+
+**2/**
+Here's the flow for a tumor board:
+
+A clinician feeds in a structured patient profile (FHIR/mCODE-shaped JSON). The engine returns ONE plan with at least two alternative tracks side by side — a standard track and a more aggressive track — for the clinician to verify and tailor.
+
+**3/**
+Each track ships with: regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim.
+
+Citations aren't optional — a 3-layer guard enforces them. Nothing is unsourced by construction.
+
+**4/**
+No confirmed histology? No treatment plan.
+
+Instead the engine returns a Diagnostic Brief with workup steps. It refuses to act outside the FDA non-device CDS envelope it was designed for (CHARTER §15): no raw images/NGS, no per-patient dose math, no time-critical use.
+
+**5/**
+Privacy is structural, not a policy line.
+
+The engine is deterministic and runs locally — CLI, in-browser via Pyodide (Python WASM, no backend), or Python import. Patient JSON never leaves your machine. No server-side PHI, no logs, no DB. ~50–200 ms per profile.
+
+**6/**
+Honest scope: this is a v0.1 draft.
+
+The engine + a 92-disease, 444-source cited KB are live, but only 15 of 806 clinical entities have two-reviewer sign-off — the rest are STUB (data + algorithm + sources, not yet dual-signed). It's a proposed plan, not an approved one.
+
+**7/**
+You can even route an oncology question through it from your LLM: an MCP server exposes the deterministic engine to Claude Desktop, Cursor, etc. The model relays cited engine output instead of answering from memory.
+
+Code is MIT. Content is CC BY 4.0. Fork it.
+
+**8/**
+Try the in-browser demo on a case you know and tell us what's wrong — clinician feedback is the most valuable contribution right now.
+
+🔗 Site: https://openonco.info
+▶️ Demo: https://openonco.info/try.html
+💻 Repo: https://github.com/romeo111/OpenOnco
+
+For HCPs/tumor boards. Not a medical device; not for patient self-use. Verify all output with a qualified oncologist.
+
+#Oncology #ClinicalDecisionSupport #OpenSource #HealthTech #TumorBoard #Hematology #MedTech #MCP
+
+---
+
+### Alternative hook A (open-source / builder angle)
+
+**1/**
+We open-sourced a rules-first clinical decision support engine for oncology (for clinicians & tumor boards).
+
+Deterministic. Fully cited. Runs offline. No LLM picks the regimen or dose — clinical logic is declarative rules over a human-reviewed knowledge base.
+
+Early-stage v0.1; verify output with an oncologist. Code MIT, content CC BY 4.0. 🧵
+
+### Alternative hook B (the "no plan without histology" angle)
+
+**1/**
+An oncology decision-support tool (for clinicians, not patients) that *refuses* to give you a treatment plan when histology isn't confirmed — it hands back a diagnostic workup brief instead.
+
+That restraint is the whole point. Meet OpenOnco: rules-first, deterministic, fully source-cited, free + open. Early-stage v0.1 — verify all output with a qualified oncologist. 🧵
+
+---
+
+## LinkedIn Post
+
+**Hook (primary)**
+
+What if your oncology decision-support tool *couldn't* hallucinate a drug — because no language model ever picks the treatment?
+
+That's the design principle behind **OpenOnco**, a free, open-source clinical decision support resource for oncologists, hematologists, and tumor boards.
+
+A clinician feeds in a structured patient profile (FHIR/mCODE-shaped JSON), and a **deterministic rule engine** returns one plan containing at least two alternative treatment tracks side by side — a standard track and a more aggressive track. Each carries its regimen, supportive care, contraindications, monitoring, a step-by-step decision trace, and a source citation on every claim. The clinician verifies and tailors; the tool never issues a single binding directive — showing alternatives side by side is a deliberate guard against automation bias.
+
+A few things that make it different:
+
+🔹 **Rules-first, not LLM-first.** All clinical logic lives in a declarative rule engine over a versioned, human-reviewed knowledge base (CHARTER §8.3). Because no LLM chooses the regimen or dose, it cannot invent one.
+
+🔹 **Cited by construction.** Every recommendation ships with a source citation, enforced by a 3-layer citation guard. Actionability evidence comes from CIViC (CC0), with ESCAT tier surfaced as a badge.
+
+🔹 **Private by design.** The engine is deterministic and runs locally — CLI, in-browser via Pyodide, or Python import. Patient data never leaves the device: no backend, no server-side PHI, no logs. (~50–200 ms per profile; same input + same KB version = same output.)
+
+🔹 **Scoped honestly.** Designed to meet FDA non-device CDS criteria (CHARTER §15). No confirmed histology → no treatment plan; the engine returns a diagnostic workup brief instead. It excludes raw image/NGS input, per-patient dose calculation, pediatrics, direct-to-patient use, and time-critical decisions.
+
+🔹 **Composable.** An MCP server exposes the engine to any Model Context Protocol client (Claude Desktop, Cursor, etc.), so a model can relay cited engine output instead of answering from memory.
+
+**Where it stands — honestly:** OpenOnco is a v0.1 draft. The engine and a 92-disease knowledge base (664 indications, 384 regimens, 298 drugs, 594 red flags, 444 cited sources) are live across hematologic and solid-tumor oncology. But only 15 of 806 clinical entities have completed two-Clinical-Co-Lead sign-off — the rest are STUB: structured data, algorithm, and sources in place, but not yet dual-reviewed. There has been no formal clinical validation study. This is a proposed-plan tool actively seeking clinician feedback, not a validated product.
+
+If you run or sit on tumor boards — or you build safety-critical, rules-first decision-support systems — try the in-browser demo on a case you know and tell us what's wrong. That feedback is the most valuable contribution right now. The code is MIT and the content is CC BY 4.0, so it's also a forkable pattern for any safety-critical domain.
+
+🔗 https://openonco.info
+▶️ Demo: https://openonco.info/try.html
+💻 Repo: https://github.com/romeo111/OpenOnco
+
+*OpenOnco is an informational clinical decision support tool for healthcare professionals — not a medical device, not FDA-cleared, not for direct patient use, and not for emergency or time-critical decisions. All recommendations must be verified by a qualified oncologist. Examples use synthetic data only.*
+
+#Oncology #Hematology #ClinicalDecisionSupport #HealthTech #OpenSource #DigitalHealth #TumorBoard #MedicalInformatics #MCP #PrecisionOncology
+
+---
+
+### Alternative LinkedIn hook A (clinician-credibility angle)
+
+Every recommendation in this oncology tool carries a source citation — enforced automatically, so nothing is unsourced by construction. And no language model ever picks the regimen or dose.
+
+Meet **OpenOnco**: a free, open-source, rules-first clinical decision support resource for oncologists and tumor boards. Here's how it works, and where it honestly stands. 👇
+
+### Alternative LinkedIn hook B (health-tech / safety-engineering angle)
+
+In safety-critical AI, the most important design decision is often what you *don't* let the model do.
+
+**OpenOnco** is a free, open-source oncology decision-support engine where the LLM is deliberately kept out of the clinical decision: a deterministic rule engine over a versioned, human-reviewed, fully-cited knowledge base drafts the plans — two alternative tracks side by side — and a clinician verifies. Here's the architecture, and an honest read on its maturity. 👇
+
+---
+
+**Files referenced:** none modified — this is a standalone copy deliverable returned inline per instructions.


### PR DESCRIPTION
Adds `promo/` — a channel-ready, **safety-reviewed** promotion kit for OpenOnco.

## Contents
- **Channels:** Show HN, Reddit (r/medicine, r/oncology, r/LocalLLaMA, r/mcp), X + LinkedIn, press kit, clinician one-pager, community outreach.
- **Discoverability:** MCP-registry listing entries + submission steps.
- **Guardrails:** FAQ/objection-handling, a pre-publish safety checklist, and `00-FACT-SHEET.md` (source of truth).
- **Plan:** distribution plan + completeness critique.

## How it was produced
A workflow grounded every asset in the real repo facts, then ran an **adversarial accuracy/safety review** on each. Every public-facing asset carries the **not-a-medical-device + verify-with-oncologist** disclaimer and stays honest about **early-stage maturity** (15/806 entities dual-signed; the rest STUB). Numbers use the canonical capabilities-page figures, not the README's stale ones.

## Outward actions are gated
Producing the kit is internal. **Actual promotion (posting to HN/Reddit/X, sending outreach, recording a demo) is the maintainer's call** — each action is marked `[DRAFT-READY]` vs `[OUTWARD]` in `promo/distribution-plan.md`.

Top recommended next steps (from the critique): record a 30–60s `try.html` demo (highest ROI), and recruit Clinical Co-Leads to move content out of STUB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)