### PR TITLE
growth: first-customers plan + clinician feedback/co-lead funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/clinician_feedback.md
+++ b/.github/ISSUE_TEMPLATE/clinician_feedback.md
@@ -1,0 +1,35 @@
+---
+name: Clinician feedback
+about: You're an oncologist/hematologist/pharmacist — you tried a case and want to tell us what's right or wrong
+title: "[CLINICIAN] "
+labels: clinician-feedback
+assignees: ''
+---
+
+Thank you — a clinician's eye on a real case is the single most valuable thing
+for OpenOnco right now. **Do not paste identifiable patient data** (use a
+de-identified or synthetic case; the demo runs locally and nothing leaves your
+browser).
+
+> Reminder: OpenOnco is informational decision *support*, **not a medical
+> device**, and most content is early-stage/STUB ("proposed, not approved").
+> Everything must be verified by a treating oncologist.
+
+## Your role (optional)
+<!-- e.g. medical oncologist, hematologist, clinical pharmacist, trainee; country/setting -->
+
+## The case you ran
+<!-- Disease, line of therapy, key biomarkers/findings — de-identified or synthetic. -->
+
+## What the engine got right
+
+## What's wrong or missing
+<!-- e.g. a missing contraindication, a wrong/absent regimen, a bad track split,
+a citation that doesn't support its claim, a red flag it should have raised. -->
+
+## What would make this useful to you in practice
+<!-- Optional — what's the one thing that would make you actually use it? -->
+
+## Would you be open to a follow-up?
+- [ ] Yes, you can reply here
+- [ ] I might help review content (see the "Clinical Co-Lead application" template)

