### PR TITLE
docs: README badges + CITATION.cff + refreshed KB stats

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+message: "If you use OpenOnco in your work, please cite it as below."
+title: "OpenOnco: open-source, source-cited, rules-first clinical decision support for oncology tumor boards"
+abstract: >-
+  OpenOnco is a free, open-source clinical decision support tool for oncology
+  tumor boards. A deterministic rule engine over a versioned, fully source-cited
+  knowledge base drafts two alternative treatment plans (standard and aggressive)
+  for a clinician to verify; no large language model selects the regimen or dose.
+  It runs offline / in-browser, so patient data never leaves the device.
+  Informational support, not a medical device — every recommendation must be
+  verified by a qualified oncologist.
+type: software
+authors:
+  - name: "OpenOnco contributors"
+repository-code: "https://github.com/romeo111/OpenOnco"
+url: "https://openonco.info"
+license: MIT
+version: "0.1.3"
+date-released: "2026-06-18"
+keywords:
+  - oncology
+  - clinical decision support
+  - tumor board
+  - knowledge base
+  - rule engine
+  - FHIR
+  - mCODE
+  - open source

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # OpenOnco
 
+[![Code license: MIT](https://img.shields.io/badge/code-MIT-blue.svg)](LICENSE)
+[![Content: CC BY 4.0](https://img.shields.io/badge/content-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+[![Latest release](https://img.shields.io/github/v/release/romeo111/OpenOnco)](https://github.com/romeo111/OpenOnco/releases)
+[![Website](https://img.shields.io/badge/site-openonco.info-14532d.svg)](https://openonco.info)
+[![MCP server](https://img.shields.io/badge/MCP-server-7c3aed.svg)](mcp_server/README.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/romeo111/OpenOnco/compare)
+[![Stars](https://img.shields.io/github/stars/romeo111/OpenOnco?style=social)](https://github.com/romeo111/OpenOnco/stargazers)
+
 > **Open-source clinical decision support for oncology tumor boards.**
 > Upload a patient profile → get two alternative treatment plans
 > (standard + aggressive), side by side, with every recommendation cited.
@@ -8,7 +16,7 @@
 > picks regimens** ([CHARTER §8.3](specs/CHARTER.md)).
 
 **Live demo:** **[openonco.info](https://openonco.info)** — try it in the browser, no install needed.
-**Knowledge base:** 420 indications · 377 sources · 140 algorithms across hematologic + GI + pulmonary oncology (growing).
+**Knowledge base:** 92 diseases · 664 indications · 444 cited sources across hematologic + solid-tumor oncology (growing). Most content is draft/STUB pending two-reviewer clinical sign-off.
 **FDA non-device CDS positioning** per [CHARTER §15](specs/CHARTER.md) — informational support tool, not a medical device.
 **License:** Code MIT · Content / specs CC BY 4.0.
 


### PR DESCRIPTION
Small credibility/discoverability wins:

- **README badges** (license, release, site, MCP server, PRs-welcome, stars) — lift trust + clickthrough on the repo.
- **CITATION.cff** — GitHub shows a 'Cite this repository' button; supports academic discovery and pairs with the JOSS paper draft (#625).
- **Refreshed KB stats** in the README (the old 420/377/140 were stale → 92 diseases / 664 indications / 444 sources), keeping the honest STUB caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)