--- a/.github/ISSUE_TEMPLATE/co_lead_application.md
+++ b/.github/ISSUE_TEMPLATE/co_lead_application.md
@@ -1,0 +1,28 @@
+---
+name: Clinical Co-Lead application
+about: Hem/onc or clinical-pharmacology depth — help dual-sign content out of STUB
+title: "Co-Lead application: [your area]"
+labels: co-lead-application
+assignees: ''
+---
+
+OpenOnco's biggest bottleneck is clinical sign-off: most content is **STUB**
+until two of three Clinical Co-Leads approve it ([CHARTER §6.1](../../specs/CHARTER.md)).
+If you have hematology / oncology / clinical-pharmacology depth, you can move
+real content into "reviewed" — the highest-leverage contribution to the project.
+
+## Your area
+<!-- e.g. lymphoid hematology, GI oncology, clinical pharmacology -->
+
+## Background / public profile
+<!-- A line on your training/role + a link: institutional page, ORCID, LinkedIn,
+PubMed. Public by design — the review trail is auditable. -->
+
+## What you'd want to review first
+<!-- A disease/regimen area you know cold and could sign off or correct. -->
+
+## Time you could give
+<!-- Honest estimate — even a few hours/month on one disease area helps. -->
+
+By design this is a public audit trail. You can also open a PR adding yourself to
+[`specs/CLINICAL_LEADS.md`](../../specs/CLINICAL_LEADS.md).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Try the demo first (no install, no PHI)
+    url: https://openonco.info/try.html
+    about: Run a de-identified/synthetic case in the browser, then come back and open a clinician-feedback issue.
+  - name: What OpenOnco is (and isn't)
+    url: https://openonco.info/capabilities.html
+    about: Capabilities, coverage, limitations, and the not-a-medical-device positioning.
+  - name: Use it from your LLM (MCP server)
+    url: https://github.com/romeo111/OpenOnco/tree/main/mcp_server
+    about: Call the deterministic engine from Claude Desktop, Cursor, etc.

--- a/promo/first-customers-plan.md
+++ b/promo/first-customers-plan.md
@@ -1,0 +1,140 @@
+# OpenOnco — first customers plan
+
+A concrete, implementable plan to get the **first real clinician users**. OpenOnco
+is free, so "customer" = a clinician who **runs a real (de-identified) case and
+gives feedback**, then comes back. That activation — not signups or stars — is
+the goal.
+
+> Honest framing throughout: OpenOnco is early-stage v0.1, most content STUB, not
+> a medical device, not validated. The plan is built around that reality, not
+> against it.
+
+---
+
+## 1. What counts as a "first customer" (activation)
+
+**North-star activation event:** a clinician runs ≥1 case in the engine **and**
+leaves one piece of feedback (an issue, a reply, a DM). A clinician who does that
+twice is a retained user. Everything below optimizes for that, not vanity reach.
+
+## 2. Who the realistic first users are (ICP for v0.1)
+
+Be honest about trust: a v0.1, mostly-STUB tool will **not** win busy senior
+oncologists at top academic centers yet. Go where curiosity is high and stakes
+are low first, then climb the trust ladder:
+
+1. **The maintainer's warm network** — hem/onc colleagues, ex-classmates, the
+   Ukrainian oncology community. Highest trust, fastest yes. *Start here.*
+2. **Trainees** — oncology/hematology residents & fellows. Curious, online,
+   lower stakes, generous with feedback.
+3. **Clinical-informatics / AI-in-medicine people** — they try tools and give
+   sharp technical feedback; many are also clinicians.
+4. **LMIC / rural oncologists** — where free + offline + cited is most valuable;
+   reachable via Project ECHO-style networks, HIFA, regional societies.
+5. **Open-source / dev-clinician hybrids** — via the OSS + MCP angle.
+
+## 3. The funnel (and where each step is strengthened)
+
+`Reach (warm, disclosed) → Try (a case they know) → Feedback (low friction) → Close the loop (respond/fix/credit) → Retain + refer`
+
+- **Reach:** warm intros first; then disclosed posts in *receptive* communities
+  (see `clinician-community-outreach-playbook.md`). Never spam.
+- **Try:** the in-browser demo (`try.html`) — no install, no PHI. Hand them a
+  *specific* case to run (one they'll recognize), not "go try it."
+- **Feedback:** a one-click GitHub issue template (added in this PR) — and for
+  clinicians without GitHub, accept a reply by email/DM and file it yourself.
+- **Close the loop:** respond within 48h, fix what's real, **credit them by
+  name** (with permission), and tell them it's fixed. This is what turns a
+  one-time trier into an advocate.
+- **Retain + refer:** convert the sharpest critics into **Clinical Co-Leads**
+  (template added) — that simultaneously fixes the trust/maturity bottleneck.
+
+## 4. Four-week implementable sequence
+
+### Week 0 — funnel prep  ✅ implemented in this PR
+- [x] **Clinician-feedback issue template** — `.github/ISSUE_TEMPLATE/clinician_feedback.md`
+- [x] **Clinical Co-Lead application template** — `.github/ISSUE_TEMPLATE/co_lead_application.md`
+- [x] **Issue triage config** routing people to the demo first — `.github/ISSUE_TEMPLATE/config.yml`
+- [x] Warm-network message + pilot offer (§5–§6 below)
+- [x] "Hand them a case" list (§7)
+
+### Week 1 — warm network  ▶ you
+Message 10–20 hem/onc contacts directly (DM/email/Signal) with §5. Ask for one
+concrete thing: *run this one case, tell me where it's wrong.*
+**Target:** 5 run a case, 3 leave feedback. Reply to every one within 48h.
+
+### Week 2 — receptive communities  ▶ you (disclosed, manual)
+One post each, spaced out, in the venues marked receptive in the outreach
+playbook: clinical-informatics / AI-in-medicine, MedTwitter (#hemonc), the
+Ukrainian clinician community, r/healthIT or r/clinicalresearch. Lead with "I
+built this and want clinicians to tear the logic apart."
+
+### Week 3 — one pilot  ▶ you
+Offer **one** department / tumor board / training program a structured 2-week
+look (§6). A single engaged pilot beats broad reach: it produces deep feedback,
+a testimonial, and possibly a Co-Lead.
+
+### Ongoing — the loop
+Close every feedback item fast, credit contributors, and recruit Co-Leads. Track
+the metrics in §8 weekly.
+
+## 5. Warm-network message (paste & personalize)
+
+> Hi [name] — I built a free, open-source tool that drafts oncology treatment
+> options with a citation on every line. It's deliberately *not* an LLM guessing
+> — a deterministic rule engine over guideline sources drafts two plans for you
+> to verify. It's early and I need clinicians to poke holes.
+>
+> Could you spend 5 minutes on one case you know cold? Open
+> https://openonco.info/try.html (runs in your browser, nothing leaves your
+> device — use a de-identified case), pick e.g. [a disease you treat], and tell
+> me the first thing that's wrong or missing? That single reply is hugely useful.
+>
+> It's informational support, not a medical device — everything still needs an
+> oncologist to verify. Thank you 🙏
+
+## 6. Pilot offer one-pager (for a department / tumor board)
+
+- **What:** a 2-week, no-cost look at OpenOnco on your own de-identified cases.
+- **You get:** drafted, fully-cited two-option plans to react to; a direct line
+  to fix anything wrong; optional co-authorship/credit and a Co-Lead seat.
+- **We get:** honest clinical feedback to harden the engine.
+- **Boundaries:** informational support only, not a medical device; no real PHI
+  in the public tool; every output verified by your team. Runs offline/in-browser.
+- **Ask:** 2–3 clinicians, ~1 hour/week, for two weeks.
+
+## 7. Hand them a case (lower "try" friction)
+
+Don't say "go try it." Send a clinician a case they'll recognize and the demo
+link. Good starters (synthetic, already in the gallery): DLBCL first-line,
+follicular lymphoma, CLL, multiple myeloma, gastric, NSCLC, CRC. "Run the DLBCL
+1L case and check the track split + citations" converts far better than a generic
+invite.
+
+## 8. Metrics (activation-first, honest)
+
+| Metric | What it tells you | Target (first month) |
+|---|---|---|
+| Clinician-feedback issues | real clinical scrutiny — the #1 signal | 5+ |
+| Clinicians who ran ≥1 case | top-of-activation | 15+ |
+| Repeat clinician users | retention | 3+ |
+| Co-Lead applications | trust + the maturity unlock | 1–2 |
+| Demo visits to try.html | reach → try conversion | track trend |
+| GitHub stars/forks | passive interest (secondary) | — |
+
+**Anti-metric:** vanity reach with no clinical engagement. One sharp "your logic
+here is wrong because…" from a real oncologist beats 100 stars.
+
+## 9. What I implement vs. what needs you
+
+| Action | Who |
+|---|---|
+| Feedback + Co-Lead issue templates, triage config | **done (this PR)** |
+| Warm-network message, pilot one-pager, case list | **done (this PR)** |
+| Community/registry/funding assets (other promo/ files) | done earlier |
+| DM/email the warm network; post in communities; run the pilot | you |
+| Respond to feedback, credit contributors, recruit Co-Leads | you |
+| A non-GitHub feedback form (e.g. Tally/Google Form) | you create it; I'll wire the link into the site + config |
+
+If you set up a simple feedback form and a sponsor/fiscal-host handle, tell me
+and I'll wire both into the repo/site.


### PR DESCRIPTION
A concrete, implementable plan to land the **first real clinician users** — plus the in-repo funnel pieces that support it.

## Plan — `promo/first-customers-plan.md`
- **Activation** (not vanity): a clinician runs a real de-identified case **and** leaves feedback; twice = retained.
- **Honest v0.1 ICP:** warm network → trainees → clinical-informatics → LMIC/rural → OSS-clinician. (A mostly-STUB v0.1 won't win top-center senior oncologists yet — so don't start there.)
- **Funnel:** reach (warm/disclosed) → try (a case they know) → feedback (low-friction) → close the loop (respond/fix/credit) → retain + refer.
- **4-week sequence**, warm-network message, **pilot one-pager**, "hand them a case" list, and **activation-first metrics**.

## Implemented now (the funnel)
- `clinician_feedback.md` — one-click "I tried a case, here's what's right/wrong" issue template.
- `co_lead_application.md` — recruit Clinical Co-Leads (the STUB/trust bottleneck — the real maturity unlock).
- `config.yml` — routes new issues to the demo first.

All carry the not-a-medical-device + verify-with-oncologist + early-stage framing. The outreach/pilot execution needs your accounts; the plan marks each step "you" vs "implemented".

🤖 Generated with [Claude Code](https://claude.com/claude-code)